### PR TITLE
Allow i18n component to load json

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -110,6 +110,7 @@ module.exports = function (userOptions) {
         // vue-loader after 15.0.0
         config.module.rules.push({
           resourceQuery: /blockType=i18n/,
+          type: 'javascript/auto',
           loader: '@kazupon/vue-i18n-loader'
         })
       }


### PR DESCRIPTION
Adds support for loading json in i18n component with `type: 'javascript/auto'` in webpack config.

http://kazupon.github.io/vue-i18n/guide/sfc.html#webpack