### PR TITLE
fix(lazy): make client use translations loaded on the server

### DIFF
--- a/docs/es/seo.md
+++ b/docs/es/seo.md
@@ -1,5 +1,9 @@
 # Optimización para motores de búsqueda
 
+::: tip NOTE
+Using `seo` option (or alternatively the `$nuxtI18nSeo`-based solution - see [Improving Performance](#improving-performance)) requires that locales are configured as an array of objects and not strings.
+:::
+
 Con la opción `seo`  habilitada, **nuxt-i18n** intenta agregar algunos metadatos para mejorar sus páginas SEO. Esto es lo que hace:
 
 * Agregue un atributo _lang_ que contenga el código ISO del entorno local actual a la etiqueta  `<html>`.
@@ -7,7 +11,6 @@ Con la opción `seo`  habilitada, **nuxt-i18n** intenta agregar algunos metadato
 * Genere metaetiquetas `og:locale` y `og:locale:alternate` como se define en el [protocolo Open Graph](http://ogp.me/#optional)
 * Cuando utilice la estrategia `prefix_and_default`, genere el enlace `rel="canonical"` en las rutas de idioma predeterminadas que contienen
 prefijo para evitar la indexación duplicada. [Más sobre canonical](https://support.google.com/webmasters/answer/182192#dup-content)
-
 
 Para que esta característica funcione, debe configurar la opción `locales` como una matriz de objetos, donde cada objeto tiene una opción `iso` establecida en el código ISO del idioma:
 

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -2,6 +2,10 @@
 
 ## Benefits
 
+::: tip NOTE
+Using `seo` option (or alternatively the `$nuxtI18nSeo`-based solution - see [Improving Performance](#improving-performance)) requires that locales are configured as an array of objects and not strings.
+:::
+
 When the `seo` option is enabled, **nuxt-i18n** attempts to add some metadata to improve your pages SEO. Here's what it does.
 
 - ### `lang` attribute for `<html>` tag
@@ -11,7 +15,6 @@ When the `seo` option is enabled, **nuxt-i18n** attempts to add some metadata to
 - ### Automatic hreflang generation
 
   Generates `<link rel="alternate" hreflang="x">` tags for every language configured in `nuxt.config.js`. The language's ISO codes are used as `hreflang` values.
-
 
   Since version [v6.6.0](https://github.com/nuxt-community/i18n-module/releases/tag/v6.6.0), a catchall locale hreflang link is provided for each language group (e.g. `en-*`) as well. By default, it is the first language provided but another language can be selected by setting `isCatchallLocale` to `true` on that specific language object in your `nuxt.config.js`. [More on hreflang](https://support.google.com/webmasters/answer/189077)
 

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -49,12 +49,12 @@ export default async (context) => {
 
   if (process.server) {
     context.beforeNuxtRender(({ nuxtState }) => {
-      // Add current locale if it's not the default one (that one is included in the main bundle).
       const { locale, locales, defaultLocale } = app.i18n
-      if (locale && locale !== defaultLocale) {
-        const langFile = locales.find(l => l[LOCALE_CODE_KEY] === locale).file
-        if (langFile) {
-          nuxtState.__i18n = { langs: { [langFile]: app.i18n.getLocaleMessage(app.i18n.locale) } }
+      // Add current locale if it's not the default one (that one is included in the main bundle).
+      if (lazy && locale && locale !== defaultLocale) {
+        const localeObject = locales.find(l => l[LOCALE_CODE_KEY] === locale)
+        if (localeObject && localeObject.file) {
+          nuxtState.__i18n = { langs: { [localeObject.file]: app.i18n.getLocaleMessage(app.i18n.locale) } }
         }
       }
     })

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -47,11 +47,11 @@ export default async (context) => {
     registerStore(store, vuex, localeCodes, MODULE_NAME)
   }
 
-  if (process.server) {
+  if (process.server && lazy) {
     context.beforeNuxtRender(({ nuxtState }) => {
       const { locale, locales, defaultLocale } = app.i18n
       // Add current locale if it's not the default one (that one is included in the main bundle).
-      if (lazy && locale && locale !== defaultLocale) {
+      if (locale && locale !== defaultLocale) {
         const localeObject = locales.find(l => l[LOCALE_CODE_KEY] === locale)
         if (localeObject && localeObject.file) {
           nuxtState.__i18n = { langs: { [localeObject.file]: app.i18n.getLocaleMessage(app.i18n.locale) } }

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -47,6 +47,19 @@ export default async (context) => {
     registerStore(store, vuex, localeCodes, MODULE_NAME)
   }
 
+  if (process.server) {
+    context.beforeNuxtRender(({ nuxtState }) => {
+      // Add current locale if it's not the default one (that one is included in the main bundle).
+      const { locale, locales, defaultLocale } = app.i18n
+      if (locale && locale !== defaultLocale) {
+        const langFile = locales.find(l => l[LOCALE_CODE_KEY] === locale).file
+        if (langFile) {
+          nuxtState.__i18n = { langs: { [langFile]: app.i18n.getLocaleMessage(app.i18n.locale) } }
+        }
+      }
+    })
+  }
+
   const { useCookie, cookieKey, cookieDomain } = detectBrowserLanguage
 
   const loadAndSetLocale = async (newLocale, { initialSetup = false } = {}) => {

--- a/test/fixture/basic/pages/fallback.vue
+++ b/test/fixture/basic/pages/fallback.vue
@@ -1,3 +1,6 @@
 <template>
-  <h1>{{ $t('untranslated') }}</h1>
+  <div>
+    <h1>{{ $t('untranslated') }}</h1>
+    <h2>{{ $t('home') }}</h2>
+  </div>
 </template>

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -484,11 +484,12 @@ describe('locales as string array', () => {
   let nuxt
 
   beforeAll(async () => {
-    const overrides = { i18n: { seo: true } }
+    const overrides = { i18n: { seo: false } }
     const testConfig = loadConfig(__dirname, 'no-lang-switcher', overrides, { merge: true })
     // Override those after merging to overwrite original values.
     testConfig.i18n.locales = ['en', 'fr']
 
+    console.info({ testConfig })
     nuxt = (await setup(testConfig)).nuxt
   })
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -479,6 +479,31 @@ for (const trailingSlash of TRAILING_SLASHES) {
   })
 }
 
+describe('locales as string array', () => {
+  /** @type {Nuxt} */
+  let nuxt
+
+  beforeAll(async () => {
+    const testConfig = loadConfig(__dirname, 'basic')
+
+    // Override those after merging to overwrite original values.
+    testConfig.i18n.seo = false
+    testConfig.i18n.locales = ['en', 'fr']
+
+    nuxt = (await setup(testConfig)).nuxt
+  })
+
+  afterAll(async () => {
+    await nuxt.close()
+  })
+
+  test('shows fallback string', async () => {
+    const html = await get('/fr/fallback')
+    const dom = getDom(html)
+    expect(dom.querySelector('h2')?.textContent).toBe('Accueil')
+  })
+})
+
 describe('hreflang', () => {
   /** @type {Nuxt} */
   let nuxt

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -484,10 +484,9 @@ describe('locales as string array', () => {
   let nuxt
 
   beforeAll(async () => {
-    const testConfig = loadConfig(__dirname, 'basic')
-
+    const overrides = { i18n: { seo: true } }
+    const testConfig = loadConfig(__dirname, 'no-lang-switcher', overrides, { merge: true })
     // Override those after merging to overwrite original values.
-    testConfig.i18n.seo = false
     testConfig.i18n.locales = ['en', 'fr']
 
     nuxt = (await setup(testConfig)).nuxt
@@ -498,15 +497,15 @@ describe('locales as string array', () => {
   })
 
   test('renders default locale', async () => {
-    const html = await get('/fallback')
+    const html = await get('/about')
     const dom = getDom(html)
-    expect(dom.querySelector('h2')?.textContent).toBe('Homepage')
+    expect(dom.querySelector('#current-page')?.textContent).toBe('page: About us')
   })
 
   test('renders non-default locale', async () => {
-    const html = await get('/fr/fallback')
+    const html = await get('/fr/about')
     const dom = getDom(html)
-    expect(dom.querySelector('h2')?.textContent).toBe('Accueil')
+    expect(dom.querySelector('#current-page')?.textContent).toBe('page: À propos')
   })
 })
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -497,7 +497,13 @@ describe('locales as string array', () => {
     await nuxt.close()
   })
 
-  test('shows fallback string', async () => {
+  test('renders default locale', async () => {
+    const html = await get('/fallback')
+    const dom = getDom(html)
+    expect(dom.querySelector('h2')?.textContent).toBe('Homepage')
+  })
+
+  test('renders non-default locale', async () => {
     const html = await get('/fr/fallback')
     const dom = getDom(html)
     expect(dom.querySelector('h2')?.textContent).toBe('Accueil')


### PR DESCRIPTION
Instead of client importing and processing messages (translations)
itself on load, pass already loaded messages from the server through
"nuxtState". This will in most cases allow avoiding triggering an extra
network request to fetch lang file for the given locale.

Slight behavior change: The client will no longer import the lang file
itself for the initially used locale. That means that if the lang file
has exported a function, it will only be called on the server and not on
the client. This matches behavior of "asyncData" and I think it makes
more sense in general.

Resolves #486
Resolves #663