### PR TITLE
fix: restore compatibility with Nuxt <2.14

### DIFF
--- a/src/core/hooks.js
+++ b/src/core/hooks.js
@@ -3,7 +3,7 @@ import { readdirSync } from 'fs'
 import { getLocaleCodes } from '../helpers/utils'
 import { MODULE_NAME, ROOT_DIR, LOCALE_CODE_KEY, LOCALE_ISO_KEY, LOCALE_DOMAIN_KEY, LOCALE_FILE_KEY, STRATEGIES, COMPONENT_OPTIONS_KEY } from '../helpers/constants'
 
-export function buildHook (moduleContainer, options) {
+export async function buildHook (moduleContainer, options) {
   const nuxtOptions = moduleContainer.options
 
   let defaultLangFile
@@ -69,12 +69,12 @@ export function buildHook (moduleContainer, options) {
       // Doesn't seem like we can tell whether we are in nuxt generate from the module so we'll
       // take advantage of the 'generate:before' hook to store variable.
       moduleContainer.nuxt.hook('generate:before', () => { includeUprefixedFallback = true })
-      const extendRoutes = async routes => {
-        // This import (or more specifically 'vue-template-compiler' in helpers/components.js) needs to
-        // be required only at build time to avoid problems when 'vue-template-compiler' dependency is
-        // not available (at runtime, when using nuxt-start).
-        const { makeRoutes } = await import('../helpers/routes')
 
+      // This import (or more specifically 'vue-template-compiler' in helpers/components.js) needs to
+      // be required only at build time to avoid problems when 'vue-template-compiler' dependency is
+      // not available (at runtime, when using nuxt-start).
+      const { makeRoutes } = await import('../helpers/routes')
+      moduleContainer.extendRoutes(routes => {
         const localizedRoutes = makeRoutes(routes, {
           ...options,
           pagesDir,
@@ -83,9 +83,7 @@ export function buildHook (moduleContainer, options) {
         })
         routes.splice(0, routes.length)
         routes.unshift(...localizedRoutes)
-      }
-
-      moduleContainer.extendRoutes(extendRoutes)
+      })
     }
   } else if (options.differentDomains) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
The function passed to "extendRoutes" API can't be async in older versions.

Load async import in outer scope so that the function doesn't need to be async.

Resolves #829