### PR TITLE
fix(differentDomains): Match domain properly on client if port provided

### DIFF
--- a/docs/content/en/different-domains.md
+++ b/docs/content/en/different-domains.md
@@ -9,10 +9,7 @@ You might want to use a different domain name for each language your app support
 
 * Set `differentDomains` option to `true`
 * Configure `locales` option as an array of objects, where each object has a `domain` key which value is the domain name you'd like to use for that locale (including port if non-default)
-
-<alert type="info">
-
-You might want to set `detectBrowserLanguage` to `false`. When enabled (it is by default), user can get redirected to a different domain on first visit. Set to `false` if you want to ensure that visiting given domain always shows page in the corresponding locale.
+* Optionally set `detectBrowserLanguage` to `false`. When enabled (which it is by default), user can get redirected to a different domain on first visit. Set to `false` if you want to ensure that visiting given domain always shows page in the corresponding locale.
 
 </alert>
 

--- a/docs/content/en/different-domains.md
+++ b/docs/content/en/different-domains.md
@@ -10,9 +10,11 @@ You might want to use a different domain name for each language your app support
 * Set `differentDomains` option to `true`
 * Configure `locales` option as an array of objects, where each object has a `domain` key which value is the domain name you'd like to use for that locale (including port if non-default)
 
-:::tip
+<alert type="info">
+
 You might want to set `detectBrowserLanguage` to `false`. When enabled (it is by default), user can get redirected to a different domain on first visit. Set to `false` if you want to ensure that visiting given domain always shows page in the corresponding locale.
-:::
+
+</alert>
 
 ```js{}[nuxt.config.js]
 

--- a/docs/content/en/different-domains.md
+++ b/docs/content/en/different-domains.md
@@ -8,7 +8,11 @@ category: Guide
 You might want to use a different domain name for each language your app supports. To achieve this:
 
 * Set `differentDomains` option to `true`
-* Configure `locales` option as an array of object, where each object has a `domain` key which value is the domain name you'd like to use for the locale
+* Configure `locales` option as an array of objects, where each object has a `domain` key which value is the domain name you'd like to use for that locale (including port if non-default)
+
+:::tip
+You might want to set `detectBrowserLanguage` to `false`. When enabled (it is by default), user can get redirected to a different domain on first visit. Set to `false` if you want to ensure that visiting given domain always shows page in the corresponding locale.
+:::
 
 ```js{}[nuxt.config.js]
 
@@ -46,7 +50,7 @@ When using different domain names, your lang swicher should use regular `<a>` ta
 
 ## Runtime environment variables
 
-Sometimes there's a need to change domains in different environments, e.g. staging and production. 
+Sometimes there's a need to change domains in different environments, e.g. staging and production.
 As `nuxt.config.js` is used at build time it would be necessary to create different builds for different environments.
 
 The alternative way is to keep the domains in Vuex store under `localeDomains` property. It can be accessed by the plugin

--- a/docs/content/es/different-domains.md
+++ b/docs/content/es/different-domains.md
@@ -9,12 +9,7 @@ Es posible que desee utilizar un nombre de dominio diferente para cada idioma qu
 
 * Establezca la opción `differentDomains` en `true`
 * Configure `locales` option as an array of objects, where each object has a `domain` key which value is the domain name you'd like to use for that locale (including port if non-default)
-
-<alert type="info">
-
-You might want to set `detectBrowserLanguage` to `false`. When enabled (it is by default), user can get redirected to a different domain on first visit. Set to `false` if you want to ensure that visiting given domain always shows page in the corresponding locale.
-
-</alert>
+* Optionally set `detectBrowserLanguage` to `false`. When enabled (which it is by default), user can get redirected to a different domain on first visit. Set to `false` if you want to ensure that visiting given domain always shows page in the corresponding locale.
 
 ```js{}[nuxt.config.js]
 

--- a/docs/content/es/different-domains.md
+++ b/docs/content/es/different-domains.md
@@ -10,9 +10,11 @@ Es posible que desee utilizar un nombre de dominio diferente para cada idioma qu
 * Establezca la opción `differentDomains` en `true`
 * Configure `locales` option as an array of objects, where each object has a `domain` key which value is the domain name you'd like to use for that locale (including port if non-default)
 
-:::tip
+<alert type="info">
+
 You might want to set `detectBrowserLanguage` to `false`. When enabled (it is by default), user can get redirected to a different domain on first visit. Set to `false` if you want to ensure that visiting given domain always shows page in the corresponding locale.
-:::
+
+</alert>
 
 ```js{}[nuxt.config.js]
 

--- a/docs/content/es/different-domains.md
+++ b/docs/content/es/different-domains.md
@@ -8,7 +8,11 @@ category: Guía
 Es posible que desee utilizar un nombre de dominio diferente para cada idioma que admita su aplicación. Debe lograr esto:
 
 * Establezca la opción `differentDomains` en `true`
-* Configure la opción `locales` como una matriz de objetos, donde cada objeto tiene una clave `domain` cuyo valor es el nombre de dominio que desea usar para la configuración local
+* Configure `locales` option as an array of objects, where each object has a `domain` key which value is the domain name you'd like to use for that locale (including port if non-default)
+
+:::tip
+You might want to set `detectBrowserLanguage` to `false`. When enabled (it is by default), user can get redirected to a different domain on first visit. Set to `false` if you want to ensure that visiting given domain always shows page in the corresponding locale.
+:::
 
 ```js{}[nuxt.config.js]
 

--- a/src/templates/utils-common.js
+++ b/src/templates/utils-common.js
@@ -85,18 +85,18 @@ export const resolveBaseUrl = (baseUrl, context) => {
  * @return {string | null} Locade code found if any
  */
 export const getLocaleDomain = (locales, req, { localDomainKey, localeCodeKey }) => {
-  let hostname = null
+  let host = null
 
   if (process.client) {
-    hostname = window.location.hostname
+    host = window.location.host
   } else if (req) {
-    hostname = req.headers['x-forwarded-host'] || req.headers.host
+    host = req.headers['x-forwarded-host'] || req.headers.host
   }
 
-  if (hostname) {
-    const localeDomain = locales.find(l => l[localDomainKey] === hostname)
-    if (localeDomain) {
-      return localeDomain[localeCodeKey]
+  if (host) {
+    const matchingLocale = locales.find(l => l[localDomainKey] === host)
+    if (matchingLocale) {
+      return matchingLocale[localeCodeKey]
     }
   }
 


### PR DESCRIPTION
If locale's "domain" contained a port then that wasn't matched correctly
on the client as it compared with "location.hostname" that doesn't include
the port. Use "location.host" instead.

Also, force "no-prefix" strategy when using "differentDomains" as
otherwise duplicate routes are created with the same paths but different
names. That has then caused issues when detecting locale from the route
as it would detect different locale and override what was set on
"$i18n.locale" previously.

Resolves #831