### PR TITLE
fix: don't crash on missing route when parsing page component options

### DIFF
--- a/src/helpers/components.js
+++ b/src/helpers/components.js
@@ -14,7 +14,19 @@ const { COMPONENT_OPTIONS_KEY, MODULE_NAME } = require('./constants')
  */
 exports.extractComponentOptions = path => {
   let componentOptions = {}
-  const Component = compiler.parseComponent(readFileSync(path).toString())
+  let contents
+  try {
+    contents = readFileSync(path).toString()
+  } catch (error) {
+    console.warn(`[${MODULE_NAME}] Couldn't read page component file (${error.message})`)
+  }
+
+  if (!contents) {
+    return componentOptions
+  }
+
+  const Component = compiler.parseComponent(contents)
+
   if (!Component.script || Component.script.content.length < 1) {
     return componentOptions
   }


### PR DESCRIPTION
A conflict with `@nuxtjs/svg-sprite` which extends route with a component
that it adds as a template into .nuxt directory but the file is not added
yet when "extendRoutes" hook runs.

Resolves #838