### PR TITLE
fix(routes): fix routes being generated after other modules

### DIFF
--- a/src/core/hooks.js
+++ b/src/core/hooks.js
@@ -3,7 +3,35 @@ import { readdirSync } from 'fs'
 import { getLocaleCodes } from '../helpers/utils'
 import { MODULE_NAME, ROOT_DIR, LOCALE_CODE_KEY, LOCALE_ISO_KEY, LOCALE_DOMAIN_KEY, LOCALE_FILE_KEY, STRATEGIES, COMPONENT_OPTIONS_KEY } from '../helpers/constants'
 
-export async function buildHook (moduleContainer, options) {
+export async function createExtendRoutesHook (moduleContainer, options) {
+  const nuxtOptions = moduleContainer.options
+
+  let includeUprefixedFallback = nuxtOptions.target === 'static'
+  // Doesn't seem like we can tell whether we are in nuxt generate from the module so we'll
+  // take advantage of the 'generate:before' hook to store variable.
+  moduleContainer.nuxt.hook('generate:before', () => { includeUprefixedFallback = true })
+
+  const pagesDir = nuxtOptions.dir && nuxtOptions.dir.pages ? nuxtOptions.dir.pages : 'pages'
+  const { trailingSlash } = nuxtOptions.router
+
+  // This import (or more specifically 'vue-template-compiler' in helpers/components.js) needs to
+  // be required only at build time to avoid problems when 'vue-template-compiler' dependency is
+  // not available (at runtime, when using nuxt-start).
+  const { makeRoutes } = await import('../helpers/routes')
+
+  return routes => {
+    const localizedRoutes = makeRoutes(routes, {
+      ...options,
+      pagesDir,
+      includeUprefixedFallback,
+      trailingSlash
+    })
+    routes.splice(0, routes.length)
+    routes.unshift(...localizedRoutes)
+  }
+}
+
+export function buildHook (moduleContainer, options) {
   const nuxtOptions = moduleContainer.options
 
   // Copy lang files to the build directory.
@@ -30,31 +58,7 @@ export async function buildHook (moduleContainer, options) {
     trailingSlash
   }
 
-  const pagesDir = nuxtOptions.dir && nuxtOptions.dir.pages ? nuxtOptions.dir.pages : 'pages'
-
-  if (options.strategy !== STRATEGIES.NO_PREFIX) {
-    if (localeCodes.length) {
-      let includeUprefixedFallback = nuxtOptions.target === 'static'
-      // Doesn't seem like we can tell whether we are in nuxt generate from the module so we'll
-      // take advantage of the 'generate:before' hook to store variable.
-      moduleContainer.nuxt.hook('generate:before', () => { includeUprefixedFallback = true })
-
-      // This import (or more specifically 'vue-template-compiler' in helpers/components.js) needs to
-      // be required only at build time to avoid problems when 'vue-template-compiler' dependency is
-      // not available (at runtime, when using nuxt-start).
-      const { makeRoutes } = await import('../helpers/routes')
-      moduleContainer.extendRoutes(routes => {
-        const localizedRoutes = makeRoutes(routes, {
-          ...options,
-          pagesDir,
-          includeUprefixedFallback,
-          trailingSlash
-        })
-        routes.splice(0, routes.length)
-        routes.unshift(...localizedRoutes)
-      })
-    }
-  } else if (options.differentDomains) {
+  if (options.strategy === STRATEGIES.NO_PREFIX && options.differentDomains) {
     // eslint-disable-next-line no-console
     console.warn('[' + MODULE_NAME + '] The `differentDomains` option and `no_prefix` strategy are not compatible. Change strategy or disable `differentDomains` option.')
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
 import { directive as i18nExtensionsDirective } from '@intlify/vue-i18n-extensions'
 import { MODULE_NAME, DEFAULT_OPTIONS, NESTED_OPTIONS, STRATEGIES } from './helpers/constants'
-import { buildHook } from './core/hooks'
+import { getLocaleCodes } from './helpers/utils'
+import { buildHook, createExtendRoutesHook } from './core/hooks'
 
-module.exports = function (userOptions) {
+export default async function (userOptions) {
   const options = { ...DEFAULT_OPTIONS, ...userOptions, ...this.options.i18n }
   // Options that have nested config options must be merged
   // individually with defaults to prevent missing options
@@ -16,6 +17,11 @@ module.exports = function (userOptions) {
     // eslint-disable-next-line no-console
     console.error('[' + MODULE_NAME + '] Invalid "strategy" option "' + options.strategy + '" (must be one of: ' + Object.values(STRATEGIES).join(', ') + ').')
     return
+  }
+
+  const localeCodes = getLocaleCodes(options.locales)
+  if (options.strategy !== STRATEGIES.NO_PREFIX && localeCodes.length) {
+    this.extendRoutes(await createExtendRoutesHook(this, options))
   }
 
   this.nuxt.hook('build:before', () => buildHook(this, options))


### PR DESCRIPTION
Calling "extendRoutes" from "build:before" hook means that we'll extend
routes after other modules and we don't want that.

Call "extendRoutes" from the main module scope so that the hook is
registered as early as possible and allows order of route generation
to be controlled by module order.

Resolves #850