### PR TITLE
Fixed matching browser locale when the only matching component is the language

### DIFF
--- a/src/templates/utils-common.js
+++ b/src/templates/utils-common.js
@@ -38,11 +38,20 @@ export const matchBrowserLocale = (appLocales, browserLocales) => {
   for (const [index, browserCode] of browserLocales.entries()) {
     if (browserCode.includes('-')) {
       // For backwards-compatibility, this is lower-cased before comparing.
-      const languageCode = browserCode.split('-')[0].toLowerCase()
+      const languageCodeBrowser = browserCode.split('-')[0].toLowerCase()
 
-      if (appLocales.includes(languageCode)) {
+      const matchedCode = appLocales.find(appCode => {
+        let languageCodeLocale
+        if (appCode.includes('-')) {
+          languageCodeLocale = appCode.split('-')[0]
+        } else {
+          languageCodeLocale = appCode
+        }
+        return languageCodeLocale.toLowerCase() === languageCodeBrowser
+      })
+      if (matchedCode) {
         // Deduct a thousandth for being non-exact match.
-        matchedLocales.push({ code: languageCode, score: 0.999 - index / browserLocales.length })
+        matchedLocales.push({ code: matchedCode, score: 0.999 - index / browserLocales.length })
         break
       }
     }

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -94,4 +94,11 @@ describe('matchBrowserLocale', () => {
 
     expect(matchBrowserLocale(appLocales, browserLocales)).toBe('en-gb')
   })
+
+  test('matches locale when only languages match', () => {
+    const appLocales = ['en-GB', 'en-US']
+    const browserLocales = ['en-IN', 'en']
+
+    expect(matchBrowserLocale(appLocales, browserLocales)).toBe('en-GB')
+  })
 })


### PR DESCRIPTION
Previously, nuxt-i18n would not find a match with app locales `['en-IN', 'hi-IN']` and browser locales: `['en-US', 'en-GB', 'en']`. Now the following cases:

app locales: ['en-IN', 'hi-IN'] browser locales: `['en-US', 'en-GB', 'en']`

and

app locales: ['en-IN', 'hi-IN'] browser locales: `['en-US', 'en-GB']`

result in the chosen locale `en-IN`.