### PR TITLE
fix(docs): Typo wrong route path

### DIFF
--- a/docs/content/es/basic-usage.md
+++ b/docs/content/es/basic-usage.md
@@ -34,7 +34,7 @@ La forma más rápida de comenzar con **nuxt-i18n** es definir la lista de entor
 }
 ```
 
-Con esta configuración, **nuxt-i18n** genera URL localizadas para todas sus páginas, utilizando los códigos proporcionados en la opción de configuración local `locales` como prefijo, excepto la configuración local predeterminada `defaultLocale` (lea más sobre el [enrutamiento](/routing.md)).
+Con esta configuración, **nuxt-i18n** genera URL localizadas para todas sus páginas, utilizando los códigos proporcionados en la opción de configuración local `locales` como prefijo, excepto la configuración local predeterminada `defaultLocale` (lea más sobre el [enrutamiento](es/routing)).
 
 La opción `vueI18n` ahora se pasa a **vue-i18n**, consulte el [documento](https://kazupon.github.io/vue-i18n/) para ver las opciones disponibles.
 


### PR DESCRIPTION
Wrong route to the spanish path to routing