### PR TITLE
fix(docs): add warnings regarding no_prefix strategy

### DIFF
--- a/docs/content/en/routing.md
+++ b/docs/content/en/routing.md
@@ -106,6 +106,12 @@ If on `Nuxt` version lower than 2.10.2, and using strategy `prefix_except_defaul
 
 In some cases, you might want to translate URLs in addition to having them prefixed with the locale code. There are 2 ways of configuring custom paths for your pages: in-component options or via the module's configuration.
 
+<alert type="warning">
+
+Custom paths are not supported with the `no-prefix` [strategy](#strategy).
+
+</alert>
+
 ### In-component options
 
 Add a `nuxtI18n.paths` property to your page and set your custom paths there:
@@ -253,6 +259,11 @@ If a custom path is missing for one of the locales, the `defaultLocale` custom p
 
 ## Ignore routes
 
+<alert type="warning">
+
+This feature is not supported with the `no-prefix` [strategy](#strategy).
+
+</alert>
 
 ### In-component options
 

--- a/docs/content/es/routing.md
+++ b/docs/content/es/routing.md
@@ -86,6 +86,12 @@ Make sure that you have a `defaultLocale` defined, especially if using **prefix_
 
 En algunos casos, es posible que desee traducir las URL además de tener el prefijo con el código de configuración regional. Hay 2 formas de configurar rutas personalizadas para sus páginas: opciones `in-component` o mediante la configuración del módulo.
 
+<alert type="warning">
+
+Custom paths are not supported with the `no-prefix` [strategy](#strategy).
+
+</alert>
+
 ### Opciones in-component
 
 Agregue una propiedad `nuxtI18n.paths` a su página y configure sus rutas personalizadas allí:
@@ -233,6 +239,11 @@ Si falta una ruta personalizada para una de las configuraciones locales, se usa 
 
 ## Ignorar rutas
 
+<alert type="warning">
+
+This feature is not supported with the `no-prefix` [strategy](#strategy).
+
+</alert>
 
 ### Opciones in-component
 


### PR DESCRIPTION
Added warning to the custom path and ignore routes section of the routing documentation

I've been spending a bit of time why my page was not found until I noticed that the custom path feature was in conflict with the `no_prefix` strategy, but nothing of that was mentioned in the corresponding section.