### PR TITLE
Added option useSortRoutes

### DIFF
--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -51,6 +51,7 @@ exports.DEFAULT_OPTIONS = {
   },
   parsePages: true,
   pages: {},
+  useSortRoutes: true,
   beforeLanguageSwitch: () => null,
   onLanguageSwitched: () => null
 }

--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -13,7 +13,8 @@ exports.makeRoutes = (baseRoutes, {
   parsePages,
   routesNameSeparator,
   strategy,
-  trailingSlash
+  trailingSlash,
+  useSortRoutes
 }) => {
   locales = getLocaleCodes(locales)
   let localizedRoutes = []
@@ -148,11 +149,13 @@ exports.makeRoutes = (baseRoutes, {
     localizedRoutes = localizedRoutes.concat(buildLocalizedRoutes(route, { locales }))
   }
 
-  try {
-    const { sortRoutes } = require('@nuxt/utils')
-    localizedRoutes = sortRoutes(localizedRoutes)
-  } catch (error) {
-    // Ignore
+  if (useSortRoutes) {
+    try {
+      const { sortRoutes } = require('@nuxt/utils')
+      localizedRoutes = sortRoutes(localizedRoutes)
+    } catch (error) {
+      // Ignore
+    }
   }
 
   return localizedRoutes


### PR DESCRIPTION
if change routes in nuxt.config.js
```
...
router: {
    extendRoutes(routes, resolve) {
      const index = routes.findIndex(item => item.name == 'profile-id');
      routes.splice(index, 1, {
        name: 'profile',
        path: '/profile-:id',
        component: resolve(__dirname, 'pages/profile/id.vue')
      })
}
...
```
nuxt-i18n reset my order routes
result:
```
/ru
/ru/:category
/ru/profile-:id
/:category
/profile-:id
/
```
bug: route `/ru/profile-:id` and `/profile-:id` never resolve

expected:
```
/profile-:id
/ru/profile-:id
/
/ru
/:category
/ru/:category
```
this fix added useSortRoutes as option
```
...
i18n: {
    useSortRoutes: false,
   ...
}
...
```
