### PR TITLE
fix: add x-default hreflang tag for improved SEO

### DIFF
--- a/src/templates/seo-head.js
+++ b/src/templates/seo-head.js
@@ -1,5 +1,6 @@
 import VueMeta from 'vue-meta'
 import {
+  defaultLocale,
   COMPONENT_OPTIONS_KEY,
   LOCALE_CODE_KEY,
   LOCALE_ISO_KEY,
@@ -72,6 +73,15 @@ function addHreflangLinks (locales, baseUrl, link) {
       rel: 'alternate',
       href: baseUrl + this.switchLocalePath(mapLocale.code),
       hreflang: iso
+    })
+  }
+
+  if (defaultLocale) {
+    link.push({
+      hid: 'alternate-x-default',
+      rel: 'alternate',
+      href: baseUrl + this.switchLocalePath(defaultLocale),
+      hreflang: 'x-default'
     })
   }
 }

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -191,6 +191,12 @@ for (const trailingSlash of TRAILING_SLASHES) {
           rel: 'alternate',
           href: pathRespectingTrailingSlash('nuxt-app.localhost/fr'),
           hreflang: 'fr-FR'
+        },
+        {
+          tagName: 'link',
+          rel: 'alternate',
+          href: 'nuxt-app.localhost/',
+          hreflang: 'x-default'
         }
       ]
 
@@ -585,6 +591,12 @@ for (const trailingSlash of TRAILING_SLASHES) {
           rel: 'alternate',
           href: pathRespectingTrailingSlash('nuxt-app.localhost/fr/loader-yaml'),
           hreflang: 'fr-FR'
+        },
+        {
+          tagName: 'link',
+          rel: 'alternate',
+          href: pathRespectingTrailingSlash('nuxt-app.localhost/loader-yaml'),
+          hreflang: 'x-default'
         }
       ]
 
@@ -687,6 +699,12 @@ describe('hreflang', () => {
       {
         href: 'nuxt-app.localhost/esVe',
         hreflang: 'es-VE',
+        rel: 'alternate',
+        tagName: 'link'
+      },
+      {
+        href: 'nuxt-app.localhost/',
+        hreflang: 'x-default',
         rel: 'alternate',
         tagName: 'link'
       }
@@ -1232,6 +1250,12 @@ describe('baseUrl', () => {
         rel: 'alternate',
         href: 'CUSTOM/fr?noncanonical',
         hreflang: 'fr-FR'
+      },
+      {
+        tagName: 'link',
+        rel: 'alternate',
+        href: 'CUSTOM/?noncanonical',
+        hreflang: 'x-default'
       },
       {
         tagName: 'link',


### PR DESCRIPTION
Add x-default hreflang to improve SEO.

https://webmasters.googleblog.com/2013/04/x-default-hreflang-for-international-pages.html

https://support.google.com/webmasters/answer/189077?hl=en#xdefault