### PR TITLE
fix(docs): add missing parenthesis

### DIFF
--- a/docs/content/en/basic-usage.md
+++ b/docs/content/en/basic-usage.md
@@ -85,5 +85,5 @@ export default ({ app }) => {
   @click="$router.push(localeRoute({
     name: 'index',
     params: { foo: '1' }
-  })">Navigate</a>
+  }))">Navigate</a>
 ```


### PR DESCRIPTION
Is this doc example, the `router.push()` closing parenthesis is missing.

I added it back in the PR.