### PR TITLE
fix(docs): include "defaultLocale" in the example configuration

### DIFF
--- a/docs/content/en/lazy-load-translations.md
+++ b/docs/content/en/lazy-load-translations.md
@@ -46,7 +46,8 @@ Configuration example:
     }
   ],
   lazy: true,
-  langDir: 'lang/'
+  langDir: 'lang/',
+  defaultLocale: 'en'
 }]
 ```
 

--- a/docs/content/es/lazy-load-translations.md
+++ b/docs/content/es/lazy-load-translations.md
@@ -46,7 +46,8 @@ Ejemplo de configuración:
     }
   ],
   lazy: true,
-  langDir: 'lang/'
+  langDir: 'lang/',
+  defaultLocale: 'en'
 }]
 ```
 


### PR DESCRIPTION
defaultLocale added successfully. If defaultLocale is not added, it will not run if the code is written as illustrated.