### PR TITLE
feat: API for handling locale change during page transitions

### DIFF
--- a/docs/content/en/api.md
+++ b/docs/content/en/api.md
@@ -108,22 +108,6 @@ Instance of [VueI18n class](http://kazupon.github.io/vue-i18n/api/#vuei18n-class
 
   Switches locale of the app to specified locale code. If `useCookie` option is enabled, locale cookie will be updated with new value. If prefixes are enabled (`strategy` other than `no_prefix`), will navigate to new locale's route.
 
-#### setPendingLocale
-
-  - **Arguments**:
-    - no arguments
-  - **Returns**: `Promise<undefined>`
-
-  Switches to the pending locale that would have been set on navigate, but was prevented by the option [`skipSettingLocaleOnNavigate`](./options-reference#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
-
-#### waitForPendingLocale
-
-  - **Arguments**:
-    - no arguments
-  - **Returns**: `Promise<undefined>`
-
-  Returns a promise that will be resolved once the pending locale is set.
-
 #### getBrowserLocale
 
   - **Arguments**:
@@ -131,6 +115,22 @@ Instance of [VueI18n class](http://kazupon.github.io/vue-i18n/api/#vuei18n-class
   - **Returns**: `string | undefined`
 
   Returns browser locale code filtered against the ones defined in options.
+
+#### setPendingLocale <badge>v6.20.0+</badge>
+
+  - **Arguments**:
+    - no arguments
+  - **Returns**: `Promise<undefined>`
+
+  Switches to the pending locale that would have been set on navigate, but was prevented by the option [`skipSettingLocaleOnNavigate`](./options-reference#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
+
+#### waitForPendingLocale <badge>v6.20.0+</badge>
+
+  - **Arguments**:
+    - no arguments
+  - **Returns**: `Promise<undefined>`
+
+  Returns a promise that will be resolved once the pending locale is set.
 
 ### Properties
 

--- a/docs/content/en/api.md
+++ b/docs/content/en/api.md
@@ -116,7 +116,7 @@ Instance of [VueI18n class](http://kazupon.github.io/vue-i18n/api/#vuei18n-class
 
   Returns browser locale code filtered against the ones defined in options.
 
-#### setPendingLocale <badge>v6.20.0+</badge>
+#### finalizePendingLocaleChange <badge>v6.20.0+</badge>
 
   - **Arguments**:
     - no arguments
@@ -124,7 +124,7 @@ Instance of [VueI18n class](http://kazupon.github.io/vue-i18n/api/#vuei18n-class
 
   Switches to the pending locale that would have been set on navigate, but was prevented by the option [`skipSettingLocaleOnNavigate`](./options-reference#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
 
-#### waitForPendingLocale <badge>v6.20.0+</badge>
+#### waitForPendingLocaleChange <badge>v6.20.0+</badge>
 
   - **Arguments**:
     - no arguments

--- a/docs/content/en/api.md
+++ b/docs/content/en/api.md
@@ -108,6 +108,22 @@ Instance of [VueI18n class](http://kazupon.github.io/vue-i18n/api/#vuei18n-class
 
   Switches locale of the app to specified locale code. If `useCookie` option is enabled, locale cookie will be updated with new value. If prefixes are enabled (`strategy` other than `no_prefix`), will navigate to new locale's route.
 
+#### setPendingLocale
+
+  - **Arguments**:
+    - no arguments
+  - **Returns**: `Promise<undefined>`
+
+  Switches to the pending locale that would have been set on navigate, but was prevented by the option [`skipSettingLocaleOnNavigate`](./options-reference#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
+
+#### waitForPendingLocale
+
+  - **Arguments**:
+    - no arguments
+  - **Returns**: `Promise<undefined>`
+
+  Returns a promise that will be resolved once the pending locale is set.
+
 #### getBrowserLocale
 
   - **Arguments**:

--- a/docs/content/en/lang-switcher.md
+++ b/docs/content/en/lang-switcher.md
@@ -119,27 +119,27 @@ export default {
 ```js {}[~/plugins/router.js]
 export default ({ app }) => {
   app.nuxt.defaultTransition.beforeEnter = () => {
-    app.i18n.setPendingLocale()
+    app.i18n.finalizePendingLocaleChange()
   }
 
   // Optional: wait for locale before scrolling for a smoother transition
   app.router.options.scrollBehavior = async (to, from, savedPosition) => {
     // Make sure the route has changed
     if (to.name !== from.name) {
-      await app.i18n.waitForPendingLocale()
+      await app.i18n.waitForPendingLocaleChange()
     }
     return savedPosition || { x: 0, y: 0 }
   }
 }
 ```
 
-If you have a specific transition defined in a page component, you would also need to call `setPendingLocale` from there.
+If you have a specific transition defined in a page component, you would also need to call `finalizePendingLocaleChange` from there.
 
 ```js {}[~/pages/foo.vue]
 export default {
   transition: {
     beforeEnter() {
-      this.$i18n.setPendingLocale()
+      this.$i18n.finalizePendingLocaleChange()
     }
   }
 }

--- a/docs/content/en/lang-switcher.md
+++ b/docs/content/en/lang-switcher.md
@@ -101,21 +101,22 @@ export default {
 
 ## Wait for page transition
 
-By default, the locale will be changed right away when calling [`switchLocalePath(path)`](./api#switchlocalepath) which means that if you have a page transition, it will fade out the page with the text already switched to the new language and fade back in with the same content.
+By default, the locale will be changed right away when navigating to a route with a different locale which means that if you have a page transition, it will fade out the page with the text already switched to the new language and fade back in with the same content.
 
 To work around the issue, you can set the option [`skipSettingLocaleOnNavigate`](./options-reference#skipsettinglocaleonnavigate) to `true` and handle setting the locale yourself from a `beforeEnter` transition hook defined in a plugin.
 
-```js{}[nuxt.config.js]
+```js {}[nuxt.config.js]
 export default {
   plugins: ['~/plugins/router'],
 
   i18n: {
+    // ... your other options
     skipSettingLocaleOnNavigate: true,
   }
 }
 ```
 
-```js{}[plugins/router.js]
+```js {}[~/plugins/router.js]
 export default ({ app }) => {
   app.nuxt.defaultTransition.beforeEnter = () => {
     app.i18n.setPendingLocale()
@@ -124,7 +125,9 @@ export default ({ app }) => {
   // Optional: wait for locale before scrolling for a smoother transition
   app.router.options.scrollBehavior = async (to, from, savedPosition) => {
     // Make sure the route has changed
-    if (to.name !== from.name) await app.i18n.waitForPendingLocale()
+    if (to.name !== from.name) {
+      await app.i18n.waitForPendingLocale()
+    }
     return savedPosition || { x: 0, y: 0 }
   }
 }
@@ -132,7 +135,7 @@ export default ({ app }) => {
 
 If you have a specific transition defined in a page component, you would also need to call `setPendingLocale` from there.
 
-```js{}[pages/foo.vue]
+```js {}[~/pages/foo.vue]
 export default {
   transition: {
     beforeEnter() {

--- a/docs/content/en/options-reference.md
+++ b/docs/content/en/options-reference.md
@@ -268,19 +268,19 @@ A listener called right before app's locale changes.
 
 A listener called after app's locale has changed.
 
+## `skipSettingLocaleOnNavigate` <badge>v6.20.0+</badge>
+
+- type: `boolean`
+- default: `false`
+
+If `true`, the locale will not be set when navigating to a new locale. This is useful if you want to wait for the page transition to end before setting the locale yourself using [`setPendingLocale`](./api#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
+
 ## `defaultLocaleRouteNameSuffix`
 
 - type: `string`
 - default: `'default'`
 
 Internal suffix added to generated route names for default locale, if strategy is `prefix_and_default`. You shouldn't need to change this.
-
-## `skipSettingLocaleOnNavigate`
-
-- type: `boolean`
-- default: `false`
-
-If true, the locale will not be set when navigating to a new locale. This is useful if you want to wait for the page transition to end before setting the locale yourself using [`setPendingLocale`](./api#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
 
 ## `routesNameSeparator`
 

--- a/docs/content/en/options-reference.md
+++ b/docs/content/en/options-reference.md
@@ -275,6 +275,13 @@ A listener called after app's locale has changed.
 
 Internal suffix added to generated route names for default locale, if strategy is `prefix_and_default`. You shouldn't need to change this.
 
+## `skipSettingLocaleOnNavigate`
+
+- type: `boolean`
+- default: `false`
+
+If true, the locale will not be set when navigating to a new locale. This is useful if you want to wait for the page transition to end before setting the locale yourself using [`setPendingLocale`](./api#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
+
 ## `routesNameSeparator`
 
 - type: `string`

--- a/docs/content/en/options-reference.md
+++ b/docs/content/en/options-reference.md
@@ -93,7 +93,7 @@ export default {
 - type: `string`
 - default: `ltr`
 
-The app's default direction. Will only be used when `dir` is not specified. 
+The app's default direction. Will only be used when `dir` is not specified.
 
 ## `defaultLocale`
 
@@ -273,7 +273,7 @@ A listener called after app's locale has changed.
 - type: `boolean`
 - default: `false`
 
-If `true`, the locale will not be set when navigating to a new locale. This is useful if you want to wait for the page transition to end before setting the locale yourself using [`setPendingLocale`](./api#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
+If `true`, the locale will not be set when navigating to a new locale. This is useful if you want to wait for the page transition to end before setting the locale yourself using [`finalizePendingLocaleChange`](./api#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
 
 ## `defaultLocaleRouteNameSuffix`
 

--- a/docs/content/en/options-reference.md
+++ b/docs/content/en/options-reference.md
@@ -270,10 +270,12 @@ A listener called after app's locale has changed.
 
 ## `skipSettingLocaleOnNavigate` <badge>v6.20.0+</badge>
 
+<badge>v6.20.0+</badge>
+
 - type: `boolean`
 - default: `false`
 
-If `true`, the locale will not be set when navigating to a new locale. This is useful if you want to wait for the page transition to end before setting the locale yourself using [`finalizePendingLocaleChange`](./api#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
+If `true`, the locale will not be set when navigating to a new locale. This is useful if you want to wait for the page transition to end before setting the locale yourself using [`skipSettingLocaleOnNavigate`](./api#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
 
 ## `defaultLocaleRouteNameSuffix`
 

--- a/docs/content/es/api.md
+++ b/docs/content/es/api.md
@@ -108,22 +108,6 @@ Instance of [VueI18n class](http://kazupon.github.io/vue-i18n/api/#vuei18n-class
 
   Switches locale of the app to specified locale code. If `useCookie` option is enabled, locale cookie will be updated with new value. If prefixes are enabled (`strategy` other than `no_prefix`), will navigate to new locale's route.
 
-#### setPendingLocale
-
-  - **Arguments**:
-    - no arguments
-  - **Returns**: `Promise<undefined>`
-
-  Switches to the pending locale that would have been set on navigate, but was prevented by the option [`skipSettingLocaleOnNavigate`](./options-reference#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
-
-#### waitForPendingLocale
-
-  - **Arguments**:
-    - no arguments
-  - **Returns**: `Promise<undefined>`
-
-  Returns a promise that will be resolved once the pending locale is set.
-
 #### getBrowserLocale
 
   - **Parámetros**:
@@ -131,6 +115,22 @@ Instance of [VueI18n class](http://kazupon.github.io/vue-i18n/api/#vuei18n-class
   - **Devuelve**: `string | undefined`
 
   Devuelve el código del idioma que utiliza el navegador, filtrado según los códigos definidos en las opciones.
+
+#### setPendingLocale <badge>v6.20.0+</badge>
+
+  - **Arguments**:
+    - no arguments
+  - **Returns**: `Promise<undefined>`
+
+  Switches to the pending locale that would have been set on navigate, but was prevented by the option [`skipSettingLocaleOnNavigate`](./options-reference#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
+
+#### waitForPendingLocale <badge>v6.20.0+</badge>
+
+  - **Arguments**:
+    - no arguments
+  - **Returns**: `Promise<undefined>`
+
+  Returns a promise that will be resolved once the pending locale is set.
 
 ### Properties
 

--- a/docs/content/es/api.md
+++ b/docs/content/es/api.md
@@ -116,7 +116,7 @@ Instance of [VueI18n class](http://kazupon.github.io/vue-i18n/api/#vuei18n-class
 
   Devuelve el código del idioma que utiliza el navegador, filtrado según los códigos definidos en las opciones.
 
-#### setPendingLocale <badge>v6.20.0+</badge>
+#### finalizePendingLocaleChange <badge>v6.20.0+</badge>
 
   - **Arguments**:
     - no arguments
@@ -124,7 +124,7 @@ Instance of [VueI18n class](http://kazupon.github.io/vue-i18n/api/#vuei18n-class
 
   Switches to the pending locale that would have been set on navigate, but was prevented by the option [`skipSettingLocaleOnNavigate`](./options-reference#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
 
-#### waitForPendingLocale <badge>v6.20.0+</badge>
+#### waitForPendingLocaleChange <badge>v6.20.0+</badge>
 
   - **Arguments**:
     - no arguments

--- a/docs/content/es/api.md
+++ b/docs/content/es/api.md
@@ -108,6 +108,22 @@ Instance of [VueI18n class](http://kazupon.github.io/vue-i18n/api/#vuei18n-class
 
   Switches locale of the app to specified locale code. If `useCookie` option is enabled, locale cookie will be updated with new value. If prefixes are enabled (`strategy` other than `no_prefix`), will navigate to new locale's route.
 
+#### setPendingLocale
+
+  - **Arguments**:
+    - no arguments
+  - **Returns**: `Promise<undefined>`
+
+  Switches to the pending locale that would have been set on navigate, but was prevented by the option [`skipSettingLocaleOnNavigate`](./options-reference#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
+
+#### waitForPendingLocale
+
+  - **Arguments**:
+    - no arguments
+  - **Returns**: `Promise<undefined>`
+
+  Returns a promise that will be resolved once the pending locale is set.
+
 #### getBrowserLocale
 
   - **Parámetros**:

--- a/docs/content/es/lang-switcher.md
+++ b/docs/content/es/lang-switcher.md
@@ -99,21 +99,22 @@ export default {
 
 ## Wait for page transition
 
-By default, the locale will be changed right away when calling [`switchLocalePath(path)`](./api#switchlocalepath) which means that if you have a page transition, it will fade out the page with the text already switched to the new language and fade back in with the same content.
+By default, the locale will be changed right away when navigating to a route with a different locale which means that if you have a page transition, it will fade out the page with the text already switched to the new language and fade back in with the same content.
 
 To work around the issue, you can set the option [`skipSettingLocaleOnNavigate`](./options-reference#skipsettinglocaleonnavigate) to `true` and handle setting the locale yourself from a `beforeEnter` transition hook defined in a plugin.
 
-```js{}[nuxt.config.js]
+```js {}[nuxt.config.js]
 export default {
   plugins: ['~/plugins/router'],
 
   i18n: {
+    // ... your other options
     skipSettingLocaleOnNavigate: true,
   }
 }
 ```
 
-```js{}[plugins/router.js]
+```js {}[~/plugins/router.js]
 export default ({ app }) => {
   app.nuxt.defaultTransition.beforeEnter = () => {
     app.i18n.setPendingLocale()
@@ -122,7 +123,9 @@ export default ({ app }) => {
   // Optional: wait for locale before scrolling for a smoother transition
   app.router.options.scrollBehavior = async (to, from, savedPosition) => {
     // Make sure the route has changed
-    if (to.name !== from.name) await app.i18n.waitForPendingLocale()
+    if (to.name !== from.name) {
+      await app.i18n.waitForPendingLocale()
+    }
     return savedPosition || { x: 0, y: 0 }
   }
 }
@@ -130,7 +133,7 @@ export default ({ app }) => {
 
 If you have a specific transition defined in a page component, you would also need to call `setPendingLocale` from there.
 
-```js{}[pages/foo.vue]
+```js {}[~/pages/foo.vue]
 export default {
   transition: {
     beforeEnter() {

--- a/docs/content/es/lang-switcher.md
+++ b/docs/content/es/lang-switcher.md
@@ -117,27 +117,27 @@ export default {
 ```js {}[~/plugins/router.js]
 export default ({ app }) => {
   app.nuxt.defaultTransition.beforeEnter = () => {
-    app.i18n.setPendingLocale()
+    app.i18n.finalizePendingLocaleChange()
   }
 
   // Optional: wait for locale before scrolling for a smoother transition
   app.router.options.scrollBehavior = async (to, from, savedPosition) => {
     // Make sure the route has changed
     if (to.name !== from.name) {
-      await app.i18n.waitForPendingLocale()
+      await app.i18n.waitForPendingLocaleChange()
     }
     return savedPosition || { x: 0, y: 0 }
   }
 }
 ```
 
-If you have a specific transition defined in a page component, you would also need to call `setPendingLocale` from there.
+If you have a specific transition defined in a page component, you would also need to call `finalizePendingLocaleChange` from there.
 
 ```js {}[~/pages/foo.vue]
 export default {
   transition: {
     beforeEnter() {
-      this.$i18n.setPendingLocale()
+      this.$i18n.finalizePendingLocaleChange()
     }
   }
 }

--- a/docs/content/es/lang-switcher.md
+++ b/docs/content/es/lang-switcher.md
@@ -96,3 +96,46 @@ export default {
 **nuxt-i18n** no restablecerá las traducciones de parámetros por usted, esto significa que si utiliza parámetros idénticos para diferentes rutas, navegar entre esas rutas podría generar parámetros conflictivos. Asegúrese de establecer siempre traducciones de parámetros en tales casos.
 
 </alert>
+
+## Wait for page transition
+
+By default, the locale will be changed right away when calling [`switchLocalePath(path)`](./api#switchlocalepath) which means that if you have a page transition, it will fade out the page with the text already switched to the new language and fade back in with the same content.
+
+To work around the issue, you can set the option [`skipSettingLocaleOnNavigate`](./options-reference#skipsettinglocaleonnavigate) to `true` and handle setting the locale yourself from a `beforeEnter` transition hook defined in a plugin.
+
+```js{}[nuxt.config.js]
+export default {
+  plugins: ['~/plugins/router'],
+
+  i18n: {
+    skipSettingLocaleOnNavigate: true,
+  }
+}
+```
+
+```js{}[plugins/router.js]
+export default ({ app }) => {
+  app.nuxt.defaultTransition.beforeEnter = () => {
+    app.i18n.setPendingLocale()
+  }
+
+  // Optional: wait for locale before scrolling for a smoother transition
+  app.router.options.scrollBehavior = async (to, from, savedPosition) => {
+    // Make sure the route has changed
+    if (to.name !== from.name) await app.i18n.waitForPendingLocale()
+    return savedPosition || { x: 0, y: 0 }
+  }
+}
+```
+
+If you have a specific transition defined in a page component, you would also need to call `setPendingLocale` from there.
+
+```js{}[pages/foo.vue]
+export default {
+  transition: {
+    beforeEnter() {
+      this.$i18n.setPendingLocale()
+    }
+  }
+}
+```

--- a/docs/content/es/options-reference.md
+++ b/docs/content/es/options-reference.md
@@ -268,10 +268,12 @@ A listener called after app's locale has changed.
 
 ## `skipSettingLocaleOnNavigate` <badge>v6.20.0+</badge>
 
+<badge>v6.20.0+</badge>
+
 - type: `boolean`
 - default: `false`
 
-If true, the locale will not be set when navigating to a new locale. This is useful if you want to wait for the page transition to end before setting the locale yourself using [`finalizePendingLocaleChange`](./api#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
+If `true`, the locale will not be set when navigating to a new locale. This is useful if you want to wait for the page transition to end before setting the locale yourself using [`skipSettingLocaleOnNavigate`](./api#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
 
 ## `defaultLocaleRouteNameSuffix`
 

--- a/docs/content/es/options-reference.md
+++ b/docs/content/es/options-reference.md
@@ -266,19 +266,19 @@ A listener called right before app's locale changes.
 
 A listener called after app's locale has changed.
 
+## `skipSettingLocaleOnNavigate` <badge>v6.20.0+</badge>
+
+- type: `boolean`
+- default: `false`
+
+If true, the locale will not be set when navigating to a new locale. This is useful if you want to wait for the page transition to end before setting the locale yourself using [`setPendingLocale`](./api#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
+
 ## `defaultLocaleRouteNameSuffix`
 
 - type: `string`
 - default: `'default'`
 
 Internal suffix added to generated route names for default locale, if strategy is `prefix_and_default`. You shouldn't need to change this.
-
-## `skipSettingLocaleOnNavigate`
-
-- type: `boolean`
-- default: `false`
-
-If true, the locale will not be set when navigating to a new locale. This is useful if you want to wait for the page transition to end before setting the locale yourself using [`setPendingLocale`](./api#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
 
 ## `routesNameSeparator`
 

--- a/docs/content/es/options-reference.md
+++ b/docs/content/es/options-reference.md
@@ -273,6 +273,13 @@ A listener called after app's locale has changed.
 
 Internal suffix added to generated route names for default locale, if strategy is `prefix_and_default`. You shouldn't need to change this.
 
+## `skipSettingLocaleOnNavigate`
+
+- type: `boolean`
+- default: `false`
+
+If true, the locale will not be set when navigating to a new locale. This is useful if you want to wait for the page transition to end before setting the locale yourself using [`setPendingLocale`](./api#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
+
 ## `routesNameSeparator`
 
 - type: `string`

--- a/docs/content/es/options-reference.md
+++ b/docs/content/es/options-reference.md
@@ -271,7 +271,7 @@ A listener called after app's locale has changed.
 - type: `boolean`
 - default: `false`
 
-If true, the locale will not be set when navigating to a new locale. This is useful if you want to wait for the page transition to end before setting the locale yourself using [`setPendingLocale`](./api#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
+If true, the locale will not be set when navigating to a new locale. This is useful if you want to wait for the page transition to end before setting the locale yourself using [`finalizePendingLocaleChange`](./api#skipsettinglocaleonnavigate). See more information in [Wait for page transition](./lang-switcher#wait-for-page-transition).
 
 ## `defaultLocaleRouteNameSuffix`
 

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -54,6 +54,7 @@ exports.DEFAULT_OPTIONS = {
   },
   parsePages: true,
   pages: {},
+  skipSettingLocaleOnNavigate: false,
   beforeLanguageSwitch: () => null,
   onLanguageSwitched: () => null
 }

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -209,7 +209,7 @@ export default async (context) => {
     return [null, null]
   }
 
-  const setPendingLocale = async () => {
+  const finalizePendingLocaleChange = async () => {
     if (!app.i18n.__pendingLocale) {
       return
     }
@@ -218,7 +218,7 @@ export default async (context) => {
     app.i18n.__pendingLocale = null
   }
 
-  const waitForPendingLocale = async () => {
+  const waitForPendingLocaleChange = async () => {
     if (app.i18n.__pendingLocale) {
       await app.i18n.__pendingLocalePromise
     }
@@ -285,8 +285,8 @@ export default async (context) => {
     i18n.getLocaleCookie = () => getLocaleCookie(req, { useCookie, cookieKey, localeCodes })
     i18n.setLocale = (locale) => loadAndSetLocale(locale)
     i18n.getBrowserLocale = () => getBrowserLocale()
-    i18n.setPendingLocale = setPendingLocale
-    i18n.waitForPendingLocale = waitForPendingLocale
+    i18n.finalizePendingLocaleChange = finalizePendingLocaleChange
+    i18n.waitForPendingLocaleChange = waitForPendingLocaleChange
     i18n.__baseUrl = app.i18n.__baseUrl
     i18n.__pendingLocale = app.i18n.__pendingLocale
     i18n.__pendingLocalePromise = app.i18n.__pendingLocalePromise

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -284,9 +284,9 @@ export default async (context) => {
     i18n.setLocaleCookie = locale => setLocaleCookie(locale, res, { useCookie, cookieDomain, cookieKey, cookieSecure, cookieCrossOrigin })
     i18n.getLocaleCookie = () => getLocaleCookie(req, { useCookie, cookieKey, localeCodes })
     i18n.setLocale = (locale) => loadAndSetLocale(locale)
+    i18n.getBrowserLocale = () => getBrowserLocale()
     i18n.setPendingLocale = setPendingLocale
     i18n.waitForPendingLocale = waitForPendingLocale
-    i18n.getBrowserLocale = () => getBrowserLocale()
     i18n.__baseUrl = app.i18n.__baseUrl
     i18n.__pendingLocale = app.i18n.__pendingLocale
     i18n.__pendingLocalePromise = app.i18n.__pendingLocalePromise

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -219,7 +219,9 @@ export default async (context) => {
   }
 
   const waitForPendingLocale = async () => {
-    return !app.i18n.__pendingLocale || (await app.i18n.__pendingLocalePromise)
+    if (app.i18n.__pendingLocale) {
+      await app.i18n.__pendingLocalePromise
+    }
   }
 
   const getBrowserLocale = () => {
@@ -286,6 +288,9 @@ export default async (context) => {
     i18n.waitForPendingLocale = waitForPendingLocale
     i18n.getBrowserLocale = () => getBrowserLocale()
     i18n.__baseUrl = app.i18n.__baseUrl
+    i18n.__pendingLocale = app.i18n.__pendingLocale
+    i18n.__pendingLocalePromise = app.i18n.__pendingLocalePromise
+    i18n.__resolvePendingLocalePromise = app.i18n.__resolvePendingLocalePromise
   }
 
   // Set instance options

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -18,6 +18,7 @@ import {
   onLanguageSwitched,
   rootRedirect,
   routesNameSeparator,
+  skipSettingLocaleOnNavigate,
   STRATEGIES,
   strategy,
   vueI18n,
@@ -72,11 +73,12 @@ export default async (context) => {
       return
     }
 
-    // Abort if newLocale did not change
-    if (newLocale === app.i18n.locale) {
+    // Abort if newLocale is falsy or did not change
+    if (!newLocale || newLocale === app.i18n.locale) {
       return
     }
 
+    app.i18n.__pendingLocale = null
     const oldLocale = app.i18n.locale
 
     if (!initialSetup) {
@@ -196,7 +198,11 @@ export default async (context) => {
       (detectBrowserLanguage && doDetectBrowserLanguage(route)) ||
       getLocaleFromRoute(route) || app.i18n.locale || app.i18n.defaultLocale || ''
 
-    await app.i18n.setLocale(finalLocale)
+    if (skipSettingLocaleOnNavigate) {
+      app.i18n.__pendingLocale = finalLocale
+    } else {
+      await app.i18n.setLocale(finalLocale)
+    }
 
     return [null, null]
   }
@@ -261,6 +267,7 @@ export default async (context) => {
     i18n.setLocaleCookie = locale => setLocaleCookie(locale, res, { useCookie, cookieDomain, cookieKey, cookieSecure, cookieCrossOrigin })
     i18n.getLocaleCookie = () => getLocaleCookie(req, { useCookie, cookieKey, localeCodes })
     i18n.setLocale = (locale) => loadAndSetLocale(locale)
+    i18n.setPendingLocale = () => loadAndSetLocale(app.i18n.__pendingLocale)
     i18n.getBrowserLocale = () => getBrowserLocale()
     i18n.__baseUrl = app.i18n.__baseUrl
   }

--- a/types/nuxt-i18n.d.ts
+++ b/types/nuxt-i18n.d.ts
@@ -80,6 +80,7 @@ declare namespace NuxtVueI18n {
       rootRedirect?: string | null | RootRedirectInterface
       routesNameSeparator?: string
       seo?: boolean
+      skipSettingLocaleOnNavigate?: boolean,
       strategy?: Strategies
       vueI18n?: VueI18n.I18nOptions | string
       vueI18nLoader?: boolean

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -12,10 +12,12 @@ declare module 'vue-i18n' {
   // it is necessary for the $i18n property in Vue interface: "readonly $i18n: VueI18n & IVueI18n"
   interface IVueI18n extends NuxtVueI18n.Options.NuxtI18nInterface {
     localeProperties: NuxtVueI18n.Options.LocaleObject
-    getLocaleCookie() : string | undefined
-    setLocaleCookie(locale: string) : undefined
-    setLocale(locale: string) : Promise<undefined>
-    getBrowserLocale() : string | undefined
+    getLocaleCookie(): string | undefined
+    setLocaleCookie(locale: string): undefined
+    setLocale(locale: string): Promise<undefined>
+    getBrowserLocale(): string | undefined
+    setPendingLocale(): Promise<void>
+    waitForPendingLocale(): Promise<void>
   }
 }
 

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -16,8 +16,8 @@ declare module 'vue-i18n' {
     setLocaleCookie(locale: string): undefined
     setLocale(locale: string): Promise<undefined>
     getBrowserLocale(): string | undefined
-    setPendingLocale(): Promise<void>
-    waitForPendingLocale(): Promise<void>
+    finalizePendingLocaleChange(): Promise<void>
+    waitForPendingLocaleChange(): Promise<void>
   }
 }
 


### PR DESCRIPTION
Closes #150 

The issue is happening since `nuxt-i18n` is setting the locale from `onNavigate` being called in a middleware which won't wait for the page transition to fade out. Unfortunately, this cannot be fully solved from this module since it is not possible to set a global `pageTransition.beforeEnter` while making sure it won't be overwritten from a `transition.beforeEnter` defined in a page component.

That being said, the new option `skipSettingLocaleOnNavigate` would allow us to workaround the issue. If it is `true`, the locale will not be set on navigate which would let us setting it ourselves from a `beforeEnter` transition hook:

```js
// nuxt.config.js

export default {
  // ...
  plugins: ['~/plugins/router'],

  i18n: {
    // ...
    skipSettingLocaleOnNavigate: true,
  },
}
```

```js
// plugins/router.js

export default ({ app }) => {
  app.nuxt.defaultTransition.beforeEnter = () => {
    app.i18n.setPendingLocale()
  }
  // Optional: wait for locale before scrolling for a smoother transition
  app.router.options.scrollBehavior = async (to, from, savedPosition) => {
    // Make sure the route has changed otherwise `beforeEnter` will never be called
    if (to.name !== from.name) await app.i18n.waitForPendingLocale()
    return savedPosition || { x: 0, y: 0 }
  }
}
```

```js
// in any page component

export default {
  transition: {
    beforeEnter() {
      this.$i18n.setPendingLocale()
    },
  }
}
```

I'll wait for your feedback before adding test and documentation. I hope it makes sense.