### PR TITLE
Update lang-switcher.md

### DIFF
--- a/docs/content/en/lang-switcher.md
+++ b/docs/content/en/lang-switcher.md
@@ -81,7 +81,7 @@ To provide dynamic parameters translations, dispatch the `i18n/setRouteParams` a
 export default {
   async asyncData ({ store }) {
     await store.dispatch('i18n/setRouteParams', {
-      en: { slug: 'my-post' },
+      en: { slug: 'my-post' }, // slug here is the dynamic parameter name, _slug here
       fr: { slug: 'mon-article' }
     })
     return {


### PR DESCRIPTION
Update the documentation. In my case saying slug made sense to use it everywhere, I didn't understand in the first place it will be the dynamic parameters name