### PR TITLE
fix(generate): don't try to redirect route when static generating

### DIFF
--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -121,6 +121,11 @@ export default async (context) => {
   }
 
   const getRedirectPathForLocale = (route, locale) => {
+    // Redirects are ignored if it is a nuxt generate.
+    if (process.static && process.server) {
+      return ''
+    }
+
     if (!locale || app.i18n.differentDomains || strategy === STRATEGIES.NO_PREFIX) {
       return ''
     }

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -1738,3 +1738,27 @@ describe('generate with differentDomains enabled', () => {
     expect(dom.querySelector('#current-page')?.textContent).toBe('page: About us')
   })
 })
+
+describe('generate with prefix strategy', () => {
+  const distDir = resolve(__dirname, 'fixture', 'basic', '.nuxt-generate')
+
+  beforeAll(async () => {
+    /** @type {import('@nuxt/types').NuxtConfig} */
+    const overrides = {
+      generate: { dir: distDir },
+      i18n: {
+        strategy: 'prefix',
+        seo: true
+      }
+    }
+
+    await generate(loadConfig(__dirname, 'basic', overrides, { merge: true }))
+  })
+
+  test('fallback route contains canonical link to actual route', () => {
+    const contents = readFileSync(resolve(distDir, 'index.html'), 'utf-8')
+    const dom = getDom(contents)
+    const canonicalLink = dom.querySelector('head link[rel="canonical"]')
+    expect(canonicalLink?.getAttribute('href')).toBe('nuxt-app.localhost/en')
+  })
+})


### PR DESCRIPTION
This avoids the generated page having no content which can be an issue
for SEO when talking about the fallback route generated for redirecting.

If this causes problems then we can make more specific fix that only
does that for those fallback routes.

Resolves #911