### PR TITLE
docs: fix i18n module declaration docs

### DIFF
--- a/docs/content/en/setup.md
+++ b/docs/content/en/setup.md
@@ -30,18 +30,27 @@ Add `nuxt-i18n` dependency to your project:
   </code-block>
 </code-group>
 
-Then, add `nuxt-i18n` to the `modules` section of `nuxt.config.js`:
+Then, add `nuxt-i18n` to the `modules` section of `nuxt.config.js`. You can use either of following ways to specify the module options:
 
 ```js {}[nuxt.config.js]
 {
   modules: [
-    [ 
+    'nuxt-i18n',
+  ],
+  i18n: {},
+}
+```
+
+or
+
+```js {}[nuxt.config.js]
+{
+  modules: [
+    [
       'nuxt-i18n',
       { /* module options */ }
     ]
   ],
-  // Or with global options
-  i18n: {}
 }
 ```
 

--- a/docs/content/en/setup.md
+++ b/docs/content/en/setup.md
@@ -35,8 +35,10 @@ Then, add `nuxt-i18n` to the `modules` section of `nuxt.config.js`:
 ```js {}[nuxt.config.js]
 {
   modules: [
-    'nuxt-i18n',
-    { /* module options */ }
+    [ 
+      'nuxt-i18n',
+      { /* module options */ }
+    ]
   ],
   // Or with global options
   i18n: {}

--- a/docs/content/en/setup.md
+++ b/docs/content/en/setup.md
@@ -30,7 +30,7 @@ Add `nuxt-i18n` dependency to your project:
   </code-block>
 </code-group>
 
-Then, add `nuxt-i18n` to the `modules` section of `nuxt.config.js`. You can use either of following ways to specify the module options:
+Then, add `nuxt-i18n` to the `modules` section of `nuxt.config.js`. You can use either of the following ways to specify the module options:
 
 ```js {}[nuxt.config.js]
 {

--- a/docs/content/es/setup.md
+++ b/docs/content/es/setup.md
@@ -30,7 +30,7 @@ Agregar `nuxt-i18n` a tus dependencias:
   </code-block>
 </code-group>
 
-Then, add `nuxt-i18n` to the `modules` section of `nuxt.config.js`. You can use either of following ways to specify the module options:
+Then, add `nuxt-i18n` to the `modules` section of `nuxt.config.js`. You can use either of the following ways to specify the module options:
 
 ```js {}[nuxt.config.js]
 {

--- a/docs/content/es/setup.md
+++ b/docs/content/es/setup.md
@@ -30,16 +30,27 @@ Agregar `nuxt-i18n` a tus dependencias:
   </code-block>
 </code-group>
 
-Luego añadir `nuxt-i18n` a la `modules` seccíon de `nuxt.config.js`:
+Then, add `nuxt-i18n` to the `modules` section of `nuxt.config.js`. You can use either of following ways to specify the module options:
 
 ```js {}[nuxt.config.js]
 {
   modules: [
     'nuxt-i18n',
-    { /* module options */ }
   ],
-  // Or with global options
-  i18n: {}
+  i18n: {},
+}
+```
+
+or
+
+```js {}[nuxt.config.js]
+{
+  modules: [
+    [
+      'nuxt-i18n',
+      { /* module options */ }
+    ]
+  ],
 }
 ```
 


### PR DESCRIPTION
module and its options should be enclosed within an array: 

https://nuxtjs.org/docs/2.x/configuration-glossary/configuration-modules/