### PR TITLE
docs: fix two broken links in options-reference

### DIFF
--- a/docs/content/en/options-reference.md
+++ b/docs/content/en/options-reference.md
@@ -62,7 +62,7 @@ List of locales supported by your app. Can either be an array of codes (`['en', 
 
 When using an object form, the properties can be:
 - `code` (**required**) - unique identifier of the locale
-- `iso` (required when using SEO features and) - The ISO code used for SEO features and for matching browser locales when using [detectBrowserLanguage](#detectBrowserLanguage) functionality. Should be in one of those formats:
+- `iso` (required when using SEO features and) - The ISO code used for SEO features and for matching browser locales when using [detectBrowserLanguage](#detectbrowserlanguage) functionality. Should be in one of those formats:
   * ISO 639-1 code (e.g. `'en'`)
   * ISO 639-1 and ISO 3166-1 alpha-2 codes, separated by hyphen (e.g. `'en-US'`)
 - `file` (required when using `lazy`) - the name of the file. Will be resolved relative to `langDir` path when loading locale messages lazily
@@ -112,7 +112,7 @@ Directory that contains translation files when lazy-loading messages. This CAN N
 
 Enables browser language detection to automatically redirect visitors to their preferred locale as they visit your site for the first time.
 
-See also [Browser language detection](./browser-language-detection) for a guide.
+See also [Browser language detection](/browser-language-detection) for a guide.
 
 <alert type="info">
 

--- a/docs/content/es/options-reference.md
+++ b/docs/content/es/options-reference.md
@@ -62,7 +62,7 @@ List of locales supported by your app. Can either be an array of codes (`['en', 
 
 When using an object form, the properties can be:
 - `code` (**required**) - unique identifier of the locale
-- `iso` (required when using SEO features and) - The ISO code used for SEO features and for matching browser locales when using [detectBrowserLanguage](#detectBrowserLanguage) functionality. Should be in one of those formats:
+- `iso` (required when using SEO features and) - The ISO code used for SEO features and for matching browser locales when using [detectBrowserLanguage](#detectbrowserlanguage) functionality. Should be in one of those formats:
   * ISO 639-1 code (e.g. `'en'`)
   * ISO 639-1 and ISO 3166-1 alpha-2 codes, separated by hyphen (e.g. `'en-US'`)
 - `file` (required when using `lazy`) - the name of the file. Will be resolved relative to `langDir` path when loading locale messages lazily
@@ -112,7 +112,7 @@ Directory that contains translation files when lazy-loading messages. This CAN N
 
 Enables browser language detection to automatically redirect visitors to their preferred locale as they visit your site for the first time.
 
-See also [Browser language detection](./browser-language-detection) for a guide.
+See also [Browser language detection](/browser-language-detection) for a guide.
 
 <alert type="info">
 


### PR DESCRIPTION
Two links in [/options-reference](https://i18n.nuxtjs.org/options-reference/) were broken in the following ways:

**First link** in [this section](https://i18n.nuxtjs.org/options-reference/#locales) was to [`/options-reference/#detectbrowserlanguage`](https://i18n.nuxtjs.org/options-reference/#detectbrowserlanguage), but when clicked, did nothing. The link initially was to `#detectBrowserLanguage`, but the capitalization was enough to break the link. To fix this, it was changed to `#detectbrowserlanguage`.

**Second link** in [this section](https://i18n.nuxtjs.org/options-reference/#detectbrowserlanguage) was to [`/browser-language-detection`](https://i18n.nuxtjs.org/browser-language-detection/) but kept routing to [`/options-reference/browser-language-detection`](https://i18n.nuxtjs.org/options-reference/browser-language-detection), an invalid route (returns 404).