### PR TITLE
fix: When the trailing slash option is the default, don't remove it on the error page.

### DIFF
--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -62,7 +62,9 @@ function localeRoute (route, locale) {
         !i18n.differentDomains
 
     let path = (isPrefixed ? `/${locale}${route.path}` : route.path)
-    path = path.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || '/'
+    if (trailingSlash !== undefined) {
+      path = path.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || '/'
+    }
     localizedRoute.path = path
   } else {
     if (!route.name && !route.path) {

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -965,7 +965,7 @@ describe(`${browserString} (onlyOnRoot + prefix)`, () => {
     const page = await browser.newPage()
     await page.goto(url('/'))
     expect(await (await page.$('body'))?.textContent()).toContain('locale: en')
-    expect(await getRouteFullPath(page)).toBe('/en')
+    expect(await getRouteFullPath(page)).toBe('/en/')
   })
 })
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -921,6 +921,7 @@ describe('prefix_and_default strategy', () => {
     // Prefer unprefixed path for default locale:
     expect(window.$nuxt.localeRoute('/simple', 'en')).toMatchObject({ name: 'simple___en___default', fullPath: '/simple' })
     expect(window.$nuxt.localeRoute('/simple', 'fr')).toMatchObject({ name: 'simple___fr', fullPath: '/fr/simple' })
+    expect(window.$nuxt.localeRoute('/simple/', 'fr')).toMatchObject({ name: 'simple___fr', fullPath: '/fr/simple/' })
   })
 
   test('canonical SEO link is added to prefixed default locale', async () => {


### PR DESCRIPTION
For example, when hosting with AWS Amplify (S3), if index.html does not exist, it will be redirected to the path with the trailing slash, resulting in a redirect loop.

The following settings will remove the trailing slash when a non-existent page is accessed, which should not be removed since the default Trailing Slash option does not redirect.

### Nuxt configuration

* `target` : static
* `router.trailingSlash` : undefined (**default**)

### Nuxt-i18n configuration
```
i18n: {
    strategy: 'prefix_and_default',
    lazy: true,
    ...
}
```
