### PR TITLE
feat: expose localeProperties property

### DIFF
--- a/docs/content/en/api.md
+++ b/docs/content/en/api.md
@@ -112,6 +112,12 @@ Instance of [VueI18n class](http://kazupon.github.io/vue-i18n/api/#vuei18n-class
   - **Type**: `Array<string | LocaleObject>`
 
   List of locales as defined in options.
+  
+#### localeProperties
+
+  - **Type**: `LocaleObject`
+
+  Object of the current locale properties.
 
 #### differentDomains
 

--- a/docs/content/en/options-reference.md
+++ b/docs/content/en/options-reference.md
@@ -69,11 +69,7 @@ When using an object form, the properties can be:
 - `domain` (required when using `differentDomains`) - the domain name you'd like to use for that locale (including the port if used)
 - `...` - any custom property set on the object will be exposed at runtime. This can be used, for example, to define the language name for the purpose of using it in a language selector on the page.
 
-When using an array of objects, you can access the current locale properties using the `localeProperties` property. 
-  ```js
-  { code: 'en', iso: 'en-US', file: 'en.js' }
-```
-  - When using an array of codes, it will be set to an empty object.
+You can access all the properties of the current locale through the `localeProperties` property. When using an array of codes, it will only include the `code` property.
 
 ## `defaultLocale`
 

--- a/docs/content/en/options-reference.md
+++ b/docs/content/en/options-reference.md
@@ -69,6 +69,19 @@ When using an object form, the properties can be:
 - `domain` (required when using `differentDomains`) - the domain name you'd like to use for that locale (including the port if used)
 - `...` - any custom property set on the object will be exposed at runtime. This can be used, for example, to define the language name for the purpose of using it in a language selector on the page.
 
+## `localeProperties`
+
+- type: `object`
+- default: `{}`
+
+Object contains the properties of the current `Locale` as defined in the `Locales` array.
+
+```js
+  { code: 'en', iso: 'en-US', file: 'en.js' }
+```
+
+When using an array of codes, it will be set to an empty object.
+
 ## `defaultLocale`
 
 - type: `string` or `null`

--- a/docs/content/en/options-reference.md
+++ b/docs/content/en/options-reference.md
@@ -69,18 +69,11 @@ When using an object form, the properties can be:
 - `domain` (required when using `differentDomains`) - the domain name you'd like to use for that locale (including the port if used)
 - `...` - any custom property set on the object will be exposed at runtime. This can be used, for example, to define the language name for the purpose of using it in a language selector on the page.
 
-## `localeProperties`
-
-- type: `object`
-- default: `{}`
-
-Object contains the properties of the current `Locale` as defined in the `Locales` array.
-
-```js
+When using an array of objects, you can access the current locale properties using the `localeProperties` property. 
+  ```js
   { code: 'en', iso: 'en-US', file: 'en.js' }
 ```
-
-When using an array of codes, it will be set to an empty object.
+  - When using an array of codes, it will be set to an empty object.
 
 ## `defaultLocale`
 

--- a/docs/content/es/api.md
+++ b/docs/content/es/api.md
@@ -113,6 +113,12 @@ Instance of [VueI18n class](http://kazupon.github.io/vue-i18n/api/#vuei18n-class
 
   List of locales as defined in options.
 
+#### localeProperties
+
+  - **Type**: `LocaleObject`
+
+  Object of the current locale properties.
+
 #### differentDomains
 
   - **Type**: `boolean`

--- a/docs/content/es/options-reference.md
+++ b/docs/content/es/options-reference.md
@@ -69,18 +69,11 @@ When using an object form, the properties can be:
 - `domain` (required when using `differentDomains`) - the domain name you'd like to use for that locale (including the port if used)
 - `...` - any custom property set on the object will be exposed at runtime. This can be used, for example, to define the language name for the purpose of using it in a language selector on the page.
 
-## `localeProperties`
-
-- type: `object`
-- default: `{}`
-
-Object contains the properties of the current `Locale` as defined in the `Locales` array.
-
-```js
-  { code: 'es', iso: 'es-ES', file: 'es.js' }
+When using an array of objects, you can access the current locale properties using the `localeProperties` property. 
+  ```js
+  { code: 'en', iso: 'en-US', file: 'en.js' }
 ```
-
-When using an array of codes, it will be set to an empty object.
+  - When using an array of codes, it will be set to an empty object.
 
 ## `defaultLocale`
 

--- a/docs/content/es/options-reference.md
+++ b/docs/content/es/options-reference.md
@@ -69,11 +69,7 @@ When using an object form, the properties can be:
 - `domain` (required when using `differentDomains`) - the domain name you'd like to use for that locale (including the port if used)
 - `...` - any custom property set on the object will be exposed at runtime. This can be used, for example, to define the language name for the purpose of using it in a language selector on the page.
 
-When using an array of objects, you can access the current locale properties using the `localeProperties` property. 
-  ```js
-  { code: 'en', iso: 'en-US', file: 'en.js' }
-```
-  - When using an array of codes, it will be set to an empty object.
+You can access all the properties of the current locale through the `localeProperties` property. When using an array of codes, it will only include the `code` property.
 
 ## `defaultLocale`
 

--- a/docs/content/es/options-reference.md
+++ b/docs/content/es/options-reference.md
@@ -69,6 +69,19 @@ When using an object form, the properties can be:
 - `domain` (required when using `differentDomains`) - the domain name you'd like to use for that locale (including the port if used)
 - `...` - any custom property set on the object will be exposed at runtime. This can be used, for example, to define the language name for the purpose of using it in a language selector on the page.
 
+## `localeProperties`
+
+- type: `object`
+- default: `{}`
+
+Object contains the properties of the current `Locale` as defined in the `Locales` array.
+
+```js
+  { code: 'es', iso: 'es-ES', file: 'es.js' }
+```
+
+When using an array of codes, it will be set to an empty object.
+
 ## `defaultLocale`
 
 - type: `string` or `null`

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -115,7 +115,7 @@ export default async (context) => {
 
     app.i18n.locale = newLocale
 
-    app.i18n.localeProperties = locales.find(l => l[LOCALE_CODE_KEY] === newLocale)
+    app.i18n.localeProperties = locales.find(l => l[LOCALE_CODE_KEY] === newLocale) || {}
 
     await syncVuex(store, newLocale, app.i18n.getLocaleMessage(newLocale), { vuex })
 
@@ -260,6 +260,7 @@ export default async (context) => {
   app.i18n = new VueI18n(vueI18nOptions)
   // Initialize locale and fallbackLocale as vue-i18n defaults those to 'en-US' if falsey
   app.i18n.locale = ''
+  app.i18n.localeProperties = {}
   app.i18n.fallbackLocale = vueI18nOptions.fallbackLocale || ''
   extendVueI18nInstance(app.i18n)
   app.i18n.__baseUrl = resolveBaseUrl(baseUrl, context)

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -114,8 +114,7 @@ export default async (context) => {
     }
 
     app.i18n.locale = newLocale
-
-    app.i18n.localeProperties = locales.find(l => l[LOCALE_CODE_KEY] === newLocale) || {}
+    app.i18n.localeProperties = klona(locales.find(l => l[LOCALE_CODE_KEY] === newLocale) || { code: newLocale })
 
     await syncVuex(store, newLocale, app.i18n.getLocaleMessage(newLocale), { vuex })
 
@@ -260,7 +259,7 @@ export default async (context) => {
   app.i18n = new VueI18n(vueI18nOptions)
   // Initialize locale and fallbackLocale as vue-i18n defaults those to 'en-US' if falsey
   app.i18n.locale = ''
-  app.i18n.localeProperties = {}
+  app.i18n.localeProperties = { code: '' }
   app.i18n.fallbackLocale = vueI18nOptions.fallbackLocale || ''
   extendVueI18nInstance(app.i18n)
   app.i18n.__baseUrl = resolveBaseUrl(baseUrl, context)

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -115,6 +115,8 @@ export default async (context) => {
 
     app.i18n.locale = newLocale
 
+    app.i18n.localeProperties = locales.find(l => l[LOCALE_CODE_KEY] === newLocale)
+
     await syncVuex(store, newLocale, app.i18n.getLocaleMessage(newLocale), { vuex })
 
     // Must retrieve from context as it might have changed since plugin initialization.

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -827,7 +827,7 @@ describe('with empty configuration', () => {
 
   test('localeProperties object exists and is set to an empty object ', async () => {
     const window = await nuxt.renderAndGetWindow(url('/'))
-    expect(window.$nuxt.$i18n.localeProperties).toEqual({})
+    expect(window.$nuxt.$i18n.localeProperties).toEqual({ code: '' })
   })
 })
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -815,6 +815,11 @@ describe('with empty configuration', () => {
   test('does not remove all routes', async () => {
     await nuxt.renderAndGetWindow(url('/about'))
   })
+
+  test('localeProperties object exists and is set to an empty object ', async () => {
+    const window = await nuxt.renderAndGetWindow(url('/'))
+    expect(window.$nuxt.$i18n.localeProperties).toEqual({})
+  })
 })
 
 describe('with rootRedirect (string)', () => {
@@ -1958,5 +1963,27 @@ describe('Locale fallback array', () => {
     expect(dom.querySelector('[data-test="en-gb-key"]')?.textContent).toEqual('en-GB translation')
     expect(dom.querySelector('[data-test="es-key"]')?.textContent).toEqual('es translation')
     expect(dom.querySelector('[data-test="de-key"]')?.textContent).toEqual('deKey')
+  })
+})
+
+describe('localeProperties object', () => {
+  /** @type {Nuxt} */
+  let nuxt
+
+  beforeAll(async () => {
+    nuxt = (await setup(loadConfig(__dirname, 'basic'))).nuxt
+  })
+
+  afterAll(async () => {
+    await nuxt.close()
+  })
+
+  test('localeProperties object exists and is set to the correct value', async () => {
+    const window = await nuxt.renderAndGetWindow(url('/'))
+    expect(window.$nuxt.$i18n.localeProperties).toEqual({
+      code: 'en',
+      iso: 'en',
+      name: 'English'
+    })
   })
 })

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -732,6 +732,15 @@ describe('hreflang', () => {
     expect(seoTags).toEqual(expectedSeoTags)
   })
 
+  test('localeProperties object exists and is set to the correct value', async () => {
+    const window = await nuxt.renderAndGetWindow(url('/'))
+    expect(window.$nuxt.$i18n.localeProperties).toEqual({
+      code: 'en',
+      iso: 'en',
+      name: 'English'
+    })
+  })
+
   afterAll(async () => {
     await nuxt.close()
   })
@@ -1963,27 +1972,5 @@ describe('Locale fallback array', () => {
     expect(dom.querySelector('[data-test="en-gb-key"]')?.textContent).toEqual('en-GB translation')
     expect(dom.querySelector('[data-test="es-key"]')?.textContent).toEqual('es translation')
     expect(dom.querySelector('[data-test="de-key"]')?.textContent).toEqual('deKey')
-  })
-})
-
-describe('localeProperties object', () => {
-  /** @type {Nuxt} */
-  let nuxt
-
-  beforeAll(async () => {
-    nuxt = (await setup(loadConfig(__dirname, 'basic'))).nuxt
-  })
-
-  afterAll(async () => {
-    await nuxt.close()
-  })
-
-  test('localeProperties object exists and is set to the correct value', async () => {
-    const window = await nuxt.renderAndGetWindow(url('/'))
-    expect(window.$nuxt.$i18n.localeProperties).toEqual({
-      code: 'en',
-      iso: 'en',
-      name: 'English'
-    })
   })
 })

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -34,6 +34,7 @@ if (localizedRoute) {
 
 // $i18n
 
+const code: string = vm.$i18n.localeProperties.code
 const cookieLocale: string | undefined = vm.$i18n.getLocaleCookie()
 vm.$i18n.setLocaleCookie(locale)
 vm.$i18n.setLocale(locale)

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -10,6 +10,7 @@ declare module 'vue-i18n' {
   // the VueI18n class expands here: https://goo.gl/Xtp9EG
   // it is necessary for the $i18n property in Vue interface: "readonly $i18n: VueI18n & IVueI18n"
   interface IVueI18n extends NuxtVueI18n.Options.NuxtI18nInterface {
+    localeProperties: NuxtVueI18n.Options.LocaleObject
     getLocaleCookie() : string | undefined
     setLocaleCookie(locale: string) : undefined
     setLocale(locale: string) : Promise<undefined>


### PR DESCRIPTION
Hi, as mentioned here https://github.com/nuxt-community/i18n-module/issues/916, @rchl decided to expose the current locale object, here's how i tackled it,  i hope i did it in the correct way since this's my first contribution!   

i think we can move the codeFromLocale function from seo-head to utils-common to use it here also, instead of duplication, if confirmed i will commit the change
