### PR TITLE
feat: expose API for detecting browser locale

### DIFF
--- a/docs/content/en/api.md
+++ b/docs/content/en/api.md
@@ -99,6 +99,14 @@ Instance of [VueI18n class](http://kazupon.github.io/vue-i18n/api/#vuei18n-class
 
   Switches locale of the app to specified locale code. If `useCookie` option is enabled, locale cookie will be updated with new value. If prefixes are enabled (`strategy` other than `no_prefix`), will navigate to new locale's route.
 
+#### getBrowserLocale
+
+  - **Arguments**:
+    - no arguments
+  - **Returns**: `string | undefined`
+
+  Returns browser locale code filtered against the ones defined in options.
+
 ### Properties
 
 #### defaultLocale
@@ -112,7 +120,7 @@ Instance of [VueI18n class](http://kazupon.github.io/vue-i18n/api/#vuei18n-class
   - **Type**: `Array<string | LocaleObject>`
 
   List of locales as defined in options.
-  
+
 #### localeProperties
 
   - **Type**: `LocaleObject`

--- a/docs/content/es/api.md
+++ b/docs/content/es/api.md
@@ -99,6 +99,14 @@ Instance of [VueI18n class](http://kazupon.github.io/vue-i18n/api/#vuei18n-class
 
   Switches locale of the app to specified locale code. If `useCookie` option is enabled, locale cookie will be updated with new value. If prefixes are enabled (`strategy` other than `no_prefix`), will navigate to new locale's route.
 
+  #### getBrowserLocale
+
+  - **Parámetros**:
+    - sin parámetros
+  - **Devuelve**: `string | undefined`
+
+  Devuelve el código del idioma que utiliza el navegador, filtrado según los códigos definidos en las opciones.
+
 ### Properties
 
 #### defaultLocale

--- a/src/templates/utils-common.js
+++ b/src/templates/utils-common.js
@@ -19,7 +19,7 @@ export const parseAcceptLanguage = input => {
  * Find locale code that best matches provided list of browser locales.
  * @param {(string[]|Object[])} appLocales The user-configured locale codes that are to be matched.
  * @param {string[]} browserLocales The locales to match against configured.
- * @return {string?}
+ * @return {string|undefined}
  */
 export const matchBrowserLocale = (appLocales, browserLocales) => {
   /** @type {{ code: string, score: number }[]} */
@@ -63,7 +63,7 @@ export const matchBrowserLocale = (appLocales, browserLocales) => {
     })
   }
 
-  return matchedLocales.length ? matchedLocales[0].code : null
+  return matchedLocales.length ? matchedLocales[0].code : undefined
 }
 
 /**

--- a/test/unit.test.js
+++ b/test/unit.test.js
@@ -13,7 +13,7 @@ describe('parsePages', () => {
   test('triggers warning with invalid in-component options', async () => {
     const { extractComponentOptions } = await import('../src/helpers/components')
 
-    const spy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const spy = jest.spyOn(console, 'warn').mockImplementation(() => { })
     const options = extractComponentOptions(path.join(__dirname, './fixture/typescript/pages/invalidOptions.vue'))
     expect(spy.mock.calls[0][0]).toContain('Error parsing')
     spy.mockRestore()
@@ -64,7 +64,7 @@ describe('matchBrowserLocale', () => {
     const appLocales = ['pl', 'fr']
     const browserLocales = ['en-US', 'en']
 
-    expect(matchBrowserLocale(appLocales, browserLocales)).toBe(null)
+    expect(matchBrowserLocale(appLocales, browserLocales)).toBe(undefined)
   })
 
   test('matches full locale with mixed short and full, full having highest rank', () => {

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -14,6 +14,7 @@ declare module 'vue-i18n' {
     getLocaleCookie() : string | undefined
     setLocaleCookie(locale: string) : undefined
     setLocale(locale: string) : Promise<undefined>
+    getBrowserLocale() : string | undefined
   }
 }
 


### PR DESCRIPTION
I've exposed a method to get the browser detected locale from nuxt-i18n. This allows me to reset a custom set locale in my application (for instance when logging out). If I used `setLocaleCookie('')` I then needed to refresh the page to apply this "reset" (as intended ofc). So this way I can fetch this method and apply the found locale with `setLocale()`.

fix #1018 