### PR TITLE
fix: localeProperties undefined when <i18n> component used

### DIFF
--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -252,6 +252,7 @@ export default async (context) => {
 
   const extendVueI18nInstance = i18n => {
     i18n.locales = locales
+    i18n.localeProperties = klona(locales.find(l => l[LOCALE_CODE_KEY] === i18n.locale) || { code: i18n.locale })
     i18n.defaultLocale = defaultLocale
     i18n.differentDomains = differentDomains
     i18n.beforeLanguageSwitch = beforeLanguageSwitch

--- a/test/fixture/basic/pages/loader-yaml.vue
+++ b/test/fixture/basic/pages/loader-yaml.vue
@@ -2,6 +2,7 @@
   <div>
     <p id="title">{{ $t('hello') }}</p>
     <p id="locales">{{ locales }}</p>
+    <p id="localeProperties">{{ JSON.stringify(localeProperties) }}</p>
   </div>
 </template>
 
@@ -10,6 +11,9 @@ export default {
   computed: {
     locales () {
       return this.$i18n.locales || []
+    },
+    localeProperties () {
+      return this.$i18n.localeProperties || {}
     }
   }
 }

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -732,7 +732,7 @@ describe('hreflang', () => {
     expect(seoTags).toEqual(expectedSeoTags)
   })
 
-  test('localeProperties object exists and is set to the correct value', async () => {
+  test('localeProperties object exists and is set to the correct object', async () => {
     const html = await get('/loader-yaml')
     const dom = getDom(html)
     const localeProperties = dom.querySelector('p#localeProperties')
@@ -829,7 +829,7 @@ describe('with empty configuration', () => {
     await nuxt.renderAndGetWindow(url('/about'))
   })
 
-  test('localeProperties object exists and is set to an empty object ', async () => {
+  test('localeProperties object exists and is set to an object with no code', async () => {
     const window = await nuxt.renderAndGetWindow(url('/'))
     expect(window.$nuxt.$i18n.localeProperties).toEqual({ code: '' })
   })

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -733,12 +733,16 @@ describe('hreflang', () => {
   })
 
   test('localeProperties object exists and is set to the correct value', async () => {
-    const window = await nuxt.renderAndGetWindow(url('/'))
-    expect(window.$nuxt.$i18n.localeProperties).toEqual({
-      code: 'en',
-      iso: 'en',
-      name: 'English'
-    })
+    const html = await get('/loader-yaml')
+    const dom = getDom(html)
+    const localeProperties = dom.querySelector('p#localeProperties')
+    const localePropertiesContent = localeProperties?.textContent || '{}'
+    expect(JSON.parse(localePropertiesContent)).toMatchObject(
+      {
+        code: 'en',
+        iso: 'en',
+        name: 'English'
+      })
   })
 
   afterAll(async () => {


### PR DESCRIPTION
Fixes: [#1023 (comment)](https://github.com/nuxt-community/i18n-module/pull/1023#discussion_r563148174)

This pull request includes: 
- Assigning the `localeProperties` in `extendVueI18nInstance`
- Altering the test to cover all cases, instead of adding a separate one. 
- re-phrasing the related tests a bit. 