### PR TITLE
fix: use mjs version of klona

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ export default function (userOptions) {
 
   this.nuxt.hook('build:before', () => buildHook(this, options))
 
-  this.options.alias['~i18n-klona'] = require.resolve('klona/full')
+  this.options.alias['~i18n-klona'] = require.resolve('klona/full').replace('.js', '.mjs')
   this.options.router.middleware.push('nuxti18n')
   this.options.render.bundleRenderer.directives = this.options.render.bundleRenderer.directives || {}
   this.options.render.bundleRenderer.directives.t = i18nExtensionsDirective


### PR DESCRIPTION
Related: #1004 #1008 nuxt/vite#58

We use `require.resolve` to use exact version of klona for i18n module. But node resolves to commonjs build which however working with webpack, is breaking vite which works with modules. (webpack also works fine with esm syntax)