### PR TITLE
fix: avoid using commonjs for runtime (vite support)

### DIFF
--- a/src/templates/options.js
+++ b/src/templates/options.js
@@ -11,7 +11,7 @@ function stringifyValue(value) {
 
 for (const [key, value] of Object.entries(options)) {
     if (key === 'vueI18n' && typeof value === 'string') {
-%>export const <%= key %> = require('<%= value %>').default
+%>export const <%= key %> = () => import('<%= value %>').then(m => m.default)
 <%
     } else {
 %>export const <%= key %> = <%= stringifyValue(value) %>

--- a/src/templates/options.js
+++ b/src/templates/options.js
@@ -11,7 +11,7 @@ function stringifyValue(value) {
 
 for (const [key, value] of Object.entries(options)) {
     if (key === 'vueI18n' && typeof value === 'string') {
-%>export const <%= key %> = () => import('<%= value %>').then(m => m.default)
+%>export const <%= key %> = (context) => import('<%= value %>').then(m => m.default(context))
 <%
     } else {
 %>export const <%= key %> = <%= stringifyValue(value) %>

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -36,6 +36,7 @@ import {
   setLocaleCookie,
   syncVuex
 } from './utils-common'
+import { loadLanguageAsync } from './utils'
 import { klona } from '~i18n-klona'
 
 Vue.use(VueI18n)
@@ -90,7 +91,6 @@ export default async (context) => {
 
     // Lazy-loading enabled
     if (lazy) {
-      const { loadLanguageAsync } = require('./utils')
       const i18nFallbackLocale = app.i18n.fallbackLocale
 
       // Load fallback locale(s).

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -294,7 +294,7 @@ export default async (context) => {
   }
 
   // Set instance options
-  const vueI18nOptions = typeof vueI18n === 'function' ? vueI18n(context) : klona(vueI18n)
+  const vueI18nOptions = typeof vueI18n === 'function' ? await vueI18n(context) : klona(vueI18n)
   vueI18nOptions.componentInstanceCreatedListener = extendVueI18nInstance
   app.i18n = new VueI18n(vueI18nOptions)
   // Initialize locale and fallbackLocale as vue-i18n defaults those to 'en-US' if falsey

--- a/src/templates/utils-common.js
+++ b/src/templates/utils-common.js
@@ -1,5 +1,6 @@
 import Cookie from 'cookie'
 import JsCookie from 'js-cookie'
+import isHTTPS from 'is-https'
 
 /**
  * Parses locales provided from browser through `accept-language` header.
@@ -104,7 +105,6 @@ export const getDomainFromLocale = (localeCode, req, { locales, localeDomainKey,
   if (lang && lang[localeDomainKey]) {
     let protocol
     if (process.server) {
-      const isHTTPS = require('is-https')
       protocol = (req && isHTTPS(req)) ? 'https' : 'http'
     } else {
       protocol = window.location.protocol.split(':')[0]


### PR DESCRIPTION
While tools like webpack allow using mixed esm/cjs syntax, it will break vite. And generally esm syntax allows having more predictable code. Dependencies like `is-https` will be treeshaked since have no side-effects and for client bundle since it is unreachable. 