### PR TITLE
refactor: add Vite compatibility when lazy loading

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,11 @@ export default function (userOptions) {
     return
   }
 
+  // Resolve langDir
+  if (options.langDir) {
+    options.langDir = this.nuxt.resolver.resolveAlias(options.langDir)
+  }
+
   // Templates (including plugins).
   // This is done here rather than in the build hook to ensure the order the plugins are added
   // is predictable between different modules.

--- a/src/templates/options.js
+++ b/src/templates/options.js
@@ -19,3 +19,9 @@ for (const [key, value] of Object.entries(options)) {
     }
 }
 %>
+
+/* <% if (options.langDir) { %> */
+export const ASYNC_LOCALES = {
+  <%= options.locales.map(l => `'${l.code}': () => import('${options.langDir}/${l.file || l.iso}' /* webpackChunkName: "lang-${l.code}" */)`).join(',\n  ') %>
+}
+/* <% } %> */

--- a/src/templates/options.js
+++ b/src/templates/options.js
@@ -22,9 +22,8 @@ for (const [key, value] of Object.entries(options)) {
 
 <% if (options.langDir) { %>
 export const ASYNC_LOCALES = {
-  <%= options.locales
-    .map(l => `'${l.file}': () => import('../${relativeToBuild(options.langDir, l.file)}' /* webpackChunkName: "lang-${l.file}" */)`)
-    .filter((l, index, self) => self.indexOf(l) === index)
-    .join(',\n  ') %>
+  <%= Array.from(
+        new Set(options.locales.map(l => `'${l.file}': () => import('../${relativeToBuild(options.langDir, l.file)}' /* webpackChunkName: "lang-${l.file}" */)`))
+      ).join(',\n  ') %>
 }
 <% } %>

--- a/src/templates/options.js
+++ b/src/templates/options.js
@@ -22,6 +22,6 @@ for (const [key, value] of Object.entries(options)) {
 
 /* <% if (options.langDir) { %> */
 export const ASYNC_LOCALES = {
-  <%= options.locales.filter(l => l.file).map(l => `'${l.code}': () => import('../${relativeToBuild(options.langDir, l.file)}' /* webpackChunkName: "lang-${l.file}" */)`).join(',\n  ') %>
+  <%= options.locales.map(l => `'${l.code}': () => import('../${relativeToBuild(options.langDir, l.file)}' /* webpackChunkName: "lang-${l.file}" */)`).join(',\n  ') %>
 }
 /* <% } %> */

--- a/src/templates/options.js
+++ b/src/templates/options.js
@@ -22,6 +22,9 @@ for (const [key, value] of Object.entries(options)) {
 
 <% if (options.langDir) { %>
 export const ASYNC_LOCALES = {
-  <%= options.locales.map(l => `'${l.file}': () => import('../${relativeToBuild(options.langDir, l.file)}' /* webpackChunkName: "lang-${l.file}" */)`).join(',\n  ') %>
+  <%= options.locales
+    .map(l => `'${l.file}': () => import('../${relativeToBuild(options.langDir, l.file)}' /* webpackChunkName: "lang-${l.file}" */)`)
+    .filter((l, index, self) => self.indexOf(l) === index)
+    .join(',\n  ') %>
 }
 <% } %>

--- a/src/templates/options.js
+++ b/src/templates/options.js
@@ -22,6 +22,6 @@ for (const [key, value] of Object.entries(options)) {
 
 /* <% if (options.langDir) { %> */
 export const ASYNC_LOCALES = {
-  <%= options.locales.map(l => `'${l.code}': () => import('../${relativeToBuild(options.langDir, l.file || l.iso)}' /* webpackChunkName: "lang-${l.code}" */)`).join(',\n  ') %>
+  <%= options.locales.filter(l => l.file).map(l => `'${l.code}': () => import('../${relativeToBuild(options.langDir, l.file)}' /* webpackChunkName: "lang-${l.file}" */)`).join(',\n  ') %>
 }
 /* <% } %> */

--- a/src/templates/options.js
+++ b/src/templates/options.js
@@ -20,8 +20,8 @@ for (const [key, value] of Object.entries(options)) {
 }
 %>
 
-/* <% if (options.langDir) { %> */
+<% if (options.langDir) { %>
 export const ASYNC_LOCALES = {
   <%= options.locales.map(l => `'${l.code}': () => import('../${relativeToBuild(options.langDir, l.file)}' /* webpackChunkName: "lang-${l.file}" */)`).join(',\n  ') %>
 }
-/* <% } %> */
+<% } %>

--- a/src/templates/options.js
+++ b/src/templates/options.js
@@ -22,6 +22,6 @@ for (const [key, value] of Object.entries(options)) {
 
 /* <% if (options.langDir) { %> */
 export const ASYNC_LOCALES = {
-  <%= options.locales.map(l => `'${l.code}': () => import('${options.langDir}/${l.file || l.iso}' /* webpackChunkName: "lang-${l.code}" */)`).join(',\n  ') %>
+  <%= options.locales.map(l => `'${l.code}': () => import('../${relativeToBuild(options.langDir, l.file || l.iso)}' /* webpackChunkName: "lang-${l.code}" */)`).join(',\n  ') %>
 }
 /* <% } %> */

--- a/src/templates/options.js
+++ b/src/templates/options.js
@@ -22,6 +22,6 @@ for (const [key, value] of Object.entries(options)) {
 
 <% if (options.langDir) { %>
 export const ASYNC_LOCALES = {
-  <%= options.locales.map(l => `'${l.code}': () => import('../${relativeToBuild(options.langDir, l.file)}' /* webpackChunkName: "lang-${l.file}" */)`).join(',\n  ') %>
+  <%= options.locales.map(l => `'${l.file}': () => import('../${relativeToBuild(options.langDir, l.file)}' /* webpackChunkName: "lang-${l.file}" */)`).join(',\n  ') %>
 }
 <% } %>

--- a/src/templates/utils.js
+++ b/src/templates/utils.js
@@ -1,20 +1,25 @@
 import { LOCALE_CODE_KEY, LOCALE_FILE_KEY, MODULE_NAME } from './options'
 
-<% const _srcDir = (isDev && (nuxtOptions.buildModules || []).includes('nuxt-vite')) ? '/@fs' + srcDir : '~' %>
-async function loadFileModule(lang) {
+// Hiding template directives from eslint so that parsing doesn't break.
+/* <% if (options.langDir) { %> */
+/* <% const _srcDir = (isDev && (nuxtOptions.buildModules || []).includes('nuxt-vite')) ? '/@fs' + srcDir : '~' %> */
+async function loadFileModule (lang) {
   let langFileModule
   switch (lang) {
-    <% for (let locale of options.locales) { %>
-      case '<%= locale.code %>':
-        langFileModule = await import(
-          /* webpackChunkName: "lang-[request]" */
-          /* webpackInclude: /\.(js|ts|json|ya?ml)$/ */
-          `<%= _srcDir %>/<%= options.langDir %><%= locale.file %>`
-        );
-        break;
-    <% } %>}
+    /* <% for (let locale of options.locales) { %> */
+    case '<%= locale.code %>':
+      langFileModule = await import(
+        /* webpackChunkName: "lang-[request]" */
+        /* webpackInclude: /\.(js|ts|json|ya?ml)$/ */
+        '<%= _srcDir %>/<%= options.langDir %><%= locale.file %>'
+      )
+      break
+    /* <% } %>} */
+  }
   return langFileModule.default || langFileModule
 }
+/* <% } %> */
+
 /**
  * Asynchronously load messages from translation files
  * @param  {Context}  context  Nuxt context
@@ -32,7 +37,6 @@ export async function loadLanguageAsync (context, locale) {
     if (localeObject) {
       const file = localeObject[LOCALE_FILE_KEY]
       if (file) {
-        // Hiding template directives from eslint so that parsing doesn't break.
         /* <% if (options.langDir) { %> */
         let messages
         if (process.client) {

--- a/src/templates/utils.js
+++ b/src/templates/utils.js
@@ -32,7 +32,7 @@ export async function loadLanguageAsync (context, locale) {
         }
         if (!messages) {
           try {
-            const getter = await ASYNC_LOCALES[locale]().then(m => m.default || m)
+            const getter = await ASYNC_LOCALES[file]().then(m => m.default || m)
             messages = typeof getter === 'function' ? await Promise.resolve(getter(context, locale)) : getter
           } catch (error) {
             // eslint-disable-next-line no-console

--- a/src/templates/utils.js
+++ b/src/templates/utils.js
@@ -32,8 +32,8 @@ export async function loadLanguageAsync (context, locale) {
         }
         if (!messages) {
           try {
-            const getter = ASYNC_LOCALES[locale]().then(m => m.default || m)
-            messages = typeof getter === 'function' ? await getter(context, locale) : getter
+            const getter = await ASYNC_LOCALES[locale]().then(m => m.default || m)
+            messages = typeof getter === 'function' ? await Promise.resolve(getter(context, locale)) : getter
           } catch (error) {
             // eslint-disable-next-line no-console
             console.error(error)

--- a/src/templates/utils.js
+++ b/src/templates/utils.js
@@ -11,7 +11,7 @@ async function loadFileModule (lang) {
       langFileModule = await import(
         /* webpackChunkName: "lang-[request]" */
         /* webpackInclude: /\.(js|ts|json|ya?ml)$/ */
-        '<%= _srcDir %>/<%= options.langDir %><%= locale.file %>'
+        '<%= _srcDir + "/" + options.langDir + locale.file %>'
       )
       break
     /* <% } %>} */

--- a/src/templates/utils.js
+++ b/src/templates/utils.js
@@ -1,24 +1,9 @@
-import { LOCALE_CODE_KEY, LOCALE_FILE_KEY, MODULE_NAME } from './options'
-
-// Hiding template directives from eslint so that parsing doesn't break.
-/* <% if (options.langDir) { %> */
-/* <% const _srcDir = (isDev && (nuxtOptions.buildModules || []).includes('nuxt-vite')) ? '/@fs' + srcDir : '~' %> */
-async function loadFileModule (lang) {
-  let langFileModule
-  switch (lang) {
-    /* <% for (let locale of options.locales) { %> */
-    case '<%= locale.code %>':
-      langFileModule = await import(
-        /* webpackChunkName: "lang-[request]" */
-        /* webpackInclude: /\.(js|ts|json|ya?ml)$/ */
-        '<%= _srcDir + "/" + options.langDir + locale.file %>'
-      )
-      break
-    /* <% } %>} */
-  }
-  return langFileModule.default || langFileModule
-}
-/* <% } %> */
+import {
+  LOCALE_CODE_KEY,
+  LOCALE_FILE_KEY,
+  MODULE_NAME/* <% if (options.langDir) { %> */,
+  ASYNC_LOCALES/* <% } %> */
+} from './options'
 
 /**
  * Asynchronously load messages from translation files
@@ -47,8 +32,8 @@ export async function loadLanguageAsync (context, locale) {
         }
         if (!messages) {
           try {
-            const getter = await loadFileModule(locale)
-            messages = typeof getter === 'function' ? await Promise.resolve(getter(context, locale)) : getter
+            const getter = ASYNC_LOCALES[locale]().then(m => m.default || m)
+            messages = typeof getter === 'function' ? await getter(context, locale) : getter
           } catch (error) {
             // eslint-disable-next-line no-console
             console.error(error)

--- a/test/fixture/basic/nuxt.config.js
+++ b/test/fixture/basic/nuxt.config.js
@@ -5,12 +5,7 @@ import BaseConfig from '../base.config'
 const config = {
   ...BaseConfig,
   buildDir: resolve(__dirname, '.nuxt'),
-  srcDir: __dirname,
-  i18n: {
-    ...BaseConfig.i18n,
-    lazy: true,
-    langDir: 'lang'
-  }
+  srcDir: __dirname
 }
 
 module.exports = config

--- a/test/fixture/basic/nuxt.config.js
+++ b/test/fixture/basic/nuxt.config.js
@@ -5,7 +5,12 @@ import BaseConfig from '../base.config'
 const config = {
   ...BaseConfig,
   buildDir: resolve(__dirname, '.nuxt'),
-  srcDir: __dirname
+  srcDir: __dirname,
+  i18n: {
+    ...BaseConfig.i18n,
+    lazy: true,
+    langDir: 'lang'
+  }
 }
 
 module.exports = config


### PR DESCRIPTION
Using the module with Nuxt Vite does not lazy load languages on client site because of limitations of dynamic import.   
 
This PR will expand dynamic import into a switch case to remove variables inside import name and automatically detects build target and change the `srcDir` alias

@pi0  What do you think about this?