### PR TITLE
fix(docs): adjusted example code in documentation to call the right context

### DIFF
--- a/docs/content/en/lang-switcher.md
+++ b/docs/content/en/lang-switcher.md
@@ -56,7 +56,7 @@ The template code might look like this, for example:
   href="#"
   v-for="locale in availableLocales"
   :key="locale.code"
-  @click.prevent.stop="setLocale(locale.code)">{{ locale.name }}</a>
+  @click.prevent.stop="$i18n.setLocale(locale.code)">{{ locale.name }}</a>
 ```
 
 ## Dynamic route parameters

--- a/docs/content/es/lang-switcher.md
+++ b/docs/content/es/lang-switcher.md
@@ -54,7 +54,7 @@ The template code might look like this, for example:
   href="#"
   v-for="locale in availableLocales"
   :key="locale.code"
-  @click.prevent.stop="setLocale(locale.code)">{{ locale.name }}</a>
+  @click.prevent.stop="$i18n.setLocale(locale.code)">{{ locale.name }}</a>
 ```
 
 ## Parámetros de ruta dinámica


### PR DESCRIPTION
https://i18n.nuxtjs.org/lang-switcher - I went to this page and tried out the given snippet; got an error; tried the obvious change inspired by the previous examples; it worked. Here's the necessary change to the documentation.