### PR TITLE
fix: support localePath with path input and customized routes

### DIFF
--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -63,19 +63,20 @@ function localeRoute (route, locale) {
       !i18n.differentDomains
     const thisRoute = this.router.resolve(route.path).route
     const routeName = this.getRouteBaseName(thisRoute)
-
     if (isPrefixed && !routeName) {
       let path = `/${locale}${route.path}`
-      path = path.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || '/'
+      path = getReplacedPath(path)
       localizedRoute.path = path
     } else {
-      localizedRoute.path = route.path.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || '/'
+      localizedRoute.path = getReplacedPath(route.path)
       if (routeName) {
-        localizedRoute.name = getLocaleRouteName(routeName, locale)
-        localizedRoute.params = thisRoute.params
-        localizedRoute.query = thisRoute.query
-        localizedRoute.hash = thisRoute.hash
-        return this.router.resolve(localizedRoute).route
+        return this.router.resolve({
+          name: getLocaleRouteName(routeName, locale),
+          params: thisRoute.params,
+          query: thisRoute.query,
+          hash: thisRoute.hash,
+          path: localizedRoute.path
+        }).route
       }
     }
   } else {
@@ -92,6 +93,10 @@ function localeRoute (route, locale) {
   }
 
   return this.router.resolve(localizedRoute).route
+}
+
+function getReplacedPath (path) {
+  return path.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || '/'
 }
 
 function switchLocalePath (locale) {

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -55,12 +55,12 @@ function localeRoute (route, locale) {
     const isDefaultLocale = locale === defaultLocale
     // if route has a path defined but no name, resolve full route using the path
     const isPrefixed =
-      // don't prefix default locale
-      !(isDefaultLocale && [STRATEGIES.PREFIX_EXCEPT_DEFAULT, STRATEGIES.PREFIX_AND_DEFAULT].includes(strategy)) &&
-      // no prefix for any language
-      !(strategy === STRATEGIES.NO_PREFIX) &&
-      // no prefix for different domains
-      !i18n.differentDomains
+        // don't prefix default locale
+        !(isDefaultLocale && [STRATEGIES.PREFIX_EXCEPT_DEFAULT, STRATEGIES.PREFIX_AND_DEFAULT].includes(strategy)) &&
+        // no prefix for any language
+        !(strategy === STRATEGIES.NO_PREFIX) &&
+        // no prefix for different domains
+        !i18n.differentDomains
     const thisRoute = this.router.resolve(route.path).route
     const routeName = this.getRouteBaseName(thisRoute)
     if (isPrefixed && !routeName) {

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -74,6 +74,8 @@ function localeRoute (route, locale) {
       localizedRoute.path = path
     } else {
       localizedRoute.name = getLocaleRouteName(routeName, locale)
+      localizedRoute.params = thisRoute.params
+      localizedRoute.query = thisRoute.query
       return this.router.resolve(localizedRoute).route
     }
   } else {

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -90,9 +90,7 @@ function localeRoute (route, locale) {
     }
   }
 
-  const resolved = this.router.resolve(localizedRoute).route
-  // console.info({ resolved })
-  return resolved
+  return this.router.resolve(localizedRoute).route
 }
 
 function switchLocalePath (locale) {

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -68,8 +68,7 @@ function localeRoute (route, locale) {
         name: getLocaleRouteName(resolvedRouteName, locale),
         params: resolvedRoute.params,
         query: resolvedRoute.query,
-        hash: resolvedRoute.hash,
-        path: route.path
+        hash: resolvedRoute.hash
       }
     } else {
       if (isPrefixed) {

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -70,10 +70,13 @@ function localeRoute (route, locale) {
       localizedRoute.path = path
     } else {
       localizedRoute.path = route.path.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || '/'
-      localizedRoute.name = getLocaleRouteName(routeName, locale)
-      localizedRoute.params = thisRoute.params
-      localizedRoute.query = thisRoute.query
-      return this.router.resolve(localizedRoute).route
+      if(routeName) {
+        localizedRoute.name = getLocaleRouteName(routeName, locale)
+        localizedRoute.params = thisRoute.params
+        localizedRoute.query = thisRoute.query
+        localizedRoute.hash = thisRoute.hash
+        return this.router.resolve(localizedRoute).route
+      }
     }
   } else {
     if (!route.name && !route.path) {

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -49,7 +49,7 @@ function localeRoute (route, locale) {
     }
   }
 
-  const localizedRoute = Object.assign({}, route)
+  let localizedRoute = Object.assign({}, route)
 
   if (route.path && !route.name) {
     const isDefaultLocale = locale === defaultLocale
@@ -63,20 +63,18 @@ function localeRoute (route, locale) {
       !i18n.differentDomains
     const thisRoute = this.router.resolve(route.path).route
     const routeName = this.getRouteBaseName(thisRoute)
+    let path = route.path
     if (isPrefixed && !routeName) {
-      let path = `/${locale}${route.path}`
-      path = getReplacedPath(path)
-      localizedRoute.path = path
-    } else {
-      localizedRoute.path = getReplacedPath(route.path)
-      if (routeName) {
-        return this.router.resolve({
-          name: getLocaleRouteName(routeName, locale),
-          params: thisRoute.params,
-          query: thisRoute.query,
-          hash: thisRoute.hash,
-          path: localizedRoute.path
-        }).route
+      path = `/${locale}${path}`
+    }
+    localizedRoute.path = path.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || '/'
+    if (routeName) {
+      localizedRoute = {
+        name: getLocaleRouteName(routeName, locale),
+        params: thisRoute.params,
+        query: thisRoute.query,
+        hash: thisRoute.hash,
+        path: localizedRoute.path
       }
     }
   } else {
@@ -93,10 +91,6 @@ function localeRoute (route, locale) {
   }
 
   return this.router.resolve(localizedRoute).route
-}
-
-function getReplacedPath (path) {
-  return path.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || '/'
 }
 
 function switchLocalePath (locale) {

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -73,6 +73,7 @@ function localeRoute (route, locale) {
       path = path.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || '/'
       localizedRoute.path = path
     } else {
+      localizedRoute.path = route.path.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || '/'
       localizedRoute.name = getLocaleRouteName(routeName, locale)
       localizedRoute.params = thisRoute.params
       localizedRoute.query = thisRoute.query

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -21,10 +21,6 @@ function localePath (route, locale) {
     return
   }
 
-  if (typeof localizedRoute === 'string') {
-    return localizedRoute
-  }
-
   return localizedRoute.fullPath
 }
 

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -21,11 +21,11 @@ function localePath (route, locale) {
     return
   }
 
-  if(typeof localizedRoute === 'string') {
-    return localizedRoute;
+  if (typeof localizedRoute === 'string') {
+    return localizedRoute
   }
 
-  return localizedRoute.fullPath;
+  return localizedRoute.fullPath
 }
 
 function localeRoute (route, locale) {
@@ -65,22 +65,17 @@ function localeRoute (route, locale) {
       !(strategy === STRATEGIES.NO_PREFIX) &&
       // no prefix for different domains
       !i18n.differentDomains
-    let thisRoute = this.router.resolve(route.path).route;
-    let routeName = this.getRouteBaseName(thisRoute);
+    const thisRoute = this.router.resolve(route.path).route
+    const routeName = this.getRouteBaseName(thisRoute)
 
-
-    if(isPrefixed && !routeName) {
-      let path = `/${locale}${route.path}`;
+    if (isPrefixed && !routeName) {
+      let path = `/${locale}${route.path}`
       path = path.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || '/'
       localizedRoute.path = path
-    }else {
-      return localePath.call(this,{
-        name: routeName,
-        params: thisRoute.params,
-        query:thisRoute.query
-      },locale);
+    } else {
+      localizedRoute.name = getLocaleRouteName(routeName, locale)
+      return this.router.resolve(localizedRoute).route
     }
-
   } else {
     if (!route.name && !route.path) {
       localizedRoute.name = this.getRouteBaseName()

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -21,7 +21,11 @@ function localePath (route, locale) {
     return
   }
 
-  return localizedRoute.fullPath
+  if(typeof localizedRoute === 'string') {
+    return localizedRoute;
+  }
+
+  return localizedRoute.fullPath;
 }
 
 function localeRoute (route, locale) {
@@ -55,16 +59,28 @@ function localeRoute (route, locale) {
     const isDefaultLocale = locale === defaultLocale
     // if route has a path defined but no name, resolve full route using the path
     const isPrefixed =
-        // don't prefix default locale
-        !(isDefaultLocale && [STRATEGIES.PREFIX_EXCEPT_DEFAULT, STRATEGIES.PREFIX_AND_DEFAULT].includes(strategy)) &&
-        // no prefix for any language
-        !(strategy === STRATEGIES.NO_PREFIX) &&
-        // no prefix for different domains
-        !i18n.differentDomains
+      // don't prefix default locale
+      !(isDefaultLocale && [STRATEGIES.PREFIX_EXCEPT_DEFAULT, STRATEGIES.PREFIX_AND_DEFAULT].includes(strategy)) &&
+      // no prefix for any language
+      !(strategy === STRATEGIES.NO_PREFIX) &&
+      // no prefix for different domains
+      !i18n.differentDomains
+    let thisRoute = this.router.resolve(route.path).route;
+    let routeName = this.getRouteBaseName(thisRoute);
 
-    let path = (isPrefixed ? `/${locale}${route.path}` : route.path)
-    path = path.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || '/'
-    localizedRoute.path = path
+    let path;
+    if(isPrefixed && !routeName) {
+      path = `/${locale}${route.path}`;
+      path = path.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || '/'
+      localizedRoute.path = path
+    }else {
+      return localePath.call(this,{
+        name: routeName,
+        params: thisRoute.params,
+        query:thisRoute.query
+      },locale);
+    }
+
   } else {
     if (!route.name && !route.path) {
       localizedRoute.name = this.getRouteBaseName()

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -61,21 +61,21 @@ function localeRoute (route, locale) {
         !(strategy === STRATEGIES.NO_PREFIX) &&
         // no prefix for different domains
         !i18n.differentDomains
-    const thisRoute = this.router.resolve(route.path).route
-    const routeName = this.getRouteBaseName(thisRoute)
-    let path = route.path
-    if (isPrefixed && !routeName) {
-      path = `/${locale}${path}`
-    }
-    localizedRoute.path = path.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || '/'
-    if (routeName) {
+    const resolvedRoute = this.router.resolve(route.path).route
+    const resolvedRouteName = this.getRouteBaseName(resolvedRoute)
+    if (resolvedRouteName) {
       localizedRoute = {
-        name: getLocaleRouteName(routeName, locale),
-        params: thisRoute.params,
-        query: thisRoute.query,
-        hash: thisRoute.hash,
-        path: localizedRoute.path
+        name: getLocaleRouteName(resolvedRouteName, locale),
+        params: resolvedRoute.params,
+        query: resolvedRoute.query,
+        hash: resolvedRoute.hash,
+        path: route.path
       }
+    } else {
+      if (isPrefixed) {
+        localizedRoute.path = `/${locale}${route.path}`
+      }
+      localizedRoute.path = localizedRoute.path.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || '/'
     }
   } else {
     if (!route.name && !route.path) {
@@ -90,7 +90,9 @@ function localeRoute (route, locale) {
     }
   }
 
-  return this.router.resolve(localizedRoute).route
+  const resolved = this.router.resolve(localizedRoute).route
+  // console.info({ resolved })
+  return resolved
 }
 
 function switchLocalePath (locale) {

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -70,7 +70,7 @@ function localeRoute (route, locale) {
       localizedRoute.path = path
     } else {
       localizedRoute.path = route.path.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || '/'
-      if(routeName) {
+      if (routeName) {
         localizedRoute.name = getLocaleRouteName(routeName, locale)
         localizedRoute.params = thisRoute.params
         localizedRoute.query = thisRoute.query

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -68,9 +68,9 @@ function localeRoute (route, locale) {
     let thisRoute = this.router.resolve(route.path).route;
     let routeName = this.getRouteBaseName(thisRoute);
 
-    let path;
+
     if(isPrefixed && !routeName) {
-      path = `/${locale}${route.path}`;
+      let path = `/${locale}${route.path}`;
       path = path.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || '/'
       localizedRoute.path = path
     }else {

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -637,6 +637,14 @@ describe(`${browserString} (SPA)`, () => {
     expect(await (await page.$('body'))?.textContent()).toContain('page could not be found')
     expect(await getRouteFullPath(page)).toBe(path)
   })
+
+  test('preserves the URL on 404 page with non-default locale', async () => {
+    const path = '/nopage?a#h'
+    page = await browser.newPage({ locale: 'fr' })
+    await page.goto(url(path))
+    expect(await (await page.$('body'))?.textContent()).toContain('page could not be found')
+    expect(await getRouteFullPath(page)).toBe(`/fr${path}`)
+  })
 })
 
 describe(`${browserString} (SPA with router in hash mode)`, () => {

--- a/test/fixture/basic/assets/main.css
+++ b/test/fixture/basic/assets/main.css
@@ -1,0 +1,8 @@
+.page-enter-active,
+.page-leave-active {
+  transition: opacity 0.5s;
+}
+.page-enter,
+.page-leave-to {
+  opacity: 0;
+}

--- a/test/fixture/basic/assets/main.css
+++ b/test/fixture/basic/assets/main.css
@@ -1,8 +1,0 @@
-.page-enter-active,
-.page-leave-active {
-  transition: opacity 0.5s;
-}
-.page-enter,
-.page-leave-to {
-  opacity: 0;
-}

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -1035,6 +1035,20 @@ describe('prefix_and_default strategy', () => {
     expect(window.$nuxt.localeRoute('/simple', 'fr')).toMatchObject({ name: 'simple___fr', fullPath: '/fr/simple' })
   })
 
+  test('localeRoute returns customized localized route (by route path)', async () => {
+    const window = await nuxt.renderAndGetWindow(url('/'))
+    // Prefer unprefixed path for default locale:
+    expect(window.$nuxt.localeRoute('/about-us', 'en')).toMatchObject({ name: 'about___en___default', fullPath: '/about-us' })
+    expect(window.$nuxt.localeRoute('/en/about-us', 'en')).toMatchObject({ name: 'about___en___default', fullPath: '/about-us' })
+    expect(window.$nuxt.localeRoute('/about-us', 'fr')).toMatchObject({ name: 'about___fr', fullPath: '/fr/a-propos' })
+    expect(window.$nuxt.localeRoute('/about-us?q=1#hash', 'en')).toMatchObject({
+      name: 'about___en___default',
+      fullPath: '/about-us?q=1#hash',
+      query: { q: '1' },
+      hash: '#hash'
+    })
+  })
+
   test('canonical SEO link is added to prefixed default locale', async () => {
     const html = await get('/en')
     const dom = getDom(html)


### PR DESCRIPTION
```js
 nuxtI18n: {
        paths: {
          en: '/about-us', 
          fr: '/a-propos',
          es: '/sobre'
      }
  }
```

Example:
Current locale is: fr.
Calling `localePath('/about-us')` --> returns /fr/a-propos;
or calling `localePath('/en/about-us')` --> returns /fr/a-propos;

tested when strategy is  'prefix_except_default'