### PR TITLE
test: add fixture that uses @nuxtjs/composition-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@babel/preset-env": "7.13.8",
     "@babel/runtime": "7.13.8",
     "@nuxt/types": "2.15.2",
-    "@nuxtjs/composition-api": "^0.21.0",
+    "@nuxtjs/composition-api": "0.21.0",
     "@nuxtjs/eslint-config-typescript": "5.0.0",
     "@nuxtjs/module-test-utils": "1.6.3",
     "@release-it/conventional-changelog": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@babel/preset-env": "7.13.8",
     "@babel/runtime": "7.13.8",
     "@nuxt/types": "2.15.2",
+    "@nuxtjs/composition-api": "^0.21.0",
     "@nuxtjs/eslint-config-typescript": "5.0.0",
     "@nuxtjs/module-test-utils": "1.6.3",
     "@release-it/conventional-changelog": "2.0.1",

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -150,7 +150,7 @@ const VueInstanceProxy = function (targetFunction) {
       getRouteBaseName: this.getRouteBaseName,
       i18n: this.$i18n,
       localePath: this.localePath,
-      req: process.server ? this.$ssrContext?.req ?? this.context?.ssrContext?.req : null,
+      req: process.server ? this.$ssrContext.req : null,
       route: this.$route,
       router: this.$router,
       store: this.$store

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -150,7 +150,7 @@ const VueInstanceProxy = function (targetFunction) {
       getRouteBaseName: this.getRouteBaseName,
       i18n: this.$i18n,
       localePath: this.localePath,
-      req: process.server ? this.$ssrContext.req : null,
+      req: process.server ? this.$ssrContext?.req ?? this.context?.ssrContext?.req : null,
       route: this.$route,
       router: this.$router,
       store: this.$store

--- a/test/fixture/composition-api/nuxt.config.js
+++ b/test/fixture/composition-api/nuxt.config.js
@@ -5,7 +5,9 @@ import BaseConfig from '../base.config'
 const config = {
   ...BaseConfig,
   buildDir: resolve(__dirname, '.nuxt'),
-  srcDir: __dirname
+  srcDir: __dirname,
+  buildModules: [
+    '@nuxtjs/composition-api'
+  ]
 }
-config.modules?.push('@nuxtjs/composition-api')
-module.exports = config
+export default config

--- a/test/fixture/composition-api/nuxt.config.js
+++ b/test/fixture/composition-api/nuxt.config.js
@@ -10,4 +10,5 @@ const config = {
     '@nuxtjs/composition-api'
   ]
 }
-export default config
+
+module.exports = config

--- a/test/fixture/composition-api/nuxt.config.js
+++ b/test/fixture/composition-api/nuxt.config.js
@@ -1,0 +1,11 @@
+import { resolve } from 'path'
+import BaseConfig from '../base.config'
+
+/** @type {import('@nuxt/types').NuxtConfig} */
+const config = {
+  ...BaseConfig,
+  buildDir: resolve(__dirname, '.nuxt'),
+  srcDir: __dirname
+}
+config.modules?.push('@nuxtjs/composition-api')
+module.exports = config

--- a/test/fixture/composition-api/pages/index.vue
+++ b/test/fixture/composition-api/pages/index.vue
@@ -1,7 +1,19 @@
 <template>
   <div>
     <div id="current-locale">locale: {{ $i18n.locale }}</div>
-    <div id="content">{{ someText }}</div>
+    <nuxt-link
+      id="unprocessed-url"
+      :to="localePath(unprocessedUrl.to)"
+      v-text="$t(unprocessedUrl.text)"
+    />
+    <nuxt-link
+      id="processed-url"
+      :to="processedUrl.to"
+      v-text="processedUrl.text"
+    />
+    <div id="route-base-name">
+      {{ getRouteBaseName() }}
+    </div>
   </div>
 </template>
 
@@ -9,9 +21,19 @@
 import { defineComponent, useContext } from '@nuxtjs/composition-api'
 export default defineComponent({
   setup () {
-    const { app: { i18n } } = useContext()
-    const someText = i18n.t('untranslated')
-    return { someText }
+    const { app: { i18n, localePath } } = useContext()
+
+    const unprocessedUrl = {
+      text: 'home',
+      to: 'index'
+    }
+
+    const processedUrl = {
+      text: i18n.t('home'),
+      to: localePath('index')
+    }
+
+    return { unprocessedUrl, processedUrl }
   }
 })
 </script>

--- a/test/fixture/composition-api/pages/index.vue
+++ b/test/fixture/composition-api/pages/index.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>
+    <div id="current-locale">locale: {{ $i18n.locale }}</div>
+    <div id="content">{{ someText }}</div>
+  </div>
+</template>
+
+<script>
+import { defineComponent, useContext } from '@nuxtjs/composition-api'
+export default defineComponent({
+  setup () {
+    const { app: { i18n } } = useContext()
+    const someText = i18n.t('untranslated')
+    return { someText }
+  }
+})
+</script>

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -2077,19 +2077,28 @@ describe('Composition API', () => {
   /** @type {Nuxt} */
   let nuxt
 
+  const override = {
+    ssr: true,
+    target: 'server'
+  }
+
   beforeAll(async () => {
-    nuxt = (await setup(loadConfig(__dirname, 'composition-api'))).nuxt
+    nuxt = (await setup(loadConfig(__dirname, 'composition-api', override, { merge: true }))).nuxt
   })
 
   afterAll(async () => {
     await nuxt.close()
   })
 
-  test('should not crash if composition API module is active', async () => {
+  test('should work with the composition API module', async () => {
     const html = await get('/')
     const dom = getDom(html)
 
-    expect(dom.querySelector('#content')?.textContent).toBe('untranslated')
     expect(dom.querySelector('#current-locale')?.textContent).toBe('locale: en')
+    expect(dom.querySelector('#unprocessed-url')?.textContent).toBe('Homepage')
+    expect(dom.querySelector('#processed-url')?.textContent).toBe('Homepage')
+
+    expect(dom.querySelector('#unprocessed-url')?.getAttribute('href')).toBe('/')
+    expect(dom.querySelector('#processed-url')?.getAttribute('href')).toBe('/')
   })
 })

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -2077,13 +2077,8 @@ describe('Composition API', () => {
   /** @type {Nuxt} */
   let nuxt
 
-  const override = {
-    ssr: true,
-    target: 'server'
-  }
-
   beforeAll(async () => {
-    nuxt = (await setup(loadConfig(__dirname, 'composition-api', override, { merge: true }))).nuxt
+    nuxt = (await setup(loadConfig(__dirname, 'composition-api'))).nuxt
   })
 
   afterAll(async () => {

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -2072,3 +2072,24 @@ describe('Locale fallback array', () => {
     expect(dom.querySelector('[data-test="de-key"]')?.textContent).toEqual('deKey')
   })
 })
+
+describe('Composition API', () => {
+  /** @type {Nuxt} */
+  let nuxt
+
+  beforeAll(async () => {
+    nuxt = (await setup(loadConfig(__dirname, 'composition-api'))).nuxt
+  })
+
+  afterAll(async () => {
+    await nuxt.close()
+  })
+
+  test('should not crash if composition API module is active', async () => {
+    const html = await get('/')
+    const dom = getDom(html)
+
+    expect(dom.querySelector('#content')?.textContent).toBe('untranslated')
+    expect(dom.querySelector('#current-locale')?.textContent).toBe('locale: en')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1602,6 +1602,16 @@
     webpack-node-externals "^2.5.2"
     webpackbar "^4.0.0"
 
+"@nuxtjs/composition-api@0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/composition-api/-/composition-api-0.21.0.tgz#ed0fe44b305412cee7ec34044db04fe59786e133"
+  integrity sha512-0MwI5D5yUXLmltI91WeoBVwrnjnyYqES1DTAv/vc5AtySLhny8uqT75LHqK3akl0rxS8m9AeHF4TvLAGFggEmQ==
+  dependencies:
+    "@vue/composition-api" "1.0.0-rc.3"
+    defu "^3.2.2"
+    ufo "^0.6.7"
+    upath "^2.0.1"
+
 "@nuxtjs/eslint-config-typescript@5.0.0":
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/@nuxtjs/eslint-config-typescript/-/eslint-config-typescript-5.0.0.tgz#060c1402e559b1df78c8c19b2f5a873eac53cab2"
@@ -2424,6 +2434,13 @@
     vue-template-es2015-compiler "^1.9.0"
   optionalDependencies:
     prettier "^1.18.2"
+
+"@vue/composition-api@1.0.0-rc.3":
+  version "1.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-1.0.0-rc.3.tgz#5174632fdda888f4f04bbaa5263cf01e34ba3fc2"
+  integrity sha512-/N/yCgIeFwAdsChML1RAke7YT5v/LYnPOyrz2zU+fE6xx2MpZfWn+DD2wCf3Vre659AvuXA8zzKLlRaFzW75XQ==
+  dependencies:
+    tslib "^2.1.0"
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -11833,7 +11850,7 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3:
+tslib@^2.0.3, tslib@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==


### PR DESCRIPTION
If one uses the @nuxtjs/composition-api module, nuxt-i18n causes a blocking error because it cannot find req on `this.$ssrContext`. This is only the case if nuxt.config contains

```js
{
  ssr: true,
  target: 'server'
}
```
(which are the default settings)

Apparently, when using the composition api module, ssrContext is moved from the root to the context object (https://github.com/nuxt-community/i18n-module/issues/711#issuecomment-733650829)

This is a fix as suggested by @manniL in https://github.com/nuxt-community/i18n-module/issues/873#issuecomment-707584305.
With this fix the default this.$ssrContext is just used if it is defined, which should be the case if composition-api is not used. If it is not found there, an attempt is done to find ssrContext on the context object, and otherwise the value simply becomes `null` (just as in the original scenario).

I know a similar PR has been submitted once before (https://github.com/nuxt-community/i18n-module/pull/596) but there was no mention of the composition API being a cause there. Without this change nuxt-i18n does not work with the (official) @nuxt/composition-api module, so I thought that would warrant to open up a new PR. The error should also be reproducible in this case by adding both nuxt-i18n and @nuxtjs/composition-api modules.
