### PR TITLE
fix: don't apply any locale-logic to non-existent routes

### DIFF
--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -162,7 +162,7 @@ export default async (context) => {
       redirectPath = app.localePath(route.fullPath, locale)
     }
 
-    if (redirectPath === route.fullPath) {
+    if (redirectPath === route.fullPath || redirectPath.startsWith('//')) {
       return ''
     }
 

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -162,7 +162,7 @@ export default async (context) => {
       redirectPath = app.localePath(route.fullPath, locale)
     }
 
-    if (redirectPath === route.fullPath || redirectPath.startsWith('//')) {
+    if (!redirectPath || redirectPath === route.fullPath || redirectPath.startsWith('//')) {
       return ''
     }
 

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -90,7 +90,11 @@ function localeRoute (route, locale) {
   }
 
   const resolvedRoute = this.router.resolve(localizedRoute).route
-  return resolvedRoute.name ? resolvedRoute : null
+  if (resolvedRoute.name) {
+    return resolvedRoute
+  }
+  // If didn't resolve to an existing route then just return resolved route based on original input.
+  return this.router.resolve(route).route
 }
 
 function switchLocalePath (locale) {

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -61,6 +61,20 @@ function localeRoute (route, locale) {
         query: resolvedRoute.query,
         hash: resolvedRoute.hash
       }
+    } else {
+      const isDefaultLocale = locale === defaultLocale
+      // if route has a path defined but no name, resolve full route using the path
+      const isPrefixed =
+          // don't prefix default locale
+          !(isDefaultLocale && [STRATEGIES.PREFIX_EXCEPT_DEFAULT, STRATEGIES.PREFIX_AND_DEFAULT].includes(strategy)) &&
+          // no prefix for any language
+          !(strategy === STRATEGIES.NO_PREFIX) &&
+          // no prefix for different domains
+          !i18n.differentDomains
+      if (isPrefixed) {
+        localizedRoute.path = `/${locale}${route.path}`
+      }
+      localizedRoute.path = localizedRoute.path.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || '/'
     }
   } else {
     if (!route.name && !route.path) {
@@ -75,7 +89,8 @@ function localeRoute (route, locale) {
     }
   }
 
-  return this.router.resolve(localizedRoute).route
+  const resolvedRoute = this.router.resolve(localizedRoute).route
+  return resolvedRoute.name ? resolvedRoute : null
 }
 
 function switchLocalePath (locale) {

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -52,15 +52,6 @@ function localeRoute (route, locale) {
   let localizedRoute = Object.assign({}, route)
 
   if (route.path && !route.name) {
-    const isDefaultLocale = locale === defaultLocale
-    // if route has a path defined but no name, resolve full route using the path
-    const isPrefixed =
-        // don't prefix default locale
-        !(isDefaultLocale && [STRATEGIES.PREFIX_EXCEPT_DEFAULT, STRATEGIES.PREFIX_AND_DEFAULT].includes(strategy)) &&
-        // no prefix for any language
-        !(strategy === STRATEGIES.NO_PREFIX) &&
-        // no prefix for different domains
-        !i18n.differentDomains
     const resolvedRoute = this.router.resolve(route.path).route
     const resolvedRouteName = this.getRouteBaseName(resolvedRoute)
     if (resolvedRouteName) {
@@ -70,11 +61,6 @@ function localeRoute (route, locale) {
         query: resolvedRoute.query,
         hash: resolvedRoute.hash
       }
-    } else {
-      if (isPrefixed) {
-        localizedRoute.path = `/${locale}${route.path}`
-      }
-      localizedRoute.path = localizedRoute.path.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || '/'
     }
   } else {
     if (!route.name && !route.path) {

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -643,7 +643,7 @@ describe(`${browserString} (SPA)`, () => {
     page = await browser.newPage({ locale: 'fr' })
     await page.goto(url(path))
     expect(await (await page.$('body'))?.textContent()).toContain('page could not be found')
-    expect(await getRouteFullPath(page)).toBe(`/fr${path}`)
+    expect(await getRouteFullPath(page)).toBe(path)
   })
 })
 


### PR DESCRIPTION
If the resolved path for a given locale is 404 then don't attempt to
redirect to that path. This affects redirects on locale change, page
load, and just the behavior of "localePath" API. Avoids redirecting
unnecessarily to a route that doesn't exist anyway.

That also fixes the security issue with redirecting to a different
domain but just in case added an additional measure against that.

Resolves #1092