### PR TITLE
fix: ensure langDir is escaped on Windows

### DIFF
--- a/src/templates/options.js
+++ b/src/templates/options.js
@@ -1,6 +1,6 @@
 <%
 function stringifyValue(value) {
-  if (value === undefined || value === null || typeof value === 'boolean' || typeof value === 'function') {
+  if (value === undefined || typeof value === 'function') {
     return String(value);
   } else {
     return JSON.stringify(value)

--- a/src/templates/options.js
+++ b/src/templates/options.js
@@ -1,8 +1,6 @@
 <%
 function stringifyValue(value) {
-  if (typeof value === 'string') {
-    return `'${value}'`
-  } else if (value === undefined || value === null || typeof value === 'boolean' || typeof value === 'function') {
+  if (value === undefined || value === null || typeof value === 'boolean' || typeof value === 'function') {
     return String(value);
   } else {
     return JSON.stringify(value)


### PR DESCRIPTION
After updating `nuxt-i18n` my project stopped compiling. 
After some digging, I've found this problem:
![image](https://user-images.githubusercontent.com/2473784/110325334-79bd8a00-8017-11eb-9481-db1ae5c89f0f.png)

I'm working on windows, and paths do use backslashes.
When creating script templates this requires for string to be properly escaped.

It's enough to pass it through `JSON.stringify`, so I think easiest way to fix that, was to remove the special case for string.
Also, checking for `boolean` and `null` should also be unnecessary - `JSON.stringify` should handle it as well.

PS: this would also break if there were `'` characters anywhere inside.