### PR TITLE
fix: Make unique codes list in the getLocalCodes helper function

### DIFF
--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -13,7 +13,16 @@ const getLocaleCodes = (locales = []) => {
     }
     // Attempt to get codes from a list of objects
     if (typeof locales[0][LOCALE_CODE_KEY] === 'string') {
-      return locales.map(locale => locale[LOCALE_CODE_KEY])
+      return locales.reduce((previousValue, currentValue) => {
+        const newLocaleCode = currentValue[LOCALE_CODE_KEY]
+
+        // Check if duplicated code
+        if (!previousValue.includes(newLocaleCode)) {
+          previousValue.push(newLocaleCode)
+        }
+
+        return previousValue
+      }, [])
     }
   }
   return []


### PR DESCRIPTION
This fix attempts to remove the warnings that appear in the console and terminal when there are same codes in different domains options.

https://github.com/nuxt-community/i18n-module/issues/1076