### PR TITLE
fix: localePath/localeRoute missing query params

### DIFF
--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -52,7 +52,7 @@ function localeRoute (route, locale) {
   let localizedRoute = Object.assign({}, route)
 
   if (route.path && !route.name) {
-    const resolvedRoute = this.router.resolve(route.path).route
+    const resolvedRoute = this.router.resolve(route).route
     const resolvedRouteName = this.getRouteBaseName(resolvedRoute)
     if (resolvedRouteName) {
       localizedRoute = {

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -1028,6 +1028,21 @@ describe('prefix_and_default strategy', () => {
     expect(window.$nuxt.localeRoute('index', 'fr')).toMatchObject({ name: 'index___fr', fullPath: '/fr' })
   })
 
+  test('localeRoute returns localized route (by route object with name)', async () => {
+    const window = await nuxt.renderAndGetWindow(url('/'))
+    // Prefer unprefixed path for default locale:
+    expect(window.$nuxt.localeRoute({ name: 'simple', query: { a: '1' } }, 'en')).toMatchObject({
+      name: 'simple___en___default',
+      query: { a: '1' },
+      fullPath: '/simple?a=1'
+    })
+    expect(window.$nuxt.localeRoute({ name: 'simple', query: { a: '1' } }, 'fr')).toMatchObject({
+      name: 'simple___fr',
+      query: { a: '1' },
+      fullPath: '/fr/simple?a=1'
+    })
+  })
+
   test('localeRoute returns localized route (by route path)', async () => {
     const window = await nuxt.renderAndGetWindow(url('/'))
     // Prefer unprefixed path for default locale:
@@ -1047,7 +1062,6 @@ describe('prefix_and_default strategy', () => {
       name: 'simple___fr',
       query: { a: '1' },
       fullPath: '/fr/simple?a=1'
-
     })
   })
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -1035,6 +1035,22 @@ describe('prefix_and_default strategy', () => {
     expect(window.$nuxt.localeRoute('/simple', 'fr')).toMatchObject({ name: 'simple___fr', fullPath: '/fr/simple' })
   })
 
+  test('localeRoute returns localized route (by route object with path)', async () => {
+    const window = await nuxt.renderAndGetWindow(url('/'))
+    // Prefer unprefixed path for default locale:
+    expect(window.$nuxt.localeRoute({ path: '/simple', query: { a: '1' } }, 'en')).toMatchObject({
+      name: 'simple___en___default',
+      query: { a: '1' },
+      fullPath: '/simple?a=1'
+    })
+    expect(window.$nuxt.localeRoute({ path: '/simple', query: { a: '1' } }, 'fr')).toMatchObject({
+      name: 'simple___fr',
+      query: { a: '1' },
+      fullPath: '/fr/simple?a=1'
+
+    })
+  })
+
   test('localeRoute returns customized localized route (by route path)', async () => {
     const window = await nuxt.renderAndGetWindow(url('/'))
     // Prefer unprefixed path for default locale:


### PR DESCRIPTION
After updating nuxt-i18n@6.20.6,`localePath/localeRoute`(with `path` input) will missing `query` parameters.
- `localePath({ path: '/', query: {test: 1} })` => `/`  (**missing query**)
- `localePath({ name: 'index', query: {test: 1} })` => `/?test=1`
- `localeRoute({ path: '/', query: {test: 1} })` => `query={}` (**missing query**)
- `localeRoute({ name: 'index', query: {test: 1} })` => `query={test: 1}`