### PR TITLE
Fix cookie params in DetectBrowserLanguageInterface

### DIFF
--- a/types/nuxt-i18n.d.ts
+++ b/types/nuxt-i18n.d.ts
@@ -34,6 +34,7 @@ declare namespace NuxtVueI18n {
       cookieCrossOrigin?: boolean
       cookieDomain?: string | null
       cookieKey?: string
+      cookieSecure: boolean
       alwaysRedirect?: boolean
       fallbackLocale?: Locale | null
       onlyOnNoPrefix?: boolean

--- a/types/nuxt-i18n.d.ts
+++ b/types/nuxt-i18n.d.ts
@@ -31,7 +31,7 @@ declare namespace NuxtVueI18n {
 
     interface DetectBrowserLanguageInterface {
       useCookie?: boolean
-      crossOriginCookie?: boolean
+      cookieCrossOrigin?: boolean
       cookieDomain?: string | null
       cookieKey?: string
       alwaysRedirect?: boolean


### PR DESCRIPTION
There is no reference to `crossOriginCookie` in the codebase. The right one is `cookieCrossOrigin`. Also, `cookieSecure` parameter was missing as well.