### PR TITLE
fix: move lodash.merge to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "is-https": "^3.0.0",
     "js-cookie": "^2.2.1",
     "klona": "^2.0.4",
+    "lodash.merge": "4.6.2",
     "ufo": "^0.6.7",
     "vue-i18n": "^8.23.0"
   },
@@ -128,7 +129,6 @@
     "jest": "26.6.3",
     "jest-dev-server": "4.4.0",
     "jsdom": "16.4.0",
-    "lodash.merge": "4.6.2",
     "messageformat": "2.3.0",
     "nuxt": "2.15.2",
     "playwright-chromium": "1.9.1",


### PR DESCRIPTION
bugfix: Cannot find module 'lodash.merge"

<img width="790" alt="スクリーンショット 2021-03-25 11 03 06" src="https://user-images.githubusercontent.com/28241535/112407599-b698b900-8d59-11eb-8d21-ce8ebf4825a7.png">


Using it in src/index.js, but it's not in dependencies.

----------------------------
resolve #1122