### PR TITLE
fix(lazy): message function not working when using lazy loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@intlify/vue-i18n-extensions": "^1.0.1",
     "@intlify/vue-i18n-loader": "^1.0.0",
     "cookie": "^0.4.0",
+    "devalue": "^2.0.1",
     "is-https": "^3.0.0",
     "js-cookie": "^2.2.1",
     "klona": "^2.0.4",

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -37,15 +37,30 @@ export default async (context) => {
   }
 
   if (process.server && options.lazy) {
+    const devalue = (await import('devalue')).default
     context.beforeNuxtRender(({ nuxtState }) => {
       /** @type {Record<string, import('vue-i18n').LocaleMessageObject>} */
       const langs = {}
       const { fallbackLocale, locale } = app.i18n
       if (locale) {
-        langs[locale] = app.i18n.getLocaleMessage(locale)
+        // @ts-ignore Using internal API to avoid unnecessary cloning.
+        const messages = app.i18n._getMessages()[locale]
+        try {
+          devalue(messages)
+          langs[locale] = messages
+        } catch {
+          // Ignore - client-side will load the chunk asynchronously.
+        }
       }
-      if (typeof (fallbackLocale) === 'string' && locale !== fallbackLocale) {
-        langs[fallbackLocale] = app.i18n.getLocaleMessage(fallbackLocale)
+      if (fallbackLocale && typeof (fallbackLocale) === 'string' && locale !== fallbackLocale) {
+        // @ts-ignore Using internal API to avoid unnecessary cloning.
+        const messages = app.i18n._getMessages()[fallbackLocale]
+        try {
+          devalue(messages)
+          langs[fallbackLocale] = messages
+        } catch {
+          // Ignore - client-side will load the chunk asynchronously.
+        }
       }
       nuxtState.__i18n = { langs }
     })
@@ -82,7 +97,6 @@ export default async (context) => {
       app.i18n.setLocaleCookie(newLocale)
     }
 
-    // Lazy-loading enabled
     if (options.lazy) {
       const i18nFallbackLocale = app.i18n.fallbackLocale
 

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -45,21 +45,25 @@ export default async (context) => {
       if (locale) {
         // @ts-ignore Using internal API to avoid unnecessary cloning.
         const messages = app.i18n._getMessages()[locale]
-        try {
-          devalue(messages)
-          langs[locale] = messages
-        } catch {
-          // Ignore - client-side will load the chunk asynchronously.
+        if (messages) {
+          try {
+            devalue(messages)
+            langs[locale] = messages
+          } catch {
+            // Ignore - client-side will load the chunk asynchronously.
+          }
         }
       }
       if (fallbackLocale && typeof (fallbackLocale) === 'string' && locale !== fallbackLocale) {
         // @ts-ignore Using internal API to avoid unnecessary cloning.
         const messages = app.i18n._getMessages()[fallbackLocale]
-        try {
-          devalue(messages)
-          langs[fallbackLocale] = messages
-        } catch {
-          // Ignore - client-side will load the chunk asynchronously.
+        if (messages) {
+          try {
+            devalue(messages)
+            langs[fallbackLocale] = messages
+          } catch {
+            // Ignore - client-side will load the chunk asynchronously.
+          }
         }
       }
       nuxtState.__i18n = { langs }

--- a/test/fixture/basic/lang/en-US.js
+++ b/test/fixture/basic/lang/en-US.js
@@ -2,5 +2,6 @@ export default {
   home: 'Homepage',
   about: 'About us',
   posts: 'Posts',
-  untranslated: 'in english'
+  untranslated: 'in english',
+  fn () { return 'Demo string' }
 }

--- a/test/fixture/basic/pages/index.vue
+++ b/test/fixture/basic/pages/index.vue
@@ -4,6 +4,7 @@
     <div id="current-page">page: {{ $t('home') }}</div>
     <nuxt-link id="link-about" exact :to="aboutPath">{{ aboutTranslation }}</nuxt-link>
     <div id="current-locale">locale: {{ $i18n.locale }}</div>
+    <div id="message-function">{{ $t('fn') }}</div>
   </div>
 </template>
 


### PR DESCRIPTION
Bail injecting locale messages into Nuxt state when it fails to
stringify. We can't stringify functions across Nuxt state so locales
in MessageFunction [1] format can't be supported. In that case the
client-side will have to trigger extra network request to load the
locale messages.

[1] https://kazupon.github.io/vue-i18n/guide/messages.html#message-function

Resolves #1124