### PR TITLE
refactor(lazy): include fallback locale messages in the main bundle

### DIFF
--- a/src/templates/options.d.ts
+++ b/src/templates/options.d.ts
@@ -13,7 +13,7 @@ interface ModuleNuxtOptions {
   trailingSlash: boolean | undefined
 }
 
-export const asyncLocales: Record<string, () => Promise<LocaleFileExport>>
+export const localeMessages: Record<string, () => Promise<LocaleFileExport>>
 export const Constants: ModuleConstants
 export const nuxtOptions: ModuleNuxtOptions
 export const options: ResolvedOptions

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -42,25 +42,13 @@ export default async (context) => {
       /** @type {Record<string, import('vue-i18n').LocaleMessageObject>} */
       const langs = {}
       const { fallbackLocale, locale } = app.i18n
-      if (locale) {
+      if (locale && locale !== fallbackLocale) {
         // @ts-ignore Using internal API to avoid unnecessary cloning.
         const messages = app.i18n._getMessages()[locale]
         if (messages) {
           try {
             devalue(messages)
             langs[locale] = messages
-          } catch {
-            // Ignore - client-side will load the chunk asynchronously.
-          }
-        }
-      }
-      if (fallbackLocale && typeof (fallbackLocale) === 'string' && locale !== fallbackLocale) {
-        // @ts-ignore Using internal API to avoid unnecessary cloning.
-        const messages = app.i18n._getMessages()[fallbackLocale]
-        if (messages) {
-          try {
-            devalue(messages)
-            langs[fallbackLocale] = messages
           } catch {
             // Ignore - client-side will load the chunk asynchronously.
           }

--- a/src/templates/utils.js
+++ b/src/templates/utils.js
@@ -1,4 +1,4 @@
-import { asyncLocales } from './options'
+import { localeMessages } from './options'
 import { formatMessage } from './utils-common'
 
 /**
@@ -30,14 +30,14 @@ export async function loadLanguageAsync (context, locale) {
             messages = nuxtState.__i18n.langs[locale]
             // Even if already cached in Nuxt state, trigger locale import so that HMR kicks-in on changes to that file.
             if (context.isDev) {
-              asyncLocales[file]()
+              localeMessages[file]()
             }
           }
         }
         if (!messages) {
           try {
             // @ts-ignore
-            const getter = await asyncLocales[file]().then(m => m.default || m)
+            const getter = await localeMessages[file]().then(m => m.default || m)
             messages = typeof getter === 'function' ? await Promise.resolve(getter(context, locale)) : getter
           } catch (error) {
             // eslint-disable-next-line no-console

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -667,20 +667,20 @@ describe(`${browserString} (with fallbackLocale, lazy)`, () => {
     expect(await (await page.$('#current-page'))?.textContent()).toBe('page: Strona glowna')
   })
 
-  test('current locale messages have been passed through Nuxt state', async () => {
+  test('fallbackLocale messages have not been passed through Nuxt state', async () => {
     page = await browser.newPage()
     await page.goto(url('/'))
     // @ts-ignore
     const i18nState = await page.evaluate(() => window.__NUXT__.__i18n)
-    expect(Object.keys(i18nState.langs)).toEqual(['pl'])
+    expect(Object.keys(i18nState.langs)).toEqual([])
   })
 
-  test('current and fallback locale messages have been passed through Nuxt state', async () => {
+  test('current (non-fallback) locale messages have been passed through Nuxt state', async () => {
     page = await browser.newPage()
     await page.goto(url('/no'))
     // @ts-ignore
     const i18nState = await page.evaluate(() => window.__NUXT__.__i18n)
-    expect(Object.keys(i18nState.langs).sort()).toEqual(['no', 'pl'])
+    expect(Object.keys(i18nState.langs).sort()).toEqual(['no'])
   })
 
   test('message function results in failing to set Nuxt state for locale', async () => {

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -688,7 +688,7 @@ describe(`${browserString} (with fallbackLocale, lazy)`, () => {
     await page.goto(url('/en'))
     // @ts-ignore
     const i18nState = await page.evaluate(() => window.__NUXT__.__i18n)
-    expect(Object.keys(i18nState.langs)).toEqual(['pl'])
+    expect(Object.keys(i18nState.langs)).toEqual([])
     // The message function should work when loaded directly through client-side.
     expect(await (await page.$('#message-function'))?.textContent()).toBe('Demo string')
   })


### PR DESCRIPTION
This is an optimization to avoid including the messages for the fallback
locale in Nuxt state.

Since the messages for the fallback locale are **always required** when
"vueI18n.fallbackLocale" is defined we can include it in the main bundle
and avoid making all server-side responses include it separately. The
amount of data is the same in both cases but this way we can take
advantage of browser caching.