### PR TITLE
refactor: initialize some variable at runtime to allow overrides

### DIFF
--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -25,13 +25,6 @@ Vue.use(VueI18n)
 export default async (context) => {
   const { app, route, store, req, res, redirect } = context
 
-  const detectBrowserLanguage = /** @type {Required<import('../../types').DetectBrowserLanguageOptions>} */(options.detectBrowserLanguage)
-  const { alwaysRedirect, onlyOnNoPrefix, onlyOnRoot, fallbackLocale } = detectBrowserLanguage
-  const getLocaleFromRoute = createLocaleFromRouteGetter(options.localeCodes, {
-    routesNameSeparator: options.routesNameSeparator,
-    defaultLocaleRouteNameSuffix: options.defaultLocaleRouteNameSuffix
-  })
-
   if (options.vuex && store) {
     registerStore(store, options.vuex, options.localeCodes)
   }
@@ -58,7 +51,17 @@ export default async (context) => {
     })
   }
 
-  const { useCookie, cookieKey, cookieDomain, cookieSecure, cookieCrossOrigin } = detectBrowserLanguage
+  const {
+    alwaysRedirect,
+    fallbackLocale,
+    onlyOnNoPrefix,
+    onlyOnRoot,
+    useCookie,
+    cookieKey,
+    cookieDomain,
+    cookieSecure,
+    cookieCrossOrigin
+  } = /** @type {Required<import('../../types').DetectBrowserLanguageOptions>} */(options.detectBrowserLanguage)
 
   /**
    * @param {string | undefined} newLocale
@@ -142,6 +145,11 @@ export default async (context) => {
       }
     }
   }
+
+  const getLocaleFromRoute = createLocaleFromRouteGetter(options.localeCodes, {
+    routesNameSeparator: options.routesNameSeparator,
+    defaultLocaleRouteNameSuffix: options.defaultLocaleRouteNameSuffix
+  })
 
   /**
    * Gets the redirect path for locale.

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -21,16 +21,16 @@ import { klona } from '~i18n-klona'
 
 Vue.use(VueI18n)
 
-const detectBrowserLanguage = /** @type {Required<import('../../types').DetectBrowserLanguageOptions>} */(options.detectBrowserLanguage)
-const { alwaysRedirect, onlyOnNoPrefix, onlyOnRoot, fallbackLocale } = detectBrowserLanguage
-const getLocaleFromRoute = createLocaleFromRouteGetter(options.localeCodes, {
-  routesNameSeparator: options.routesNameSeparator,
-  defaultLocaleRouteNameSuffix: options.defaultLocaleRouteNameSuffix
-})
-
 /** @type {import('@nuxt/types').Plugin} */
 export default async (context) => {
   const { app, route, store, req, res, redirect } = context
+
+  const detectBrowserLanguage = /** @type {Required<import('../../types').DetectBrowserLanguageOptions>} */(options.detectBrowserLanguage)
+  const { alwaysRedirect, onlyOnNoPrefix, onlyOnRoot, fallbackLocale } = detectBrowserLanguage
+  const getLocaleFromRoute = createLocaleFromRouteGetter(options.localeCodes, {
+    routesNameSeparator: options.routesNameSeparator,
+    defaultLocaleRouteNameSuffix: options.defaultLocaleRouteNameSuffix
+  })
 
   if (options.vuex && store) {
     registerStore(store, options.vuex, options.localeCodes)


### PR DESCRIPTION
Currently I need to overwrite the settings before they can be processed by the plugin, as it dynamically adds new languages from the API. Without this change, the creation of `getLocaleFromRoute` takes place at the moment of importing the file, and for me it is necessary that it takes place only during the processing of the plugin. this is a very important change if someone wants to add languages from API or other source. I tested it locally and with this change I am able to change the default i18n settings regardless of what was set in nuxt.config.js