### PR TITLE
chore(docs): fix typo in options reference

### DIFF
--- a/docs/content/en/options-reference.md
+++ b/docs/content/en/options-reference.md
@@ -229,7 +229,7 @@ Properties:
 - type: `object` or `string`
 - default: `{}`
 
-Configuration for the `vue-i18n` library that is used internally but this module. See full documentation at http://kazupon.github.io/vue-i18n/api/#constructor-options
+Configuration for the `vue-i18n` library that is used internally by this module. See full documentation at http://kazupon.github.io/vue-i18n/api/#constructor-options
 
 <alert type="info">
 

--- a/docs/content/es/options-reference.md
+++ b/docs/content/es/options-reference.md
@@ -227,7 +227,7 @@ Properties:
 - type: `object` or `string`
 - default: `{}`
 
-Configuration for the `vue-i18n` library that is used internally but this module. See full documentation at http://kazupon.github.io/vue-i18n/api/#constructor-options
+Configuration for the `vue-i18n` library that is used internally by this module. See full documentation at http://kazupon.github.io/vue-i18n/api/#constructor-options
 
 <alert type="info">
 


### PR DESCRIPTION
Just fixes a small typo. 
Thank you for you work 🙏🏼 