### PR TITLE
feat: transpile is-https

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@intlify/vue-i18n-loader": "^1.1.0",
     "cookie": "^0.4.1",
     "devalue": "^2.0.1",
+    "is-https": "^4.0.0",
     "js-cookie": "^2.2.1",
     "klona": "^2.0.4",
     "lodash.merge": "^4.6.2",

--- a/src/index.js
+++ b/src/index.js
@@ -105,6 +105,7 @@ export default function (moduleOptions) {
   this.options.render.bundleRenderer.directives = this.options.render.bundleRenderer.directives || {}
   this.options.render.bundleRenderer.directives.t = i18nExtensionsDirective
 
-  // Transpile is-https for IE11 support
-  this.nuxt.options.build.transpile.push('is-https')
+  // Transpile is-https (IE11)
+  this.options.build.transpile = this.options.build.transpile || []
+  this.options.build.transpile.push('is-https')
 }

--- a/src/index.js
+++ b/src/index.js
@@ -104,4 +104,7 @@ export default function (moduleOptions) {
   }
   this.options.render.bundleRenderer.directives = this.options.render.bundleRenderer.directives || {}
   this.options.render.bundleRenderer.directives.t = i18nExtensionsDirective
+
+  // Transpile is-https for IE11 support
+  this.nuxt.options.build.transpile.push('is-https')
 }

--- a/src/templates/utils-common.js
+++ b/src/templates/utils-common.js
@@ -1,5 +1,6 @@
 import Cookie from 'cookie'
 import JsCookie from 'js-cookie'
+import isHTTPS from 'is-https'
 import { hasProtocol } from 'ufo'
 
 /** @typedef {import('../../types/internal').ResolvedOptions} ResolvedOptions */
@@ -135,35 +136,6 @@ export function getDomainFromLocale (localeCode, req, { normalizedLocales }) {
 
   // eslint-disable-next-line no-console
   console.warn(formatMessage(`Could not find domain name for locale ${localeCode}`))
-}
-
-/**
- * Determines if a server-side request is using HTTPS.
- *
- * @param {import('http').IncomingMessage} req
- * @param {Boolean} [trustProxy=true]
- * @return {Boolean | undefined}.
- */
-function isHTTPS (req, trustProxy = true) {
-  // Check x-forwarded-proto header
-  const _xForwardedProto = (trustProxy && req.headers) ? req.headers['x-forwarded-proto'] : undefined
-  const protoCheck = typeof _xForwardedProto === 'string' ? _xForwardedProto.includes('https') : undefined
-  if (protoCheck) {
-    return true
-  }
-
-  const socket = /** @type {import('tls').TLSSocket} */(req.socket)
-  const _encrypted = socket ? socket.encrypted : undefined
-  const encryptedCheck = _encrypted !== undefined ? _encrypted === true : undefined
-  if (encryptedCheck) {
-    return true
-  }
-
-  if (protoCheck === undefined && encryptedCheck === undefined) {
-    return undefined
-  }
-
-  return false
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -7493,6 +7493,11 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-https@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-https/-/is-https-4.0.0.tgz#9ee725a334fb517b988278d2674efc96e4f348ed"
+  integrity sha512-FeMLiqf8E5g6SdiVJsPcNZX8k4h2fBs1wp5Bb6uaNxn58ufK1axBqQZdmAQsqh0t9BuwFObybrdVJh6MKyPlyg==
+
 is-installed-globally@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.4.0.tgz#9a0fd407949c30f86eb6959ef1b7994ed0b7b520"


### PR DESCRIPTION
Adding an option to transpile `is-https` instead of inlining it.

Many other nuxt libraries are using it, and even if it's small, it's better to transpile and make things simpler.

Also, it might get some updates later.

Related https://github.com/nuxt-community/i18n-module/issues/1137 , https://github.com/nuxt-community/i18n-module/pull/1138

Thanks