### PR TITLE
fix(types): fix "lazy" type in deprecated types

### DIFF
--- a/types/nuxt-i18n.d.ts
+++ b/types/nuxt-i18n.d.ts
@@ -68,7 +68,7 @@ declare namespace NuxtVueI18n {
       baseUrl?: string | ((context: NuxtContext) => string)
       detectBrowserLanguage?: DetectBrowserLanguageInterface | false
       langDir?: string | null
-      lazy?: boolean
+      lazy?: boolean | {skipNuxtState: boolean}
       // see https://goo.gl/NbzX3f
       pages?: {
         [key: string]: boolean | {

--- a/types/nuxt-i18n.d.ts
+++ b/types/nuxt-i18n.d.ts
@@ -68,7 +68,7 @@ declare namespace NuxtVueI18n {
       baseUrl?: string | ((context: NuxtContext) => string)
       detectBrowserLanguage?: DetectBrowserLanguageInterface | false
       langDir?: string | null
-      lazy?: boolean | {skipNuxtState: boolean}
+      lazy?: boolean | {skipNuxtState?: boolean}
       // see https://goo.gl/NbzX3f
       pages?: {
         [key: string]: boolean | {


### PR DESCRIPTION
The current typing is wrong, the `lazy` option can be a bool value or an object
https://i18n.nuxtjs.org/lazy-load-translations#lazy-configuration-options