### PR TITLE
docs: specify that `routeId` in example is not hard-coded

### DIFF
--- a/docs/content/en/lang-switcher.md
+++ b/docs/content/en/lang-switcher.md
@@ -71,6 +71,8 @@ Make sure that Vuex [is enabled](https://nuxtjs.org/guides/directory-structure/s
 
 To provide dynamic parameters translations, dispatch the `i18n/setRouteParams` mutation as early as possible when loading a page. The passed in object must contain the mappings from the locale `code` to an object with a mapping from slug name to expected slug value for given locale.
 
+You should replace `postId` with the appropriate route parameter.
+
 An example:
 
 ```vue

--- a/docs/content/en/lang-switcher.md
+++ b/docs/content/en/lang-switcher.md
@@ -71,9 +71,7 @@ Make sure that Vuex [is enabled](https://nuxtjs.org/guides/directory-structure/s
 
 To provide dynamic parameters translations, dispatch the `i18n/setRouteParams` mutation as early as possible when loading a page. The passed in object must contain the mappings from the locale `code` to an object with a mapping from slug name to expected slug value for given locale.
 
-You should replace `postId` with the appropriate route parameter.
-
-An example:
+An example (replace `postId` with the appropriate route parameter):
 
 ```vue
 <template>

--- a/docs/content/es/lang-switcher.md
+++ b/docs/content/es/lang-switcher.md
@@ -69,7 +69,7 @@ Asegúrese de que Vuex [esté habilitado](https://nuxtjs.org/guides/directory-st
 
 To provide dynamic parameters translations, dispatch the `i18n/setRouteParams` mutation as early as possible when loading a page. The passed in object must contain the mappings from the locale `code` to an object with a mapping from slug name to expected slug value for given locale.
 
-An example:
+An example (replace `postId` with the appropriate route parameter):
 
 ```vue
 <template>


### PR DESCRIPTION
Specify that `routeId` references a path parameter and is not hard-coded.

I spent too many hours figuring this out.