### PR TITLE
fix: don't skip the cookie if no locale is detected in the route

### DIFF
--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -395,9 +395,11 @@ export default async (context) => {
     } else if (options.strategy !== Constants.STRATEGIES.NO_PREFIX) {
       const routeLocale = getLocaleFromRoute(route)
       finalLocale = routeLocale
-    } else if (useCookie) {
-      finalLocale = app.i18n.getLocaleCookie()
     }
+  }
+
+  if (!finalLocale && useCookie) {
+    finalLocale = app.i18n.getLocaleCookie()
   }
 
   if (!finalLocale) {

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -1260,6 +1260,20 @@ describe(`${browserString} (onlyOnRoot + prefix)`, () => {
     expect(await (await page.$('body'))?.textContent()).toContain('locale: en')
     expect(await getRouteFullPath(page)).toBe('/en')
   })
+
+  test('uses saved locale cookie when redirecting from root', async () => {
+    const page = await browser.newPage({ locale: 'fr' })
+
+    // Ensure the detected locale cookie is saved
+    await page.goto(url('/fr'))
+    expect(await (await page.$('body'))?.textContent()).toContain('locale: fr')
+    expect(await getRouteFullPath(page)).toBe('/fr')
+
+    // Verify that we navigate to saved locale
+    await page.goto(url('/'))
+    expect(await (await page.$('body'))?.textContent()).toContain('locale: fr')
+    expect(await getRouteFullPath(page)).toBe('/fr')
+  })
 })
 
 describe(`${browserString} (vuex disabled)`, () => {


### PR DESCRIPTION
That PR fixes #1234.

It uses the cookie locale, if no locale is set yet.