### PR TITLE
fix: custom routes with optional params adjusted incorrectly

### DIFF
--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -1,6 +1,6 @@
 import { STRATEGIES } from './constants'
 import { extractComponentOptions } from './components'
-import { adjustRouteForTrailingSlash, getPageOptions } from './utils'
+import { adjustRouteDefinitionForTrailingSlash, getPageOptions } from './utils'
 
 /**
  * @typedef {import('@nuxt/types/config/router').NuxtRouteConfig} NuxtRouteConfig
@@ -149,7 +149,7 @@ export function makeRoutes (baseRoutes, {
       // - If "router.trailingSlash" is not specified then default to no trailing slash (like Nuxt)
       // - Children with relative paths must not start with slash so don't append if path is empty.
       if (path.length) { // Don't replace empty (child) path with a slash!
-        path = adjustRouteForTrailingSlash(path, trailingSlash, isChildWithRelativePath)
+        path = adjustRouteDefinitionForTrailingSlash(path, trailingSlash, isChildWithRelativePath)
       }
 
       if (shouldAddPrefix && isDefaultLocale && strategy === STRATEGIES.PREFIX && includeUprefixedFallback) {

--- a/src/helpers/routes.js
+++ b/src/helpers/routes.js
@@ -1,7 +1,6 @@
-import { withoutTrailingSlash, withTrailingSlash } from 'ufo'
 import { STRATEGIES } from './constants'
 import { extractComponentOptions } from './components'
-import { getPageOptions } from './utils'
+import { adjustRouteForTrailingSlash, getPageOptions } from './utils'
 
 /**
  * @typedef {import('@nuxt/types/config/router').NuxtRouteConfig} NuxtRouteConfig
@@ -150,7 +149,7 @@ export function makeRoutes (baseRoutes, {
       // - If "router.trailingSlash" is not specified then default to no trailing slash (like Nuxt)
       // - Children with relative paths must not start with slash so don't append if path is empty.
       if (path.length) { // Don't replace empty (child) path with a slash!
-        path = (trailingSlash ? withTrailingSlash(path, true) : withoutTrailingSlash(path, true)) || (isChildWithRelativePath ? '' : '/')
+        path = adjustRouteForTrailingSlash(path, trailingSlash, isChildWithRelativePath)
       }
 
       if (shouldAddPrefix && isDefaultLocale && strategy === STRATEGIES.PREFIX && includeUprefixedFallback) {

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -60,6 +60,6 @@ export function getPageOptions (route, pages, localeCodes, pagesDir, defaultLoca
  * @param {boolean} [isChildWithRelativePath] Indicates if it is a child route that has relative path
  * @return {string}
  */
-export function adjustRouteForTrailingSlash (routePath, trailingSlash, isChildWithRelativePath) {
+export function adjustRouteDefinitionForTrailingSlash (routePath, trailingSlash, isChildWithRelativePath) {
   return routePath.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || (isChildWithRelativePath ? '' : '/')
 }

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -53,3 +53,13 @@ export function getPageOptions (route, pages, localeCodes, pagesDir, defaultLoca
 
   return options
 }
+
+/**
+ * @param {string} routePath
+ * @param {boolean | undefined} trailingSlash
+ * @param {boolean} [isChildWithRelativePath] Indicates if it is a child route that has relative path
+ * @return {string}
+ */
+export function adjustRouteForTrailingSlash (routePath, trailingSlash, isChildWithRelativePath) {
+  return routePath.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || (isChildWithRelativePath ? '' : '/')
+}

--- a/test/fixture/basic/extend-routes.js
+++ b/test/fixture/basic/extend-routes.js
@@ -1,0 +1,13 @@
+import { resolve } from 'path'
+
+/** @type {import('@nuxt/types').Module} */
+export default function () {
+  // @ts-ignore
+  this.extendRoutes(function (routes) {
+    routes.push({
+      name: 'custom-route-with-optional-slug',
+      path: '/custom-route/:slug?',
+      component: resolve(__dirname, 'pages/locale.vue')
+    })
+  })
+}

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -3,7 +3,7 @@ import { readFileSync } from 'fs'
 import { generate, setup, loadConfig, get, url } from '@nuxtjs/module-test-utils'
 import { JSDOM } from 'jsdom'
 import { withoutTrailingSlash, withTrailingSlash } from 'ufo'
-import { adjustRouteForTrailingSlash } from '../src/helpers/utils'
+import { adjustRouteDefinitionForTrailingSlash } from '../src/helpers/utils'
 import { getSeoTags } from './utils'
 
 /**
@@ -284,8 +284,8 @@ for (const trailingSlash of TRAILING_SLASHES) {
           // Routes added through extendRoutes are not processed by nuxt-i18n
           extendRoutes (routes) {
             routes.push({
-              path: adjustRouteForTrailingSlash('/about', trailingSlash),
-              redirect: adjustRouteForTrailingSlash('/about-us', trailingSlash)
+              path: adjustRouteDefinitionForTrailingSlash('/about', trailingSlash),
+              redirect: adjustRouteDefinitionForTrailingSlash('/about-us', trailingSlash)
             })
           }
         }


### PR DESCRIPTION
Don't use ufo on Vue Router route definitions as those are not
a normal paths, or not always at least.

Fixes #1242