### PR TITLE
fix: error on loading when using nuxt-vite

### DIFF
--- a/src/templates/options.js
+++ b/src/templates/options.js
@@ -67,5 +67,9 @@ export const localeMessages = {
 %>
 }
 <%
+} else {
+%>
+export const localeMessages = {}
+<%
 }
 %>


### PR DESCRIPTION
The import needs to be provided since it's imported unconditionally.

Fixes https://github.com/nuxt/vite/issues/156