### PR TITLE
feat: Multi domain support proposal per locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "js-cookie": "^3.0.0",
     "klona": "^2.0.4",
     "lodash.merge": "^4.6.2",
+    "string-similarity": "^4.0.4",
     "ufo": "^0.7.9",
     "vue-i18n": "^8.25.0"
   },

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -357,10 +357,20 @@ export default async (context) => {
       for (const [index, locale] of options.normalizedLocales.entries()) {
         const domain = store.state.localeDomains[locale.code]
         if (domain) {
-          locale.domain = domain
+          if (Array.isArray(domain)) {
+            // Map over the Array to avoid issue with Klona using a reactive Array.
+            locale.domains = domain.map(dom => dom)
+          } else {
+            locale.domain = domain
+          }
           const optionsLocale = options.locales[index]
           if (typeof (optionsLocale) !== 'string') {
-            optionsLocale.domain = domain
+            if (Array.isArray(domain)) {
+              // Map over the Array to avoid issue with Klona using a reactive Array.
+              optionsLocale.domains = domain.map(dom => dom)
+            } else {
+              optionsLocale.domain = domain
+            }
           }
         }
       }

--- a/src/templates/plugin.utils.js
+++ b/src/templates/plugin.utils.js
@@ -1,4 +1,7 @@
+// @ts-ignore
 import isHTTPS from 'is-https'
+// @ts-ignore
+import { findBestMatch } from 'string-similarity'
 import { localeMessages, options } from './options'
 import { formatMessage, getHost } from './utils-common'
 // @ts-ignore
@@ -105,6 +108,16 @@ export function getDomainFromLocale (localeCode, req, { normalizedLocales }) {
       const host = getHost(req)
       if (host) {
         domain = lang.domains.find(domain => domain === host)
+        if (!domain) {
+          if (lang.domains.length === 1) {
+            domain = lang.domains[0]
+          } else {
+            const stringMatch = findBestMatch(host, lang.domains)
+            if (stringMatch && stringMatch.bestMatch && stringMatch.bestMatch.target) {
+              domain = stringMatch.bestMatch.target
+            }
+          }
+        }
       }
     } else {
       domain = lang.domain

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,6 +11,7 @@ export interface LocaleObject extends Record<string, any> {
   code: Locale
   dir?: Directions
   domain?: string
+  domains?: Array<string>
   file?: string
   isCatchallLocale?: boolean
   iso?: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -12020,6 +12020,11 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
+string-similarity@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/string-similarity/-/string-similarity-4.0.4.tgz#42d01ab0b34660ea8a018da8f56a3309bb8b2a5b"
+  integrity sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==
+
 string-width@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"


### PR DESCRIPTION
# Support for multiple domains per locale
This is a feature we needed in our use of Nuxt i18n. We are hosting a Nuxt app on multiple domains, that then shows specific content depending on the domain, and we of course needed localization support.

So what this allows you to do is pass in a "new" parameter in each locale object called `domains`, as an alternative to the already existing `domain` parameter. In this case you provide an Array of strings, being each domain you want to match to the locale. We then match that locale to the host the app is served on.

One thing to note, while building this, was that I had to make a choice in how we determine the domain for the complementing locales on the app. Meaning, if you are hosting your app on the domains `nuxtprod-domain.com` and `nuxttest-domain.com`, you are visiting the app on `nuxtprod-domain.com`, and your locales look like this:
```javascript
locales: [
  {
    {
      code: 'en',
      domains: ['nuxtprod-domain.com', 'nuxttest-domain.com'],
      file: 'en.js'
    },
    {
      code: 'fr',
      domains: ['fr.nuxtprod-domain.com', 'fr.nuxttest-domain.com'],
      file: 'fr.js'
    }
  }
]
```
How do we find the correct url for the complementing locale? Well, I though about using simple comparison of the sub-domain and top domain without the extension. However, in some cases, this might not be the desired outcome. The best solution I found was to do a string comparison between the current host and the different domains provided, and use the one that matches best. But I am open to suggestions into how we can do this differently. Especially since this introduced a new dependency ([string-similarity](https://www.npmjs.com/package/string-similarity)).

## Updating the docs
I didn't take the time to update the docs yet, since I'm not sure this will be accepted or if any changes will be proposed. But I will of course take the time to update them if this proposal is accepted.

Solves issue #1100.