### PR TITLE
fix: adjust strange redirection logic for prefix_and_default

### DIFF
--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -176,9 +176,9 @@ export default async (context) => {
     }
 
     if (getLocaleFromRoute(route) === locale) {
-      // If "redirectOn" is "all" and strategy is "prefix_and_default", prefer unprefixed route for
-      // default locale.
-      if (redirectOn === Constants.REDIRECT_ON_OPTIONS.ALL || locale !== options.defaultLocale || options.strategy !== Constants.STRATEGIES.PREFIX_AND_DEFAULT) {
+      // For "prefix_and_default" strategy prefer the unprefixed route for the default locale.
+      const attemptRedirect = options.strategy === Constants.STRATEGIES.PREFIX_AND_DEFAULT && locale === options.defaultLocale
+      if (!attemptRedirect) {
         return ''
       }
     }

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -176,9 +176,9 @@ export default async (context) => {
     }
 
     if (getLocaleFromRoute(route) === locale) {
-      // For "prefix_and_default" strategy prefer the unprefixed route for the default locale.
-      const attemptRedirect = options.strategy === Constants.STRATEGIES.PREFIX_AND_DEFAULT && locale === options.defaultLocale
-      if (!attemptRedirect) {
+      // We can stop the logic short here unless the strategy is "prefix_and_default" and this is the default
+      // locale in which case we might still redirect as we prefer unprefixed route in this case.
+      if (options.strategy !== Constants.STRATEGIES.PREFIX_AND_DEFAULT || locale !== options.defaultLocale) {
         return ''
       }
     }

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -1091,6 +1091,17 @@ describe('prefix_and_default strategy', () => {
     await expect(get('/fr')).resolves.toContain('page: Accueil')
   })
 
+  test('prefers unprefixed route for default locale', async () => {
+    const requestOptions = {
+      followRedirect: false,
+      resolveWithFullResponse: true,
+      simple: false // Don't reject on non-2xx response
+    }
+    const response = await get('/en/', requestOptions)
+    expect(response.statusCode).toBe(302)
+    expect(response.headers.location).toBe('/')
+  })
+
   test('localeRoute returns localized route (by route name)', async () => {
     const window = await nuxt.renderAndGetWindow(url('/'))
     expect(window.$nuxt.localeRoute('index', 'en')).toMatchObject({ name: 'index___en___default', fullPath: '/' })


### PR DESCRIPTION
That "redirectOn === Constants.REDIRECT_ON_OPTIONS.ALL" seemed a bit
weird. Not sure why we wanted to attempt the redirect when it was not
"ALL".