### PR TITLE
docs: fix default branch name

### DIFF
--- a/docs/content/settings.json
+++ b/docs/content/settings.json
@@ -5,7 +5,7 @@
     "light": "/logo-light.svg",
     "dark": "/logo-dark.svg"
   },
-  "defaultBranch": "master",
+  "defaultBranch": "main",
   "github": "nuxt-community/i18n-module",
   "twitter": "@nuxt_js"
 }


### PR DESCRIPTION
*Edit this page on GitHub* link is leading to 404, because default branch has changed.

Usage: https://content.nuxtjs.org/themes/docs/#properties