### PR TITLE
fix(parse-pages): add jsx plugin for .vue files using jsx syntax

### DIFF
--- a/src/helpers/components.js
+++ b/src/helpers/components.js
@@ -54,7 +54,8 @@ export function extractComponentOptions (component, parseComponent) {
         'dynamicImport',
         'estree',
         'exportDefaultFrom',
-        'typescript'
+        'typescript',
+        'jsx'
       ]
     })
 


### PR DESCRIPTION
### Description

Fix `[nuxt-i18n] Error parsing "nuxtI18n" component option in file` warning when using JSX in `.vue` file.

### What is the purpose of this pull request?

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other