### PR TITLE
fix(docs): correct links to [Custom paths] and [Ignore routes]

### DIFF
--- a/docs/content/en/strategies.md
+++ b/docs/content/en/strategies.md
@@ -13,7 +13,7 @@ With this strategy, your routes won't have a locale prefix added. The locale wil
 
 <alert type="warning">
 
-This strategy doesn't support [Custom paths](#custom-paths) and [Ignore routes](#ignore-routes) features.
+This strategy doesn't support [Custom paths](/custom-paths) and [Ignore routes](/ignoring-localized-routes) features.
 
 </alert>
 


### PR DESCRIPTION
It seems these links are not correct (with anchor, but they are not on this page.)