### PR TITLE
chore: add scripts for releasing -edge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,31 @@ jobs:
         run: yarn workspace @nuxtjs/i18n build
       - name: Testing
         run: yarn test
+  edge-release:
+    needs:
+      - build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [14]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'yarn'
+      - name: yarn install
+        run: yarn --immutable
+      - name: Building
+        run: yarn workspace @nuxtjs/i18n build
+      - name: Release Edge
+        if: |
+          github.event_name == 'push' &&
+          !contains(github.event.head_commit.message, '[skip-release]') &&
+          !contains(github.event.head_commit.message, 'chore') &&
+          !contains(github.event.head_commit.message, 'docs')
+        run: ./scripts/release-edge.sh
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - next
-      - chore/release-edge
   pull_request:
     branches:
       - next
@@ -39,17 +38,13 @@ jobs:
   edge-release:
     needs:
       - build
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        node: [14]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 14
           cache: 'yarn'
       - name: yarn install
         run: yarn --immutable
@@ -63,4 +58,4 @@ jobs:
           !contains(github.event.head_commit.message, 'docs')
         run: ./scripts/release-edge.sh
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NPM_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,4 +63,4 @@ jobs:
           !contains(github.event.head_commit.message, 'docs')
         run: ./scripts/release-edge.sh
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - next
+      - chore/release-edge
   pull_request:
     branches:
       - next

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         if: ${{ matrix.node-version == '16.11' }}
         run: yarn lint
       - name: Building
-        run: yarn workspace @nuxtjs/i18n build
+        run: yarn build
       - name: Testing
         run: yarn test
   edge-release:
@@ -54,7 +54,7 @@ jobs:
       - name: yarn install
         run: yarn --immutable
       - name: Building
-        run: yarn workspace @nuxtjs/i18n build
+        run: yarn build
       - name: Release Edge
         if: |
           github.event_name == 'push' &&

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+# This npmrc is used by CI edge releasing

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-# This npmrc is used by CI edge releasing

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "packageManager": "yarn@3.1.1",
   "resolutions": {
-    "@nuxtjs/i18n": "workspace:./packages/nuxt-i18n"
+    "@nuxtjs/i18n": "npm:@nuxtjs/i18n-edge@latest"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "packageManager": "yarn@3.1.1",
   "resolutions": {
-    "@nuxtjs/i18n": "workspace:./packages/nuxt-i18n"
+    "@nuxtjs/i18n": "workspace:packages/nuxt-i18n"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "packageManager": "yarn@3.1.1",
   "resolutions": {
-    "@nuxtjs/i18n": "npm:@nuxtjs/i18n-edge@latest"
+    "@nuxtjs/i18n": "workspace:./packages/nuxt-i18n"
   },
   "devDependencies": {
     "@types/debug": "^4.1.7",

--- a/scripts/bump-edge.ts
+++ b/scripts/bump-edge.ts
@@ -1,0 +1,111 @@
+import { promises as fsp } from 'fs'
+import { execSync } from 'child_process'
+import { resolve } from 'pathe'
+import { globby } from 'globby'
+
+async function loadPackage(dir: string) {
+  const pkgPath = resolve(dir, 'package.json')
+  const data = JSON.parse(await fsp.readFile(pkgPath, 'utf-8').catch(() => '{}'))
+  const save = () => fsp.writeFile(pkgPath, JSON.stringify(data, null, 2) + '\n')
+
+  const updateDeps = (reviver: Function) => {
+    for (const type of ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies']) {
+      if (!data[type]) {
+        continue
+      }
+      for (const e of Object.entries(data[type])) {
+        const dep = { name: e[0], range: e[1], type }
+        delete data[type][dep.name]
+        const updated = reviver(dep) || dep
+        data[updated.type] = data[updated.type] || {}
+        data[updated.type][updated.name] = updated.range
+      }
+    }
+  }
+
+  return {
+    dir,
+    data,
+    save,
+    updateDeps
+  }
+}
+
+type ThenArg<T> = T extends PromiseLike<infer U> ? U : T
+type Package = ThenArg<ReturnType<typeof loadPackage>>
+
+async function loadWorkspace(dir: string) {
+  const workspacePkg = await loadPackage(dir)
+  const pkgDirs = await globby(workspacePkg.data.workspaces || [], { onlyDirectories: true })
+
+  const packages: Package[] = []
+
+  for (const pkgDir of pkgDirs) {
+    const pkg = await loadPackage(pkgDir)
+    if (!pkg.data.name) {
+      continue
+    }
+    packages.push(pkg)
+  }
+
+  const find = (name: string) => {
+    const pkg = packages.find(pkg => pkg.data.name === name)
+    if (!pkg) {
+      throw new Error('Workspace package not found: ' + name)
+    }
+    return pkg
+  }
+
+  const rename = (from: string, to: string) => {
+    find(from).data.name = to
+    for (const pkg of packages) {
+      pkg.updateDeps(dep => {
+        if (dep.name === from && !dep.range.startsWith('npm:')) {
+          dep.range = 'npm:' + to + '@' + dep.range
+        }
+      })
+    }
+  }
+
+  const setVersion = (name: string, newVersion: string) => {
+    find(name).data.version = newVersion
+    for (const pkg of packages) {
+      pkg.updateDeps(dep => {
+        if (dep.name === name) {
+          dep.range = newVersion
+        }
+      })
+    }
+  }
+
+  const save = () => Promise.all(packages.map(pkg => pkg.save()))
+
+  return {
+    dir,
+    workspacePkg,
+    packages,
+    save,
+    find,
+    rename,
+    setVersion
+  }
+}
+
+async function main() {
+  const workspace = await loadWorkspace(process.cwd())
+
+  const commit = execSync('git rev-parse --short HEAD').toString('utf-8').trim()
+  const date = Math.round(Date.now() / (1000 * 60))
+
+  for (const pkg of workspace.packages.filter(p => !p.data.private)) {
+    workspace.setVersion(pkg.data.name, `${pkg.data.version}-${date}.${commit}`)
+    workspace.rename(pkg.data.name, pkg.data.name + '-edge')
+  }
+
+  await workspace.save()
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/bump-edge.ts
+++ b/scripts/bump-edge.ts
@@ -3,18 +3,20 @@ import { execSync } from 'child_process'
 import { resolve } from 'pathe'
 import { globby } from 'globby'
 
+type Dep = { name: string; range: string; type: string }
+
 async function loadPackage(dir: string) {
   const pkgPath = resolve(dir, 'package.json')
   const data = JSON.parse(await fsp.readFile(pkgPath, 'utf-8').catch(() => '{}'))
   const save = () => fsp.writeFile(pkgPath, JSON.stringify(data, null, 2) + '\n')
 
-  const updateDeps = (reviver: Function) => {
+  const updateDeps = (reviver: (dep: Dep) => Dep | void) => {
     for (const type of ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies']) {
       if (!data[type]) {
         continue
       }
       for (const e of Object.entries(data[type])) {
-        const dep = { name: e[0], range: e[1], type }
+        const dep: Dep = { name: e[0], range: e[1] as string, type }
         delete data[type][dep.name]
         const updated = reviver(dep) || dep
         data[updated.type] = data[updated.type] || {}

--- a/scripts/bump-edge.ts
+++ b/scripts/bump-edge.ts
@@ -67,6 +67,11 @@ async function loadWorkspace(dir: string) {
         }
       })
     }
+    // Update resolutions field in the root package.json.
+    if (workspacePkg.data.resolutions?.hasOwnProperty(from)) {
+      workspacePkg.data.resolutions[to] = workspacePkg.data.resolutions[from]
+      delete workspacePkg.data.resolutions[from]
+    }
   }
 
   const setVersion = (name: string, newVersion: string) => {
@@ -80,7 +85,7 @@ async function loadWorkspace(dir: string) {
     }
   }
 
-  const save = () => Promise.all(packages.map(pkg => pkg.save()))
+  const save = () => Promise.all([...packages.map(pkg => pkg.save()), workspacePkg.save()])
 
   return {
     dir,

--- a/scripts/release-edge.sh
+++ b/scripts/release-edge.sh
@@ -23,6 +23,6 @@ fi
 for p in packages/* ; do
   pushd $p
   echo "Publishing $p"
-  yarn npm publish --access public --tolerate-republish
+  npm publish --access public
   popd
 done

--- a/scripts/release-edge.sh
+++ b/scripts/release-edge.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -xe
+
+# Restore all git changes
+git restore -s@ -SW  -- packages
+
+# Bump versions to edge
+yarn jiti ./scripts/bump-edge
+
+# Resolve yarn
+YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
+
+# Release packages
+# for p in packages/* ; do
+#   pushd $p
+#   echo "Publishing $p"
+#   yarn npm publish --access public --tolerate-republish
+#   popd
+# done
+

--- a/scripts/release-edge.sh
+++ b/scripts/release-edge.sh
@@ -12,10 +12,11 @@ yarn jiti ./scripts/bump-edge
 YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
 
 # Update token
-if [[ ! -z ${NPM_TOKEN} ]] ; then
-  echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+if [[ ! -z ${NODE_AUTH_TOKEN} ]] ; then
+  echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
   echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
   echo "always-auth=true" >> ~/.npmrc
+  echo "npmAuthToken: ${NODE_AUTH_TOKEN}" >> ~/.yarnrc.yml
   npm whoami
 fi
 

--- a/scripts/release-edge.sh
+++ b/scripts/release-edge.sh
@@ -12,10 +12,9 @@ yarn jiti ./scripts/bump-edge
 YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
 
 # Release packages
-# for p in packages/* ; do
-#   pushd $p
-#   echo "Publishing $p"
-#   yarn npm publish --access public --tolerate-republish
-#   popd
-# done
-
+for p in packages/* ; do
+  pushd $p
+  echo "Publishing $p"
+  yarn npm publish --access public --tolerate-republish
+  popd
+done

--- a/scripts/release-edge.sh
+++ b/scripts/release-edge.sh
@@ -12,8 +12,8 @@ yarn jiti ./scripts/bump-edge
 YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
 
 # Update token
-if [[ ! -z ${NODE_AUTH_TOKEN} ]] ; then
-  echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
+if [[ ! -z ${NPM_TOKEN} ]] ; then
+  echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
   echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
   echo "always-auth=true" >> ~/.npmrc
   npm whoami

--- a/scripts/release-edge.sh
+++ b/scripts/release-edge.sh
@@ -11,6 +11,14 @@ yarn jiti ./scripts/bump-edge
 # Resolve yarn
 YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
 
+# Update token
+if [[ ! -z ${NODE_AUTH_TOKEN} ]] ; then
+  echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
+  echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
+  echo "always-auth=true" >> ~/.npmrc
+  npm whoami
+fi
+
 # Release packages
 for p in packages/* ; do
   pushd $p

--- a/scripts/release-edge.sh
+++ b/scripts/release-edge.sh
@@ -3,7 +3,7 @@
 set -xe
 
 # Restore all git changes
-git restore -s@ -SW  -- packages
+git restore --source=HEAD --staged --worktree -- package.json yarn.lock packages
 
 # Bump versions to edge
 yarn jiti ./scripts/bump-edge
@@ -13,9 +13,9 @@ YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
 
 # Update token
 if [[ ! -z ${NODE_AUTH_TOKEN} ]] ; then
-  echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
-  echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
-  echo "always-auth=true" >> ~/.npmrc
+  echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> ./.npmrc
+  echo "registry=https://registry.npmjs.org/" >> ./.npmrc
+  echo "always-auth=true" >> ./.npmrc
   npm whoami
 fi
 

--- a/scripts/release-edge.sh
+++ b/scripts/release-edge.sh
@@ -13,9 +13,9 @@ YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
 
 # Update token
 if [[ ! -z ${NODE_AUTH_TOKEN} ]] ; then
-  echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> ./.npmrc
-  echo "registry=https://registry.npmjs.org/" >> ./.npmrc
-  echo "always-auth=true" >> ./.npmrc
+  echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
+  echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
+  echo "always-auth=true" >> ~/.npmrc
   npm whoami
 fi
 
@@ -23,6 +23,6 @@ fi
 for p in packages/* ; do
   pushd $p
   echo "Publishing $p"
-  npm publish --access public --tolerate-republish
+  yarn npm publish --access public --tolerate-republish
   popd
 done

--- a/scripts/release-edge.sh
+++ b/scripts/release-edge.sh
@@ -12,10 +12,10 @@ yarn jiti ./scripts/bump-edge
 YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
 
 # Update token
-if [[ ! -z ${NODE_AUTH_TOKEN} ]] ; then
-  echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
-  echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
-  echo "always-auth=true" >> ~/.npmrc
+if [[ ! -z ${NPM_TOKEN} ]] ; then
+  echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ./.npmrc
+  echo "registry=https://registry.npmjs.org/" >> ./.npmrc
+  echo "always-auth=true" >> ./.npmrc
   npm whoami
 fi
 

--- a/scripts/release-edge.sh
+++ b/scripts/release-edge.sh
@@ -16,7 +16,6 @@ if [[ ! -z ${NODE_AUTH_TOKEN} ]] ; then
   echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> ~/.npmrc
   echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
   echo "always-auth=true" >> ~/.npmrc
-  echo "npmAuthToken: ${NODE_AUTH_TOKEN}" >> ~/.yarnrc.yml
   npm whoami
 fi
 

--- a/scripts/release-edge.sh
+++ b/scripts/release-edge.sh
@@ -23,6 +23,6 @@ fi
 for p in packages/* ; do
   pushd $p
   echo "Publishing $p"
-  yarn npm publish --access public --tolerate-republish
+  npm publish --access public --tolerate-republish
   popd
 done

--- a/scripts/release-edge.sh
+++ b/scripts/release-edge.sh
@@ -13,9 +13,9 @@ YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install
 
 # Update token
 if [[ ! -z ${NPM_TOKEN} ]] ; then
-  echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ./.npmrc
-  echo "registry=https://registry.npmjs.org/" >> ./.npmrc
-  echo "always-auth=true" >> ./.npmrc
+  echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+  echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
+  echo "always-auth=true" >> ~/.npmrc
   npm whoami
 fi
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,12 +5,12 @@ __metadata:
   version: 5
   cacheKey: 8
 
-"@ampproject/remapping@npm:^2.1.0":
-  version: 2.1.2
-  resolution: "@ampproject/remapping@npm:2.1.2"
+"@ampproject/remapping@npm:^2.0.0":
+  version: 2.1.1
+  resolution: "@ampproject/remapping@npm:2.1.1"
   dependencies:
     "@jridgewell/trace-mapping": ^0.3.0
-  checksum: e023f92cdd9723f3042cde3b4d922adfeef0e198aa73486b0b6c034ad36af5f96e5c0cc72b335b30b2eb9852d907efc92af6bfcd3f4b4d286177ee32a189cf92
+  checksum: cc5cf29833e2b8bdf420821a6e027a35cf6a48605df64ae5095b55cb722581b236554fc8f920138e6da3f7a99ec99273b07ebe2e2bb98b6a4a8d8e33648cac77
   languageName: node
   linkType: hard
 
@@ -32,44 +32,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/compat-data@npm:^7.13.11, @babel/compat-data@npm:^7.16.0, @babel/compat-data@npm:^7.16.4, @babel/compat-data@npm:^7.16.8, @babel/compat-data@npm:^7.17.0":
+"@babel/compat-data@npm:^7.13.11, @babel/compat-data@npm:^7.16.0, @babel/compat-data@npm:^7.16.4, @babel/compat-data@npm:^7.16.8":
   version: 7.17.0
   resolution: "@babel/compat-data@npm:7.17.0"
   checksum: fe5afaf529d107a223cd5937dace248464b6df1e9f4ea4031a5723e9571b46a4db1c4ff226bac6351148b1bc02ba1b39cb142662cd235aa99c1dda77882f8c9d
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.16.0, @babel/core@npm:^7.16.10, @babel/core@npm:^7.16.7, @babel/core@npm:^7.17.2, @babel/core@npm:^7.17.5":
-  version: 7.17.5
-  resolution: "@babel/core@npm:7.17.5"
+"@babel/core@npm:^7.16.0, @babel/core@npm:^7.16.10, @babel/core@npm:^7.16.7, @babel/core@npm:^7.17.2":
+  version: 7.17.2
+  resolution: "@babel/core@npm:7.17.2"
   dependencies:
-    "@ampproject/remapping": ^2.1.0
+    "@ampproject/remapping": ^2.0.0
     "@babel/code-frame": ^7.16.7
-    "@babel/generator": ^7.17.3
+    "@babel/generator": ^7.17.0
     "@babel/helper-compilation-targets": ^7.16.7
     "@babel/helper-module-transforms": ^7.16.7
     "@babel/helpers": ^7.17.2
-    "@babel/parser": ^7.17.3
+    "@babel/parser": ^7.17.0
     "@babel/template": ^7.16.7
-    "@babel/traverse": ^7.17.3
+    "@babel/traverse": ^7.17.0
     "@babel/types": ^7.17.0
     convert-source-map: ^1.7.0
     debug: ^4.1.0
     gensync: ^1.0.0-beta.2
     json5: ^2.1.2
     semver: ^6.3.0
-  checksum: c5e7dddb4feaacb91175d22a6edc8e93804242328a82b80732c6e84a0647bc0a9c9d5b05f3ce13138b8e59bf7aba4ff9f7b7446302f141f243ba51df02c318a5
+  checksum: 68ab3459f41b41feb5cb263937f15e418e1c46998d482d1b6dfe34f78064765466cfd5b10205c22fb16b69dbd1d46e7a3c26c067884ca4eb514b3dac1e09a57f
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.16.8, @babel/generator@npm:^7.17.3":
-  version: 7.17.3
-  resolution: "@babel/generator@npm:7.17.3"
+"@babel/generator@npm:^7.16.8, @babel/generator@npm:^7.17.0":
+  version: 7.17.0
+  resolution: "@babel/generator@npm:7.17.0"
   dependencies:
     "@babel/types": ^7.17.0
     jsesc: ^2.5.1
     source-map: ^0.5.0
-  checksum: ddf70e3489976018dfc2da8b9f43ec8c582cac2da681ed4a6227c53b26a9626223e4dca90098b3d3afe43bc67f20160856240e826c56b48e577f34a5a7e22b9f
+  checksum: 2987dbebb484727a227f1ce3db90810320986cfb3ffd23e6d1d87f75bbd8e7871b5bc44252822d4d5f048a2d872a5702b2a9bf7bab7e07f087d7f306f0ea6c0a
   languageName: node
   linkType: hard
 
@@ -349,12 +349,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.16.10, @babel/parser@npm:^7.16.4, @babel/parser@npm:^7.16.7, @babel/parser@npm:^7.16.8, @babel/parser@npm:^7.17.3":
-  version: 7.17.3
-  resolution: "@babel/parser@npm:7.17.3"
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.16.10, @babel/parser@npm:^7.16.4, @babel/parser@npm:^7.16.7, @babel/parser@npm:^7.16.8, @babel/parser@npm:^7.17.0":
+  version: 7.17.0
+  resolution: "@babel/parser@npm:7.17.0"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 311869baef97c7630ac3b3c4600da18229b95aa2785b2daab2044384745fe0653070916ade28749fb003f7369a081111ada53e37284ba48d6b5858cbb9e411d1
+  checksum: d0ac5ffba0b234dde516f867edf5da5d92d6f841592b370ae3244cd7c8f27a7f5e3e3d4e90ca9c15ea58bc46823f1643f3f75b6eb9a9f676ae16e8b2365e922a
   languageName: node
   linkType: hard
 
@@ -508,17 +508,17 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-proposal-object-rest-spread@npm:^7.16.7":
-  version: 7.17.3
-  resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.17.3"
+  version: 7.16.7
+  resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.16.7"
   dependencies:
-    "@babel/compat-data": ^7.17.0
+    "@babel/compat-data": ^7.16.4
     "@babel/helper-compilation-targets": ^7.16.7
     "@babel/helper-plugin-utils": ^7.16.7
     "@babel/plugin-syntax-object-rest-spread": ^7.8.3
     "@babel/plugin-transform-parameters": ^7.16.7
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 02810f158db4aaf6883131621b5d2c7d901ea3c034df2c2b78663f8b26813795d78a346c37e56770a720c54773732fd1d7fe40947dbf11d1d8de0e9a38e856d3
+  checksum: 2d3740e4df6d3f51d57862100c45c000104571aa98b7f798fdfc05ae0c12b9e7cc9b55f4a28612d626e29f3369a1481a0ee8a0241b23508b9d3da00c55f99d41
   languageName: node
   linkType: hard
 
@@ -859,13 +859,13 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-destructuring@npm:^7.16.7":
-  version: 7.17.3
-  resolution: "@babel/plugin-transform-destructuring@npm:7.17.3"
+  version: 7.16.7
+  resolution: "@babel/plugin-transform-destructuring@npm:7.16.7"
   dependencies:
     "@babel/helper-plugin-utils": ^7.16.7
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: af58115da1b5f1b7aa9c07af8fee53c1db05d2d68be3ba67aae162242d22e5ccd1bcd0fb149fced4618b31c0c6b4f99d32b472567c5f0807586b7fe5216ba7f0
+  checksum: d1c2e15e7be2a7c57ac8ec4df06fbb706c7ecc872ab7bc2193606e6d6a01929b6d5a1bb41540e41180e42a5ce0e70dce22e7896cb6578dd581d554f77780971b
   languageName: node
   linkType: hard
 
@@ -1299,9 +1299,9 @@ __metadata:
   linkType: hard
 
 "@babel/standalone@npm:^7.17.2":
-  version: 7.17.5
-  resolution: "@babel/standalone@npm:7.17.5"
-  checksum: 5fe157dd3f9ede55eca9d477a177e9b824b68e2247bd1c6d49627724e0ee982c793b48f68d7e161ed5ceecc9518c8a2b251ef60820c9a3899a50f40cdd1c3c1f
+  version: 7.17.2
+  resolution: "@babel/standalone@npm:7.17.2"
+  checksum: 14a628bd4866ea5285a0f218dde7f526b8019a55f0f4ae324faf0791257fddeb618d6a6154c91996dcb38d91389a9a7d8c79539bdb6ed846cce3794aac918175
   languageName: node
   linkType: hard
 
@@ -1316,21 +1316,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.0.0, @babel/traverse@npm:^7.13.0, @babel/traverse@npm:^7.16.7, @babel/traverse@npm:^7.16.8, @babel/traverse@npm:^7.17.0, @babel/traverse@npm:^7.17.3":
-  version: 7.17.3
-  resolution: "@babel/traverse@npm:7.17.3"
+"@babel/traverse@npm:^7.0.0, @babel/traverse@npm:^7.13.0, @babel/traverse@npm:^7.16.7, @babel/traverse@npm:^7.16.8, @babel/traverse@npm:^7.17.0":
+  version: 7.17.0
+  resolution: "@babel/traverse@npm:7.17.0"
   dependencies:
     "@babel/code-frame": ^7.16.7
-    "@babel/generator": ^7.17.3
+    "@babel/generator": ^7.17.0
     "@babel/helper-environment-visitor": ^7.16.7
     "@babel/helper-function-name": ^7.16.7
     "@babel/helper-hoist-variables": ^7.16.7
     "@babel/helper-split-export-declaration": ^7.16.7
-    "@babel/parser": ^7.17.3
+    "@babel/parser": ^7.17.0
     "@babel/types": ^7.17.0
     debug: ^4.1.0
     globals: ^11.1.0
-  checksum: 780d7ecf711758174989794891af08d378f81febdb8932056c0d9979524bf0298e28f8e7708a872d7781151506c28f56c85c63ea3f1f654662c2fcb8a3eb9fdc
+  checksum: 9b7de053d8a29453fd7b9614a028d8dc811817f02948eaee02093274b67927a1cfb0513b521bc4a9328c9b6e5b021fd343b358c3526bbb6ee61ec078d4110c0c
   languageName: node
   linkType: hard
 
@@ -1360,18 +1360,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@csstools/postcss-color-function@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "@csstools/postcss-color-function@npm:1.0.2"
-  dependencies:
-    "@csstools/postcss-progressive-custom-properties": ^1.1.0
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.4
-  checksum: 0fc5c8924dbffca13307038e3363b4e75bd3f32769907b13309d7170c3ab0716ee9e7f7c7a4c4f972ddc6f1e2b4103f910f465a250062fdce5aef1fcd9579610
-  languageName: node
-  linkType: hard
-
 "@csstools/postcss-font-format-keywords@npm:^1.0.0":
   version: 1.0.0
   resolution: "@csstools/postcss-font-format-keywords@npm:1.0.0"
@@ -1391,18 +1379,6 @@ __metadata:
   peerDependencies:
     postcss: ^8.3
   checksum: 7d91ae87d40ece32d57f0fc0c777ff9256bb85c609e2c5e812dc9d9ea98688ea959c3d94b296f69135e99822db361ac447cb7f398a2daeebcc0203d0ee5961c9
-  languageName: node
-  linkType: hard
-
-"@csstools/postcss-ic-unit@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@csstools/postcss-ic-unit@npm:1.0.0"
-  dependencies:
-    "@csstools/postcss-progressive-custom-properties": ^1.1.0
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.3
-  checksum: d194b13a66027558d2d0dd3be3b795167b5e751bb3a3e62928c77ef1c524f0d672a7658852f07e589abbb64e827096eac00d9b6d7ec79e21006fd4f6f0b3ce87
   languageName: node
   linkType: hard
 
@@ -1428,26 +1404,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@csstools/postcss-oklab-function@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@csstools/postcss-oklab-function@npm:1.0.1"
-  dependencies:
-    "@csstools/postcss-progressive-custom-properties": ^1.1.0
-    postcss-value-parser: ^4.2.0
-  peerDependencies:
-    postcss: ^8.4
-  checksum: 2de8f679a2ceccfa6c65cd349b8548a9c38627dfdcbde0cbbdaa82be6181bb63924ccdaac9fcbc2173be867e4f251eafbfe2af574ed79180de607809abdb45c2
-  languageName: node
-  linkType: hard
-
-"@csstools/postcss-progressive-custom-properties@npm:^1.1.0, @csstools/postcss-progressive-custom-properties@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "@csstools/postcss-progressive-custom-properties@npm:1.2.0"
+"@csstools/postcss-progressive-custom-properties@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@csstools/postcss-progressive-custom-properties@npm:1.1.0"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
     postcss: ^8.3
-  checksum: 879fc52e8c55c8a4539fdf34f92d4a85f06d83d4d38d0a707061b13522b915f41d531a410092a2993e185094d5cba1c5d1612d123f60641dd44b7f5bc516c92d
+  checksum: d8bb27f1fd83d3b5f3740cd9c85063c63178c765acf4af59cef62f5af90c46f49e5048a37e274f614cfd6b37c4d653a43b67ffb391fde306829997936bc76a24
   languageName: node
   linkType: hard
 
@@ -1469,9 +1433,9 @@ __metadata:
   linkType: hard
 
 "@gar/promisify@npm:^1.0.1":
-  version: 1.1.3
-  resolution: "@gar/promisify@npm:1.1.3"
-  checksum: 4059f790e2d07bf3c3ff3e0fec0daa8144fe35c1f6e0111c9921bd32106adaa97a4ab096ad7dab1e28ee6a9060083c4d1a4ada42a7f5f3f7a96b8812e2b757c1
+  version: 1.1.2
+  resolution: "@gar/promisify@npm:1.1.2"
+  checksum: d05081e0887a49c178b75ee3067bd6ee086f73c154d121b854fb2e044e8a89cb1cbb6de3a0dd93a519b80f0531fda68b099dd7256205f7fbb3490324342f2217
   languageName: node
   linkType: hard
 
@@ -1680,20 +1644,11 @@ __metadata:
   linkType: hard
 
 "@netlify/functions@npm:^0.11.0":
-  version: 0.11.1
-  resolution: "@netlify/functions@npm:0.11.1"
+  version: 0.11.0
+  resolution: "@netlify/functions@npm:0.11.0"
   dependencies:
     is-promise: ^4.0.0
-  checksum: 760f7e042b054314203ed4503ce674c973c5fe939c56811a0c4376525ff7fe4da46dbf3a8e611b81124d8c231e848e7f468969ba6d53ffdde187f8dc415c3f99
-  languageName: node
-  linkType: hard
-
-"@netlify/functions@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@netlify/functions@npm:1.0.0"
-  dependencies:
-    is-promise: ^4.0.0
-  checksum: 1e3c234f14fd2fe8f46cae9336679054bf067b60217ee1c424adec1b1d1e4208eeaacb3401c48b625fe057df56f5dc553b961d4758f53bb0eae6f5b78d6385ad
+  checksum: 87bb43fb5f5e893e3495842384086b2565f24c5872ae38f5afc4756314b2aa58cc937b442e51264cf2c17735700c53676e3ebc2861cdb9eec78a89ffa6cc3ef5
   languageName: node
   linkType: hard
 
@@ -2017,17 +1972,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nuxt/kit@npm:@nuxt/kit-edge@3.0.0-27420403.16e2a54":
-  version: 3.0.0-27420403.16e2a54
-  resolution: "@nuxt/kit-edge@npm:3.0.0-27420403.16e2a54"
+"@nuxt/kit@npm:@nuxt/kit-edge@3.0.0-27409835.c53c736":
+  version: 3.0.0-27409835.c53c736
+  resolution: "@nuxt/kit-edge@npm:3.0.0-27409835.c53c736"
   dependencies:
-    "@nuxt/schema": "npm:@nuxt/schema-edge@3.0.0-27420403.16e2a54"
+    "@nuxt/schema": "npm:@nuxt/schema-edge@3.0.0-27409835.c53c736"
     c12: ^0.1.3
     consola: ^2.15.3
     defu: ^5.0.1
     globby: ^13.1.1
     hash-sum: ^2.0.0
-    jiti: ^1.13.0
+    jiti: ^1.12.15
     knitwork: ^0.1.0
     lodash.template: ^4.5.0
     mlly: ^0.4.3
@@ -2037,7 +1992,7 @@ __metadata:
     semver: ^7.3.5
     unctx: ^1.0.2
     untyped: ^0.3.0
-  checksum: 6b6b89ac170f21b133f6381538e77d0c3a5c1fa118d7a9305c656d2ed7c3530bcf8aa97d247b9ff0e9721765a9628b9859b629206e82d6e7a2cac4e2585610d1
+  checksum: 5593d05cf54e85740a5207e5b0fe327971c0fc013e8ca8e5e751e6ec6227b157bc109ef5a7e339166dd776b5eef173669de34295d05133fa9b23161a09c53f2e
   languageName: node
   linkType: hard
 
@@ -2135,21 +2090,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nuxt/nitro@npm:@nuxt/nitro-edge@3.0.0-27420403.16e2a54":
-  version: 3.0.0-27420403.16e2a54
-  resolution: "@nuxt/nitro-edge@npm:3.0.0-27420403.16e2a54"
+"@nuxt/nitro@npm:@nuxt/nitro-edge@3.0.0-27409835.c53c736":
+  version: 3.0.0-27409835.c53c736
+  resolution: "@nuxt/nitro-edge@npm:3.0.0-27409835.c53c736"
   dependencies:
     "@cloudflare/kv-asset-handler": ^0.2.0
-    "@netlify/functions": ^1.0.0
+    "@netlify/functions": ^0.11.0
     "@nuxt/design": 0.1.5
     "@nuxt/devalue": ^2.0.0
-    "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27420403.16e2a54"
+    "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27409835.c53c736"
     "@rollup/plugin-alias": ^3.1.9
     "@rollup/plugin-commonjs": ^21.0.1
     "@rollup/plugin-inject": ^4.0.4
     "@rollup/plugin-json": ^4.1.0
     "@rollup/plugin-node-resolve": ^13.1.3
-    "@rollup/plugin-replace": ^3.1.0
+    "@rollup/plugin-replace": ^3.0.1
     "@rollup/plugin-virtual": ^2.0.3
     "@rollup/plugin-wasm": ^5.1.2
     "@rollup/pluginutils": ^4.1.2
@@ -2162,8 +2117,8 @@ __metadata:
     consola: ^2.15.3
     defu: ^5.0.1
     destr: ^1.1.0
-    dot-prop: ^7.2.0
-    esbuild: ^0.14.22
+    dot-prop: ^7.1.1
+    esbuild: ^0.14.21
     etag: ^1.8.1
     fs-extra: ^10.0.0
     globby: ^13.1.1
@@ -2173,7 +2128,7 @@ __metadata:
     hookable: ^5.1.1
     http-proxy: ^1.18.1
     is-primitive: ^3.0.1
-    jiti: ^1.13.0
+    jiti: ^1.12.15
     knitwork: ^0.1.0
     listhen: ^0.2.6
     mime: ^3.0.0
@@ -2184,8 +2139,8 @@ __metadata:
     p-debounce: ^4.0.0
     pathe: ^0.2.0
     pkg-types: ^0.3.2
-    pretty-bytes: ^6.0.0
-    rollup: ^2.67.3
+    pretty-bytes: ^5.6.0
+    rollup: ^2.67.2
     rollup-plugin-terser: ^7.0.2
     rollup-plugin-visualizer: ^5.5.4
     serve-placeholder: ^1.2.4
@@ -2197,7 +2152,7 @@ __metadata:
     unstorage: ^0.3.3
     vue-bundle-renderer: ^0.3.5
     vue-server-renderer: ^2.6.14
-  checksum: c41971e8fada51c57142920beb56558c5df7802d8cb416242d047a15400721b3d7263403d4e8e5e7ccddb2ddb1085e636521eb683f0b3a13bd4718ff79cb010a
+  checksum: ee9294d85df55995b1f5ddfba8639d5abc3b3d91fe5925215e655beed6d3a33f9e7a025ec22152a804d85e9333b0544cafd22dde26c1c152ea9b44f66e47e3de
   languageName: node
   linkType: hard
 
@@ -2262,19 +2217,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nuxt/schema@npm:@nuxt/schema-edge@3.0.0-27420403.16e2a54":
-  version: 3.0.0-27420403.16e2a54
-  resolution: "@nuxt/schema-edge@npm:3.0.0-27420403.16e2a54"
+"@nuxt/schema@npm:@nuxt/schema-edge@3.0.0-27409835.c53c736":
+  version: 3.0.0-27409835.c53c736
+  resolution: "@nuxt/schema-edge@npm:3.0.0-27409835.c53c736"
   dependencies:
     c12: ^0.1.3
     create-require: ^1.1.1
     defu: ^5.0.1
-    jiti: ^1.13.0
+    jiti: ^1.12.15
     pathe: ^0.2.0
     scule: ^0.2.1
     std-env: ^3.0.1
     ufo: ^0.7.9
-  checksum: 77502c422ce68c3388d4384b3c0946107d5b4dad0f93b7d98c3bc3cb4263e59292226b9f62fccb7817bd3bedfb12092e0b61ce312eab4aeb811ac6e6cc126608
+  checksum: 51937809936db85e712efe8a29960900644a59cbb463f167bd605531a1dff855116d770ae725b491dd48b47713c67b61c5f974a0176a7932c3823a1a5c84c9eb
   languageName: node
   linkType: hard
 
@@ -2392,17 +2347,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nuxt/vite-builder@npm:@nuxt/vite-builder-edge@3.0.0-27420403.16e2a54":
-  version: 3.0.0-27420403.16e2a54
-  resolution: "@nuxt/vite-builder-edge@npm:3.0.0-27420403.16e2a54"
+"@nuxt/vite-builder@npm:@nuxt/vite-builder-edge@3.0.0-27409835.c53c736":
+  version: 3.0.0-27409835.c53c736
+  resolution: "@nuxt/vite-builder-edge@npm:3.0.0-27409835.c53c736"
   dependencies:
-    "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27420403.16e2a54"
-    "@vitejs/plugin-vue": ^2.2.2
-    "@vitejs/plugin-vue-jsx": ^1.3.7
+    "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27409835.c53c736"
+    "@vitejs/plugin-vue": ^2.2.0
+    "@vitejs/plugin-vue-jsx": ^1.3.4
     autoprefixer: ^10.4.2
     chokidar: ^3.5.3
+    consola: ^2.15.3
     defu: ^5.0.1
-    esbuild: ^0.14.22
+    esbuild: ^0.14.21
     escape-string-regexp: ^5.0.0
     externality: ^0.1.6
     fs-extra: ^10.0.0
@@ -2418,10 +2374,10 @@ __metadata:
     rollup-plugin-visualizer: ^5.5.4
     ufo: ^0.7.9
     unplugin: ^0.3.2
-    vite: ^2.8.4
+    vite: ^2.8.0
   peerDependencies:
-    vue: 3.2.31
-  checksum: 549c74d95efa1a3dad3388e520fca86b2085019c9edbca0489af3e98f92b42bf1158e43d608a28c919758a0daa0b99879413bab6a645d45bfe03fdc08a390db7
+    vue: 3.2.30
+  checksum: 0541ede8db56e92777c1741a40aad027ddcdd40e7f9d0d6814bd35eb921df1ad1d55e25d74698f13dec433806c85b828c480a0602d04045bd60f77786971d805
   languageName: node
   linkType: hard
 
@@ -2462,16 +2418,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nuxt/webpack-builder@npm:@nuxt/webpack-builder-edge@3.0.0-27420403.16e2a54":
-  version: 3.0.0-27420403.16e2a54
-  resolution: "@nuxt/webpack-builder-edge@npm:3.0.0-27420403.16e2a54"
+"@nuxt/webpack-builder@npm:@nuxt/webpack-builder-edge@3.0.0-27409835.c53c736":
+  version: 3.0.0-27409835.c53c736
+  resolution: "@nuxt/webpack-builder-edge@npm:3.0.0-27409835.c53c736"
   dependencies:
-    "@babel/core": ^7.17.5
+    "@babel/core": ^7.17.2
     "@nuxt/friendly-errors-webpack-plugin": ^2.5.2
-    "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27420403.16e2a54"
+    "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27409835.c53c736"
     "@vue/babel-preset-jsx": ^1.2.4
     autoprefixer: ^10.4.2
     babel-loader: ^8.2.3
+    consola: ^2.15.3
     css-loader: ^6.6.0
     css-minimizer-webpack-plugin: ^3.4.1
     cssnano: ^5.0.17
@@ -2499,15 +2456,15 @@ __metadata:
     url-loader: ^4.1.1
     vue-loader: ^17.0.0
     vue-style-loader: ^4.1.3
-    webpack: ^5.69.1
+    webpack: ^5.68.0
     webpack-bundle-analyzer: ^4.5.0
     webpack-dev-middleware: ^5.3.1
     webpack-hot-middleware: ^2.25.1
     webpack-virtual-modules: ^0.4.3
     webpackbar: ^5.0.2
   peerDependencies:
-    vue: 3.2.31
-  checksum: 352a123ab17a030806cf34a995f6558c1426763d6043c7db3c30c36a77cd660ecec610838822dc63049bb2b10ff787173b7a244917106f10337c976fb9cda415
+    vue: 3.2.30
+  checksum: e2b4985d58e5bd83803e82a5b807b152c1b17d80dba3035f212d097b64cd2bbd795348f2a8c67c6b7dfaa53b0fdaa08f88ed0605ec189947494fdeccd38a99b6
   languageName: node
   linkType: hard
 
@@ -2703,7 +2660,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/plugin-replace@npm:^3.0.1, @rollup/plugin-replace@npm:^3.1.0":
+"@rollup/plugin-replace@npm:^3.0.1":
   version: 3.1.0
   resolution: "@rollup/plugin-replace@npm:3.1.0"
   dependencies:
@@ -2907,7 +2864,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint-scope@npm:^3.7.3":
+"@types/eslint-scope@npm:^3.7.0":
   version: 3.7.3
   resolution: "@types/eslint-scope@npm:3.7.3"
   dependencies:
@@ -2927,7 +2884,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*, @types/estree@npm:^0.0.51":
+"@types/estree@npm:*":
   version: 0.0.51
   resolution: "@types/estree@npm:0.0.51"
   checksum: e56a3bcf759fd9185e992e7fdb3c6a5f81e8ff120e871641607581fb3728d16c811702a7d40fa5f869b7f7b4437ab6a87eb8d98ffafeee51e85bbe955932a189
@@ -2938,6 +2895,13 @@ __metadata:
   version: 0.0.39
   resolution: "@types/estree@npm:0.0.39"
   checksum: 412fb5b9868f2c418126451821833414189b75cc6bf84361156feed733e3d92ec220b9d74a89e52722e03d5e241b2932732711b7497374a404fad49087adc248
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:^0.0.50":
+  version: 0.0.50
+  resolution: "@types/estree@npm:0.0.50"
+  checksum: 9a2b6a4a8c117f34d08fbda5e8f69b1dfb109f7d149b60b00fd7a9fb6ac545c078bc590aa4ec2f0a256d680cf72c88b3b28b60c326ee38a7bc8ee1ee95624922
   languageName: node
   linkType: hard
 
@@ -3049,9 +3013,9 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 17.0.18
-  resolution: "@types/node@npm:17.0.18"
-  checksum: 6c4edfc2b3ba2342a9c3d56e934c5245948ab752f4dc04bd6790b9603e6ebc53bc4f5befc3662e207f7dba2ddd17ccf657f915e319ea7cdd4f77b851079d1611
+  version: 17.0.17
+  resolution: "@types/node@npm:17.0.17"
+  checksum: 8ddba2829acdf1684fbd8fd248ec13f033efb70ecd1085677b547c40ef8e936a006b95eac3bdc28c47939c62526f3f027afeb4a930e30e4394923bbae4626476
   languageName: node
   linkType: hard
 
@@ -3294,12 +3258,12 @@ __metadata:
   linkType: hard
 
 "@typescript-eslint/eslint-plugin@npm:^5.8.0":
-  version: 5.12.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:5.12.0"
+  version: 5.11.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:5.11.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 5.12.0
-    "@typescript-eslint/type-utils": 5.12.0
-    "@typescript-eslint/utils": 5.12.0
+    "@typescript-eslint/scope-manager": 5.11.0
+    "@typescript-eslint/type-utils": 5.11.0
+    "@typescript-eslint/utils": 5.11.0
     debug: ^4.3.2
     functional-red-black-tree: ^1.0.1
     ignore: ^5.1.8
@@ -3312,42 +3276,42 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: ac7074b51456748ef8770d82f5b4e691e1b93bb1353b448bb1b43db5b5a9722a6a012dc1dc0a3b35ab0c0ca7c1b5412f535ad992115132ed84ed6f4179778d37
+  checksum: fa546ba4397f3e693870c39d1e8df6feccb728a7092be6312b78806a64c4ff4648cff0462503d3e510e8b173b9704c19e78d2a7af790ab1c0309782e33a89c32
   languageName: node
   linkType: hard
 
 "@typescript-eslint/parser@npm:^5.8.0":
-  version: 5.12.0
-  resolution: "@typescript-eslint/parser@npm:5.12.0"
+  version: 5.11.0
+  resolution: "@typescript-eslint/parser@npm:5.11.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 5.12.0
-    "@typescript-eslint/types": 5.12.0
-    "@typescript-eslint/typescript-estree": 5.12.0
+    "@typescript-eslint/scope-manager": 5.11.0
+    "@typescript-eslint/types": 5.11.0
+    "@typescript-eslint/typescript-estree": 5.11.0
     debug: ^4.3.2
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 0453c14d967ebba4ebe0d763882b7a1258f23a710d127f53196d360b78722d880cc8c0299feb52ecc4e10600834c22559bf543211249d878efad864f7ec856bc
+  checksum: 521b6e701d877dc0514c6a3992f4900aa6fea28ba7c0bc03c634dad2b50aa195401e45683dfebd9e8492a857cd84bba3b585d8fe8d0cd1d7e2720372c34c50a3
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:5.12.0":
-  version: 5.12.0
-  resolution: "@typescript-eslint/scope-manager@npm:5.12.0"
+"@typescript-eslint/scope-manager@npm:5.11.0":
+  version: 5.11.0
+  resolution: "@typescript-eslint/scope-manager@npm:5.11.0"
   dependencies:
-    "@typescript-eslint/types": 5.12.0
-    "@typescript-eslint/visitor-keys": 5.12.0
-  checksum: 87cc4e8ab3b495293e51685566cafca6f217c7328fc1210e4a9c3a89e864c5e3a04ddde11708e07820185fd158cb448980607a93fd658fa2089c152f27a847d0
+    "@typescript-eslint/types": 5.11.0
+    "@typescript-eslint/visitor-keys": 5.11.0
+  checksum: bf7feaed495ed4cafa1b89a2b73781b30061d019e1c1b3765dc8006e7f36b537f6f451e37c77400067771318b4f0c5915804084dc6299ea7c6ecde2daf0aca1c
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:5.12.0":
-  version: 5.12.0
-  resolution: "@typescript-eslint/type-utils@npm:5.12.0"
+"@typescript-eslint/type-utils@npm:5.11.0":
+  version: 5.11.0
+  resolution: "@typescript-eslint/type-utils@npm:5.11.0"
   dependencies:
-    "@typescript-eslint/utils": 5.12.0
+    "@typescript-eslint/utils": 5.11.0
     debug: ^4.3.2
     tsutils: ^3.21.0
   peerDependencies:
@@ -3355,23 +3319,23 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 90390603319441493b62611730db78f8a732e32a5d9097d1e9c6581da6caeb71cc08a3ed6c716f2fc490b153f956c9a2471d9fbe97c22214ca86f58511c7581a
+  checksum: fd570806d82874289ded6bfd90ff5414d4365b95b4a2e911f7ff2fee6e2c7675d0f2f71580c24cb8be733c3dfe2cd33eedff99ae2aa50f61b1b5af76499074eb
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:5.12.0":
-  version: 5.12.0
-  resolution: "@typescript-eslint/types@npm:5.12.0"
-  checksum: f5e7f8270cb0f9f18886bf00f8f1fd589b793f4c05dc2de53cc826beb969161e19ffc10f51237402fb9f3d24f5aaf3bb41b1d8da70e115ec3ff11e79b3471988
+"@typescript-eslint/types@npm:5.11.0":
+  version: 5.11.0
+  resolution: "@typescript-eslint/types@npm:5.11.0"
+  checksum: b1531481da75a6c89510ad03f3db68e4797b25438bb902ee322bd1c154b83396016271cc00356dcdbc300a8ee421493aae803b8c716f36d7b4808fe045ae3a2a
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:5.12.0":
-  version: 5.12.0
-  resolution: "@typescript-eslint/typescript-estree@npm:5.12.0"
+"@typescript-eslint/typescript-estree@npm:5.11.0":
+  version: 5.11.0
+  resolution: "@typescript-eslint/typescript-estree@npm:5.11.0"
   dependencies:
-    "@typescript-eslint/types": 5.12.0
-    "@typescript-eslint/visitor-keys": 5.12.0
+    "@typescript-eslint/types": 5.11.0
+    "@typescript-eslint/visitor-keys": 5.11.0
     debug: ^4.3.2
     globby: ^11.0.4
     is-glob: ^4.0.3
@@ -3380,33 +3344,33 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 6a8e852c210b20370eb564f3beb245c425e65a4de3e78a1e2f278a241b6acf72ba43b10767df18fc1654b529453529f721fa673569406ace4011712c9c837900
+  checksum: 7bda55501c586efd7f8065b4158016486d8af92b8419931fbea7cec9bfe074075de8cdebec8baa1ac8a5c3f973599b9dd44a51fced1792176e49cd60cc8e5442
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:5.12.0":
-  version: 5.12.0
-  resolution: "@typescript-eslint/utils@npm:5.12.0"
+"@typescript-eslint/utils@npm:5.11.0":
+  version: 5.11.0
+  resolution: "@typescript-eslint/utils@npm:5.11.0"
   dependencies:
     "@types/json-schema": ^7.0.9
-    "@typescript-eslint/scope-manager": 5.12.0
-    "@typescript-eslint/types": 5.12.0
-    "@typescript-eslint/typescript-estree": 5.12.0
+    "@typescript-eslint/scope-manager": 5.11.0
+    "@typescript-eslint/types": 5.11.0
+    "@typescript-eslint/typescript-estree": 5.11.0
     eslint-scope: ^5.1.1
     eslint-utils: ^3.0.0
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-  checksum: 34c394db0510be78c5cbb8928c9eb81405a117dd9e5903a149e4f3c20218dcda89a29e5012984d07c8ce9e5c7f5d7c38f5c3061558028f3f518ac98bbeb9a006
+  checksum: 5ab1a15db1e0a2fbb857a8a16325459ad3d5239066f2641aa93ad9f7d08252d3a4ca6ae356c51cba1c6c81a65d84883436566b01932fa55b64a69796b950900d
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:5.12.0":
-  version: 5.12.0
-  resolution: "@typescript-eslint/visitor-keys@npm:5.12.0"
+"@typescript-eslint/visitor-keys@npm:5.11.0":
+  version: 5.11.0
+  resolution: "@typescript-eslint/visitor-keys@npm:5.11.0"
   dependencies:
-    "@typescript-eslint/types": 5.12.0
+    "@typescript-eslint/types": 5.11.0
     eslint-visitor-keys: ^3.0.0
-  checksum: c3774f542aae801926edf86fe6cab534c4cdac914b035730912443ed53fcc701b0f0e7b1a0d5fc959484637c55f63409fc43df5508c334e202d66d4654484d11
+  checksum: 8f0b6fe1e86bc93825a137be3220f57e3a4bee410cca5d35963a0cd416750b31291a73c4294676d94ed0f5066b4cfb3a8f512d409881daa550d1645f4381eb21
   languageName: node
   linkType: hard
 
@@ -3446,9 +3410,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-vue-jsx@npm:^1.3.7":
-  version: 1.3.7
-  resolution: "@vitejs/plugin-vue-jsx@npm:1.3.7"
+"@vitejs/plugin-vue-jsx@npm:^1.3.4":
+  version: 1.3.5
+  resolution: "@vitejs/plugin-vue-jsx@npm:1.3.5"
   dependencies:
     "@babel/core": ^7.17.2
     "@babel/plugin-syntax-import-meta": ^7.10.4
@@ -3456,17 +3420,17 @@ __metadata:
     "@rollup/pluginutils": ^4.1.2
     "@vue/babel-plugin-jsx": ^1.1.1
     hash-sum: ^2.0.0
-  checksum: 2cb2969becfb33e6ff1f9e3b06c756be5a3f85bd24e222b6e0511866425701a2678db0ecc8826e4aa1749e71339ebd152e5c65c9521eb2d6f589d116b40baff6
+  checksum: 0b4ce6cfe61e13cc6fa87a5cdf298389707ccee45d2030d4ad952d5f9cf7a3fdb743bf39ef3c8c6335386eaa6912e00cd18fe6daf625f3bc0e0796727ab7a473
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-vue@npm:^2.2.2":
-  version: 2.2.2
-  resolution: "@vitejs/plugin-vue@npm:2.2.2"
+"@vitejs/plugin-vue@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@vitejs/plugin-vue@npm:2.2.0"
   peerDependencies:
     vite: ^2.5.10
     vue: ^3.2.25
-  checksum: f05920e282569c3721dbbd730c83e40978134c0f53cd10f9429cc37b22152c494782f7b9541db937a2fd7ed324b819ec8aa0b54f136c3c6adbed7298c9c9e9da
+  checksum: ab3e3c77c251eada60c8394f8cdce67430a7efdf9f8f7d98bbfc98dd1915c639db43228a2a95d5d43e41acc54a65573169ae23044e848a36c1e8bf609fe41acf
   languageName: node
   linkType: hard
 
@@ -3688,9 +3652,9 @@ __metadata:
   linkType: hard
 
 "@vue/devtools-api@npm:^6.0.0-beta.13, @vue/devtools-api@npm:^6.0.0-beta.18":
-  version: 6.0.12
-  resolution: "@vue/devtools-api@npm:6.0.12"
-  checksum: 5eb4601a6f6601c4481eab54c7f05f8e373ac3f2b5ab6973847a47e7ddbec7a9d2cd80dc692905da9e8615ac64a208702c54f7dfac47f7aa2168a5b7dd176545
+  version: 6.0.8
+  resolution: "@vue/devtools-api@npm:6.0.8"
+  checksum: 4601fad607538af52962636eb6045b22e71cf17578ef835c836c58d76c3f2778c2960d10645ed782c39a39a8881e5e763a6cc32536b973aac913fbb248b19632
   languageName: node
   linkType: hard
 
@@ -3707,7 +3671,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/reactivity@npm:3.2.31, @vue/reactivity@npm:^3.2.31":
+"@vue/reactivity@npm:3.2.31, @vue/reactivity@npm:^3.2.30":
   version: 3.2.31
   resolution: "@vue/reactivity@npm:3.2.31"
   dependencies:
@@ -3749,7 +3713,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/shared@npm:3.2.31, @vue/shared@npm:^3.2.26, @vue/shared@npm:^3.2.31":
+"@vue/shared@npm:3.2.31, @vue/shared@npm:^3.2.26, @vue/shared@npm:^3.2.30":
   version: 3.2.31
   resolution: "@vue/shared@npm:3.2.31"
   checksum: bf614d9d06f7c01fbe3f5f50d8f7621fffd83d2eebd6c2ccf540c59754283d3b659aa93f7d610ed4c16284a4d5208ef5aec12337f2d4d0ab05e9a271cd4a2051
@@ -4951,17 +4915,17 @@ __metadata:
   linkType: hard
 
 "browserslist@npm:^4.0.0, browserslist@npm:^4.12.0, browserslist@npm:^4.14.5, browserslist@npm:^4.16.6, browserslist@npm:^4.17.5, browserslist@npm:^4.19.1, browserslist@npm:^4.6.4":
-  version: 4.19.3
-  resolution: "browserslist@npm:4.19.3"
+  version: 4.19.1
+  resolution: "browserslist@npm:4.19.1"
   dependencies:
-    caniuse-lite: ^1.0.30001312
-    electron-to-chromium: ^1.4.71
+    caniuse-lite: ^1.0.30001286
+    electron-to-chromium: ^1.4.17
     escalade: ^3.1.1
-    node-releases: ^2.0.2
+    node-releases: ^2.0.1
     picocolors: ^1.0.0
   bin:
     browserslist: cli.js
-  checksum: c28958313dd17f345dd6e26379cc863126cd7d855588e57a1ed9e552a1135d64f05ec57063b48fff0d94a9b785bd248e9472c2d63ce8460ca56fc2444f5a1e66
+  checksum: c0777fd483691638fd6801e16c9d809e1d65f6d2b06db2e806654be51045cbab1452a89841a2c5caea2cbe19d621b4f1d391cffbb24512aa33280039ab345875
   languageName: node
   linkType: hard
 
@@ -5239,7 +5203,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000981, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001275, caniuse-lite@npm:^1.0.30001297, caniuse-lite@npm:^1.0.30001312":
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000981, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001275, caniuse-lite@npm:^1.0.30001286, caniuse-lite@npm:^1.0.30001297":
   version: 1.0.30001312
   resolution: "caniuse-lite@npm:1.0.30001312"
   checksum: 753fb9ea1e02e999430b323a71b5acab5120f3b5fc0161b01669f54a3ef5c5296240b6ae9b79b12a3742e3aed216aa9ee3d5398a23c16d08625ccd376b79545d
@@ -5836,19 +5800,19 @@ __metadata:
   linkType: hard
 
 "core-js-compat@npm:^3.19.1, core-js-compat@npm:^3.20.2, core-js-compat@npm:^3.21.0":
-  version: 3.21.1
-  resolution: "core-js-compat@npm:3.21.1"
+  version: 3.21.0
+  resolution: "core-js-compat@npm:3.21.0"
   dependencies:
     browserslist: ^4.19.1
     semver: 7.0.0
-  checksum: 6af1bcbc94ede50b109e54bf3f5a9ca28b8a303124e07c2bf76c2257a8a94a0b550cf4a318f6ec0594b351b6f9a5453fd4516e3681560b6d984b95d1988baf13
+  checksum: 7914d2f8a2f7c1b400e1c04c7560f4c96028bf23cec3cea6063ba594e38023cccbd38ad88af41c5d6b65450e97a989eb37598f609e3f7fbc6ebc1856d4195cbb
   languageName: node
   linkType: hard
 
 "core-js@npm:^3.15.1, core-js@npm:^3.19.0, core-js@npm:^3.21.0":
-  version: 3.21.1
-  resolution: "core-js@npm:3.21.1"
-  checksum: d68eddd831340ad5b24ac29c72fda022a43b17f194c4278b6b875a843283d316502cb4abd07f28631d6ebc4387f66aa06e2b1b3c8fd7e08096a751b5c63f6889
+  version: 3.21.0
+  resolution: "core-js@npm:3.21.0"
+  checksum: 87df49aa2c5d0a521c52102b6669842dd30b334742e86dd4e0173c51230bc48d610060ab6de0f149766d188325b8c1b84598f901cf455674fe6c03ccc5c8026f
   languageName: node
   linkType: hard
 
@@ -6295,10 +6259,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssdb@npm:^6.3.1":
-  version: 6.4.0
-  resolution: "cssdb@npm:6.4.0"
-  checksum: 9daed448f2414b31080fe8e6ed6812584254bbfa540589116fc62dfba6719adbfdf552883e4c789dd4124e9697f7b8cd3f3149aeaca3c1e5bd4a3c4bff38d36f
+"cssdb@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "cssdb@npm:6.3.0"
+  checksum: 8c76e4c63ce0399b3a2ce0620c6d23e63cf08429f71a8371214b423030bc0c8654043aa220d90beefc90fa4bdc83c461a96ff4a8831f706549cbfa87f7481a0a
   languageName: node
   linkType: hard
 
@@ -6859,12 +6823,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dot-prop@npm:^7.1.1, dot-prop@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "dot-prop@npm:7.2.0"
+"dot-prop@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "dot-prop@npm:7.1.1"
   dependencies:
-    type-fest: ^2.11.2
-  checksum: 08e4ff14f7305ffb5fda7e4c88f3cdbeb3cd97bd27efa4f47503869a2ee7f96938b4c21b0a2abf9c37d891a1bdb3994a09d219b0dcfd6130da4eaeb44c6f067e
+    type-fest: ^2.10.0
+  checksum: c4b75618da609b2eefe04a173e89181d200283a1c68c404c4041b730ab49d6adb8ad4a806ebd4feaa6d76bcb7fd943b4129c23b0729a05623ef0d12fe203a7cf
   languageName: node
   linkType: hard
 
@@ -6922,10 +6886,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.4.71":
-  version: 1.4.71
-  resolution: "electron-to-chromium@npm:1.4.71"
-  checksum: ecb2546eed6b0e95003d787c259de730f32e2f5c0fa2acb27069c0cd21378cbc2a6c7516f4ec677a5960db4e180644f87ed91a729825a238454e31e4e74617db
+"electron-to-chromium@npm:^1.4.17":
+  version: 1.4.68
+  resolution: "electron-to-chromium@npm:1.4.68"
+  checksum: d7654d07ab7c504a0683cf29715db227bdbd3e397ad3a41bad3d1e35e9f837447be2bc5dea54b3350d51be5c9c7b79756dcbe44903fbee5949d67d783e788acb
   languageName: node
   linkType: hard
 
@@ -7114,9 +7078,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-android-arm64@npm:0.14.23":
-  version: 0.14.23
-  resolution: "esbuild-android-arm64@npm:0.14.23"
+"esbuild-android-arm64@npm:0.14.21":
+  version: 0.14.21
+  resolution: "esbuild-android-arm64@npm:0.14.21"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -7128,9 +7092,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-darwin-64@npm:0.14.23":
-  version: 0.14.23
-  resolution: "esbuild-darwin-64@npm:0.14.23"
+"esbuild-darwin-64@npm:0.14.21":
+  version: 0.14.21
+  resolution: "esbuild-darwin-64@npm:0.14.21"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -7142,9 +7106,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-darwin-arm64@npm:0.14.23":
-  version: 0.14.23
-  resolution: "esbuild-darwin-arm64@npm:0.14.23"
+"esbuild-darwin-arm64@npm:0.14.21":
+  version: 0.14.21
+  resolution: "esbuild-darwin-arm64@npm:0.14.21"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -7156,9 +7120,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-freebsd-64@npm:0.14.23":
-  version: 0.14.23
-  resolution: "esbuild-freebsd-64@npm:0.14.23"
+"esbuild-freebsd-64@npm:0.14.21":
+  version: 0.14.21
+  resolution: "esbuild-freebsd-64@npm:0.14.21"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -7170,9 +7134,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-freebsd-arm64@npm:0.14.23":
-  version: 0.14.23
-  resolution: "esbuild-freebsd-arm64@npm:0.14.23"
+"esbuild-freebsd-arm64@npm:0.14.21":
+  version: 0.14.21
+  resolution: "esbuild-freebsd-arm64@npm:0.14.21"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -7184,9 +7148,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-32@npm:0.14.23":
-  version: 0.14.23
-  resolution: "esbuild-linux-32@npm:0.14.23"
+"esbuild-linux-32@npm:0.14.21":
+  version: 0.14.21
+  resolution: "esbuild-linux-32@npm:0.14.21"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
@@ -7198,9 +7162,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-64@npm:0.14.23":
-  version: 0.14.23
-  resolution: "esbuild-linux-64@npm:0.14.23"
+"esbuild-linux-64@npm:0.14.21":
+  version: 0.14.21
+  resolution: "esbuild-linux-64@npm:0.14.21"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
@@ -7212,9 +7176,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-arm64@npm:0.14.23":
-  version: 0.14.23
-  resolution: "esbuild-linux-arm64@npm:0.14.23"
+"esbuild-linux-arm64@npm:0.14.21":
+  version: 0.14.21
+  resolution: "esbuild-linux-arm64@npm:0.14.21"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
@@ -7226,9 +7190,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-arm@npm:0.14.23":
-  version: 0.14.23
-  resolution: "esbuild-linux-arm@npm:0.14.23"
+"esbuild-linux-arm@npm:0.14.21":
+  version: 0.14.21
+  resolution: "esbuild-linux-arm@npm:0.14.21"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -7240,9 +7204,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-mips64le@npm:0.14.23":
-  version: 0.14.23
-  resolution: "esbuild-linux-mips64le@npm:0.14.23"
+"esbuild-linux-mips64le@npm:0.14.21":
+  version: 0.14.21
+  resolution: "esbuild-linux-mips64le@npm:0.14.21"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
@@ -7254,23 +7218,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-ppc64le@npm:0.14.23":
-  version: 0.14.23
-  resolution: "esbuild-linux-ppc64le@npm:0.14.23"
+"esbuild-linux-ppc64le@npm:0.14.21":
+  version: 0.14.21
+  resolution: "esbuild-linux-ppc64le@npm:0.14.21"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
-"esbuild-linux-riscv64@npm:0.14.23":
-  version: 0.14.23
-  resolution: "esbuild-linux-riscv64@npm:0.14.23"
+"esbuild-linux-riscv64@npm:0.14.21":
+  version: 0.14.21
+  resolution: "esbuild-linux-riscv64@npm:0.14.21"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
-"esbuild-linux-s390x@npm:0.14.23":
-  version: 0.14.23
-  resolution: "esbuild-linux-s390x@npm:0.14.23"
+"esbuild-linux-s390x@npm:0.14.21":
+  version: 0.14.21
+  resolution: "esbuild-linux-s390x@npm:0.14.21"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -7298,9 +7262,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-netbsd-64@npm:0.14.23":
-  version: 0.14.23
-  resolution: "esbuild-netbsd-64@npm:0.14.23"
+"esbuild-netbsd-64@npm:0.14.21":
+  version: 0.14.21
+  resolution: "esbuild-netbsd-64@npm:0.14.21"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -7312,9 +7276,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-openbsd-64@npm:0.14.23":
-  version: 0.14.23
-  resolution: "esbuild-openbsd-64@npm:0.14.23"
+"esbuild-openbsd-64@npm:0.14.21":
+  version: 0.14.21
+  resolution: "esbuild-openbsd-64@npm:0.14.21"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -7326,9 +7290,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-sunos-64@npm:0.14.23":
-  version: 0.14.23
-  resolution: "esbuild-sunos-64@npm:0.14.23"
+"esbuild-sunos-64@npm:0.14.21":
+  version: 0.14.21
+  resolution: "esbuild-sunos-64@npm:0.14.21"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
@@ -7340,9 +7304,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-windows-32@npm:0.14.23":
-  version: 0.14.23
-  resolution: "esbuild-windows-32@npm:0.14.23"
+"esbuild-windows-32@npm:0.14.21":
+  version: 0.14.21
+  resolution: "esbuild-windows-32@npm:0.14.21"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
@@ -7354,9 +7318,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-windows-64@npm:0.14.23":
-  version: 0.14.23
-  resolution: "esbuild-windows-64@npm:0.14.23"
+"esbuild-windows-64@npm:0.14.21":
+  version: 0.14.21
+  resolution: "esbuild-windows-64@npm:0.14.21"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -7368,9 +7332,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-windows-arm64@npm:0.14.23":
-  version: 0.14.23
-  resolution: "esbuild-windows-arm64@npm:0.14.23"
+"esbuild-windows-arm64@npm:0.14.21":
+  version: 0.14.21
+  resolution: "esbuild-windows-arm64@npm:0.14.21"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -7437,29 +7401,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.14.14, esbuild@npm:^0.14.22, esbuild@npm:^0.14.6":
-  version: 0.14.23
-  resolution: "esbuild@npm:0.14.23"
+"esbuild@npm:^0.14.14, esbuild@npm:^0.14.21, esbuild@npm:^0.14.6":
+  version: 0.14.21
+  resolution: "esbuild@npm:0.14.21"
   dependencies:
-    esbuild-android-arm64: 0.14.23
-    esbuild-darwin-64: 0.14.23
-    esbuild-darwin-arm64: 0.14.23
-    esbuild-freebsd-64: 0.14.23
-    esbuild-freebsd-arm64: 0.14.23
-    esbuild-linux-32: 0.14.23
-    esbuild-linux-64: 0.14.23
-    esbuild-linux-arm: 0.14.23
-    esbuild-linux-arm64: 0.14.23
-    esbuild-linux-mips64le: 0.14.23
-    esbuild-linux-ppc64le: 0.14.23
-    esbuild-linux-riscv64: 0.14.23
-    esbuild-linux-s390x: 0.14.23
-    esbuild-netbsd-64: 0.14.23
-    esbuild-openbsd-64: 0.14.23
-    esbuild-sunos-64: 0.14.23
-    esbuild-windows-32: 0.14.23
-    esbuild-windows-64: 0.14.23
-    esbuild-windows-arm64: 0.14.23
+    esbuild-android-arm64: 0.14.21
+    esbuild-darwin-64: 0.14.21
+    esbuild-darwin-arm64: 0.14.21
+    esbuild-freebsd-64: 0.14.21
+    esbuild-freebsd-arm64: 0.14.21
+    esbuild-linux-32: 0.14.21
+    esbuild-linux-64: 0.14.21
+    esbuild-linux-arm: 0.14.21
+    esbuild-linux-arm64: 0.14.21
+    esbuild-linux-mips64le: 0.14.21
+    esbuild-linux-ppc64le: 0.14.21
+    esbuild-linux-riscv64: 0.14.21
+    esbuild-linux-s390x: 0.14.21
+    esbuild-netbsd-64: 0.14.21
+    esbuild-openbsd-64: 0.14.21
+    esbuild-sunos-64: 0.14.21
+    esbuild-windows-32: 0.14.21
+    esbuild-windows-64: 0.14.21
+    esbuild-windows-arm64: 0.14.21
   dependenciesMeta:
     esbuild-android-arm64:
       optional: true
@@ -7501,7 +7465,7 @@ __metadata:
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: 41d26f9022a9f95a1ccf280fd6c2cf2684264663c03d5d4338bfab17710292b9c2ca45624ed55d9f37d7be5f29557ebd6d101b21ed5592fb0b6e6ac5e76bc58d
+  checksum: 21a0b302740a36c7b5166761f0174a3937222e0f3fb612a5363f0be6b44e32b4070940488df5733b2034150a3c8ef74b1129d7e179daea1bfcb8e88d7998f96b
   languageName: node
   linkType: hard
 
@@ -7548,13 +7512,13 @@ __metadata:
   linkType: hard
 
 "eslint-config-prettier@npm:^8.3.0":
-  version: 8.4.0
-  resolution: "eslint-config-prettier@npm:8.4.0"
+  version: 8.3.0
+  resolution: "eslint-config-prettier@npm:8.3.0"
   peerDependencies:
     eslint: ">=7.0.0"
   bin:
     eslint-config-prettier: bin/cli.js
-  checksum: ee8dc343f1fed15dc0658e190a966cc23644477f2331a7f56ae2bb79dd74892e3cde8ea5c142e7a3329a8291a1de041e13ca96e54d0c85ff4a2aba13390c5f10
+  checksum: df4cea3032671995bb5ab07e016169072f7fa59f44a53251664d9ca60951b66cdc872683b5c6a3729c91497c11490ca44a79654b395dd6756beb0c3903a37196
   languageName: node
   linkType: hard
 
@@ -8219,12 +8183,12 @@ __metadata:
   linkType: hard
 
 "follow-redirects@npm:^1.0.0":
-  version: 1.14.9
-  resolution: "follow-redirects@npm:1.14.9"
+  version: 1.14.8
+  resolution: "follow-redirects@npm:1.14.8"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: f5982e0eb481818642492d3ca35a86989c98af1128b8e1a62911a3410621bc15d2b079e8170b35b19d3bdee770b73ed431a257ed86195af773771145baa57845
+  checksum: 40c67899c2e3149a27e8b6498a338ff27f39fe138fde8d7f0756cb44b073ba0bfec3d52af28f20c5bdd67263d564d0d8d7b5efefd431de95c18c42f7b4aef457
   languageName: node
   linkType: hard
 
@@ -8479,8 +8443,8 @@ __metadata:
   linkType: hard
 
 "gauge@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "gauge@npm:4.0.1"
+  version: 4.0.0
+  resolution: "gauge@npm:4.0.0"
   dependencies:
     ansi-regex: ^5.0.1
     aproba: ^1.0.3 || ^2.0.0
@@ -8491,7 +8455,7 @@ __metadata:
     string-width: ^4.2.3
     strip-ansi: ^6.0.1
     wide-align: ^1.1.2
-  checksum: 398540c761f2efbd8c35323b781a572db09a3ab2d62ea672fc440eb88e9249624ac8b64275731d9ef266cde6491880df5360d74d0829da077136ee614b08f85c
+  checksum: 637b34c84f518defa89319dbef68211a24e9302182ad2a619e3be1be5b7dcf2a962c8359e889294af667440f4722e7e6e61671859e00bd8ec280a136ded89b25
   languageName: node
   linkType: hard
 
@@ -9938,12 +9902,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jiti@npm:^1.12.13, jiti@npm:^1.12.14, jiti@npm:^1.12.15, jiti@npm:^1.12.9, jiti@npm:^1.13.0, jiti@npm:^1.9.2":
-  version: 1.13.0
-  resolution: "jiti@npm:1.13.0"
+"jiti@npm:^1.12.13, jiti@npm:^1.12.14, jiti@npm:^1.12.15, jiti@npm:^1.12.9, jiti@npm:^1.9.2":
+  version: 1.12.15
+  resolution: "jiti@npm:1.12.15"
   bin:
     jiti: bin/jiti.js
-  checksum: 1e74d99b9a551df952057b8bce56f744caccca0044aa05021643e6ce0837ed47bc2d5b290fecb462e32988c6bf318afe77e341310c5ecf6bb63c19c80c929cb6
+  checksum: 8e53259f427eb7a7c0cd834c284e18cd05760cb7f0f15b4971ab11874e8b0e7b15fc1f13000eb3a8c7f804ff15637a283d6595858811d61effe8c5aeaacb02ac
   languageName: node
   linkType: hard
 
@@ -10840,20 +10804,20 @@ __metadata:
   linkType: hard
 
 "minimatch@npm:^3.0.4":
-  version: 3.1.2
-  resolution: "minimatch@npm:3.1.2"
+  version: 3.1.1
+  resolution: "minimatch@npm:3.1.1"
   dependencies:
     brace-expansion: ^1.1.7
-  checksum: c154e566406683e7bcb746e000b84d74465b3a832c45d59912b9b55cd50dee66e5c4b1e5566dba26154040e51672f9aa450a9aef0c97cfc7336b78b7afb9540a
+  checksum: e9e3772e4ea06ea3a888d39bc7690d3c812ee7e5a70c2d2f568ccadac0249a027f865589d19ad03ed937e6ca3b4ad35f85411db9670f7877d8fc2ed452f1cd37
   languageName: node
   linkType: hard
 
 "minimatch@npm:~3.0.4":
-  version: 3.0.8
-  resolution: "minimatch@npm:3.0.8"
+  version: 3.0.7
+  resolution: "minimatch@npm:3.0.7"
   dependencies:
     brace-expansion: ^1.1.7
-  checksum: 850cca179cad715133132693e6963b0db64ab0988c4d211415b087fc23a3e46321e2c5376a01bf5623d8782aba8bdf43c571e2e902e51fdce7175c7215c29f8b
+  checksum: 904b52bbe9a4c12a11c3ea9b503b8f64e0f822997a8fed8e8f2eaa4cb8805e2a03468a4940a63c198aac9c036f2388dfbfb9cd3b63667077ed7cb2e761bff2a4
   languageName: node
   linkType: hard
 
@@ -11119,11 +11083,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.1.23, nanoid@npm:^3.1.32, nanoid@npm:^3.2.0":
-  version: 3.3.1
-  resolution: "nanoid@npm:3.3.1"
+  version: 3.2.0
+  resolution: "nanoid@npm:3.2.0"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 4ef0969e1bbe866fc223eb32276cbccb0961900bfe79104fa5abe34361979dead8d0e061410a5c03bc3d47455685adf32c09d6f27790f4a6898fb51f7df7ec86
+  checksum: 3d1d5a69fea84e538057cf64106e713931c4ef32af344068ecff153ff91252f39b0f2b472e09b0dfff43ac3cf520c92938d90e6455121fe93976e23660f4fccc
   languageName: node
   linkType: hard
 
@@ -11412,7 +11376,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^2.0.2":
+"node-releases@npm:^2.0.1":
   version: 2.0.2
   resolution: "node-releases@npm:2.0.2"
   checksum: da858bf86b4d512842379749f5a5e4196ddab05ba18ffcf29f05bf460beceaca927f070f4430bb5046efec18941ddbc85e4c5fdbb83afc28a38dd6069a2f255e
@@ -11671,9 +11635,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nuxi@npm:nuxi-edge@3.0.0-27420403.16e2a54":
-  version: 3.0.0-27420403.16e2a54
-  resolution: "nuxi-edge@npm:3.0.0-27420403.16e2a54"
+"nuxi@npm:nuxi-edge@3.0.0-27409835.c53c736":
+  version: 3.0.0-27409835.c53c736
+  resolution: "nuxi-edge@npm:3.0.0-27409835.c53c736"
   dependencies:
     fsevents: ~2.3.2
   dependenciesMeta:
@@ -11681,7 +11645,7 @@ __metadata:
       optional: true
   bin:
     nuxi-edge: ./bin/nuxi.mjs
-  checksum: 1810fa97aca00c06d07e59e51359875c1001bfbfe25909e7cc2815b000a0f38300bac27c5802f7968e8ae6f4134463400fddbda5dec9761e1616bc19a3d96fdd
+  checksum: 6f2010fdabfcb9475531cbc13ef29efdf3e3b076c63fd8ef5eafbb037d759698072782b62684b956a1b14f031541d23afca0b881b56b24ac18e8be5760274c96
   languageName: node
   linkType: hard
 
@@ -11733,19 +11697,20 @@ __metadata:
   linkType: soft
 
 "nuxt3@npm:latest":
-  version: 3.0.0-27420403.16e2a54
-  resolution: "nuxt3@npm:3.0.0-27420403.16e2a54"
+  version: 3.0.0-27409835.c53c736
+  resolution: "nuxt3@npm:3.0.0-27409835.c53c736"
   dependencies:
     "@nuxt/design": ^0.1.5
-    "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27420403.16e2a54"
-    "@nuxt/nitro": "npm:@nuxt/nitro-edge@3.0.0-27420403.16e2a54"
-    "@nuxt/schema": "npm:@nuxt/schema-edge@3.0.0-27420403.16e2a54"
-    "@nuxt/vite-builder": "npm:@nuxt/vite-builder-edge@3.0.0-27420403.16e2a54"
-    "@nuxt/webpack-builder": "npm:@nuxt/webpack-builder-edge@3.0.0-27420403.16e2a54"
-    "@vue/reactivity": ^3.2.31
-    "@vue/shared": ^3.2.31
+    "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27409835.c53c736"
+    "@nuxt/nitro": "npm:@nuxt/nitro-edge@3.0.0-27409835.c53c736"
+    "@nuxt/schema": "npm:@nuxt/schema-edge@3.0.0-27409835.c53c736"
+    "@nuxt/vite-builder": "npm:@nuxt/vite-builder-edge@3.0.0-27409835.c53c736"
+    "@nuxt/webpack-builder": "npm:@nuxt/webpack-builder-edge@3.0.0-27409835.c53c736"
+    "@vue/reactivity": ^3.2.30
+    "@vue/shared": ^3.2.30
     "@vueuse/head": ^0.7.5
     chokidar: ^3.5.3
+    consola: ^2.15.3
     cookie-es: ^0.5.0
     defu: ^5.0.1
     destr: ^1.1.0
@@ -11760,18 +11725,18 @@ __metadata:
     mlly: ^0.4.3
     murmurhash-es: ^0.1.1
     nitropack: "npm:nitropack-edge@latest"
-    nuxi: "npm:nuxi-edge@3.0.0-27420403.16e2a54"
+    nuxi: "npm:nuxi-edge@3.0.0-27409835.c53c736"
     ohmyfetch: ^0.4.15
     pathe: ^0.2.0
     scule: ^0.2.1
     ufo: ^0.7.9
     unplugin: ^0.3.2
-    vue: ^3.2.31
+    vue: ^3.2.30
     vue-router: ^4.0.12
   bin:
     nuxi: ./bin/nuxt.mjs
     nuxt: ./bin/nuxt.mjs
-  checksum: 3fcffdcc4ed22e48bddb2df909abc104ee9473555094ca0b8e31dcff8d69245baf58f48f3c7e688b5065daad4ccdbf5439658c4defd8491d6e523cb2265f8871
+  checksum: aa09c5aa11ee58c910820eab03049d76cb39f63e72ca24e8e6cc68202ff5725a1e9021a491a253182c96bf6df0ac88f740a98fa9ad5abdab9662db2f8c9f53d1
   languageName: node
   linkType: hard
 
@@ -12412,19 +12377,19 @@ __metadata:
   linkType: hard
 
 "playwright-chromium@npm:^1.17.1":
-  version: 1.19.1
-  resolution: "playwright-chromium@npm:1.19.1"
+  version: 1.19.0
+  resolution: "playwright-chromium@npm:1.19.0"
   dependencies:
-    playwright-core: 1.19.1
+    playwright-core: 1.19.0
   bin:
     playwright: cli.js
-  checksum: 4186020819a6d5b57034574207d53817d7865f0773339efd01141a8a98b6302468e7f297cfd20c95bcc4450b5fbad0d3d6c3ac3b5d06825cbb04479416a1ad71
+  checksum: a74ea6df6c1e2d580913f1ea81cdf7613e3f7ede03c908b11d682f98fc8949594163d0ca31038e35a6e58c98dd6a2c1135a3cde5460ad124234dd1f924044159
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.19.1":
-  version: 1.19.1
-  resolution: "playwright-core@npm:1.19.1"
+"playwright-core@npm:1.19.0":
+  version: 1.19.0
+  resolution: "playwright-core@npm:1.19.0"
   dependencies:
     commander: 8.3.0
     debug: 4.3.3
@@ -12444,7 +12409,7 @@ __metadata:
     yazl: 2.5.1
   bin:
     playwright: cli.js
-  checksum: a88b055d1180b128bc073b58dd63aff29d1f996711e8f72cae4df03ecc8c133822caf04a9f6838b4bd3f6473b9c58661274f39e9db3b4570b18bbe0a3eef1fb6
+  checksum: 2725ae393f9af30280111a7f40c1982fd8d6183b75403faa0a7e97e460da848dc3417b360abd7408dd4e3bc2e72074cdd8fdd015c89f126968ee4f5e1cccdf01
   languageName: node
   linkType: hard
 
@@ -12515,14 +12480,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-clamp@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "postcss-clamp@npm:4.0.0"
+"postcss-clamp@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "postcss-clamp@npm:3.0.0"
   dependencies:
-    postcss-value-parser: ^4.2.0
+    postcss-value-parser: ^4.1.0
   peerDependencies:
-    postcss: ^8.4.6
-  checksum: 103ae5039a55623f2835c11684367bb094d62ac21a99ee612741f4dcec827eccd21ad3a11d6792f66f90e86133f046e352addbab4576b90d98b3c4ea0dce1e53
+    postcss: ^8.4.5
+  checksum: a7428a91b8167a9f0930499bd5937c9fda03c81a20825479d2ce0bea131f865d90ab76cd377e3664112699393f73c1a1bc3591151ebf290219a893af8fe71d10
   languageName: node
   linkType: hard
 
@@ -12822,15 +12787,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-double-position-gradients@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "postcss-double-position-gradients@npm:3.1.0"
+"postcss-double-position-gradients@npm:^3.0.5":
+  version: 3.0.5
+  resolution: "postcss-double-position-gradients@npm:3.0.5"
   dependencies:
-    "@csstools/postcss-progressive-custom-properties": ^1.1.0
     postcss-value-parser: ^4.2.0
   peerDependencies:
     postcss: ^8.4
-  checksum: 168810c5e9a38c8cab5c19fe9209a6819d35fce7e4e66dc7b67aafacd0bdfa2c24247cb187b63893bfe65339f3981dacdaf0071abf1fca2dbe826bd935673f29
+  checksum: 43c676a085ba908e7ceabffb180e367a949d3a566d31271ca2194fb398260393de4e1aaa95733184d5c337a97ec47cd8c42e42573ed5d60736533f44a1bb5ebd
   languageName: node
   linkType: hard
 
@@ -13028,15 +12992,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-lab-function@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "postcss-lab-function@npm:4.1.1"
+"postcss-lab-function@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "postcss-lab-function@npm:4.1.0"
   dependencies:
     "@csstools/postcss-progressive-custom-properties": ^1.1.0
     postcss-value-parser: ^4.2.0
   peerDependencies:
     postcss: ^8.4
-  checksum: 8f2b319c84494aef05b1a3bec08f4aa5b0ce199bc3154ba2297397955d74ef3c3e0dfa485b05d83a7a02347b8bedb9ee7a658c2cae71accbbb129ac91e71a99c
+  checksum: cf48efa4e23a94a2c7c639b929e57b3ef1ccbb21f636d64ae571a1a72bb0538878c8239c95371e9372448e06890bc2010303e75cc8a715bd2323cc189895872e
   languageName: node
   linkType: hard
 
@@ -13712,25 +13676,22 @@ __metadata:
   linkType: hard
 
 "postcss-preset-env@npm:^7.3.0":
-  version: 7.4.1
-  resolution: "postcss-preset-env@npm:7.4.1"
+  version: 7.3.3
+  resolution: "postcss-preset-env@npm:7.3.3"
   dependencies:
-    "@csstools/postcss-color-function": ^1.0.2
     "@csstools/postcss-font-format-keywords": ^1.0.0
     "@csstools/postcss-hwb-function": ^1.0.0
-    "@csstools/postcss-ic-unit": ^1.0.0
     "@csstools/postcss-is-pseudo-class": ^2.0.0
     "@csstools/postcss-normalize-display-values": ^1.0.0
-    "@csstools/postcss-oklab-function": ^1.0.1
-    "@csstools/postcss-progressive-custom-properties": ^1.2.0
+    "@csstools/postcss-progressive-custom-properties": ^1.1.0
     autoprefixer: ^10.4.2
     browserslist: ^4.19.1
     css-blank-pseudo: ^3.0.3
     css-has-pseudo: ^3.0.4
     css-prefers-color-scheme: ^6.0.3
-    cssdb: ^6.3.1
+    cssdb: ^6.3.0
     postcss-attribute-case-insensitive: ^5.0.0
-    postcss-clamp: ^4.0.0
+    postcss-clamp: ^3.0.0
     postcss-color-functional-notation: ^4.2.2
     postcss-color-hex-alpha: ^8.0.3
     postcss-color-rebeccapurple: ^7.0.2
@@ -13738,7 +13699,7 @@ __metadata:
     postcss-custom-properties: ^12.1.4
     postcss-custom-selectors: ^6.0.0
     postcss-dir-pseudo-class: ^6.0.4
-    postcss-double-position-gradients: ^3.1.0
+    postcss-double-position-gradients: ^3.0.5
     postcss-env-function: ^4.0.5
     postcss-focus-visible: ^6.0.4
     postcss-focus-within: ^5.0.4
@@ -13746,7 +13707,7 @@ __metadata:
     postcss-gap-properties: ^3.0.3
     postcss-image-set-function: ^4.0.6
     postcss-initial: ^4.0.1
-    postcss-lab-function: ^4.1.1
+    postcss-lab-function: ^4.1.0
     postcss-logical: ^5.0.4
     postcss-media-minmax: ^5.0.0
     postcss-nesting: ^10.1.2
@@ -13759,7 +13720,7 @@ __metadata:
     postcss-selector-not: ^5.0.0
   peerDependencies:
     postcss: ^8.4
-  checksum: adfa72f3c1d344630fbb2b7ea0c6832cbcdce9abf84c65237a833cc31ac2095315a5fb13a6e4222938801367212038aa8e2afd425527ba8d45e4fb13cd293ab7
+  checksum: c93da81f8b78ddcfcfb2787be537272dd1beba37b0ce44da0e14e38efb2ac5b1e2e80377aa0da7107fac30544e79b337e11951ebc7960499db261e3d4e4cc35d
   languageName: node
   linkType: hard
 
@@ -14066,13 +14027,6 @@ __metadata:
   version: 5.6.0
   resolution: "pretty-bytes@npm:5.6.0"
   checksum: 9c082500d1e93434b5b291bd651662936b8bd6204ec9fa17d563116a192d6d86b98f6d328526b4e8d783c07d5499e2614a807520249692da9ec81564b2f439cd
-  languageName: node
-  linkType: hard
-
-"pretty-bytes@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "pretty-bytes@npm:6.0.0"
-  checksum: 0bb9f95e617236404b29a8392c6efd82d65805f622f5e809ecd70068102be857d4e3276c86d2a32fa2ef851cc29472e380945dab7bec83ec79bd57a19a10faf7
   languageName: node
   linkType: hard
 
@@ -14822,9 +14776,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^2.58.0, rollup@npm:^2.59.0, rollup@npm:^2.66.1, rollup@npm:^2.67.3":
-  version: 2.67.3
-  resolution: "rollup@npm:2.67.3"
+"rollup@npm:^2.58.0, rollup@npm:^2.59.0, rollup@npm:^2.66.1, rollup@npm:^2.67.2":
+  version: 2.67.2
+  resolution: "rollup@npm:2.67.2"
   dependencies:
     fsevents: ~2.3.2
   dependenciesMeta:
@@ -14832,7 +14786,7 @@ __metadata:
       optional: true
   bin:
     rollup: dist/bin/rollup
-  checksum: c4013a2ceef6918375fd07a6548e05d0f3df1db9f0a0281aebe6e993a45c0e667c5a06f53b55c0ffaf72f72266c1879bc181b13199aace97d93f0fc47691d4a9
+  checksum: 9aca5251ba4b441064183cde2394b91567259002d68086bdd3906db66d55dd148ab27e57c51eb53830d7b9b813c2d4e834b7735d65e2a869780bc639d4a20c38
   languageName: node
   linkType: hard
 
@@ -16378,10 +16332,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^2.11.2":
-  version: 2.12.0
-  resolution: "type-fest@npm:2.12.0"
-  checksum: 3ebe6529db84c7ceb579a0c693b92c4bf83fa5a78b5d6a1d3c2138696ad69e0a1ebc7e1b707ee0a2a6bd5aef71bf2bf4fc6fc81a6c752330e10faf0deea80f05
+"type-fest@npm:^2.10.0":
+  version: 2.11.2
+  resolution: "type-fest@npm:2.11.2"
+  checksum: b36f73b9e739d4044f511fa3233eb36d365f5fbf5b120810ec5c6a31b8a6c7a2caeba2fb725491ccfb41a37aac8862e67f4383fc178a0c6074d27c424fe7c764
   languageName: node
   linkType: hard
 
@@ -16942,9 +16896,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:>=2.7.13, vite@npm:^2.7.13, vite@npm:^2.8.4":
-  version: 2.8.4
-  resolution: "vite@npm:2.8.4"
+"vite@npm:>=2.7.13, vite@npm:^2.7.13, vite@npm:^2.8.0":
+  version: 2.8.1
+  resolution: "vite@npm:2.8.1"
   dependencies:
     esbuild: ^0.14.14
     fsevents: ~2.3.2
@@ -16967,7 +16921,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 0531ea17d354c35026c87e732d28c777492cc5165c4abdaa507c4894535ecbbfcf447fa3f270bbb160cd7cba8ad319cc86a221be18b2ccd40d8be139f9d7381d
+  checksum: 4ce8acc2dd2a7ca8727511ff575f72de162114402e55e5d081001f05ef1656782cd5611d4f6091c29efb455e72d30967467bad5b6b329bfe5279fbe8d5169d67
   languageName: node
   linkType: hard
 
@@ -17071,8 +17025,8 @@ __metadata:
   linkType: hard
 
 "vue-i18n-routing@npm:edge":
-  version: 0.0.0-33d6652
-  resolution: "vue-i18n-routing@npm:0.0.0-33d6652"
+  version: 0.0.0-5735bda
+  resolution: "vue-i18n-routing@npm:0.0.0-5735bda"
   dependencies:
     "@intlify/shared": beta
     "@intlify/vue-i18n-bridge": ^0.3.5
@@ -17088,7 +17042,7 @@ __metadata:
   peerDependenciesMeta:
     "@vue/composition-api":
       optional: true
-  checksum: 2766a940d51cc12059d518317220955247da67d0141ccaecf58a88db3da581541e09501a58e860462ca199809d8d33cb3b46f8901fcdc35184c4165f01a672bf
+  checksum: 03291100e3e15bdfb3c83b82c9f6f38870740004db711d48e656d083a2dcc80a7e5b7454f42f0866c3d292001603ca403f0eeb0bbde1879722b0f9df4dfee634
   languageName: node
   linkType: hard
 
@@ -17224,7 +17178,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue@npm:^3.2.31":
+"vue@npm:^3.2.30":
   version: 3.2.31
   resolution: "vue@npm:3.2.31"
   dependencies:
@@ -17430,12 +17384,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:^5.69.1":
-  version: 5.69.1
-  resolution: "webpack@npm:5.69.1"
+"webpack@npm:^5.68.0":
+  version: 5.68.0
+  resolution: "webpack@npm:5.68.0"
   dependencies:
-    "@types/eslint-scope": ^3.7.3
-    "@types/estree": ^0.0.51
+    "@types/eslint-scope": ^3.7.0
+    "@types/estree": ^0.0.50
     "@webassemblyjs/ast": 1.11.1
     "@webassemblyjs/wasm-edit": 1.11.1
     "@webassemblyjs/wasm-parser": 1.11.1
@@ -17463,7 +17417,7 @@ __metadata:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: 490a6e9e4cd9d0ed3b6c7ca08015da2628919fda8fcf9c36f0f6c0e3ad71eaaaf4b0d12753109f22a4faf79fe9a9063552d9708e0ee2352cf8568433b8e296a7
+  checksum: ac6efd861a0bfb35d8a467fba0d87f905ef6e1a9a9f7e3db42ea459cf191268094cedd025d3eb36a1464e2208a0c193f3f4a92531ba58850246f3c6b8f210b03
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2550,7 +2550,28 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nuxtjs/i18n@workspace:./packages/nuxt-i18n, @nuxtjs/i18n@workspace:packages/nuxt-i18n":
+"@nuxtjs/i18n@npm:@nuxtjs/i18n-edge@latest":
+  version: 8.0.0-alpha.0-27419678.39bcf0f
+  resolution: "@nuxtjs/i18n-edge@npm:8.0.0-alpha.0-27419678.39bcf0f"
+  dependencies:
+    "@intlify/shared": next
+    "@intlify/vite-plugin-vue-i18n": next
+    "@intlify/vue-i18n-loader": next
+    "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27398533.8edd481"
+    debug: ^4.3.2
+    defu: latest
+    knitwork: ^0.1.0
+    mlly: ^0.3.19
+    pathe: ^0.2.0
+    vue-i18n: beta
+    vue-i18n-bridge: beta
+    vue-i18n-legacy: "npm:vue-i18n@8"
+    vue-i18n-routing: edge
+  checksum: 6b94310310f2e7b783448f3f3f6800bfba0f1a27917b385e3457f64cbe4becd8922df7cc2223b5761ceced3559b1ef558d6b4fae88b04a3c3c1beeb4eefd779f
+  languageName: node
+  linkType: hard
+
+"@nuxtjs/i18n@workspace:packages/nuxt-i18n":
   version: 0.0.0-use.local
   resolution: "@nuxtjs/i18n@workspace:packages/nuxt-i18n"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2593,7 +2593,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nuxtjs/i18n@workspace:./packages/nuxt-i18n, @nuxtjs/i18n@workspace:packages/nuxt-i18n":
+"@nuxtjs/i18n@workspace:packages/nuxt-i18n":
   version: 0.0.0-use.local
   resolution: "@nuxtjs/i18n@workspace:packages/nuxt-i18n"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,12 +5,12 @@ __metadata:
   version: 5
   cacheKey: 8
 
-"@ampproject/remapping@npm:^2.0.0":
-  version: 2.1.1
-  resolution: "@ampproject/remapping@npm:2.1.1"
+"@ampproject/remapping@npm:^2.1.0":
+  version: 2.1.2
+  resolution: "@ampproject/remapping@npm:2.1.2"
   dependencies:
     "@jridgewell/trace-mapping": ^0.3.0
-  checksum: cc5cf29833e2b8bdf420821a6e027a35cf6a48605df64ae5095b55cb722581b236554fc8f920138e6da3f7a99ec99273b07ebe2e2bb98b6a4a8d8e33648cac77
+  checksum: e023f92cdd9723f3042cde3b4d922adfeef0e198aa73486b0b6c034ad36af5f96e5c0cc72b335b30b2eb9852d907efc92af6bfcd3f4b4d286177ee32a189cf92
   languageName: node
   linkType: hard
 
@@ -32,44 +32,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/compat-data@npm:^7.13.11, @babel/compat-data@npm:^7.16.0, @babel/compat-data@npm:^7.16.4, @babel/compat-data@npm:^7.16.8":
+"@babel/compat-data@npm:^7.13.11, @babel/compat-data@npm:^7.16.0, @babel/compat-data@npm:^7.16.4, @babel/compat-data@npm:^7.16.8, @babel/compat-data@npm:^7.17.0":
   version: 7.17.0
   resolution: "@babel/compat-data@npm:7.17.0"
   checksum: fe5afaf529d107a223cd5937dace248464b6df1e9f4ea4031a5723e9571b46a4db1c4ff226bac6351148b1bc02ba1b39cb142662cd235aa99c1dda77882f8c9d
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.16.0, @babel/core@npm:^7.16.10, @babel/core@npm:^7.16.7, @babel/core@npm:^7.17.2":
-  version: 7.17.2
-  resolution: "@babel/core@npm:7.17.2"
+"@babel/core@npm:^7.16.0, @babel/core@npm:^7.16.10, @babel/core@npm:^7.16.7, @babel/core@npm:^7.17.2, @babel/core@npm:^7.17.5":
+  version: 7.17.5
+  resolution: "@babel/core@npm:7.17.5"
   dependencies:
-    "@ampproject/remapping": ^2.0.0
+    "@ampproject/remapping": ^2.1.0
     "@babel/code-frame": ^7.16.7
-    "@babel/generator": ^7.17.0
+    "@babel/generator": ^7.17.3
     "@babel/helper-compilation-targets": ^7.16.7
     "@babel/helper-module-transforms": ^7.16.7
     "@babel/helpers": ^7.17.2
-    "@babel/parser": ^7.17.0
+    "@babel/parser": ^7.17.3
     "@babel/template": ^7.16.7
-    "@babel/traverse": ^7.17.0
+    "@babel/traverse": ^7.17.3
     "@babel/types": ^7.17.0
     convert-source-map: ^1.7.0
     debug: ^4.1.0
     gensync: ^1.0.0-beta.2
     json5: ^2.1.2
     semver: ^6.3.0
-  checksum: 68ab3459f41b41feb5cb263937f15e418e1c46998d482d1b6dfe34f78064765466cfd5b10205c22fb16b69dbd1d46e7a3c26c067884ca4eb514b3dac1e09a57f
+  checksum: c5e7dddb4feaacb91175d22a6edc8e93804242328a82b80732c6e84a0647bc0a9c9d5b05f3ce13138b8e59bf7aba4ff9f7b7446302f141f243ba51df02c318a5
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.16.8, @babel/generator@npm:^7.17.0":
-  version: 7.17.0
-  resolution: "@babel/generator@npm:7.17.0"
+"@babel/generator@npm:^7.16.8, @babel/generator@npm:^7.17.3":
+  version: 7.17.3
+  resolution: "@babel/generator@npm:7.17.3"
   dependencies:
     "@babel/types": ^7.17.0
     jsesc: ^2.5.1
     source-map: ^0.5.0
-  checksum: 2987dbebb484727a227f1ce3db90810320986cfb3ffd23e6d1d87f75bbd8e7871b5bc44252822d4d5f048a2d872a5702b2a9bf7bab7e07f087d7f306f0ea6c0a
+  checksum: ddf70e3489976018dfc2da8b9f43ec8c582cac2da681ed4a6227c53b26a9626223e4dca90098b3d3afe43bc67f20160856240e826c56b48e577f34a5a7e22b9f
   languageName: node
   linkType: hard
 
@@ -349,12 +349,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.16.10, @babel/parser@npm:^7.16.4, @babel/parser@npm:^7.16.7, @babel/parser@npm:^7.16.8, @babel/parser@npm:^7.17.0":
-  version: 7.17.0
-  resolution: "@babel/parser@npm:7.17.0"
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.16.10, @babel/parser@npm:^7.16.4, @babel/parser@npm:^7.16.7, @babel/parser@npm:^7.16.8, @babel/parser@npm:^7.17.3":
+  version: 7.17.3
+  resolution: "@babel/parser@npm:7.17.3"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: d0ac5ffba0b234dde516f867edf5da5d92d6f841592b370ae3244cd7c8f27a7f5e3e3d4e90ca9c15ea58bc46823f1643f3f75b6eb9a9f676ae16e8b2365e922a
+  checksum: 311869baef97c7630ac3b3c4600da18229b95aa2785b2daab2044384745fe0653070916ade28749fb003f7369a081111ada53e37284ba48d6b5858cbb9e411d1
   languageName: node
   linkType: hard
 
@@ -508,17 +508,17 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-proposal-object-rest-spread@npm:^7.16.7":
-  version: 7.16.7
-  resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.16.7"
+  version: 7.17.3
+  resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.17.3"
   dependencies:
-    "@babel/compat-data": ^7.16.4
+    "@babel/compat-data": ^7.17.0
     "@babel/helper-compilation-targets": ^7.16.7
     "@babel/helper-plugin-utils": ^7.16.7
     "@babel/plugin-syntax-object-rest-spread": ^7.8.3
     "@babel/plugin-transform-parameters": ^7.16.7
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 2d3740e4df6d3f51d57862100c45c000104571aa98b7f798fdfc05ae0c12b9e7cc9b55f4a28612d626e29f3369a1481a0ee8a0241b23508b9d3da00c55f99d41
+  checksum: 02810f158db4aaf6883131621b5d2c7d901ea3c034df2c2b78663f8b26813795d78a346c37e56770a720c54773732fd1d7fe40947dbf11d1d8de0e9a38e856d3
   languageName: node
   linkType: hard
 
@@ -859,13 +859,13 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-destructuring@npm:^7.16.7":
-  version: 7.16.7
-  resolution: "@babel/plugin-transform-destructuring@npm:7.16.7"
+  version: 7.17.3
+  resolution: "@babel/plugin-transform-destructuring@npm:7.17.3"
   dependencies:
     "@babel/helper-plugin-utils": ^7.16.7
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: d1c2e15e7be2a7c57ac8ec4df06fbb706c7ecc872ab7bc2193606e6d6a01929b6d5a1bb41540e41180e42a5ce0e70dce22e7896cb6578dd581d554f77780971b
+  checksum: af58115da1b5f1b7aa9c07af8fee53c1db05d2d68be3ba67aae162242d22e5ccd1bcd0fb149fced4618b31c0c6b4f99d32b472567c5f0807586b7fe5216ba7f0
   languageName: node
   linkType: hard
 
@@ -1299,9 +1299,9 @@ __metadata:
   linkType: hard
 
 "@babel/standalone@npm:^7.17.2":
-  version: 7.17.2
-  resolution: "@babel/standalone@npm:7.17.2"
-  checksum: 14a628bd4866ea5285a0f218dde7f526b8019a55f0f4ae324faf0791257fddeb618d6a6154c91996dcb38d91389a9a7d8c79539bdb6ed846cce3794aac918175
+  version: 7.17.5
+  resolution: "@babel/standalone@npm:7.17.5"
+  checksum: 5fe157dd3f9ede55eca9d477a177e9b824b68e2247bd1c6d49627724e0ee982c793b48f68d7e161ed5ceecc9518c8a2b251ef60820c9a3899a50f40cdd1c3c1f
   languageName: node
   linkType: hard
 
@@ -1316,21 +1316,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.0.0, @babel/traverse@npm:^7.13.0, @babel/traverse@npm:^7.16.7, @babel/traverse@npm:^7.16.8, @babel/traverse@npm:^7.17.0":
-  version: 7.17.0
-  resolution: "@babel/traverse@npm:7.17.0"
+"@babel/traverse@npm:^7.0.0, @babel/traverse@npm:^7.13.0, @babel/traverse@npm:^7.16.7, @babel/traverse@npm:^7.16.8, @babel/traverse@npm:^7.17.0, @babel/traverse@npm:^7.17.3":
+  version: 7.17.3
+  resolution: "@babel/traverse@npm:7.17.3"
   dependencies:
     "@babel/code-frame": ^7.16.7
-    "@babel/generator": ^7.17.0
+    "@babel/generator": ^7.17.3
     "@babel/helper-environment-visitor": ^7.16.7
     "@babel/helper-function-name": ^7.16.7
     "@babel/helper-hoist-variables": ^7.16.7
     "@babel/helper-split-export-declaration": ^7.16.7
-    "@babel/parser": ^7.17.0
+    "@babel/parser": ^7.17.3
     "@babel/types": ^7.17.0
     debug: ^4.1.0
     globals: ^11.1.0
-  checksum: 9b7de053d8a29453fd7b9614a028d8dc811817f02948eaee02093274b67927a1cfb0513b521bc4a9328c9b6e5b021fd343b358c3526bbb6ee61ec078d4110c0c
+  checksum: 780d7ecf711758174989794891af08d378f81febdb8932056c0d9979524bf0298e28f8e7708a872d7781151506c28f56c85c63ea3f1f654662c2fcb8a3eb9fdc
   languageName: node
   linkType: hard
 
@@ -1360,6 +1360,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@csstools/postcss-color-function@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@csstools/postcss-color-function@npm:1.0.2"
+  dependencies:
+    "@csstools/postcss-progressive-custom-properties": ^1.1.0
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.4
+  checksum: 0fc5c8924dbffca13307038e3363b4e75bd3f32769907b13309d7170c3ab0716ee9e7f7c7a4c4f972ddc6f1e2b4103f910f465a250062fdce5aef1fcd9579610
+  languageName: node
+  linkType: hard
+
 "@csstools/postcss-font-format-keywords@npm:^1.0.0":
   version: 1.0.0
   resolution: "@csstools/postcss-font-format-keywords@npm:1.0.0"
@@ -1379,6 +1391,18 @@ __metadata:
   peerDependencies:
     postcss: ^8.3
   checksum: 7d91ae87d40ece32d57f0fc0c777ff9256bb85c609e2c5e812dc9d9ea98688ea959c3d94b296f69135e99822db361ac447cb7f398a2daeebcc0203d0ee5961c9
+  languageName: node
+  linkType: hard
+
+"@csstools/postcss-ic-unit@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@csstools/postcss-ic-unit@npm:1.0.0"
+  dependencies:
+    "@csstools/postcss-progressive-custom-properties": ^1.1.0
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.3
+  checksum: d194b13a66027558d2d0dd3be3b795167b5e751bb3a3e62928c77ef1c524f0d672a7658852f07e589abbb64e827096eac00d9b6d7ec79e21006fd4f6f0b3ce87
   languageName: node
   linkType: hard
 
@@ -1404,14 +1428,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@csstools/postcss-progressive-custom-properties@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@csstools/postcss-progressive-custom-properties@npm:1.1.0"
+"@csstools/postcss-oklab-function@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@csstools/postcss-oklab-function@npm:1.0.1"
+  dependencies:
+    "@csstools/postcss-progressive-custom-properties": ^1.1.0
+    postcss-value-parser: ^4.2.0
+  peerDependencies:
+    postcss: ^8.4
+  checksum: 2de8f679a2ceccfa6c65cd349b8548a9c38627dfdcbde0cbbdaa82be6181bb63924ccdaac9fcbc2173be867e4f251eafbfe2af574ed79180de607809abdb45c2
+  languageName: node
+  linkType: hard
+
+"@csstools/postcss-progressive-custom-properties@npm:^1.1.0, @csstools/postcss-progressive-custom-properties@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@csstools/postcss-progressive-custom-properties@npm:1.2.0"
   dependencies:
     postcss-value-parser: ^4.2.0
   peerDependencies:
     postcss: ^8.3
-  checksum: d8bb27f1fd83d3b5f3740cd9c85063c63178c765acf4af59cef62f5af90c46f49e5048a37e274f614cfd6b37c4d653a43b67ffb391fde306829997936bc76a24
+  checksum: 879fc52e8c55c8a4539fdf34f92d4a85f06d83d4d38d0a707061b13522b915f41d531a410092a2993e185094d5cba1c5d1612d123f60641dd44b7f5bc516c92d
   languageName: node
   linkType: hard
 
@@ -1433,9 +1469,9 @@ __metadata:
   linkType: hard
 
 "@gar/promisify@npm:^1.0.1":
-  version: 1.1.2
-  resolution: "@gar/promisify@npm:1.1.2"
-  checksum: d05081e0887a49c178b75ee3067bd6ee086f73c154d121b854fb2e044e8a89cb1cbb6de3a0dd93a519b80f0531fda68b099dd7256205f7fbb3490324342f2217
+  version: 1.1.3
+  resolution: "@gar/promisify@npm:1.1.3"
+  checksum: 4059f790e2d07bf3c3ff3e0fec0daa8144fe35c1f6e0111c9921bd32106adaa97a4ab096ad7dab1e28ee6a9060083c4d1a4ada42a7f5f3f7a96b8812e2b757c1
   languageName: node
   linkType: hard
 
@@ -1644,11 +1680,20 @@ __metadata:
   linkType: hard
 
 "@netlify/functions@npm:^0.11.0":
-  version: 0.11.0
-  resolution: "@netlify/functions@npm:0.11.0"
+  version: 0.11.1
+  resolution: "@netlify/functions@npm:0.11.1"
   dependencies:
     is-promise: ^4.0.0
-  checksum: 87bb43fb5f5e893e3495842384086b2565f24c5872ae38f5afc4756314b2aa58cc937b442e51264cf2c17735700c53676e3ebc2861cdb9eec78a89ffa6cc3ef5
+  checksum: 760f7e042b054314203ed4503ce674c973c5fe939c56811a0c4376525ff7fe4da46dbf3a8e611b81124d8c231e848e7f468969ba6d53ffdde187f8dc415c3f99
+  languageName: node
+  linkType: hard
+
+"@netlify/functions@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@netlify/functions@npm:1.0.0"
+  dependencies:
+    is-promise: ^4.0.0
+  checksum: 1e3c234f14fd2fe8f46cae9336679054bf067b60217ee1c424adec1b1d1e4208eeaacb3401c48b625fe057df56f5dc553b961d4758f53bb0eae6f5b78d6385ad
   languageName: node
   linkType: hard
 
@@ -1972,17 +2017,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nuxt/kit@npm:@nuxt/kit-edge@3.0.0-27409835.c53c736":
-  version: 3.0.0-27409835.c53c736
-  resolution: "@nuxt/kit-edge@npm:3.0.0-27409835.c53c736"
+"@nuxt/kit@npm:@nuxt/kit-edge@3.0.0-27420403.16e2a54":
+  version: 3.0.0-27420403.16e2a54
+  resolution: "@nuxt/kit-edge@npm:3.0.0-27420403.16e2a54"
   dependencies:
-    "@nuxt/schema": "npm:@nuxt/schema-edge@3.0.0-27409835.c53c736"
+    "@nuxt/schema": "npm:@nuxt/schema-edge@3.0.0-27420403.16e2a54"
     c12: ^0.1.3
     consola: ^2.15.3
     defu: ^5.0.1
     globby: ^13.1.1
     hash-sum: ^2.0.0
-    jiti: ^1.12.15
+    jiti: ^1.13.0
     knitwork: ^0.1.0
     lodash.template: ^4.5.0
     mlly: ^0.4.3
@@ -1992,7 +2037,7 @@ __metadata:
     semver: ^7.3.5
     unctx: ^1.0.2
     untyped: ^0.3.0
-  checksum: 5593d05cf54e85740a5207e5b0fe327971c0fc013e8ca8e5e751e6ec6227b157bc109ef5a7e339166dd776b5eef173669de34295d05133fa9b23161a09c53f2e
+  checksum: 6b6b89ac170f21b133f6381538e77d0c3a5c1fa118d7a9305c656d2ed7c3530bcf8aa97d247b9ff0e9721765a9628b9859b629206e82d6e7a2cac4e2585610d1
   languageName: node
   linkType: hard
 
@@ -2090,21 +2135,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nuxt/nitro@npm:@nuxt/nitro-edge@3.0.0-27409835.c53c736":
-  version: 3.0.0-27409835.c53c736
-  resolution: "@nuxt/nitro-edge@npm:3.0.0-27409835.c53c736"
+"@nuxt/nitro@npm:@nuxt/nitro-edge@3.0.0-27420403.16e2a54":
+  version: 3.0.0-27420403.16e2a54
+  resolution: "@nuxt/nitro-edge@npm:3.0.0-27420403.16e2a54"
   dependencies:
     "@cloudflare/kv-asset-handler": ^0.2.0
-    "@netlify/functions": ^0.11.0
+    "@netlify/functions": ^1.0.0
     "@nuxt/design": 0.1.5
     "@nuxt/devalue": ^2.0.0
-    "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27409835.c53c736"
+    "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27420403.16e2a54"
     "@rollup/plugin-alias": ^3.1.9
     "@rollup/plugin-commonjs": ^21.0.1
     "@rollup/plugin-inject": ^4.0.4
     "@rollup/plugin-json": ^4.1.0
     "@rollup/plugin-node-resolve": ^13.1.3
-    "@rollup/plugin-replace": ^3.0.1
+    "@rollup/plugin-replace": ^3.1.0
     "@rollup/plugin-virtual": ^2.0.3
     "@rollup/plugin-wasm": ^5.1.2
     "@rollup/pluginutils": ^4.1.2
@@ -2117,8 +2162,8 @@ __metadata:
     consola: ^2.15.3
     defu: ^5.0.1
     destr: ^1.1.0
-    dot-prop: ^7.1.1
-    esbuild: ^0.14.21
+    dot-prop: ^7.2.0
+    esbuild: ^0.14.22
     etag: ^1.8.1
     fs-extra: ^10.0.0
     globby: ^13.1.1
@@ -2128,7 +2173,7 @@ __metadata:
     hookable: ^5.1.1
     http-proxy: ^1.18.1
     is-primitive: ^3.0.1
-    jiti: ^1.12.15
+    jiti: ^1.13.0
     knitwork: ^0.1.0
     listhen: ^0.2.6
     mime: ^3.0.0
@@ -2139,8 +2184,8 @@ __metadata:
     p-debounce: ^4.0.0
     pathe: ^0.2.0
     pkg-types: ^0.3.2
-    pretty-bytes: ^5.6.0
-    rollup: ^2.67.2
+    pretty-bytes: ^6.0.0
+    rollup: ^2.67.3
     rollup-plugin-terser: ^7.0.2
     rollup-plugin-visualizer: ^5.5.4
     serve-placeholder: ^1.2.4
@@ -2152,7 +2197,7 @@ __metadata:
     unstorage: ^0.3.3
     vue-bundle-renderer: ^0.3.5
     vue-server-renderer: ^2.6.14
-  checksum: ee9294d85df55995b1f5ddfba8639d5abc3b3d91fe5925215e655beed6d3a33f9e7a025ec22152a804d85e9333b0544cafd22dde26c1c152ea9b44f66e47e3de
+  checksum: c41971e8fada51c57142920beb56558c5df7802d8cb416242d047a15400721b3d7263403d4e8e5e7ccddb2ddb1085e636521eb683f0b3a13bd4718ff79cb010a
   languageName: node
   linkType: hard
 
@@ -2217,19 +2262,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nuxt/schema@npm:@nuxt/schema-edge@3.0.0-27409835.c53c736":
-  version: 3.0.0-27409835.c53c736
-  resolution: "@nuxt/schema-edge@npm:3.0.0-27409835.c53c736"
+"@nuxt/schema@npm:@nuxt/schema-edge@3.0.0-27420403.16e2a54":
+  version: 3.0.0-27420403.16e2a54
+  resolution: "@nuxt/schema-edge@npm:3.0.0-27420403.16e2a54"
   dependencies:
     c12: ^0.1.3
     create-require: ^1.1.1
     defu: ^5.0.1
-    jiti: ^1.12.15
+    jiti: ^1.13.0
     pathe: ^0.2.0
     scule: ^0.2.1
     std-env: ^3.0.1
     ufo: ^0.7.9
-  checksum: 51937809936db85e712efe8a29960900644a59cbb463f167bd605531a1dff855116d770ae725b491dd48b47713c67b61c5f974a0176a7932c3823a1a5c84c9eb
+  checksum: 77502c422ce68c3388d4384b3c0946107d5b4dad0f93b7d98c3bc3cb4263e59292226b9f62fccb7817bd3bedfb12092e0b61ce312eab4aeb811ac6e6cc126608
   languageName: node
   linkType: hard
 
@@ -2347,18 +2392,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nuxt/vite-builder@npm:@nuxt/vite-builder-edge@3.0.0-27409835.c53c736":
-  version: 3.0.0-27409835.c53c736
-  resolution: "@nuxt/vite-builder-edge@npm:3.0.0-27409835.c53c736"
+"@nuxt/vite-builder@npm:@nuxt/vite-builder-edge@3.0.0-27420403.16e2a54":
+  version: 3.0.0-27420403.16e2a54
+  resolution: "@nuxt/vite-builder-edge@npm:3.0.0-27420403.16e2a54"
   dependencies:
-    "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27409835.c53c736"
-    "@vitejs/plugin-vue": ^2.2.0
-    "@vitejs/plugin-vue-jsx": ^1.3.4
+    "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27420403.16e2a54"
+    "@vitejs/plugin-vue": ^2.2.2
+    "@vitejs/plugin-vue-jsx": ^1.3.7
     autoprefixer: ^10.4.2
     chokidar: ^3.5.3
-    consola: ^2.15.3
     defu: ^5.0.1
-    esbuild: ^0.14.21
+    esbuild: ^0.14.22
     escape-string-regexp: ^5.0.0
     externality: ^0.1.6
     fs-extra: ^10.0.0
@@ -2374,10 +2418,10 @@ __metadata:
     rollup-plugin-visualizer: ^5.5.4
     ufo: ^0.7.9
     unplugin: ^0.3.2
-    vite: ^2.8.0
+    vite: ^2.8.4
   peerDependencies:
-    vue: 3.2.30
-  checksum: 0541ede8db56e92777c1741a40aad027ddcdd40e7f9d0d6814bd35eb921df1ad1d55e25d74698f13dec433806c85b828c480a0602d04045bd60f77786971d805
+    vue: 3.2.31
+  checksum: 549c74d95efa1a3dad3388e520fca86b2085019c9edbca0489af3e98f92b42bf1158e43d608a28c919758a0daa0b99879413bab6a645d45bfe03fdc08a390db7
   languageName: node
   linkType: hard
 
@@ -2418,17 +2462,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nuxt/webpack-builder@npm:@nuxt/webpack-builder-edge@3.0.0-27409835.c53c736":
-  version: 3.0.0-27409835.c53c736
-  resolution: "@nuxt/webpack-builder-edge@npm:3.0.0-27409835.c53c736"
+"@nuxt/webpack-builder@npm:@nuxt/webpack-builder-edge@3.0.0-27420403.16e2a54":
+  version: 3.0.0-27420403.16e2a54
+  resolution: "@nuxt/webpack-builder-edge@npm:3.0.0-27420403.16e2a54"
   dependencies:
-    "@babel/core": ^7.17.2
+    "@babel/core": ^7.17.5
     "@nuxt/friendly-errors-webpack-plugin": ^2.5.2
-    "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27409835.c53c736"
+    "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27420403.16e2a54"
     "@vue/babel-preset-jsx": ^1.2.4
     autoprefixer: ^10.4.2
     babel-loader: ^8.2.3
-    consola: ^2.15.3
     css-loader: ^6.6.0
     css-minimizer-webpack-plugin: ^3.4.1
     cssnano: ^5.0.17
@@ -2456,15 +2499,15 @@ __metadata:
     url-loader: ^4.1.1
     vue-loader: ^17.0.0
     vue-style-loader: ^4.1.3
-    webpack: ^5.68.0
+    webpack: ^5.69.1
     webpack-bundle-analyzer: ^4.5.0
     webpack-dev-middleware: ^5.3.1
     webpack-hot-middleware: ^2.25.1
     webpack-virtual-modules: ^0.4.3
     webpackbar: ^5.0.2
   peerDependencies:
-    vue: 3.2.30
-  checksum: e2b4985d58e5bd83803e82a5b807b152c1b17d80dba3035f212d097b64cd2bbd795348f2a8c67c6b7dfaa53b0fdaa08f88ed0605ec189947494fdeccd38a99b6
+    vue: 3.2.31
+  checksum: 352a123ab17a030806cf34a995f6558c1426763d6043c7db3c30c36a77cd660ecec610838822dc63049bb2b10ff787173b7a244917106f10337c976fb9cda415
   languageName: node
   linkType: hard
 
@@ -2660,7 +2703,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/plugin-replace@npm:^3.0.1":
+"@rollup/plugin-replace@npm:^3.0.1, @rollup/plugin-replace@npm:^3.1.0":
   version: 3.1.0
   resolution: "@rollup/plugin-replace@npm:3.1.0"
   dependencies:
@@ -2864,7 +2907,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint-scope@npm:^3.7.0":
+"@types/eslint-scope@npm:^3.7.3":
   version: 3.7.3
   resolution: "@types/eslint-scope@npm:3.7.3"
   dependencies:
@@ -2884,7 +2927,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*":
+"@types/estree@npm:*, @types/estree@npm:^0.0.51":
   version: 0.0.51
   resolution: "@types/estree@npm:0.0.51"
   checksum: e56a3bcf759fd9185e992e7fdb3c6a5f81e8ff120e871641607581fb3728d16c811702a7d40fa5f869b7f7b4437ab6a87eb8d98ffafeee51e85bbe955932a189
@@ -2895,13 +2938,6 @@ __metadata:
   version: 0.0.39
   resolution: "@types/estree@npm:0.0.39"
   checksum: 412fb5b9868f2c418126451821833414189b75cc6bf84361156feed733e3d92ec220b9d74a89e52722e03d5e241b2932732711b7497374a404fad49087adc248
-  languageName: node
-  linkType: hard
-
-"@types/estree@npm:^0.0.50":
-  version: 0.0.50
-  resolution: "@types/estree@npm:0.0.50"
-  checksum: 9a2b6a4a8c117f34d08fbda5e8f69b1dfb109f7d149b60b00fd7a9fb6ac545c078bc590aa4ec2f0a256d680cf72c88b3b28b60c326ee38a7bc8ee1ee95624922
   languageName: node
   linkType: hard
 
@@ -3013,9 +3049,9 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 17.0.17
-  resolution: "@types/node@npm:17.0.17"
-  checksum: 8ddba2829acdf1684fbd8fd248ec13f033efb70ecd1085677b547c40ef8e936a006b95eac3bdc28c47939c62526f3f027afeb4a930e30e4394923bbae4626476
+  version: 17.0.18
+  resolution: "@types/node@npm:17.0.18"
+  checksum: 6c4edfc2b3ba2342a9c3d56e934c5245948ab752f4dc04bd6790b9603e6ebc53bc4f5befc3662e207f7dba2ddd17ccf657f915e319ea7cdd4f77b851079d1611
   languageName: node
   linkType: hard
 
@@ -3258,12 +3294,12 @@ __metadata:
   linkType: hard
 
 "@typescript-eslint/eslint-plugin@npm:^5.8.0":
-  version: 5.11.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:5.11.0"
+  version: 5.12.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:5.12.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 5.11.0
-    "@typescript-eslint/type-utils": 5.11.0
-    "@typescript-eslint/utils": 5.11.0
+    "@typescript-eslint/scope-manager": 5.12.0
+    "@typescript-eslint/type-utils": 5.12.0
+    "@typescript-eslint/utils": 5.12.0
     debug: ^4.3.2
     functional-red-black-tree: ^1.0.1
     ignore: ^5.1.8
@@ -3276,42 +3312,42 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: fa546ba4397f3e693870c39d1e8df6feccb728a7092be6312b78806a64c4ff4648cff0462503d3e510e8b173b9704c19e78d2a7af790ab1c0309782e33a89c32
+  checksum: ac7074b51456748ef8770d82f5b4e691e1b93bb1353b448bb1b43db5b5a9722a6a012dc1dc0a3b35ab0c0ca7c1b5412f535ad992115132ed84ed6f4179778d37
   languageName: node
   linkType: hard
 
 "@typescript-eslint/parser@npm:^5.8.0":
-  version: 5.11.0
-  resolution: "@typescript-eslint/parser@npm:5.11.0"
+  version: 5.12.0
+  resolution: "@typescript-eslint/parser@npm:5.12.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 5.11.0
-    "@typescript-eslint/types": 5.11.0
-    "@typescript-eslint/typescript-estree": 5.11.0
+    "@typescript-eslint/scope-manager": 5.12.0
+    "@typescript-eslint/types": 5.12.0
+    "@typescript-eslint/typescript-estree": 5.12.0
     debug: ^4.3.2
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 521b6e701d877dc0514c6a3992f4900aa6fea28ba7c0bc03c634dad2b50aa195401e45683dfebd9e8492a857cd84bba3b585d8fe8d0cd1d7e2720372c34c50a3
+  checksum: 0453c14d967ebba4ebe0d763882b7a1258f23a710d127f53196d360b78722d880cc8c0299feb52ecc4e10600834c22559bf543211249d878efad864f7ec856bc
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:5.11.0":
-  version: 5.11.0
-  resolution: "@typescript-eslint/scope-manager@npm:5.11.0"
+"@typescript-eslint/scope-manager@npm:5.12.0":
+  version: 5.12.0
+  resolution: "@typescript-eslint/scope-manager@npm:5.12.0"
   dependencies:
-    "@typescript-eslint/types": 5.11.0
-    "@typescript-eslint/visitor-keys": 5.11.0
-  checksum: bf7feaed495ed4cafa1b89a2b73781b30061d019e1c1b3765dc8006e7f36b537f6f451e37c77400067771318b4f0c5915804084dc6299ea7c6ecde2daf0aca1c
+    "@typescript-eslint/types": 5.12.0
+    "@typescript-eslint/visitor-keys": 5.12.0
+  checksum: 87cc4e8ab3b495293e51685566cafca6f217c7328fc1210e4a9c3a89e864c5e3a04ddde11708e07820185fd158cb448980607a93fd658fa2089c152f27a847d0
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:5.11.0":
-  version: 5.11.0
-  resolution: "@typescript-eslint/type-utils@npm:5.11.0"
+"@typescript-eslint/type-utils@npm:5.12.0":
+  version: 5.12.0
+  resolution: "@typescript-eslint/type-utils@npm:5.12.0"
   dependencies:
-    "@typescript-eslint/utils": 5.11.0
+    "@typescript-eslint/utils": 5.12.0
     debug: ^4.3.2
     tsutils: ^3.21.0
   peerDependencies:
@@ -3319,23 +3355,23 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: fd570806d82874289ded6bfd90ff5414d4365b95b4a2e911f7ff2fee6e2c7675d0f2f71580c24cb8be733c3dfe2cd33eedff99ae2aa50f61b1b5af76499074eb
+  checksum: 90390603319441493b62611730db78f8a732e32a5d9097d1e9c6581da6caeb71cc08a3ed6c716f2fc490b153f956c9a2471d9fbe97c22214ca86f58511c7581a
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:5.11.0":
-  version: 5.11.0
-  resolution: "@typescript-eslint/types@npm:5.11.0"
-  checksum: b1531481da75a6c89510ad03f3db68e4797b25438bb902ee322bd1c154b83396016271cc00356dcdbc300a8ee421493aae803b8c716f36d7b4808fe045ae3a2a
+"@typescript-eslint/types@npm:5.12.0":
+  version: 5.12.0
+  resolution: "@typescript-eslint/types@npm:5.12.0"
+  checksum: f5e7f8270cb0f9f18886bf00f8f1fd589b793f4c05dc2de53cc826beb969161e19ffc10f51237402fb9f3d24f5aaf3bb41b1d8da70e115ec3ff11e79b3471988
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:5.11.0":
-  version: 5.11.0
-  resolution: "@typescript-eslint/typescript-estree@npm:5.11.0"
+"@typescript-eslint/typescript-estree@npm:5.12.0":
+  version: 5.12.0
+  resolution: "@typescript-eslint/typescript-estree@npm:5.12.0"
   dependencies:
-    "@typescript-eslint/types": 5.11.0
-    "@typescript-eslint/visitor-keys": 5.11.0
+    "@typescript-eslint/types": 5.12.0
+    "@typescript-eslint/visitor-keys": 5.12.0
     debug: ^4.3.2
     globby: ^11.0.4
     is-glob: ^4.0.3
@@ -3344,33 +3380,33 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 7bda55501c586efd7f8065b4158016486d8af92b8419931fbea7cec9bfe074075de8cdebec8baa1ac8a5c3f973599b9dd44a51fced1792176e49cd60cc8e5442
+  checksum: 6a8e852c210b20370eb564f3beb245c425e65a4de3e78a1e2f278a241b6acf72ba43b10767df18fc1654b529453529f721fa673569406ace4011712c9c837900
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:5.11.0":
-  version: 5.11.0
-  resolution: "@typescript-eslint/utils@npm:5.11.0"
+"@typescript-eslint/utils@npm:5.12.0":
+  version: 5.12.0
+  resolution: "@typescript-eslint/utils@npm:5.12.0"
   dependencies:
     "@types/json-schema": ^7.0.9
-    "@typescript-eslint/scope-manager": 5.11.0
-    "@typescript-eslint/types": 5.11.0
-    "@typescript-eslint/typescript-estree": 5.11.0
+    "@typescript-eslint/scope-manager": 5.12.0
+    "@typescript-eslint/types": 5.12.0
+    "@typescript-eslint/typescript-estree": 5.12.0
     eslint-scope: ^5.1.1
     eslint-utils: ^3.0.0
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-  checksum: 5ab1a15db1e0a2fbb857a8a16325459ad3d5239066f2641aa93ad9f7d08252d3a4ca6ae356c51cba1c6c81a65d84883436566b01932fa55b64a69796b950900d
+  checksum: 34c394db0510be78c5cbb8928c9eb81405a117dd9e5903a149e4f3c20218dcda89a29e5012984d07c8ce9e5c7f5d7c38f5c3061558028f3f518ac98bbeb9a006
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:5.11.0":
-  version: 5.11.0
-  resolution: "@typescript-eslint/visitor-keys@npm:5.11.0"
+"@typescript-eslint/visitor-keys@npm:5.12.0":
+  version: 5.12.0
+  resolution: "@typescript-eslint/visitor-keys@npm:5.12.0"
   dependencies:
-    "@typescript-eslint/types": 5.11.0
+    "@typescript-eslint/types": 5.12.0
     eslint-visitor-keys: ^3.0.0
-  checksum: 8f0b6fe1e86bc93825a137be3220f57e3a4bee410cca5d35963a0cd416750b31291a73c4294676d94ed0f5066b4cfb3a8f512d409881daa550d1645f4381eb21
+  checksum: c3774f542aae801926edf86fe6cab534c4cdac914b035730912443ed53fcc701b0f0e7b1a0d5fc959484637c55f63409fc43df5508c334e202d66d4654484d11
   languageName: node
   linkType: hard
 
@@ -3410,9 +3446,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-vue-jsx@npm:^1.3.4":
-  version: 1.3.5
-  resolution: "@vitejs/plugin-vue-jsx@npm:1.3.5"
+"@vitejs/plugin-vue-jsx@npm:^1.3.7":
+  version: 1.3.7
+  resolution: "@vitejs/plugin-vue-jsx@npm:1.3.7"
   dependencies:
     "@babel/core": ^7.17.2
     "@babel/plugin-syntax-import-meta": ^7.10.4
@@ -3420,17 +3456,17 @@ __metadata:
     "@rollup/pluginutils": ^4.1.2
     "@vue/babel-plugin-jsx": ^1.1.1
     hash-sum: ^2.0.0
-  checksum: 0b4ce6cfe61e13cc6fa87a5cdf298389707ccee45d2030d4ad952d5f9cf7a3fdb743bf39ef3c8c6335386eaa6912e00cd18fe6daf625f3bc0e0796727ab7a473
+  checksum: 2cb2969becfb33e6ff1f9e3b06c756be5a3f85bd24e222b6e0511866425701a2678db0ecc8826e4aa1749e71339ebd152e5c65c9521eb2d6f589d116b40baff6
   languageName: node
   linkType: hard
 
-"@vitejs/plugin-vue@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@vitejs/plugin-vue@npm:2.2.0"
+"@vitejs/plugin-vue@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "@vitejs/plugin-vue@npm:2.2.2"
   peerDependencies:
     vite: ^2.5.10
     vue: ^3.2.25
-  checksum: ab3e3c77c251eada60c8394f8cdce67430a7efdf9f8f7d98bbfc98dd1915c639db43228a2a95d5d43e41acc54a65573169ae23044e848a36c1e8bf609fe41acf
+  checksum: f05920e282569c3721dbbd730c83e40978134c0f53cd10f9429cc37b22152c494782f7b9541db937a2fd7ed324b819ec8aa0b54f136c3c6adbed7298c9c9e9da
   languageName: node
   linkType: hard
 
@@ -3652,9 +3688,9 @@ __metadata:
   linkType: hard
 
 "@vue/devtools-api@npm:^6.0.0-beta.13, @vue/devtools-api@npm:^6.0.0-beta.18":
-  version: 6.0.8
-  resolution: "@vue/devtools-api@npm:6.0.8"
-  checksum: 4601fad607538af52962636eb6045b22e71cf17578ef835c836c58d76c3f2778c2960d10645ed782c39a39a8881e5e763a6cc32536b973aac913fbb248b19632
+  version: 6.0.12
+  resolution: "@vue/devtools-api@npm:6.0.12"
+  checksum: 5eb4601a6f6601c4481eab54c7f05f8e373ac3f2b5ab6973847a47e7ddbec7a9d2cd80dc692905da9e8615ac64a208702c54f7dfac47f7aa2168a5b7dd176545
   languageName: node
   linkType: hard
 
@@ -3671,7 +3707,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/reactivity@npm:3.2.31, @vue/reactivity@npm:^3.2.30":
+"@vue/reactivity@npm:3.2.31, @vue/reactivity@npm:^3.2.31":
   version: 3.2.31
   resolution: "@vue/reactivity@npm:3.2.31"
   dependencies:
@@ -3713,7 +3749,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vue/shared@npm:3.2.31, @vue/shared@npm:^3.2.26, @vue/shared@npm:^3.2.30":
+"@vue/shared@npm:3.2.31, @vue/shared@npm:^3.2.26, @vue/shared@npm:^3.2.31":
   version: 3.2.31
   resolution: "@vue/shared@npm:3.2.31"
   checksum: bf614d9d06f7c01fbe3f5f50d8f7621fffd83d2eebd6c2ccf540c59754283d3b659aa93f7d610ed4c16284a4d5208ef5aec12337f2d4d0ab05e9a271cd4a2051
@@ -4915,17 +4951,17 @@ __metadata:
   linkType: hard
 
 "browserslist@npm:^4.0.0, browserslist@npm:^4.12.0, browserslist@npm:^4.14.5, browserslist@npm:^4.16.6, browserslist@npm:^4.17.5, browserslist@npm:^4.19.1, browserslist@npm:^4.6.4":
-  version: 4.19.1
-  resolution: "browserslist@npm:4.19.1"
+  version: 4.19.3
+  resolution: "browserslist@npm:4.19.3"
   dependencies:
-    caniuse-lite: ^1.0.30001286
-    electron-to-chromium: ^1.4.17
+    caniuse-lite: ^1.0.30001312
+    electron-to-chromium: ^1.4.71
     escalade: ^3.1.1
-    node-releases: ^2.0.1
+    node-releases: ^2.0.2
     picocolors: ^1.0.0
   bin:
     browserslist: cli.js
-  checksum: c0777fd483691638fd6801e16c9d809e1d65f6d2b06db2e806654be51045cbab1452a89841a2c5caea2cbe19d621b4f1d391cffbb24512aa33280039ab345875
+  checksum: c28958313dd17f345dd6e26379cc863126cd7d855588e57a1ed9e552a1135d64f05ec57063b48fff0d94a9b785bd248e9472c2d63ce8460ca56fc2444f5a1e66
   languageName: node
   linkType: hard
 
@@ -5203,7 +5239,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000981, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001275, caniuse-lite@npm:^1.0.30001286, caniuse-lite@npm:^1.0.30001297":
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30000981, caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001275, caniuse-lite@npm:^1.0.30001297, caniuse-lite@npm:^1.0.30001312":
   version: 1.0.30001312
   resolution: "caniuse-lite@npm:1.0.30001312"
   checksum: 753fb9ea1e02e999430b323a71b5acab5120f3b5fc0161b01669f54a3ef5c5296240b6ae9b79b12a3742e3aed216aa9ee3d5398a23c16d08625ccd376b79545d
@@ -5800,19 +5836,19 @@ __metadata:
   linkType: hard
 
 "core-js-compat@npm:^3.19.1, core-js-compat@npm:^3.20.2, core-js-compat@npm:^3.21.0":
-  version: 3.21.0
-  resolution: "core-js-compat@npm:3.21.0"
+  version: 3.21.1
+  resolution: "core-js-compat@npm:3.21.1"
   dependencies:
     browserslist: ^4.19.1
     semver: 7.0.0
-  checksum: 7914d2f8a2f7c1b400e1c04c7560f4c96028bf23cec3cea6063ba594e38023cccbd38ad88af41c5d6b65450e97a989eb37598f609e3f7fbc6ebc1856d4195cbb
+  checksum: 6af1bcbc94ede50b109e54bf3f5a9ca28b8a303124e07c2bf76c2257a8a94a0b550cf4a318f6ec0594b351b6f9a5453fd4516e3681560b6d984b95d1988baf13
   languageName: node
   linkType: hard
 
 "core-js@npm:^3.15.1, core-js@npm:^3.19.0, core-js@npm:^3.21.0":
-  version: 3.21.0
-  resolution: "core-js@npm:3.21.0"
-  checksum: 87df49aa2c5d0a521c52102b6669842dd30b334742e86dd4e0173c51230bc48d610060ab6de0f149766d188325b8c1b84598f901cf455674fe6c03ccc5c8026f
+  version: 3.21.1
+  resolution: "core-js@npm:3.21.1"
+  checksum: d68eddd831340ad5b24ac29c72fda022a43b17f194c4278b6b875a843283d316502cb4abd07f28631d6ebc4387f66aa06e2b1b3c8fd7e08096a751b5c63f6889
   languageName: node
   linkType: hard
 
@@ -6259,10 +6295,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssdb@npm:^6.3.0":
-  version: 6.3.0
-  resolution: "cssdb@npm:6.3.0"
-  checksum: 8c76e4c63ce0399b3a2ce0620c6d23e63cf08429f71a8371214b423030bc0c8654043aa220d90beefc90fa4bdc83c461a96ff4a8831f706549cbfa87f7481a0a
+"cssdb@npm:^6.3.1":
+  version: 6.4.0
+  resolution: "cssdb@npm:6.4.0"
+  checksum: 9daed448f2414b31080fe8e6ed6812584254bbfa540589116fc62dfba6719adbfdf552883e4c789dd4124e9697f7b8cd3f3149aeaca3c1e5bd4a3c4bff38d36f
   languageName: node
   linkType: hard
 
@@ -6823,12 +6859,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dot-prop@npm:^7.1.1":
-  version: 7.1.1
-  resolution: "dot-prop@npm:7.1.1"
+"dot-prop@npm:^7.1.1, dot-prop@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "dot-prop@npm:7.2.0"
   dependencies:
-    type-fest: ^2.10.0
-  checksum: c4b75618da609b2eefe04a173e89181d200283a1c68c404c4041b730ab49d6adb8ad4a806ebd4feaa6d76bcb7fd943b4129c23b0729a05623ef0d12fe203a7cf
+    type-fest: ^2.11.2
+  checksum: 08e4ff14f7305ffb5fda7e4c88f3cdbeb3cd97bd27efa4f47503869a2ee7f96938b4c21b0a2abf9c37d891a1bdb3994a09d219b0dcfd6130da4eaeb44c6f067e
   languageName: node
   linkType: hard
 
@@ -6886,10 +6922,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.4.17":
-  version: 1.4.68
-  resolution: "electron-to-chromium@npm:1.4.68"
-  checksum: d7654d07ab7c504a0683cf29715db227bdbd3e397ad3a41bad3d1e35e9f837447be2bc5dea54b3350d51be5c9c7b79756dcbe44903fbee5949d67d783e788acb
+"electron-to-chromium@npm:^1.4.71":
+  version: 1.4.71
+  resolution: "electron-to-chromium@npm:1.4.71"
+  checksum: ecb2546eed6b0e95003d787c259de730f32e2f5c0fa2acb27069c0cd21378cbc2a6c7516f4ec677a5960db4e180644f87ed91a729825a238454e31e4e74617db
   languageName: node
   linkType: hard
 
@@ -7078,9 +7114,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-android-arm64@npm:0.14.21":
-  version: 0.14.21
-  resolution: "esbuild-android-arm64@npm:0.14.21"
+"esbuild-android-arm64@npm:0.14.23":
+  version: 0.14.23
+  resolution: "esbuild-android-arm64@npm:0.14.23"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -7092,9 +7128,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-darwin-64@npm:0.14.21":
-  version: 0.14.21
-  resolution: "esbuild-darwin-64@npm:0.14.21"
+"esbuild-darwin-64@npm:0.14.23":
+  version: 0.14.23
+  resolution: "esbuild-darwin-64@npm:0.14.23"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -7106,9 +7142,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-darwin-arm64@npm:0.14.21":
-  version: 0.14.21
-  resolution: "esbuild-darwin-arm64@npm:0.14.21"
+"esbuild-darwin-arm64@npm:0.14.23":
+  version: 0.14.23
+  resolution: "esbuild-darwin-arm64@npm:0.14.23"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -7120,9 +7156,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-freebsd-64@npm:0.14.21":
-  version: 0.14.21
-  resolution: "esbuild-freebsd-64@npm:0.14.21"
+"esbuild-freebsd-64@npm:0.14.23":
+  version: 0.14.23
+  resolution: "esbuild-freebsd-64@npm:0.14.23"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -7134,9 +7170,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-freebsd-arm64@npm:0.14.21":
-  version: 0.14.21
-  resolution: "esbuild-freebsd-arm64@npm:0.14.21"
+"esbuild-freebsd-arm64@npm:0.14.23":
+  version: 0.14.23
+  resolution: "esbuild-freebsd-arm64@npm:0.14.23"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -7148,9 +7184,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-32@npm:0.14.21":
-  version: 0.14.21
-  resolution: "esbuild-linux-32@npm:0.14.21"
+"esbuild-linux-32@npm:0.14.23":
+  version: 0.14.23
+  resolution: "esbuild-linux-32@npm:0.14.23"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
@@ -7162,9 +7198,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-64@npm:0.14.21":
-  version: 0.14.21
-  resolution: "esbuild-linux-64@npm:0.14.21"
+"esbuild-linux-64@npm:0.14.23":
+  version: 0.14.23
+  resolution: "esbuild-linux-64@npm:0.14.23"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
@@ -7176,9 +7212,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-arm64@npm:0.14.21":
-  version: 0.14.21
-  resolution: "esbuild-linux-arm64@npm:0.14.21"
+"esbuild-linux-arm64@npm:0.14.23":
+  version: 0.14.23
+  resolution: "esbuild-linux-arm64@npm:0.14.23"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
@@ -7190,9 +7226,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-arm@npm:0.14.21":
-  version: 0.14.21
-  resolution: "esbuild-linux-arm@npm:0.14.21"
+"esbuild-linux-arm@npm:0.14.23":
+  version: 0.14.23
+  resolution: "esbuild-linux-arm@npm:0.14.23"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -7204,9 +7240,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-mips64le@npm:0.14.21":
-  version: 0.14.21
-  resolution: "esbuild-linux-mips64le@npm:0.14.21"
+"esbuild-linux-mips64le@npm:0.14.23":
+  version: 0.14.23
+  resolution: "esbuild-linux-mips64le@npm:0.14.23"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
@@ -7218,23 +7254,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-linux-ppc64le@npm:0.14.21":
-  version: 0.14.21
-  resolution: "esbuild-linux-ppc64le@npm:0.14.21"
+"esbuild-linux-ppc64le@npm:0.14.23":
+  version: 0.14.23
+  resolution: "esbuild-linux-ppc64le@npm:0.14.23"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
-"esbuild-linux-riscv64@npm:0.14.21":
-  version: 0.14.21
-  resolution: "esbuild-linux-riscv64@npm:0.14.21"
+"esbuild-linux-riscv64@npm:0.14.23":
+  version: 0.14.23
+  resolution: "esbuild-linux-riscv64@npm:0.14.23"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
-"esbuild-linux-s390x@npm:0.14.21":
-  version: 0.14.21
-  resolution: "esbuild-linux-s390x@npm:0.14.21"
+"esbuild-linux-s390x@npm:0.14.23":
+  version: 0.14.23
+  resolution: "esbuild-linux-s390x@npm:0.14.23"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -7262,9 +7298,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-netbsd-64@npm:0.14.21":
-  version: 0.14.21
-  resolution: "esbuild-netbsd-64@npm:0.14.21"
+"esbuild-netbsd-64@npm:0.14.23":
+  version: 0.14.23
+  resolution: "esbuild-netbsd-64@npm:0.14.23"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -7276,9 +7312,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-openbsd-64@npm:0.14.21":
-  version: 0.14.21
-  resolution: "esbuild-openbsd-64@npm:0.14.21"
+"esbuild-openbsd-64@npm:0.14.23":
+  version: 0.14.23
+  resolution: "esbuild-openbsd-64@npm:0.14.23"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
@@ -7290,9 +7326,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-sunos-64@npm:0.14.21":
-  version: 0.14.21
-  resolution: "esbuild-sunos-64@npm:0.14.21"
+"esbuild-sunos-64@npm:0.14.23":
+  version: 0.14.23
+  resolution: "esbuild-sunos-64@npm:0.14.23"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
@@ -7304,9 +7340,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-windows-32@npm:0.14.21":
-  version: 0.14.21
-  resolution: "esbuild-windows-32@npm:0.14.21"
+"esbuild-windows-32@npm:0.14.23":
+  version: 0.14.23
+  resolution: "esbuild-windows-32@npm:0.14.23"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
@@ -7318,9 +7354,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-windows-64@npm:0.14.21":
-  version: 0.14.21
-  resolution: "esbuild-windows-64@npm:0.14.21"
+"esbuild-windows-64@npm:0.14.23":
+  version: 0.14.23
+  resolution: "esbuild-windows-64@npm:0.14.23"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -7332,9 +7368,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-windows-arm64@npm:0.14.21":
-  version: 0.14.21
-  resolution: "esbuild-windows-arm64@npm:0.14.21"
+"esbuild-windows-arm64@npm:0.14.23":
+  version: 0.14.23
+  resolution: "esbuild-windows-arm64@npm:0.14.23"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -7401,29 +7437,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild@npm:^0.14.14, esbuild@npm:^0.14.21, esbuild@npm:^0.14.6":
-  version: 0.14.21
-  resolution: "esbuild@npm:0.14.21"
+"esbuild@npm:^0.14.14, esbuild@npm:^0.14.22, esbuild@npm:^0.14.6":
+  version: 0.14.23
+  resolution: "esbuild@npm:0.14.23"
   dependencies:
-    esbuild-android-arm64: 0.14.21
-    esbuild-darwin-64: 0.14.21
-    esbuild-darwin-arm64: 0.14.21
-    esbuild-freebsd-64: 0.14.21
-    esbuild-freebsd-arm64: 0.14.21
-    esbuild-linux-32: 0.14.21
-    esbuild-linux-64: 0.14.21
-    esbuild-linux-arm: 0.14.21
-    esbuild-linux-arm64: 0.14.21
-    esbuild-linux-mips64le: 0.14.21
-    esbuild-linux-ppc64le: 0.14.21
-    esbuild-linux-riscv64: 0.14.21
-    esbuild-linux-s390x: 0.14.21
-    esbuild-netbsd-64: 0.14.21
-    esbuild-openbsd-64: 0.14.21
-    esbuild-sunos-64: 0.14.21
-    esbuild-windows-32: 0.14.21
-    esbuild-windows-64: 0.14.21
-    esbuild-windows-arm64: 0.14.21
+    esbuild-android-arm64: 0.14.23
+    esbuild-darwin-64: 0.14.23
+    esbuild-darwin-arm64: 0.14.23
+    esbuild-freebsd-64: 0.14.23
+    esbuild-freebsd-arm64: 0.14.23
+    esbuild-linux-32: 0.14.23
+    esbuild-linux-64: 0.14.23
+    esbuild-linux-arm: 0.14.23
+    esbuild-linux-arm64: 0.14.23
+    esbuild-linux-mips64le: 0.14.23
+    esbuild-linux-ppc64le: 0.14.23
+    esbuild-linux-riscv64: 0.14.23
+    esbuild-linux-s390x: 0.14.23
+    esbuild-netbsd-64: 0.14.23
+    esbuild-openbsd-64: 0.14.23
+    esbuild-sunos-64: 0.14.23
+    esbuild-windows-32: 0.14.23
+    esbuild-windows-64: 0.14.23
+    esbuild-windows-arm64: 0.14.23
   dependenciesMeta:
     esbuild-android-arm64:
       optional: true
@@ -7465,7 +7501,7 @@ __metadata:
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: 21a0b302740a36c7b5166761f0174a3937222e0f3fb612a5363f0be6b44e32b4070940488df5733b2034150a3c8ef74b1129d7e179daea1bfcb8e88d7998f96b
+  checksum: 41d26f9022a9f95a1ccf280fd6c2cf2684264663c03d5d4338bfab17710292b9c2ca45624ed55d9f37d7be5f29557ebd6d101b21ed5592fb0b6e6ac5e76bc58d
   languageName: node
   linkType: hard
 
@@ -7512,13 +7548,13 @@ __metadata:
   linkType: hard
 
 "eslint-config-prettier@npm:^8.3.0":
-  version: 8.3.0
-  resolution: "eslint-config-prettier@npm:8.3.0"
+  version: 8.4.0
+  resolution: "eslint-config-prettier@npm:8.4.0"
   peerDependencies:
     eslint: ">=7.0.0"
   bin:
     eslint-config-prettier: bin/cli.js
-  checksum: df4cea3032671995bb5ab07e016169072f7fa59f44a53251664d9ca60951b66cdc872683b5c6a3729c91497c11490ca44a79654b395dd6756beb0c3903a37196
+  checksum: ee8dc343f1fed15dc0658e190a966cc23644477f2331a7f56ae2bb79dd74892e3cde8ea5c142e7a3329a8291a1de041e13ca96e54d0c85ff4a2aba13390c5f10
   languageName: node
   linkType: hard
 
@@ -8183,12 +8219,12 @@ __metadata:
   linkType: hard
 
 "follow-redirects@npm:^1.0.0":
-  version: 1.14.8
-  resolution: "follow-redirects@npm:1.14.8"
+  version: 1.14.9
+  resolution: "follow-redirects@npm:1.14.9"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 40c67899c2e3149a27e8b6498a338ff27f39fe138fde8d7f0756cb44b073ba0bfec3d52af28f20c5bdd67263d564d0d8d7b5efefd431de95c18c42f7b4aef457
+  checksum: f5982e0eb481818642492d3ca35a86989c98af1128b8e1a62911a3410621bc15d2b079e8170b35b19d3bdee770b73ed431a257ed86195af773771145baa57845
   languageName: node
   linkType: hard
 
@@ -8443,8 +8479,8 @@ __metadata:
   linkType: hard
 
 "gauge@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "gauge@npm:4.0.0"
+  version: 4.0.1
+  resolution: "gauge@npm:4.0.1"
   dependencies:
     ansi-regex: ^5.0.1
     aproba: ^1.0.3 || ^2.0.0
@@ -8455,7 +8491,7 @@ __metadata:
     string-width: ^4.2.3
     strip-ansi: ^6.0.1
     wide-align: ^1.1.2
-  checksum: 637b34c84f518defa89319dbef68211a24e9302182ad2a619e3be1be5b7dcf2a962c8359e889294af667440f4722e7e6e61671859e00bd8ec280a136ded89b25
+  checksum: 398540c761f2efbd8c35323b781a572db09a3ab2d62ea672fc440eb88e9249624ac8b64275731d9ef266cde6491880df5360d74d0829da077136ee614b08f85c
   languageName: node
   linkType: hard
 
@@ -9902,12 +9938,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jiti@npm:^1.12.13, jiti@npm:^1.12.14, jiti@npm:^1.12.15, jiti@npm:^1.12.9, jiti@npm:^1.9.2":
-  version: 1.12.15
-  resolution: "jiti@npm:1.12.15"
+"jiti@npm:^1.12.13, jiti@npm:^1.12.14, jiti@npm:^1.12.15, jiti@npm:^1.12.9, jiti@npm:^1.13.0, jiti@npm:^1.9.2":
+  version: 1.13.0
+  resolution: "jiti@npm:1.13.0"
   bin:
     jiti: bin/jiti.js
-  checksum: 8e53259f427eb7a7c0cd834c284e18cd05760cb7f0f15b4971ab11874e8b0e7b15fc1f13000eb3a8c7f804ff15637a283d6595858811d61effe8c5aeaacb02ac
+  checksum: 1e74d99b9a551df952057b8bce56f744caccca0044aa05021643e6ce0837ed47bc2d5b290fecb462e32988c6bf318afe77e341310c5ecf6bb63c19c80c929cb6
   languageName: node
   linkType: hard
 
@@ -10804,20 +10840,20 @@ __metadata:
   linkType: hard
 
 "minimatch@npm:^3.0.4":
-  version: 3.1.1
-  resolution: "minimatch@npm:3.1.1"
+  version: 3.1.2
+  resolution: "minimatch@npm:3.1.2"
   dependencies:
     brace-expansion: ^1.1.7
-  checksum: e9e3772e4ea06ea3a888d39bc7690d3c812ee7e5a70c2d2f568ccadac0249a027f865589d19ad03ed937e6ca3b4ad35f85411db9670f7877d8fc2ed452f1cd37
+  checksum: c154e566406683e7bcb746e000b84d74465b3a832c45d59912b9b55cd50dee66e5c4b1e5566dba26154040e51672f9aa450a9aef0c97cfc7336b78b7afb9540a
   languageName: node
   linkType: hard
 
 "minimatch@npm:~3.0.4":
-  version: 3.0.7
-  resolution: "minimatch@npm:3.0.7"
+  version: 3.0.8
+  resolution: "minimatch@npm:3.0.8"
   dependencies:
     brace-expansion: ^1.1.7
-  checksum: 904b52bbe9a4c12a11c3ea9b503b8f64e0f822997a8fed8e8f2eaa4cb8805e2a03468a4940a63c198aac9c036f2388dfbfb9cd3b63667077ed7cb2e761bff2a4
+  checksum: 850cca179cad715133132693e6963b0db64ab0988c4d211415b087fc23a3e46321e2c5376a01bf5623d8782aba8bdf43c571e2e902e51fdce7175c7215c29f8b
   languageName: node
   linkType: hard
 
@@ -11083,11 +11119,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.1.23, nanoid@npm:^3.1.32, nanoid@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "nanoid@npm:3.2.0"
+  version: 3.3.1
+  resolution: "nanoid@npm:3.3.1"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 3d1d5a69fea84e538057cf64106e713931c4ef32af344068ecff153ff91252f39b0f2b472e09b0dfff43ac3cf520c92938d90e6455121fe93976e23660f4fccc
+  checksum: 4ef0969e1bbe866fc223eb32276cbccb0961900bfe79104fa5abe34361979dead8d0e061410a5c03bc3d47455685adf32c09d6f27790f4a6898fb51f7df7ec86
   languageName: node
   linkType: hard
 
@@ -11376,7 +11412,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^2.0.1":
+"node-releases@npm:^2.0.2":
   version: 2.0.2
   resolution: "node-releases@npm:2.0.2"
   checksum: da858bf86b4d512842379749f5a5e4196ddab05ba18ffcf29f05bf460beceaca927f070f4430bb5046efec18941ddbc85e4c5fdbb83afc28a38dd6069a2f255e
@@ -11635,9 +11671,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nuxi@npm:nuxi-edge@3.0.0-27409835.c53c736":
-  version: 3.0.0-27409835.c53c736
-  resolution: "nuxi-edge@npm:3.0.0-27409835.c53c736"
+"nuxi@npm:nuxi-edge@3.0.0-27420403.16e2a54":
+  version: 3.0.0-27420403.16e2a54
+  resolution: "nuxi-edge@npm:3.0.0-27420403.16e2a54"
   dependencies:
     fsevents: ~2.3.2
   dependenciesMeta:
@@ -11645,7 +11681,7 @@ __metadata:
       optional: true
   bin:
     nuxi-edge: ./bin/nuxi.mjs
-  checksum: 6f2010fdabfcb9475531cbc13ef29efdf3e3b076c63fd8ef5eafbb037d759698072782b62684b956a1b14f031541d23afca0b881b56b24ac18e8be5760274c96
+  checksum: 1810fa97aca00c06d07e59e51359875c1001bfbfe25909e7cc2815b000a0f38300bac27c5802f7968e8ae6f4134463400fddbda5dec9761e1616bc19a3d96fdd
   languageName: node
   linkType: hard
 
@@ -11697,20 +11733,19 @@ __metadata:
   linkType: soft
 
 "nuxt3@npm:latest":
-  version: 3.0.0-27409835.c53c736
-  resolution: "nuxt3@npm:3.0.0-27409835.c53c736"
+  version: 3.0.0-27420403.16e2a54
+  resolution: "nuxt3@npm:3.0.0-27420403.16e2a54"
   dependencies:
     "@nuxt/design": ^0.1.5
-    "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27409835.c53c736"
-    "@nuxt/nitro": "npm:@nuxt/nitro-edge@3.0.0-27409835.c53c736"
-    "@nuxt/schema": "npm:@nuxt/schema-edge@3.0.0-27409835.c53c736"
-    "@nuxt/vite-builder": "npm:@nuxt/vite-builder-edge@3.0.0-27409835.c53c736"
-    "@nuxt/webpack-builder": "npm:@nuxt/webpack-builder-edge@3.0.0-27409835.c53c736"
-    "@vue/reactivity": ^3.2.30
-    "@vue/shared": ^3.2.30
+    "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27420403.16e2a54"
+    "@nuxt/nitro": "npm:@nuxt/nitro-edge@3.0.0-27420403.16e2a54"
+    "@nuxt/schema": "npm:@nuxt/schema-edge@3.0.0-27420403.16e2a54"
+    "@nuxt/vite-builder": "npm:@nuxt/vite-builder-edge@3.0.0-27420403.16e2a54"
+    "@nuxt/webpack-builder": "npm:@nuxt/webpack-builder-edge@3.0.0-27420403.16e2a54"
+    "@vue/reactivity": ^3.2.31
+    "@vue/shared": ^3.2.31
     "@vueuse/head": ^0.7.5
     chokidar: ^3.5.3
-    consola: ^2.15.3
     cookie-es: ^0.5.0
     defu: ^5.0.1
     destr: ^1.1.0
@@ -11725,18 +11760,18 @@ __metadata:
     mlly: ^0.4.3
     murmurhash-es: ^0.1.1
     nitropack: "npm:nitropack-edge@latest"
-    nuxi: "npm:nuxi-edge@3.0.0-27409835.c53c736"
+    nuxi: "npm:nuxi-edge@3.0.0-27420403.16e2a54"
     ohmyfetch: ^0.4.15
     pathe: ^0.2.0
     scule: ^0.2.1
     ufo: ^0.7.9
     unplugin: ^0.3.2
-    vue: ^3.2.30
+    vue: ^3.2.31
     vue-router: ^4.0.12
   bin:
     nuxi: ./bin/nuxt.mjs
     nuxt: ./bin/nuxt.mjs
-  checksum: aa09c5aa11ee58c910820eab03049d76cb39f63e72ca24e8e6cc68202ff5725a1e9021a491a253182c96bf6df0ac88f740a98fa9ad5abdab9662db2f8c9f53d1
+  checksum: 3fcffdcc4ed22e48bddb2df909abc104ee9473555094ca0b8e31dcff8d69245baf58f48f3c7e688b5065daad4ccdbf5439658c4defd8491d6e523cb2265f8871
   languageName: node
   linkType: hard
 
@@ -12377,19 +12412,19 @@ __metadata:
   linkType: hard
 
 "playwright-chromium@npm:^1.17.1":
-  version: 1.19.0
-  resolution: "playwright-chromium@npm:1.19.0"
+  version: 1.19.1
+  resolution: "playwright-chromium@npm:1.19.1"
   dependencies:
-    playwright-core: 1.19.0
+    playwright-core: 1.19.1
   bin:
     playwright: cli.js
-  checksum: a74ea6df6c1e2d580913f1ea81cdf7613e3f7ede03c908b11d682f98fc8949594163d0ca31038e35a6e58c98dd6a2c1135a3cde5460ad124234dd1f924044159
+  checksum: 4186020819a6d5b57034574207d53817d7865f0773339efd01141a8a98b6302468e7f297cfd20c95bcc4450b5fbad0d3d6c3ac3b5d06825cbb04479416a1ad71
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.19.0":
-  version: 1.19.0
-  resolution: "playwright-core@npm:1.19.0"
+"playwright-core@npm:1.19.1":
+  version: 1.19.1
+  resolution: "playwright-core@npm:1.19.1"
   dependencies:
     commander: 8.3.0
     debug: 4.3.3
@@ -12409,7 +12444,7 @@ __metadata:
     yazl: 2.5.1
   bin:
     playwright: cli.js
-  checksum: 2725ae393f9af30280111a7f40c1982fd8d6183b75403faa0a7e97e460da848dc3417b360abd7408dd4e3bc2e72074cdd8fdd015c89f126968ee4f5e1cccdf01
+  checksum: a88b055d1180b128bc073b58dd63aff29d1f996711e8f72cae4df03ecc8c133822caf04a9f6838b4bd3f6473b9c58661274f39e9db3b4570b18bbe0a3eef1fb6
   languageName: node
   linkType: hard
 
@@ -12480,14 +12515,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-clamp@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "postcss-clamp@npm:3.0.0"
+"postcss-clamp@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "postcss-clamp@npm:4.0.0"
   dependencies:
-    postcss-value-parser: ^4.1.0
+    postcss-value-parser: ^4.2.0
   peerDependencies:
-    postcss: ^8.4.5
-  checksum: a7428a91b8167a9f0930499bd5937c9fda03c81a20825479d2ce0bea131f865d90ab76cd377e3664112699393f73c1a1bc3591151ebf290219a893af8fe71d10
+    postcss: ^8.4.6
+  checksum: 103ae5039a55623f2835c11684367bb094d62ac21a99ee612741f4dcec827eccd21ad3a11d6792f66f90e86133f046e352addbab4576b90d98b3c4ea0dce1e53
   languageName: node
   linkType: hard
 
@@ -12787,14 +12822,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-double-position-gradients@npm:^3.0.5":
-  version: 3.0.5
-  resolution: "postcss-double-position-gradients@npm:3.0.5"
+"postcss-double-position-gradients@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "postcss-double-position-gradients@npm:3.1.0"
   dependencies:
+    "@csstools/postcss-progressive-custom-properties": ^1.1.0
     postcss-value-parser: ^4.2.0
   peerDependencies:
     postcss: ^8.4
-  checksum: 43c676a085ba908e7ceabffb180e367a949d3a566d31271ca2194fb398260393de4e1aaa95733184d5c337a97ec47cd8c42e42573ed5d60736533f44a1bb5ebd
+  checksum: 168810c5e9a38c8cab5c19fe9209a6819d35fce7e4e66dc7b67aafacd0bdfa2c24247cb187b63893bfe65339f3981dacdaf0071abf1fca2dbe826bd935673f29
   languageName: node
   linkType: hard
 
@@ -12992,15 +13028,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-lab-function@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "postcss-lab-function@npm:4.1.0"
+"postcss-lab-function@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "postcss-lab-function@npm:4.1.1"
   dependencies:
     "@csstools/postcss-progressive-custom-properties": ^1.1.0
     postcss-value-parser: ^4.2.0
   peerDependencies:
     postcss: ^8.4
-  checksum: cf48efa4e23a94a2c7c639b929e57b3ef1ccbb21f636d64ae571a1a72bb0538878c8239c95371e9372448e06890bc2010303e75cc8a715bd2323cc189895872e
+  checksum: 8f2b319c84494aef05b1a3bec08f4aa5b0ce199bc3154ba2297397955d74ef3c3e0dfa485b05d83a7a02347b8bedb9ee7a658c2cae71accbbb129ac91e71a99c
   languageName: node
   linkType: hard
 
@@ -13676,22 +13712,25 @@ __metadata:
   linkType: hard
 
 "postcss-preset-env@npm:^7.3.0":
-  version: 7.3.3
-  resolution: "postcss-preset-env@npm:7.3.3"
+  version: 7.4.1
+  resolution: "postcss-preset-env@npm:7.4.1"
   dependencies:
+    "@csstools/postcss-color-function": ^1.0.2
     "@csstools/postcss-font-format-keywords": ^1.0.0
     "@csstools/postcss-hwb-function": ^1.0.0
+    "@csstools/postcss-ic-unit": ^1.0.0
     "@csstools/postcss-is-pseudo-class": ^2.0.0
     "@csstools/postcss-normalize-display-values": ^1.0.0
-    "@csstools/postcss-progressive-custom-properties": ^1.1.0
+    "@csstools/postcss-oklab-function": ^1.0.1
+    "@csstools/postcss-progressive-custom-properties": ^1.2.0
     autoprefixer: ^10.4.2
     browserslist: ^4.19.1
     css-blank-pseudo: ^3.0.3
     css-has-pseudo: ^3.0.4
     css-prefers-color-scheme: ^6.0.3
-    cssdb: ^6.3.0
+    cssdb: ^6.3.1
     postcss-attribute-case-insensitive: ^5.0.0
-    postcss-clamp: ^3.0.0
+    postcss-clamp: ^4.0.0
     postcss-color-functional-notation: ^4.2.2
     postcss-color-hex-alpha: ^8.0.3
     postcss-color-rebeccapurple: ^7.0.2
@@ -13699,7 +13738,7 @@ __metadata:
     postcss-custom-properties: ^12.1.4
     postcss-custom-selectors: ^6.0.0
     postcss-dir-pseudo-class: ^6.0.4
-    postcss-double-position-gradients: ^3.0.5
+    postcss-double-position-gradients: ^3.1.0
     postcss-env-function: ^4.0.5
     postcss-focus-visible: ^6.0.4
     postcss-focus-within: ^5.0.4
@@ -13707,7 +13746,7 @@ __metadata:
     postcss-gap-properties: ^3.0.3
     postcss-image-set-function: ^4.0.6
     postcss-initial: ^4.0.1
-    postcss-lab-function: ^4.1.0
+    postcss-lab-function: ^4.1.1
     postcss-logical: ^5.0.4
     postcss-media-minmax: ^5.0.0
     postcss-nesting: ^10.1.2
@@ -13720,7 +13759,7 @@ __metadata:
     postcss-selector-not: ^5.0.0
   peerDependencies:
     postcss: ^8.4
-  checksum: c93da81f8b78ddcfcfb2787be537272dd1beba37b0ce44da0e14e38efb2ac5b1e2e80377aa0da7107fac30544e79b337e11951ebc7960499db261e3d4e4cc35d
+  checksum: adfa72f3c1d344630fbb2b7ea0c6832cbcdce9abf84c65237a833cc31ac2095315a5fb13a6e4222938801367212038aa8e2afd425527ba8d45e4fb13cd293ab7
   languageName: node
   linkType: hard
 
@@ -14027,6 +14066,13 @@ __metadata:
   version: 5.6.0
   resolution: "pretty-bytes@npm:5.6.0"
   checksum: 9c082500d1e93434b5b291bd651662936b8bd6204ec9fa17d563116a192d6d86b98f6d328526b4e8d783c07d5499e2614a807520249692da9ec81564b2f439cd
+  languageName: node
+  linkType: hard
+
+"pretty-bytes@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "pretty-bytes@npm:6.0.0"
+  checksum: 0bb9f95e617236404b29a8392c6efd82d65805f622f5e809ecd70068102be857d4e3276c86d2a32fa2ef851cc29472e380945dab7bec83ec79bd57a19a10faf7
   languageName: node
   linkType: hard
 
@@ -14776,9 +14822,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^2.58.0, rollup@npm:^2.59.0, rollup@npm:^2.66.1, rollup@npm:^2.67.2":
-  version: 2.67.2
-  resolution: "rollup@npm:2.67.2"
+"rollup@npm:^2.58.0, rollup@npm:^2.59.0, rollup@npm:^2.66.1, rollup@npm:^2.67.3":
+  version: 2.67.3
+  resolution: "rollup@npm:2.67.3"
   dependencies:
     fsevents: ~2.3.2
   dependenciesMeta:
@@ -14786,7 +14832,7 @@ __metadata:
       optional: true
   bin:
     rollup: dist/bin/rollup
-  checksum: 9aca5251ba4b441064183cde2394b91567259002d68086bdd3906db66d55dd148ab27e57c51eb53830d7b9b813c2d4e834b7735d65e2a869780bc639d4a20c38
+  checksum: c4013a2ceef6918375fd07a6548e05d0f3df1db9f0a0281aebe6e993a45c0e667c5a06f53b55c0ffaf72f72266c1879bc181b13199aace97d93f0fc47691d4a9
   languageName: node
   linkType: hard
 
@@ -16332,10 +16378,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^2.10.0":
-  version: 2.11.2
-  resolution: "type-fest@npm:2.11.2"
-  checksum: b36f73b9e739d4044f511fa3233eb36d365f5fbf5b120810ec5c6a31b8a6c7a2caeba2fb725491ccfb41a37aac8862e67f4383fc178a0c6074d27c424fe7c764
+"type-fest@npm:^2.11.2":
+  version: 2.12.0
+  resolution: "type-fest@npm:2.12.0"
+  checksum: 3ebe6529db84c7ceb579a0c693b92c4bf83fa5a78b5d6a1d3c2138696ad69e0a1ebc7e1b707ee0a2a6bd5aef71bf2bf4fc6fc81a6c752330e10faf0deea80f05
   languageName: node
   linkType: hard
 
@@ -16896,9 +16942,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:>=2.7.13, vite@npm:^2.7.13, vite@npm:^2.8.0":
-  version: 2.8.1
-  resolution: "vite@npm:2.8.1"
+"vite@npm:>=2.7.13, vite@npm:^2.7.13, vite@npm:^2.8.4":
+  version: 2.8.4
+  resolution: "vite@npm:2.8.4"
   dependencies:
     esbuild: ^0.14.14
     fsevents: ~2.3.2
@@ -16921,7 +16967,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 4ce8acc2dd2a7ca8727511ff575f72de162114402e55e5d081001f05ef1656782cd5611d4f6091c29efb455e72d30967467bad5b6b329bfe5279fbe8d5169d67
+  checksum: 0531ea17d354c35026c87e732d28c777492cc5165c4abdaa507c4894535ecbbfcf447fa3f270bbb160cd7cba8ad319cc86a221be18b2ccd40d8be139f9d7381d
   languageName: node
   linkType: hard
 
@@ -17025,8 +17071,8 @@ __metadata:
   linkType: hard
 
 "vue-i18n-routing@npm:edge":
-  version: 0.0.0-5735bda
-  resolution: "vue-i18n-routing@npm:0.0.0-5735bda"
+  version: 0.0.0-33d6652
+  resolution: "vue-i18n-routing@npm:0.0.0-33d6652"
   dependencies:
     "@intlify/shared": beta
     "@intlify/vue-i18n-bridge": ^0.3.5
@@ -17042,7 +17088,7 @@ __metadata:
   peerDependenciesMeta:
     "@vue/composition-api":
       optional: true
-  checksum: 03291100e3e15bdfb3c83b82c9f6f38870740004db711d48e656d083a2dcc80a7e5b7454f42f0866c3d292001603ca403f0eeb0bbde1879722b0f9df4dfee634
+  checksum: 2766a940d51cc12059d518317220955247da67d0141ccaecf58a88db3da581541e09501a58e860462ca199809d8d33cb3b46f8901fcdc35184c4165f01a672bf
   languageName: node
   linkType: hard
 
@@ -17178,7 +17224,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue@npm:^3.2.30":
+"vue@npm:^3.2.31":
   version: 3.2.31
   resolution: "vue@npm:3.2.31"
   dependencies:
@@ -17384,12 +17430,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:^5.68.0":
-  version: 5.68.0
-  resolution: "webpack@npm:5.68.0"
+"webpack@npm:^5.69.1":
+  version: 5.69.1
+  resolution: "webpack@npm:5.69.1"
   dependencies:
-    "@types/eslint-scope": ^3.7.0
-    "@types/estree": ^0.0.50
+    "@types/eslint-scope": ^3.7.3
+    "@types/estree": ^0.0.51
     "@webassemblyjs/ast": 1.11.1
     "@webassemblyjs/wasm-edit": 1.11.1
     "@webassemblyjs/wasm-parser": 1.11.1
@@ -17417,7 +17463,7 @@ __metadata:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: ac6efd861a0bfb35d8a467fba0d87f905ef6e1a9a9f7e3db42ea459cf191268094cedd025d3eb36a1464e2208a0c193f3f4a92531ba58850246f3c6b8f210b03
+  checksum: 490a6e9e4cd9d0ed3b6c7ca08015da2628919fda8fcf9c36f0f6c0e3ad71eaaaf4b0d12753109f22a4faf79fe9a9063552d9708e0ee2352cf8568433b8e296a7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2550,28 +2550,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@nuxtjs/i18n@npm:@nuxtjs/i18n-edge@latest":
-  version: 8.0.0-alpha.0-27419678.39bcf0f
-  resolution: "@nuxtjs/i18n-edge@npm:8.0.0-alpha.0-27419678.39bcf0f"
-  dependencies:
-    "@intlify/shared": next
-    "@intlify/vite-plugin-vue-i18n": next
-    "@intlify/vue-i18n-loader": next
-    "@nuxt/kit": "npm:@nuxt/kit-edge@3.0.0-27398533.8edd481"
-    debug: ^4.3.2
-    defu: latest
-    knitwork: ^0.1.0
-    mlly: ^0.3.19
-    pathe: ^0.2.0
-    vue-i18n: beta
-    vue-i18n-bridge: beta
-    vue-i18n-legacy: "npm:vue-i18n@8"
-    vue-i18n-routing: edge
-  checksum: 6b94310310f2e7b783448f3f3f6800bfba0f1a27917b385e3457f64cbe4becd8922df7cc2223b5761ceced3559b1ef558d6b4fae88b04a3c3c1beeb4eefd779f
-  languageName: node
-  linkType: hard
-
-"@nuxtjs/i18n@workspace:packages/nuxt-i18n":
+"@nuxtjs/i18n@workspace:./packages/nuxt-i18n, @nuxtjs/i18n@workspace:packages/nuxt-i18n":
   version: 0.0.0-use.local
   resolution: "@nuxtjs/i18n@workspace:packages/nuxt-i18n"
   dependencies:


### PR DESCRIPTION
NOTE: This doesn't work currently.

The main issue with getting it to work is the fact that there is:
```
  "resolutions": {
    "@nuxtjs/i18n": "workspace:./packages/nuxt-i18n"
  },
```
in `package-json`.

For the script to work, I think this would need to be also renamed to `@nuxtjs/i18n-edge` and possibility other references would also have to be updated...

It might be a bit of work and I don't have time right now to work on it so if you have time, you could try to make it work @kazupon .