### PR TITLE
fix: don't detect locale from route when using no_prefix

### DIFF
--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -216,7 +216,7 @@ export default async (context) => {
 
     const finalLocale =
       (options.detectBrowserLanguage && doDetectBrowserLanguage(route)) ||
-      (!options.differentDomains && getLocaleFromRoute(route)) ||
+      (!options.differentDomains && options.strategy !== Constants.STRATEGIES.NO_PREFIX && getLocaleFromRoute(route)) ||
       app.i18n.locale || app.i18n.defaultLocale || ''
 
     if (options.skipSettingLocaleOnNavigate) {

--- a/src/templates/utils-common.js
+++ b/src/templates/utils-common.js
@@ -118,7 +118,7 @@ export function getLocaleDomain (locales, req) {
  * @return {RegExp}
  */
 export function getLocalesRegex (localeCodes) {
-  return new RegExp(`^/(${localeCodes.join('|')})(?:/|$)`, 'i')
+  return new RegExp(`^/(${localeCodes.join('|')})(?:/|$)`)
 }
 
 /**
@@ -130,7 +130,7 @@ export function getLocalesRegex (localeCodes) {
 export function createLocaleFromRouteGetter (localeCodes, { routesNameSeparator, defaultLocaleRouteNameSuffix }) {
   const localesPattern = `(${localeCodes.join('|')})`
   const defaultSuffixPattern = `(?:${routesNameSeparator}${defaultLocaleRouteNameSuffix})?`
-  const regexpName = new RegExp(`${routesNameSeparator}${localesPattern}${defaultSuffixPattern}$`, 'i')
+  const regexpName = new RegExp(`${routesNameSeparator}${localesPattern}${defaultSuffixPattern}$`)
   const regexpPath = getLocalesRegex(localeCodes)
   /**
    * Extract locale code from given route:

--- a/test/fixture/no-lang-switcher/layouts/error.vue
+++ b/test/fixture/no-lang-switcher/layouts/error.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    <p>Page not found</p>
+    <p id="locale-properties">{{ JSON.stringify($i18n.localeProperties) }}</p>
+  </div>
+</template>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4585,20 +4585,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001228:
-  version "1.0.30001239"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz#66e8669985bb2cb84ccb10f68c25ce6dd3e4d2b8"
-  integrity sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==
-
-caniuse-lite@^1.0.30001274:
-  version "1.0.30001274"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001274.tgz#26ca36204d15b17601ba6fc35dbdad950a647cc7"
-  integrity sha512-+Nkvv0fHyhISkiMIjnyjmf5YJcQ1IQHZN6U9TLUMroWR38FNwpsC51Gb68yueafX1V6ifOisInSgP9WJFS13ew==
-
-caniuse-lite@^1.0.30001280:
-  version "1.0.30001283"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz#8573685bdae4d733ef18f78d44ba0ca5fe9e896b"
-  integrity sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001228, caniuse-lite@^1.0.30001274, caniuse-lite@^1.0.30001280:
+  version "1.0.30001323"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001323.tgz"
+  integrity sha512-e4BF2RlCVELKx8+RmklSEIVub1TWrmdhvA5kEUueummz1XyySW0DVk+3x9HyhU9MuWTa2BhqLgEuEmUwASAdCA==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
It was wrong to attempt to detect locale from route when using the `no_prefix` strategy.

Using `no_prefix` and visiting something like `/EN/not-found` has been handled incorrectly if there was locale `en` defined. We would use the upper-case `EN` for the locale which would then not match in certain places causing `localeProperties` to not be set appropriately, for example.