### PR TITLE
fix: fixed locale changing issue in server side middleware

### DIFF
--- a/src/templates/utils-common.js
+++ b/src/templates/utils-common.js
@@ -214,8 +214,21 @@ export function setLocaleCookie (locale, res, { useCookie, cookieDomain, cookieK
     }
 
     const redirectCookie = cookieSerialize(cookieKey, locale, cookieOptions)
-    headers.push(redirectCookie)
+    let foundRedirectCookie = false
+    const cookies = headers.map(header => {
+      const cookie = cookieParse(header)
+      if (cookie[cookieKey]) {
+        cookie[cookieKey] = locale
+        foundRedirectCookie = true
+        return redirectCookie
+      }
+      return header
+    })
 
-    res.setHeader('Set-Cookie', headers)
+    if (!foundRedirectCookie) {
+      cookies.push(redirectCookie)
+    }
+
+    res.setHeader('Set-Cookie', cookies)
   }
 }

--- a/src/templates/utils-common.js
+++ b/src/templates/utils-common.js
@@ -214,21 +214,12 @@ export function setLocaleCookie (locale, res, { useCookie, cookieDomain, cookieK
     }
 
     const redirectCookie = cookieSerialize(cookieKey, locale, cookieOptions)
-    let foundRedirectCookie = false
-    const cookies = headers.map(header => {
+    headers = headers.filter(header => {
       const cookie = cookieParse(header)
-      if (cookie[cookieKey]) {
-        cookie[cookieKey] = locale
-        foundRedirectCookie = true
-        return redirectCookie
-      }
-      return header
+      return !(cookieKey in cookie)
     })
+    headers.push(redirectCookie)
 
-    if (!foundRedirectCookie) {
-      cookies.push(redirectCookie)
-    }
-
-    res.setHeader('Set-Cookie', cookies)
+    res.setHeader('Set-Cookie', headers)
   }
 }


### PR DESCRIPTION
Close: https://github.com/nuxt-community/i18n-module/issues/1310

When I tried to change the language in middleware running on the server side, I called setLocale, but the language did not change. While investigating the situation, I noticed that the language I added was added to the end of the array of previously added cookie headers. This means that there are more than one redirect cookie in the cookie headers and this prevents language change.

So I made a fix like this:
If there is a redirect cookie in the cookies in the incoming request, then override that cookie, otherwise add the new locale cookie as the value of the 'Set-Cookie' header.