### PR TITLE
feat: add possibility to disable default redirect for prefix_and_default strategy

### DIFF
--- a/docs/content/en/api.md
+++ b/docs/content/en/api.md
@@ -28,11 +28,17 @@ All [Vue I18n properties and methods](http://kazupon.github.io/vue-i18n/api/#vue
 
   - **Arguments**:
     - locale: (type: `string`)
+    - forcePrefix: (type: `boolean`)
   - **Returns**: `string`
 
-  Returns path of the current route for specified `locale`.
+  Returns path of the current route for specified `locale`. 
+
+  If `forcePrefix` is set to `true`, it returns the path with the prefix. Useful for `prefix_and_default` strategy. 
+  You can also set global behavior through option prefixAndDefaultRules.
 
   See also [Basic usage - nuxt-link](../basic-usage#nuxt-link).
+
+  See more details about [prefixAndDefaultRules](../options-reference#prefixanddefaultrules).
 
   See type definition for [Location](https://github.com/vuejs/vue-router/blob/f40139c27a9736efcbda69ec136cb00d8e00fa97/types/router.d.ts#L125).
 

--- a/docs/content/en/api.md
+++ b/docs/content/en/api.md
@@ -28,17 +28,11 @@ All [Vue I18n properties and methods](http://kazupon.github.io/vue-i18n/api/#vue
 
   - **Arguments**:
     - locale: (type: `string`)
-    - forcePrefix: (type: `boolean`)
   - **Returns**: `string`
 
   Returns path of the current route for specified `locale`. 
 
-  If `forcePrefix` is set to `true`, it returns the path with the prefix. Useful for `prefix_and_default` strategy. 
-  You can also set global behavior through option prefixAndDefaultRules.
-
   See also [Basic usage - nuxt-link](../basic-usage#nuxt-link).
-
-  See more details about [prefixAndDefaultRules](../options-reference#prefixanddefaultrules).
 
   See type definition for [Location](https://github.com/vuejs/vue-router/blob/f40139c27a9736efcbda69ec136cb00d8e00fa97/types/router.d.ts#L125).
 

--- a/docs/content/en/options-reference.md
+++ b/docs/content/en/options-reference.md
@@ -186,17 +186,15 @@ Set this to `true` when using different domains for each locale. If enabled, no 
 
 Whether [custom paths](/routing#custom-paths) are extracted from page files using babel parser.
 
-## `prefixAndDefaultRules`
+## `prefixAndDefaultRule`
 
 - type: `object`
-- default: `{ routing: 'default', switchLocale: 'default' }`
+- default: `'default'`
 
 Modification of the standard behavior of the `prefix_and_default` strategy.
 
-By setting the value `routing = 'prefix'` we are no longer being redirected from prefixed path.
+By setting the value `prefixAndDefaultRule = 'prefix'` we are no longer being redirected from prefixed path.
 If there is no prefix then the other routers will also have no prefix.
-
-By setting the value `switchLocale = 'prefix'` the `switchLocalePath()` method adds a prefix to the current route.
 
 ## `pages`
 

--- a/docs/content/en/options-reference.md
+++ b/docs/content/en/options-reference.md
@@ -186,6 +186,18 @@ Set this to `true` when using different domains for each locale. If enabled, no 
 
 Whether [custom paths](/routing#custom-paths) are extracted from page files using babel parser.
 
+## `prefixAndDefaultRules`
+
+- type: `object`
+- default: `{ routing: 'default', switchLocale: 'default' }`
+
+Modification of the standard behavior of the `prefix_and_default` strategy.
+
+By setting the value `routing = 'prefix'` we are no longer being redirected from prefixed path.
+If there is no prefix then the other routers will also have no prefix.
+
+By setting the value `switchLocale = 'prefix'` the `switchLocalePath()` method adds a prefix to the current route.
+
 ## `pages`
 
 - type: `object`

--- a/docs/content/en/strategies.md
+++ b/docs/content/en/strategies.md
@@ -29,7 +29,7 @@ With this strategy, all routes will have a locale prefix.
 
 This strategy combines both previous strategies behaviours, meaning that you will get URLs with prefixes for every language, but URLs for the default language will also have a non-prefixed version (though the prefixed version will be preferred when `detectBrowserLanguage` is enabled.)
 
-The behavior of the strategy can be modified, more - [prefixAndDefaultRules](../options-reference#prefixanddefaultrules)
+The behavior of the strategy can be modified, more - [prefixAndDefaultRule](../options-reference#prefixanddefaultrule)
 
 ### Configuration
 

--- a/docs/content/en/strategies.md
+++ b/docs/content/en/strategies.md
@@ -27,7 +27,9 @@ With this strategy, all routes will have a locale prefix.
 
 ### prefix_and_default
 
-This strategy combines both previous strategies behaviours, meaning that you will get URLs with prefixes for every language, but URLs for the default language will also have a non-prefixed version (though the prefixed version will be preferred when `detectBrowserLanguage` is enabled.
+This strategy combines both previous strategies behaviours, meaning that you will get URLs with prefixes for every language, but URLs for the default language will also have a non-prefixed version (though the prefixed version will be preferred when `detectBrowserLanguage` is enabled.)
+
+The behavior of the strategy can be modified, more - [prefixAndDefaultRules](../options-reference#prefixanddefaultrules)
 
 ### Configuration
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "scripts": {
     "dev:basic": "nuxt -c ./test/fixture/basic/nuxt.config.js",
+    "dev:redirect": "nuxt -c ./test/fixture/disable-redirect/nuxt.config.js",
     "dev:basic:generate": "nuxt generate -c ./test/fixture/basic/nuxt.config.js",
     "dev:basic:start": "nuxt start -c ./test/fixture/basic/nuxt.config.js",
     "start:dist": "jiti ./test/utils/http-server-internal.js --port 8080 -v dist",

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -34,6 +34,7 @@ export const DEFAULT_OPTIONS = {
   vueI18nLoader: false,
   locales: [],
   defaultLocale: '',
+  disableDefaultRedirect: false,
   defaultDirection: 'ltr',
   routesNameSeparator: '___',
   defaultLocaleRouteNameSuffix: 'default',

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -37,6 +37,10 @@ export const DEFAULT_OPTIONS = {
   defaultDirection: 'ltr',
   routesNameSeparator: '___',
   defaultLocaleRouteNameSuffix: 'default',
+  prefixAndDefaultRules: {
+    switchLocal: 'default',
+    routing: 'default'
+  },
   sortRoutes: true,
   strategy: STRATEGY_PREFIX_EXCEPT_DEFAULT,
   lazy: false,

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -38,7 +38,7 @@ export const DEFAULT_OPTIONS = {
   routesNameSeparator: '___',
   defaultLocaleRouteNameSuffix: 'default',
   prefixAndDefaultRules: {
-    switchLocal: 'default',
+    switchLocale: 'default',
     routing: 'default'
   },
   sortRoutes: true,

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -38,7 +38,6 @@ export const DEFAULT_OPTIONS = {
   routesNameSeparator: '___',
   defaultLocaleRouteNameSuffix: 'default',
   prefixAndDefaultRules: {
-    switchLocale: 'default',
     routing: 'default'
   },
   sortRoutes: true,

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -34,7 +34,6 @@ export const DEFAULT_OPTIONS = {
   vueI18nLoader: false,
   locales: [],
   defaultLocale: '',
-  disableDefaultRedirect: false,
   defaultDirection: 'ltr',
   routesNameSeparator: '___',
   defaultLocaleRouteNameSuffix: 'default',

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -153,7 +153,7 @@ export default async (context) => {
     let redirectPath = ''
 
     const isStaticGenerate = process.static && process.server
-    const isSameLocale = getLocaleFromRoute(route) !== newLocale
+    const isDifferentLocale = getLocaleFromRoute(route) !== newLocale
     const isPrefixAndDefaultStrategy = options.strategy === Constants.STRATEGIES.PREFIX_AND_DEFAULT
     const isDefaultLocale = newLocale === options.defaultLocale
     const isEnabledRedirectForRoute = isEnabledRedirectForPath(route.fullPath, app.i18n.localeCodes, options.disableDefaultRedirect)
@@ -166,7 +166,7 @@ export default async (context) => {
       // Skip if already on the new locale unless the strategy is "prefix_and_default" and this is the default
       // locale, in which case we might still redirect as we prefer unprefixed route in this case, but let user a
       // possibility to disable this behavior by switching disableDefaultRedirect option to true.
-      (isSameLocale || (isPrefixAndDefaultStrategy && isDefaultLocale && isEnabledRedirectForRoute))
+      (isDifferentLocale || (isPrefixAndDefaultStrategy && isDefaultLocale && isEnabledRedirectForRoute))
     ) {
       // The current route could be 404 in which case attempt to find matching route using the full path since
       // "switchLocalePath" can only find routes if the current route exists.

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -15,7 +15,7 @@ import {
   loadLanguageAsync,
   resolveBaseUrl,
   registerStore,
-  mergeAdditionalMessages, isEnabledRedirectForPath
+  mergeAdditionalMessages
 } from './plugin.utils'
 // @ts-ignore
 import { joinURL } from '~i18n-ufo'
@@ -156,7 +156,6 @@ export default async (context) => {
     const isDifferentLocale = getLocaleFromRoute(route) !== newLocale
     const isPrefixAndDefaultStrategy = options.strategy === Constants.STRATEGIES.PREFIX_AND_DEFAULT
     const isDefaultLocale = newLocale === options.defaultLocale
-    const isEnabledRedirectForRoute = isEnabledRedirectForPath(route.fullPath, app.i18n.localeCodes, options.prefixAndDefaultRedirect)
 
     // Decide whether we should redirect to a different route.
     if (
@@ -166,11 +165,10 @@ export default async (context) => {
       // Skip if already on the new locale unless the strategy is "prefix_and_default" and this is the default
       // locale, in which case we might still redirect as we prefer unprefixed route in this case, but let user a
       // possibility to disable this behavior by switching disableDefaultRedirect option to true.
-      (isDifferentLocale || (isPrefixAndDefaultStrategy && isDefaultLocale && isEnabledRedirectForRoute))
+      (isDifferentLocale || (isPrefixAndDefaultStrategy && isDefaultLocale))
     ) {
-      // The current route could be 404 in which case attempt to find matching route using the full path since
-      // "switchLocalePath" can only find routes if the current route exists.
-      const routePath = app.switchLocalePath(newLocale) || app.localePath(route.fullPath, newLocale)
+      const routePath = app.localePath(route.fullPath, newLocale)
+
       if (routePath && routePath !== route.fullPath && !routePath.startsWith('//')) {
         redirectPath = routePath
       }

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -156,7 +156,7 @@ export default async (context) => {
     const isDifferentLocale = getLocaleFromRoute(route) !== newLocale
     const isPrefixAndDefaultStrategy = options.strategy === Constants.STRATEGIES.PREFIX_AND_DEFAULT
     const isDefaultLocale = newLocale === options.defaultLocale
-    const isEnabledRedirectForRoute = isEnabledRedirectForPath(route.fullPath, app.i18n.localeCodes, options.disableDefaultRedirect)
+    const isEnabledRedirectForRoute = isEnabledRedirectForPath(route.fullPath, app.i18n.localeCodes, options.prefixAndDefaultRedirect)
 
     // Decide whether we should redirect to a different route.
     if (

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -143,9 +143,9 @@ function switchLocalePath (locale, forcePrefix = false) {
   })
   let path = this.localePath(baseRoute, locale)
 
-  const { prefixAndDefaultRules: { switchLocal } } = options
+  const { prefixAndDefaultRules: { switchLocale } } = options
   const { isPrefixAndDefault, isDefaultLocale } = getHelpers(locale)
-  const shouldSwitchToPrefix = switchLocal === 'prefix'
+  const shouldSwitchToPrefix = switchLocale === 'prefix'
 
   if (isPrefixAndDefault && isDefaultLocale && (shouldSwitchToPrefix || forcePrefix)) {
     const cleanPath = removeLocaleFromPath(path, [locale])

--- a/src/templates/plugin.utils.js
+++ b/src/templates/plugin.utils.js
@@ -1,8 +1,8 @@
 import isHTTPS from 'is-https'
 import { localeMessages, options } from './options'
-import { removeLocaleFromPath, formatMessage } from './utils-common'
+import { formatMessage } from './utils-common'
 // @ts-ignore
-import { hasProtocol, withTrailingSlash } from '~i18n-ufo'
+import { hasProtocol } from '~i18n-ufo'
 
 /** @typedef {import('../../types/internal').ResolvedOptions} ResolvedOptions */
 
@@ -214,40 +214,6 @@ export function mergeAdditionalMessages (i18n, additionalMessages, localeCodes, 
       i18n.mergeLocaleMessage(locale, existingMessages)
     }
   }
-}
-
-/**
- * @param {string} pathString
- * @param {readonly string[]} localeCodes
- * @param {import('../../types').PrefixAndDefaultRedirect} prefixAndDefaultRedirect
- * @return {boolean}
- */
-export function isEnabledRedirectForPath (pathString, localeCodes, prefixAndDefaultRedirect) {
-  if (!prefixAndDefaultRedirect) {
-    return true
-  }
-
-  if (!prefixAndDefaultRedirect?.pages?.length) {
-    return false
-  }
-
-  const cleanPath = removeLocaleFromPath(pathString, localeCodes)
-  const cleanPathWithSlash = withTrailingSlash(cleanPath)
-
-  return !prefixAndDefaultRedirect.pages
-    .map((patternString) => {
-      const isPattern = patternString.endsWith('*')
-      const pathPattern = patternString.replace('*', '')
-      const normalizedPathPattern = withTrailingSlash(pathPattern)
-
-      return {
-        isPattern,
-        path: normalizedPathPattern
-      }
-    })
-    .some(({ isPattern, path }) => {
-      return isPattern ? cleanPathWithSlash.startsWith(path) : cleanPathWithSlash === path
-    })
 }
 
 /**

--- a/src/templates/plugin.utils.js
+++ b/src/templates/plugin.utils.js
@@ -219,22 +219,22 @@ export function mergeAdditionalMessages (i18n, additionalMessages, localeCodes, 
 /**
  * @param {string} pathString
  * @param {readonly string[]} localeCodes
- * @param {import('../../types').DisableDefaultRedirect} disableDefaultRedirect
+ * @param {import('../../types').PrefixAndDefaultRedirect} prefixAndDefaultRedirect
  * @return {boolean}
  */
-export function isEnabledRedirectForPath (pathString, localeCodes, disableDefaultRedirect) {
-  if (!disableDefaultRedirect) {
+export function isEnabledRedirectForPath (pathString, localeCodes, prefixAndDefaultRedirect) {
+  if (!prefixAndDefaultRedirect) {
     return true
   }
 
-  if (typeof disableDefaultRedirect === 'boolean') {
+  if (!prefixAndDefaultRedirect?.pages?.length) {
     return false
   }
 
   const cleanPath = removeLocaleFromPath(pathString, localeCodes)
   const cleanPathWithSlash = withTrailingSlash(cleanPath)
 
-  return !disableDefaultRedirect
+  return !prefixAndDefaultRedirect.pages
     .map((patternString) => {
       const isPattern = patternString.endsWith('*')
       const pathPattern = patternString.replace('*', '')

--- a/src/templates/plugin.utils.js
+++ b/src/templates/plugin.utils.js
@@ -1,8 +1,8 @@
 import isHTTPS from 'is-https'
 import { localeMessages, options } from './options'
-import { addSlashToPath, clearPathFromLocale, formatMessage } from './utils-common'
+import { removeLocaleFromPath, formatMessage } from './utils-common'
 // @ts-ignore
-import { hasProtocol } from '~i18n-ufo'
+import { hasProtocol, withTrailingSlash } from '~i18n-ufo'
 
 /** @typedef {import('../../types/internal').ResolvedOptions} ResolvedOptions */
 
@@ -231,14 +231,14 @@ export function isEnabledRedirectForPath (pathString, localeCodes, disableDefaul
     return false
   }
 
-  const clearPath = clearPathFromLocale(pathString, localeCodes)
-  const clearPathWithSlash = addSlashToPath(clearPath)
+  const cleanPath = removeLocaleFromPath(pathString, localeCodes)
+  const cleanPathWithSlash = withTrailingSlash(cleanPath)
 
   return !disableDefaultRedirect
     .map((patternString) => {
-      const isPattern = patternString.includes('*')
+      const isPattern = patternString.endsWith('*')
       const pathPattern = patternString.replace('*', '')
-      const normalizedPathPattern = addSlashToPath(pathPattern)
+      const normalizedPathPattern = withTrailingSlash(pathPattern)
 
       return {
         isPattern,
@@ -246,7 +246,7 @@ export function isEnabledRedirectForPath (pathString, localeCodes, disableDefaul
       }
     })
     .some(({ isPattern, path }) => {
-      return isPattern ? clearPathWithSlash.startsWith(path) : clearPathWithSlash === path
+      return isPattern ? cleanPathWithSlash.startsWith(path) : cleanPathWithSlash === path
     })
 }
 

--- a/src/templates/plugin.utils.js
+++ b/src/templates/plugin.utils.js
@@ -1,6 +1,6 @@
 import isHTTPS from 'is-https'
 import { localeMessages, options } from './options'
-import { formatMessage } from './utils-common'
+import { addSlashToPath, clearPathFromLocale, formatMessage } from './utils-common'
 // @ts-ignore
 import { hasProtocol } from '~i18n-ufo'
 
@@ -214,6 +214,40 @@ export function mergeAdditionalMessages (i18n, additionalMessages, localeCodes, 
       i18n.mergeLocaleMessage(locale, existingMessages)
     }
   }
+}
+
+/**
+ * @param {string} pathString
+ * @param {readonly string[]} localeCodes
+ * @param {import('../../types').DisableDefaultRedirect} disableDefaultRedirect
+ * @return {boolean}
+ */
+export function isEnabledRedirectForPath (pathString, localeCodes, disableDefaultRedirect) {
+  if (!disableDefaultRedirect) {
+    return true
+  }
+
+  if (typeof disableDefaultRedirect === 'boolean') {
+    return false
+  }
+
+  const clearPath = clearPathFromLocale(pathString, localeCodes)
+  const clearPathWithSlash = addSlashToPath(clearPath)
+
+  return !disableDefaultRedirect
+    .map((patternString) => {
+      const isPattern = patternString.includes('*')
+      const pathPattern = patternString.replace('*', '')
+      const normalizedPathPattern = addSlashToPath(pathPattern)
+
+      return {
+        isPattern,
+        path: normalizedPathPattern
+      }
+    })
+    .some(({ isPattern, path }) => {
+      return isPattern ? clearPathWithSlash.startsWith(path) : clearPathWithSlash === path
+    })
 }
 
 /**

--- a/src/templates/plugin.utils.js
+++ b/src/templates/plugin.utils.js
@@ -1,5 +1,5 @@
 import isHTTPS from 'is-https'
-import { localeMessages, options } from './options'
+import { Constants, localeMessages, options } from './options'
 import { formatMessage } from './utils-common'
 // @ts-ignore
 import { hasProtocol } from '~i18n-ufo'
@@ -213,6 +213,21 @@ export function mergeAdditionalMessages (i18n, additionalMessages, localeCodes, 
       i18n.mergeLocaleMessage(locale, additionalEntry[locale])
       i18n.mergeLocaleMessage(locale, existingMessages)
     }
+  }
+}
+
+/**
+ * @param {string} locale
+ */
+export function getHelpers (locale = '') {
+  const isDefaultLocale = locale === options.defaultLocale
+  const isPrefixAndDefault = options.strategy === Constants.STRATEGIES.PREFIX_AND_DEFAULT
+  const isPrefixExceptDefault = options.strategy === Constants.STRATEGIES.PREFIX_EXCEPT_DEFAULT
+
+  return {
+    isDefaultLocale,
+    isPrefixAndDefault,
+    isPrefixExceptDefault
   }
 }
 

--- a/src/templates/utils-common.js
+++ b/src/templates/utils-common.js
@@ -229,16 +229,8 @@ export function setLocaleCookie (locale, res, { useCookie, cookieDomain, cookieK
  * @param  {readonly string[]} localeCodes
  * @return {string}
  */
-export function clearPathFromLocale (pathString, localeCodes) {
+export function removeLocaleFromPath (pathString, localeCodes) {
   const regexp = new RegExp(`^(\\/${localeCodes.join('|\\/')})(?=\\/|$)`)
 
   return pathString.replace(regexp, '') || '/'
-}
-
-/**
- * @param  {string} pathString
- * @return {string}
- */
-export function addSlashToPath (pathString) {
-  return pathString.endsWith('/') ? pathString : `${pathString}/`
 }

--- a/src/templates/utils-common.js
+++ b/src/templates/utils-common.js
@@ -223,3 +223,22 @@ export function setLocaleCookie (locale, res, { useCookie, cookieDomain, cookieK
     res.setHeader('Set-Cookie', headers)
   }
 }
+
+/**
+ * @param  {string} pathString
+ * @param  {readonly string[]} localeCodes
+ * @return {string}
+ */
+export function clearPathFromLocale (pathString, localeCodes) {
+  const regexp = new RegExp(`^(\\/${localeCodes.join('|\\/')})(?=\\/|$)`)
+
+  return pathString.replace(regexp, '') || '/'
+}
+
+/**
+ * @param  {string} pathString
+ * @return {string}
+ */
+export function addSlashToPath (pathString) {
+  return pathString.endsWith('/') ? pathString : `${pathString}/`
+}

--- a/test/fixture/disable-redirect/components/LangSwitcher.vue
+++ b/test/fixture/disable-redirect/components/LangSwitcher.vue
@@ -1,12 +1,23 @@
 <template>
   <ul class="lang-switcher">
     <li v-for="locale in $i18n.locales" :key="locale.code">
-      <nuxt-link :to="switchLocalePath(locale.code)">
+      <nuxt-link :to="switchLocalePath(locale.code, forcePrefix)">
         {{ locale.code.toUpperCase() }}
       </nuxt-link>
     </li>
   </ul>
 </template>
+
+<script>
+export default {
+  props: {
+    forcePrefix: {
+      type: Boolean,
+      default: false
+    }
+  }
+}
+</script>
 
 <style scoped>
 .lang-switcher {

--- a/test/fixture/disable-redirect/components/LangSwitcher.vue
+++ b/test/fixture/disable-redirect/components/LangSwitcher.vue
@@ -1,0 +1,15 @@
+<template>
+  <ul class="lang-switcher">
+    <li v-for="locale in $i18n.locales" :key="locale.code">
+      <nuxt-link :to="switchLocalePath(locale.code)">
+        {{ locale.code.toUpperCase() }}
+      </nuxt-link>
+    </li>
+  </ul>
+</template>
+
+<style scoped>
+.lang-switcher {
+  margin: 20px;
+}
+</style>

--- a/test/fixture/disable-redirect/components/LangSwitcher.vue
+++ b/test/fixture/disable-redirect/components/LangSwitcher.vue
@@ -1,23 +1,12 @@
 <template>
   <ul class="lang-switcher">
     <li v-for="locale in $i18n.locales" :key="locale.code">
-      <nuxt-link :to="switchLocalePath(locale.code, forcePrefix)">
+      <nuxt-link :to="switchLocalePath(locale.code)">
         {{ locale.code.toUpperCase() }}
       </nuxt-link>
     </li>
   </ul>
 </template>
-
-<script>
-export default {
-  props: {
-    forcePrefix: {
-      type: Boolean,
-      default: false
-    }
-  }
-}
-</script>
 
 <style scoped>
 .lang-switcher {

--- a/test/fixture/disable-redirect/components/NavBar.vue
+++ b/test/fixture/disable-redirect/components/NavBar.vue
@@ -1,0 +1,34 @@
+<template>
+  <div class="navbar">
+    <nuxt-link v-for="link in links" :key="link.label" tag="a" :to="localePath(link.path)">
+      {{ link.label }}
+    </nuxt-link>
+  </div>
+</template>
+
+<script>
+export default {
+  computed: {
+    links () {
+      return [
+        { label: 'Home', path: '/' },
+        { label: 'About', path: '/about' },
+        { label: 'Foo', path: '/foo' },
+        { label: 'FooBar', path: '/foo/bar' }
+      ]
+    }
+  }
+}
+</script>
+
+<style>
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.navbar a {
+  padding: 0 10px;
+}
+</style>

--- a/test/fixture/disable-redirect/components/NavBar.vue
+++ b/test/fixture/disable-redirect/components/NavBar.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="navbar">
+    <nuxt-link to="/">
+      Home Default
+    </nuxt-link>
     <nuxt-link v-for="link in links" :key="link.label" tag="a" :to="localePath(link.path)">
       {{ link.label }}
     </nuxt-link>

--- a/test/fixture/disable-redirect/layouts/default.vue
+++ b/test/fixture/disable-redirect/layouts/default.vue
@@ -8,8 +8,6 @@
 
     <hr>
 
-    <LangSwitcher force-prefix />
-
     <Nuxt />
   </div>
 </template>

--- a/test/fixture/disable-redirect/layouts/default.vue
+++ b/test/fixture/disable-redirect/layouts/default.vue
@@ -1,0 +1,19 @@
+<template>
+  <div>
+    <p><strong>Default Layout</strong></p>
+
+    <NavBar />
+
+    <LangSwitcher />
+
+    <Nuxt />
+  </div>
+</template>
+
+<script>
+import LangSwitcher from '../components/LangSwitcher'
+import NavBar from '../components/NavBar'
+export default {
+  components: { NavBar, LangSwitcher }
+}
+</script>

--- a/test/fixture/disable-redirect/layouts/default.vue
+++ b/test/fixture/disable-redirect/layouts/default.vue
@@ -6,6 +6,10 @@
 
     <LangSwitcher />
 
+    <hr>
+
+    <LangSwitcher force-prefix />
+
     <Nuxt />
   </div>
 </template>

--- a/test/fixture/disable-redirect/nuxt.config.js
+++ b/test/fixture/disable-redirect/nuxt.config.js
@@ -5,9 +5,9 @@ import BaseConfig from '../base.config'
 const config = {
   ...BaseConfig,
   i18n: {
-    prefixAndDefaultRedirect: {
-      localeSwitcher: 'prefix',
-      pages: ['/foo/*']
+    prefixAndDefaultRules: {
+      switchLocal: 'default',
+      routing: 'prefix'
     },
     strategy: 'prefix_and_default',
     locales: [

--- a/test/fixture/disable-redirect/nuxt.config.js
+++ b/test/fixture/disable-redirect/nuxt.config.js
@@ -4,11 +4,11 @@ import BaseConfig from '../base.config'
 /** @type {import('@nuxt/types').NuxtConfig} */
 const config = {
   ...BaseConfig,
+  router: {
+    trailingSlash: true
+  },
   i18n: {
-    prefixAndDefaultRules: {
-      switchLocale: 'default',
-      routing: 'prefix'
-    },
+    prefixAndDefaultRule: 'default',
     strategy: 'prefix_and_default',
     locales: [
       {

--- a/test/fixture/disable-redirect/nuxt.config.js
+++ b/test/fixture/disable-redirect/nuxt.config.js
@@ -1,0 +1,16 @@
+import { resolve } from 'path'
+import BaseConfig from '../base.config'
+
+/** @type {import('@nuxt/types').NuxtConfig} */
+const config = {
+  ...BaseConfig,
+  disableDefaultRedirect: true,
+  strategy: 'prefix_and_default',
+  buildDir: resolve(__dirname, '.nuxt'),
+  srcDir: __dirname,
+  buildModules: [
+    '@nuxtjs/composition-api/module'
+  ]
+}
+
+module.exports = config

--- a/test/fixture/disable-redirect/nuxt.config.js
+++ b/test/fixture/disable-redirect/nuxt.config.js
@@ -6,7 +6,7 @@ const config = {
   ...BaseConfig,
   i18n: {
     prefixAndDefaultRules: {
-      switchLocal: 'default',
+      switchLocale: 'default',
       routing: 'prefix'
     },
     strategy: 'prefix_and_default',

--- a/test/fixture/disable-redirect/nuxt.config.js
+++ b/test/fixture/disable-redirect/nuxt.config.js
@@ -4,13 +4,28 @@ import BaseConfig from '../base.config'
 /** @type {import('@nuxt/types').NuxtConfig} */
 const config = {
   ...BaseConfig,
-  disableDefaultRedirect: true,
-  strategy: 'prefix_and_default',
+  i18n: {
+    prefixAndDefaultRedirect: {
+      localeSwitcher: 'prefix',
+      pages: ['/foo/*']
+    },
+    strategy: 'prefix_and_default',
+    locales: [
+      {
+        code: 'en',
+        iso: 'en',
+        name: 'English'
+      },
+      {
+        code: 'fr',
+        iso: 'fr-FR',
+        name: 'Français'
+      }
+    ],
+    defaultLocale: 'en'
+  },
   buildDir: resolve(__dirname, '.nuxt'),
-  srcDir: __dirname,
-  buildModules: [
-    '@nuxtjs/composition-api/module'
-  ]
+  srcDir: __dirname
 }
 
 module.exports = config

--- a/test/fixture/disable-redirect/pages/about.vue
+++ b/test/fixture/disable-redirect/pages/about.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <h1>About</h1>
+  </div>
+</template>

--- a/test/fixture/disable-redirect/pages/foo/bar.vue
+++ b/test/fixture/disable-redirect/pages/foo/bar.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <h1>Bar</h1>
+  </div>
+</template>

--- a/test/fixture/disable-redirect/pages/foo/index.vue
+++ b/test/fixture/disable-redirect/pages/foo/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <h1>Foo</h1>
+  </div>
+</template>

--- a/test/fixture/disable-redirect/pages/index.vue
+++ b/test/fixture/disable-redirect/pages/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <h1>Home</h1>
+  </div>
+</template>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,7 +6,7 @@ export { Locale }
 export type Strategies = 'no_prefix' | 'prefix_except_default' | 'prefix' | 'prefix_and_default'
 export type Directions = 'ltr' | 'rtl' | 'auto'
 export type RedirectOnOptions = 'all' | 'root' | 'no prefix'
-export type PrefixAndDefaultRule = 'default' | 'prefix'
+export type RoutingRule = 'default' | 'prefix'
 
 export interface LocaleObject extends Record<string, any> {
   code: Locale
@@ -54,8 +54,7 @@ export interface BaseOptions {
 }
 
 export interface PrefixAndDefaultRules {
-  switchLocale: PrefixAndDefaultRule
-  routing: PrefixAndDefaultRule
+  routing: RoutingRule
 }
 
 export interface Options extends BaseOptions {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,6 +6,7 @@ export { Locale }
 export type Strategies = 'no_prefix' | 'prefix_except_default' | 'prefix' | 'prefix_and_default'
 export type Directions = 'ltr' | 'rtl' | 'auto'
 export type RedirectOnOptions = 'all' | 'root' | 'no prefix'
+export type LocaleSwitcher = 'default' | 'prefix'
 
 export interface LocaleObject extends Record<string, any> {
   code: Locale
@@ -52,12 +53,14 @@ export interface BaseOptions {
   onLanguageSwitched?: (oldLocale: string, newLocale: string) => void
 }
 
-export type DisableDefaultRedirect = boolean | string[]
+export interface PrefixAndDefaultRedirect {
+  pages?: string[]
+  localeSwitcher: LocaleSwitcher
+}
 
 export interface Options extends BaseOptions {
   baseUrl?: string | ((context: NuxtContext) => string)
   detectBrowserLanguage?: DetectBrowserLanguageOptions | false
-  disableDefaultRedirect?: DisableDefaultRedirect;
   langDir?: string | null
   lazy?: boolean | LazyOptions
   pages?: {
@@ -66,6 +69,7 @@ export interface Options extends BaseOptions {
     }
   }
   parsePages?: boolean
+  prefixAndDefaultRedirect?: PrefixAndDefaultRedirect
   rootRedirect?: string | null | RootRedirectOptions
   routesNameSeparator?: string
   skipSettingLocaleOnNavigate?: boolean,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,7 +6,7 @@ export { Locale }
 export type Strategies = 'no_prefix' | 'prefix_except_default' | 'prefix' | 'prefix_and_default'
 export type Directions = 'ltr' | 'rtl' | 'auto'
 export type RedirectOnOptions = 'all' | 'root' | 'no prefix'
-export type LocaleSwitcher = 'default' | 'prefix'
+export type PrefixAndDefaultRule = 'default' | 'prefix'
 
 export interface LocaleObject extends Record<string, any> {
   code: Locale
@@ -53,9 +53,9 @@ export interface BaseOptions {
   onLanguageSwitched?: (oldLocale: string, newLocale: string) => void
 }
 
-export interface PrefixAndDefaultRedirect {
-  pages?: string[]
-  localeSwitcher: LocaleSwitcher
+export interface PrefixAndDefaultRules {
+  switchLocal: PrefixAndDefaultRule
+  routing: PrefixAndDefaultRule
 }
 
 export interface Options extends BaseOptions {
@@ -69,7 +69,7 @@ export interface Options extends BaseOptions {
     }
   }
   parsePages?: boolean
-  prefixAndDefaultRedirect?: PrefixAndDefaultRedirect
+  prefixAndDefaultRules?: PrefixAndDefaultRules
   rootRedirect?: string | null | RootRedirectOptions
   routesNameSeparator?: string
   skipSettingLocaleOnNavigate?: boolean,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -52,9 +52,12 @@ export interface BaseOptions {
   onLanguageSwitched?: (oldLocale: string, newLocale: string) => void
 }
 
+export type DisableDefaultRedirect = boolean | string[]
+
 export interface Options extends BaseOptions {
   baseUrl?: string | ((context: NuxtContext) => string)
   detectBrowserLanguage?: DetectBrowserLanguageOptions | false
+  disableDefaultRedirect?: DisableDefaultRedirect;
   langDir?: string | null
   lazy?: boolean | LazyOptions
   pages?: {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -54,7 +54,7 @@ export interface BaseOptions {
 }
 
 export interface PrefixAndDefaultRules {
-  switchLocal: PrefixAndDefaultRule
+  switchLocale: PrefixAndDefaultRule
   routing: PrefixAndDefaultRule
 }
 

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -41,7 +41,7 @@ interface NuxtI18nApi {
     localePath(route: RawLocation, locale?: string): string
     localeRoute(route: RawLocation, locale?: string): Route | undefined
     localeLocation(route: RawLocation, locale?: string): Location | undefined
-    switchLocalePath(locale: string, forcePrefix?: boolean): string
+    switchLocalePath(locale: string): string
 }
 
 declare module 'vue-i18n' {

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -41,7 +41,7 @@ interface NuxtI18nApi {
     localePath(route: RawLocation, locale?: string): string
     localeRoute(route: RawLocation, locale?: string): Route | undefined
     localeLocation(route: RawLocation, locale?: string): Location | undefined
-    switchLocalePath(locale: string): string
+    switchLocalePath(locale: string, forcePrefix?: boolean): string
 }
 
 declare module 'vue-i18n' {


### PR DESCRIPTION
Regarding to issue #1401 

Added property to config: 
```
i18n: {
  disableDefaultRedirect: boolean | string[] // false by default
}
```
It works only for strategy **prefix_and_default**.
It disables redirect for routes are prefixed with default language, or we can choose custom path pattern for disabling redirect behaviour:
```
i18n: {
  disableDefaultRedirect: [
    '/about',
    '/blog/*'
  ]
}
```

**UPD:**

Added property to config: 
``` 
type PrefixAndDefaultRule = 'default' | 'prefix'

i18n: {
  prefixAndDefaultRule?: PrefixAndDefaultRule
}
```

By setting the value **prefixAndDefaultRule = 'prefix'**  we are no longer redirected from prefixed routes and if there is no prefix  then the other routers will also have no prefix.

For now, I decided not to implement an array with a list of routes for which the default behavior is disabled