### PR TITLE
fix: infinite redirect on URL with special characters

### DIFF
--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -17,7 +17,7 @@ import {
   registerStore,
   mergeAdditionalMessages
 } from './plugin.utils'
-import { joinURL } from '~i18n-ufo'
+import { isEqual as isURLEqual, joinURL } from '~i18n-ufo'
 import { klona } from '~i18n-klona'
 
 Vue.use(VueI18n)
@@ -163,7 +163,7 @@ export default async (context) => {
       // The current route could be 404 in which case attempt to find matching route using the full path since
       // "switchLocalePath" can only find routes if the current route exists.
       const routePath = app.switchLocalePath(newLocale) || app.localePath(route.fullPath, newLocale)
-      if (routePath && routePath !== route.fullPath && !routePath.startsWith('//')) {
+      if (routePath && !isURLEqual(routePath, route.fullPath) && !routePath.startsWith('//')) {
         redirectPath = routePath
       }
     }

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -1,24 +1,11 @@
 import Vue from 'vue'
 import VueI18n from 'vue-i18n'
-import { nuxtI18nHead } from './head-meta'
-import { Constants, nuxtOptions, options } from './options'
-import {
-  createLocaleFromRouteGetter,
-  getLocaleCookie,
-  getLocaleDomain,
-  getLocalesRegex,
-  matchBrowserLocale,
-  parseAcceptLanguage,
-  setLocaleCookie
-} from './utils-common'
-import {
-  loadLanguageAsync,
-  resolveBaseUrl,
-  registerStore,
-  mergeAdditionalMessages
-} from './plugin.utils'
 import { isEqual as isURLEqual, joinURL } from '~i18n-ufo'
 import { klona } from '~i18n-klona'
+import { nuxtI18nHead } from './head-meta'
+import { Constants, nuxtOptions, options } from './options'
+import { createLocaleFromRouteGetter, getLocaleCookie, getLocaleDomain, getLocalesRegex, matchBrowserLocale, parseAcceptLanguage, setLocaleCookie } from './utils-common'
+import { loadLanguageAsync, resolveBaseUrl, registerStore, mergeAdditionalMessages } from './plugin.utils'
 
 Vue.use(VueI18n)
 

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -17,9 +17,7 @@ import {
   registerStore,
   mergeAdditionalMessages
 } from './plugin.utils'
-// @ts-ignore
 import { joinURL } from '~i18n-ufo'
-// @ts-ignore
 import { klona } from '~i18n-klona'
 
 Vue.use(VueI18n)

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -1,8 +1,8 @@
 import './middleware'
 import Vue from 'vue'
+import { withoutTrailingSlash, withTrailingSlash } from '~i18n-ufo'
 import { Constants, nuxtOptions, options } from './options'
 import { getDomainFromLocale } from './plugin.utils'
-import { withoutTrailingSlash, withTrailingSlash } from '~i18n-ufo'
 
 /**
  * @this {import('../../types/internal').PluginProxy}

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -2,8 +2,7 @@ import './middleware'
 import Vue from 'vue'
 import { Constants, nuxtOptions, options } from './options'
 import { getDomainFromLocale } from './plugin.utils'
-// @ts-ignore
-import { withoutTrailingSlash, withTrailingSlash } from '~i18n-ufo'
+import { normalizeURL, withoutTrailingSlash, withTrailingSlash } from '~i18n-ufo'
 
 /**
  * @this {import('../../types/internal').PluginProxy}
@@ -11,7 +10,7 @@ import { withoutTrailingSlash, withTrailingSlash } from '~i18n-ufo'
  */
 function localePath (route, locale) {
   const localizedRoute = resolveRoute.call(this, route, locale)
-  return localizedRoute ? localizedRoute.route.redirectedFrom || localizedRoute.route.fullPath : ''
+  return localizedRoute ? normalizeURL(localizedRoute.route.redirectedFrom || localizedRoute.route.fullPath) : ''
 }
 
 /**

--- a/src/templates/plugin.routing.js
+++ b/src/templates/plugin.routing.js
@@ -2,7 +2,7 @@ import './middleware'
 import Vue from 'vue'
 import { Constants, nuxtOptions, options } from './options'
 import { getDomainFromLocale } from './plugin.utils'
-import { normalizeURL, withoutTrailingSlash, withTrailingSlash } from '~i18n-ufo'
+import { withoutTrailingSlash, withTrailingSlash } from '~i18n-ufo'
 
 /**
  * @this {import('../../types/internal').PluginProxy}
@@ -10,7 +10,7 @@ import { normalizeURL, withoutTrailingSlash, withTrailingSlash } from '~i18n-ufo
  */
 function localePath (route, locale) {
   const localizedRoute = resolveRoute.call(this, route, locale)
-  return localizedRoute ? normalizeURL(localizedRoute.route.redirectedFrom || localizedRoute.route.fullPath) : ''
+  return localizedRoute ? localizedRoute.route.redirectedFrom || localizedRoute.route.fullPath : ''
 }
 
 /**

--- a/src/templates/plugin.utils.js
+++ b/src/templates/plugin.utils.js
@@ -1,8 +1,7 @@
 import isHTTPS from 'is-https'
+import { hasProtocol } from '~i18n-ufo'
 import { localeMessages, options } from './options'
 import { formatMessage } from './utils-common'
-// @ts-ignore
-import { hasProtocol } from '~i18n-ufo'
 
 /** @typedef {import('../../types/internal').ResolvedOptions} ResolvedOptions */
 

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -1108,6 +1108,16 @@ describe('prefix_and_default strategy', () => {
     expect(response.headers.location).toBe('/')
   })
 
+  test('does not redirect when only path encoding differs', async () => {
+    const requestOptions = {
+      followRedirect: false,
+      resolveWithFullResponse: true,
+      simple: false // Don't reject on non-2xx response
+    }
+    const response = await get('/posts/a-&', requestOptions)
+    expect(response.statusCode).toBe(200)
+  })
+
   test('localeRoute returns localized route (by route name)', async () => {
     const window = await nuxt.renderAndGetWindow(url('/'))
     expect(window.$nuxt.localeRoute('index', 'en')).toMatchObject({ name: 'index___en___default', fullPath: '/' })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,12 @@
     "noEmit": true,
     "baseUrl": ".",
     "paths": {
+      "~i18n-klona": [
+        "node_modules/klona"
+      ],
+      "~i18n-ufo": [
+        "node_modules/ufo"
+      ],
       "~/*": [
         "./*",
       ],


### PR DESCRIPTION
For the currently loaded route, when Nuxt.js resolves the route, it passes "normalized" URL to `router.resolve`. This results in resolved route returning that normalized URL. In the case of the original issue the initial URL `/foo-&/1` would get normalized to `/foo-%26/1`. This created discrepancy when comparing path of the route resolved by this module. Since this module did not normalize the URL, the returned path would be different (encoded vs. decoded char) and the module would attempt to redirect indefinitely.

This is caused by a change introduced in some newer version of `ufo`.

Fix by using same normalization logic when comparing the current route and the route we are redirecting to.

Resolves #1469