### PR TITLE
feat: allow composable

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
     "klona": "^2.0.5",
     "lodash.merge": "^4.6.2",
     "ufo": "^0.8.5",
-    "vue-i18n": "^8.27.2"
+    "vue-i18n": "^8.27.2",
+    "vue-i18n-composable": "^2.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.18.10",

--- a/src/templates/plugin.main.js
+++ b/src/templates/plugin.main.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import VueI18n from 'vue-i18n'
+import { createI18n } from 'vue-i18n-composable'
 import { isEqual as isURLEqual, joinURL } from '~i18n-ufo'
 import { klona } from '~i18n-klona'
 import { nuxtI18nHead } from './head-meta'
@@ -314,7 +315,7 @@ export default async (context) => {
   const vueI18nOptions = typeof options.vueI18n === 'function' ? await options.vueI18n(context) : klona(options.vueI18n)
   vueI18nOptions.componentInstanceCreatedListener = extendVueI18nInstance
   // @ts-ignore
-  app.i18n = context.i18n = new VueI18n(vueI18nOptions)
+  app.i18n = context.i18n = createI18n(vueI18nOptions)
   // Initialize locale and fallbackLocale as vue-i18n defaults those to 'en-US' if falsey
   app.i18n.locale = ''
   app.i18n.fallbackLocale = vueI18nOptions.fallbackLocale || ''

--- a/yarn.lock
+++ b/yarn.lock
@@ -13041,6 +13041,11 @@ vue-hot-reload-api@^2.3.0:
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"
   integrity sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==
 
+vue-i18n-composable@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/vue-i18n-composable/-/vue-i18n-composable-2.0.0.tgz#36c33aa116eb5c5d09c5050db8f55f5cd53ae330"
+  integrity sha512-oCiX+xoNZKISv7/G1ZtSpi4/E16mQnI5DkZlBlEt++YVj6PZBCyqaiNotfzqDXz8TODnugi8sM39x+MRe+8ziA==
+
 vue-i18n@^8.27.2:
   version "8.27.2"
   resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-8.27.2.tgz#b649a65ff42b7d1a482679b732902f889965a068"


### PR DESCRIPTION
Uses https://github.com/intlify/vue-i18n-composable/ to allow usage of this module in Vue 2.7's setup function. The currently supported usage outside of the setup functions remains working in my testing.