### PR TITLE
[next] fix(module): remove nuxt 2 error

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -34,16 +34,6 @@ export default defineNuxtModule<NuxtI18nOptions>({
 
     checkOptions(options)
 
-    if (isNuxt2(nuxt)) {
-      throw new Error(
-        formatMessage(
-          `We will release >=7.3 <8, See about GitHub Discussions https://github.com/nuxt-community/i18n-module/discussions/1287#discussioncomment-3042457: ${getNuxtVersion(
-            nuxt
-          )}`
-        )
-      )
-    }
-
     if (!isNuxt3(nuxt)) {
       throw new Error(formatMessage(`Cannot support nuxt version: ${getNuxtVersion(nuxt)}`))
     }


### PR DESCRIPTION
Nuxt 2 can be used with bridge, which supports running Nuxt 3 modules.
@kazupon 