### PR TITLE
[next] fix(alias): use mjs import

### DIFF
--- a/src/alias.ts
+++ b/src/alias.ts
@@ -14,7 +14,7 @@ export async function setupAlias(nuxt: Nuxt) {
   nuxt.options.build.transpile.push('vue-i18n')
 
   // resolve @intlify/shared
-  nuxt.options.alias['@intlify/shared'] = resolveModule('@intlify/shared/dist/shared.esm-bundler.js', {
+  nuxt.options.alias['@intlify/shared'] = resolveModule('@intlify/shared/dist/shared.esm-bundler.mjs', {
     paths: nuxt.options.modulesDir
   })
   nuxt.options.build.transpile.push('@intlify/shared')


### PR DESCRIPTION
When I try to build using the next branch, I receive the following error:

```
 ERROR  Cannot find module '/mnt/data/WorkingDirectory/Git/maevsi/maevsi/nuxt/node_modules/@intlify/shared/dist/shared.esm-bundler.js'                                                                                                                                                                                                       15:05:50

  at createEsmNotFoundErr (node:internal/modules/cjs/loader:977:15)
  at finalizeEsmResolution (node:internal/modules/cjs/loader:970:15)
  at resolveExports (node:internal/modules/cjs/loader:493:14)
  at Module._findPath (node:internal/modules/cjs/loader:533:31)
  at Module._resolveFilename (node:internal/modules/cjs/loader:942:27)
  at Function.resolve (node:internal/modules/cjs/helpers:108:19)
  at Function._resolve [as resolve] (node_modules/.pnpm/jiti@1.14.0/node_modules/jiti/dist/jiti.js:1:108181)
  at resolveModule (node_modules/.pnpm/@nuxt+kit@3.0.0-rc.8_webpack@5.74.0/node_modules/@nuxt/kit/dist/index.mjs:253:29)
  at setupAlias (node_modules/.pnpm/@nuxtjs+i18n-edge@8.0.0-alpha.0-27694154.4d62fb4_vue@3.2.37+webpack@5.74.0/node_modules/@nuxtjs/i18n-edge/dist/module.mjs:59:43)
  at setup (node_modules/.pnpm/@nuxtjs+i18n-edge@8.0.0-alpha.0-27694154.4d62fb4_vue@3.2.37+webpack@5.74.0/node_modules/@nuxtjs/i18n-edge/dist/module.mjs:400:11)
```

I found that there is not `.js` but a `.mjs` file instead.
@kazupon 