### PR TITLE
Replace logical OR assignment

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -81,8 +81,7 @@ export default defineNuxtPlugin(async nuxt => {
    *  If `initLocale` is not set, then the `vueI18n` option `locale` is respect!
    *  It means a mode that works only with simple vue-i18n, without nuxtjs/i18n routing, browser detection, SEO, and other features.
    */
-  initialLocale ||= vueI18nOptions.locale || 'en-US'
-
+  initialLocale = initialLocale || vueI18nOptions.locale || 'en-US'
   // create i18n instance
   const i18n = createI18n({
     ...vueI18nOptions,


### PR DESCRIPTION
Hello,

I am using the next branch in my nuxt3 project, and i have node version 14.18
And as you may know nuxt 3 is required to have node 14.16 or above 16.11

However, when i am using the new next/i18n i got the below error 

`
[nuxt] [request error] [unhandled] [500] Unexpected token '||='
  at Loader.moduleStrategy (internal/modules/esm/translators.js:145:18)  
  at async link (internal/modules/esm/module_job.js:67:21)
`
and it turns out you are using the logical OR assignment which is only working on node 15.0 and above

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment#browser_compatibility

to fix the issue i made this change.

Thank you.