### PR TITLE
feat!: drop omit name and path for url path resolving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .DS_Store
 .idea
-.vscode
 *.tgz
 
 .yarn/*

--- a/.npmignore
+++ b/.npmignore
@@ -13,3 +13,4 @@ types
 scripts
 playground
 sandbox
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+  "files.associations": {
+    "*.json": "jsonc"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/docs/content/20.getting-started/2.basic-usage.md
+++ b/docs/content/20.getting-started/2.basic-usage.md
@@ -130,8 +130,6 @@ const localePath = useLocalePath()
   <NuxtLink :to="localePath({ name: 'category-slug', params: { slug: category.slug } })">
     {{ category.title }}
   </NuxtLink>
-  <!-- It is also allowed to omit `name` and `path` -->
-  <NuxtLink :to="localePath({ params: { slug: 'ball' } })">{{ category.title }}</NuxtLink>
 </template>
 ```
 
@@ -175,9 +173,9 @@ It works like `useLocalePath` but returns route resolved by Vue Router rather th
 const localeRoute = useLocaleRoute()
 
 function onClick() {
-  const route = localeRoute({ name: 'user-profile', params: { foo: '1' } })
+  const route = localeRoute({ name: 'user-profile', query: { foo: '1' } })
   if (route) {
-    return navigateTo(`${route.fullPath}?foo=${route.params.foo}`)
+    return navigateTo(route.fullPath)
   }
 }
 </script>

--- a/specs/basic_usage.spec.ts
+++ b/specs/basic_usage.spec.ts
@@ -32,7 +32,6 @@ test('basic usage', async () => {
   expect(await page.locator('#locale-path-usages .object-with-named a').getAttribute('href')).toEqual(
     '/category/nintendo'
   )
-  expect(await page.locator('#locale-path-usages .omit-named-in-object a').getAttribute('href')).toEqual('/')
 
   // Language switching path localizing with `useSwitchLocalePath`
   expect(await page.locator('#switch-locale-path-usages .switch-to-en a').getAttribute('href')).toEqual('/')
@@ -43,4 +42,5 @@ test('basic usage', async () => {
   await button.click()
   await page.waitForTimeout(100)
   expect(await getText(page, '#profile-page')).toEqual('This is profile page')
+  expect(await page.url()).include('/user/profile?foo=1')
 })

--- a/specs/fixtures/basic/components/BasicUsage.vue
+++ b/specs/fixtures/basic/components/BasicUsage.vue
@@ -13,9 +13,9 @@ const category = ref({
 })
 
 function onClick() {
-  const route = localeRoute({ name: 'user-profile', params: { foo: '1' } })
+  const route = localeRoute({ name: 'user-profile', query: { foo: '1' } })
   if (route) {
-    return navigateTo(`${route.fullPath}?foo=${route.params.foo}`)
+    return navigateTo(route.fullPath)
   }
 }
 </script>
@@ -57,9 +57,6 @@ function onClick() {
           <NuxtLink :to="localePath({ name: 'category-slug', params: { slug: category.slug } })">
             {{ category.title }}
           </NuxtLink>
-        </li>
-        <li class="omit-named-in-object">
-          <NuxtLink :to="localePath({ params: { slug: 'ball' } })">{{ category.title }}</NuxtLink>
         </li>
       </ul>
     </section>

--- a/specs/fixtures/basic_usage/pages/index.vue
+++ b/specs/fixtures/basic_usage/pages/index.vue
@@ -12,9 +12,9 @@ const category = ref({
 })
 
 function onClick() {
-  const route = localeRoute({ name: 'user-profile', params: { foo: '1' } })
+  const route = localeRoute({ name: 'user-profile', query: { foo: '1' } })
   if (route) {
-    return navigateTo(`${route.fullPath}?foo=${route.params.foo}`)
+    return navigateTo(route.fullPath)
   }
 }
 </script>
@@ -52,9 +52,6 @@ function onClick() {
           <NuxtLink :to="localePath({ name: 'category-slug', params: { slug: category.slug } })">
             {{ category.title }}
           </NuxtLink>
-        </li>
-        <li class="omit-named-in-object">
-          <NuxtLink :to="localePath({ params: { slug: 'ball' } })">{{ category.title }}</NuxtLink>
         </li>
       </ul>
     </section>


### PR DESCRIPTION
BREAKING CHANGE:

The vue router v4 no longer resolves the url, if name and path are omitted.
https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22
And usage without `params` defined is deprecated.