### PR TITLE
fix!: injection fields completion for nuxt app instance and page meta

### DIFF
--- a/docs/content/3.options/2.routing.md
+++ b/docs/content/3.options/2.routing.md
@@ -167,7 +167,7 @@ Set to a path to which you want to redirect users accessing the root URL (`/`). 
 
 ## `dynamicRouteParams`
 
-- type: `boolean` or `string`
+- type: `boolean`
 - default: `false`
 
 Whether to localize dynamic route parameters. 
@@ -195,41 +195,6 @@ export default defineNuxtConfig({
 definPageMeta({
   // ...
   nuxtI18n: {
-    en: { id: 'my-post' },
-    fr: { id: 'mon-article' }
-  }
-  // ...
-})
-</script>
-
-<template>
-  <!-- pages/post/[id].vue -->
-</template>
-```
-
-If you specify a `string` value, you can change from `nuxtI18n` field name:
-
-```ts {}[nuxt.config.ts]
-export default defineNuxtConfig({
-  modules: [
-    '@nuxtjs/i18n'
-  ],
-
-  i18n: {
-    // ...
-    dynamicRouteParams: 'localize',
-    // ...
-  },
-
-  // ...
-})
-```
-
-```vue
-<script setup>
-definPageMeta({
-  // ...
-  localize: {
     en: { id: 'my-post' },
     fr: { id: 'mon-article' }
   }

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "ufo": "^1.0.0",
     "unplugin": "^1.0.0",
     "vue-i18n": "^9.3.0-beta.10",
-    "vue-i18n-routing": "^0.10.1"
+    "vue-i18n-routing": "^0.10.2"
   },
   "devDependencies": {
     "@babel/parser": "^7.20.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
       vitest: ^0.25.3
       vue: ^3.2.44
       vue-i18n: ^9.3.0-beta.10
-      vue-i18n-routing: ^0.10.1
+      vue-i18n-routing: ^0.10.2
       yorkie: ^2.0.0
     dependencies:
       '@intlify/bundle-utils': 3.4.0_vue-i18n@9.3.0-beta.10
@@ -76,7 +76,7 @@ importers:
       ufo: 1.0.0
       unplugin: 1.0.0
       vue-i18n: 9.3.0-beta.10_vue@3.2.45
-      vue-i18n-routing: 0.10.1_36lc2e5k5j5o5ffxrxnvapozte
+      vue-i18n-routing: 0.10.2_36lc2e5k5j5o5ffxrxnvapozte
     devDependencies:
       '@babel/parser': 7.20.3
       '@babel/plugin-syntax-import-assertions': 7.20.0
@@ -7378,8 +7378,8 @@ packages:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
     dev: true
 
-  /vue-i18n-routing/0.10.1_36lc2e5k5j5o5ffxrxnvapozte:
-    resolution: {integrity: sha512-7sS6yPLtG87xQxeUIK1kt0SyyhVP57lnkmGciWIBRkM6TNRHzOpU9Ur0I2+IxHCPxmd9UkkwfLIhARoZRDcRDQ==}
+  /vue-i18n-routing/0.10.2_36lc2e5k5j5o5ffxrxnvapozte:
+    resolution: {integrity: sha512-TnGUmRsciC/SJSysOAeoY0BBp3S35LFF1EfvPCybd8vU/vsOwHIyJF/Z5tPlAo4I0Y5AyJSa5WMaqpXs8F9DdQ==}
     engines: {node: '>= 14.6'}
     peerDependencies:
       '@vue/composition-api': ^1.0.0-rc.1

--- a/src/module.ts
+++ b/src/module.ts
@@ -162,31 +162,11 @@ export default defineNuxtModule<NuxtI18nOptions>({
     })
 
     /**
-     * generate type definition for page meta
+     * To be plugged for `PageMeta` type definition on `NuxtApp`
      */
 
     if (!!options.dynamicRouteParams) {
       addPlugin(resolve(runtimeDir, 'plugins/meta'))
-      /*
-      const metaKey = isBoolean(options.dynamicRouteParams) ? 'nuxtI18n' : options.dynamicRouteParams
-      const typeMetaFilename = 'types/i18n-page-meta.d.ts'
-      addTemplate({
-        filename: typeMetaFilename,
-        getContents: () => {
-          return [
-            `declare module '#app' {`,
-            '  interface PageMeta {',
-            `    ${metaKey}?: Record<string, any>`,
-            '  }',
-            '}'
-          ].join('\n')
-        }
-      })
-      // add declarations for page meta
-      nuxt.hook('prepare:types', ({ references }) => {
-        references.push({ path: resolve(nuxt.options.buildDir, typeMetaFilename) })
-      })
-      //*/
     }
 
     /**
@@ -202,45 +182,10 @@ export default defineNuxtModule<NuxtI18nOptions>({
           : false
     }
 
-    // for `$i18n` type definition on `NuxtApp`
-    if (isLegacyMode()) {
-      addPlugin(resolve(runtimeDir, 'plugins/legacy'))
-    } else {
-      addPlugin(resolve(runtimeDir, 'plugins/composition'))
-    }
+    // To be plugged for `$i18n` type definition on `NuxtApp`
+    addPlugin(resolve(runtimeDir, isLegacyMode() ? 'plugins/legacy' : 'plugins/composition'))
 
-    /*
-    const nuxtAppExtendFilename = 'types/i18n-nuxt-app.d.ts'
-    const vueI18nRoutingVueI18nDtsPath = await resolveVueI18nRoutingDtsPath('vue-i18n', nuxt.options.rootDir)
-    const vueI18nRoutingMixinDtsPath = await resolveVueI18nRoutingDtsPath('vue', nuxt.options.rootDir)
-    addTemplate({
-      filename: nuxtAppExtendFilename,
-      getContents: () => {
-        return [
-          `import type { ${isLegacyMode() ? 'VueI18n' : 'ExportedGlobalComposer, Composer'} } from 'vue-i18n'`,
-          // prettier-ignore
-          `import type { NuxtI18nRoutingCustomProperties } from '${resolve(runtimeDir, 'types')}'`,
-          `import type { I18nRoutingCustomProperties } from '${vueI18nRoutingVueI18nDtsPath}'`,
-          // import legacy mixins
-          isLegacyMode() ? `import '${vueI18nRoutingMixinDtsPath}'` : '',
-          `declare module '#app' {`,
-          '  interface NuxtApp {',
-          // prettier-ignore
-          `    $i18n: ${isLegacyMode() ? 'VueI18n' : 'ExportedGlobalComposer & Composer'} & NuxtI18nRoutingCustomProperties & I18nRoutingCustomProperties`,
-          '  }',
-          '}',
-          `declare module 'nuxt/dist/app/nuxt' {`,
-          '  interface NuxtApp {',
-          // prettier-ignore
-          `    $i18n: ${isLegacyMode() ? 'VueI18n' : 'ExportedGlobalComposer & Composer'} & NuxtI18nRoutingCustomProperties & I18nRoutingCustomProperties`,
-          '  }',
-          '}'
-        ].join('\n')
-      }
-    })
-    //*/
     nuxt.hook('prepare:types', ({ references }) => {
-      // references.push({ path: resolve(nuxt.options.buildDir, nuxtAppExtendFilename) })
       const vueI18nTypeFilename = resolve(runtimeDir, 'types')
       references.push({ path: resolve(nuxt.options.buildDir, vueI18nTypeFilename) })
     })

--- a/src/module.ts
+++ b/src/module.ts
@@ -9,7 +9,7 @@ import { extendBundler } from './bundler'
 import { generateLoaderOptions } from './gen'
 import { NUXT_I18N_MODULE_ID, DEFAULT_OPTIONS } from './constants'
 import { formatMessage, getNormalizedLocales, resolveLocales } from './utils'
-import { distDir, runtimeDir, resolveVueI18nRoutingDtsPath } from './dirs'
+import { distDir, runtimeDir } from './dirs'
 
 import type { NuxtI18nOptions } from './types'
 import type { DefineLocaleMessage, LocaleMessages } from 'vue-i18n'

--- a/src/module.ts
+++ b/src/module.ts
@@ -112,8 +112,8 @@ export default defineNuxtModule<NuxtI18nOptions>({
      * add plugin and templates
      */
 
-    // plugin
-    addPlugin(resolve(runtimeDir, 'plugin'))
+    // for core plugin
+    addPlugin(resolve(runtimeDir, 'plugins/i18n'))
 
     // for compoables
     nuxt.options.alias['#i18n'] = resolve(distDir, 'runtime/composables.mjs')
@@ -166,6 +166,8 @@ export default defineNuxtModule<NuxtI18nOptions>({
      */
 
     if (!!options.dynamicRouteParams) {
+      addPlugin(resolve(runtimeDir, 'plugins/meta'))
+      /*
       const metaKey = isBoolean(options.dynamicRouteParams) ? 'nuxtI18n' : options.dynamicRouteParams
       const typeMetaFilename = 'types/i18n-page-meta.d.ts'
       addTemplate({
@@ -184,6 +186,7 @@ export default defineNuxtModule<NuxtI18nOptions>({
       nuxt.hook('prepare:types', ({ references }) => {
         references.push({ path: resolve(nuxt.options.buildDir, typeMetaFilename) })
       })
+      //*/
     }
 
     /**
@@ -194,10 +197,19 @@ export default defineNuxtModule<NuxtI18nOptions>({
     const isLegacyMode = () => {
       return isString(options.types)
         ? options.types === 'legacy'
-        : isObject(options.vueI18n)
+        : isObject(options.vueI18n) && isBoolean(options.vueI18n.legacy)
           ? options.vueI18n.legacy
           : false
     }
+
+    // for `$i18n` type definition on `NuxtApp`
+    if (isLegacyMode()) {
+      addPlugin(resolve(runtimeDir, 'plugins/legacy'))
+    } else {
+      addPlugin(resolve(runtimeDir, 'plugins/composition'))
+    }
+
+    /*
     const nuxtAppExtendFilename = 'types/i18n-nuxt-app.d.ts'
     const vueI18nRoutingVueI18nDtsPath = await resolveVueI18nRoutingDtsPath('vue-i18n', nuxt.options.rootDir)
     const vueI18nRoutingMixinDtsPath = await resolveVueI18nRoutingDtsPath('vue', nuxt.options.rootDir)
@@ -226,8 +238,9 @@ export default defineNuxtModule<NuxtI18nOptions>({
         ].join('\n')
       }
     })
+    //*/
     nuxt.hook('prepare:types', ({ references }) => {
-      references.push({ path: resolve(nuxt.options.buildDir, nuxtAppExtendFilename) })
+      // references.push({ path: resolve(nuxt.options.buildDir, nuxtAppExtendFilename) })
       const vueI18nTypeFilename = resolve(runtimeDir, 'types')
       references.push({ path: resolve(nuxt.options.buildDir, vueI18nTypeFilename) })
     })

--- a/src/runtime/plugins/composition.ts
+++ b/src/runtime/plugins/composition.ts
@@ -4,15 +4,8 @@ import type { Composer, ExportedGlobalComposer } from 'vue-i18n'
 import type { I18nRoutingCustomProperties } from 'vue-i18n-routing/dist/vue-i18n'
 import type { NuxtI18nRoutingCustomProperties } from '../types'
 
-export default defineNuxtPlugin<{
-  i18n: ExportedGlobalComposer & Composer & NuxtI18nRoutingCustomProperties & I18nRoutingCustomProperties
-}>(() => {
+export default defineNuxtPlugin(() => {
   __DEBUG__ && console.log('load $i18n type definition plugin for composition mode')
-  // return {
-  //   provide: {
-  //     i18n: nuxt.__i18n.global
-  //   }
-  // }
 })
 
 declare module '#app' {
@@ -21,12 +14,3 @@ declare module '#app' {
     $i18n: ExportedGlobalComposer & Composer & NuxtI18nRoutingCustomProperties & I18nRoutingCustomProperties
   }
 }
-
-/*
-// @ts-ignore
-declare module 'nuxt/dist/app/nuxt' {
-  interface NuxtApp {
-    $i18n: ExportedGlobalComposer & Composer & NuxtI18nRoutingCustomProperties & I18nRoutingCustomProperties
-  }
-}
-//*/

--- a/src/runtime/plugins/composition.ts
+++ b/src/runtime/plugins/composition.ts
@@ -1,0 +1,32 @@
+import { defineNuxtPlugin } from '#imports'
+
+import type { Composer, ExportedGlobalComposer } from 'vue-i18n'
+import type { I18nRoutingCustomProperties } from 'vue-i18n-routing/dist/vue-i18n'
+import type { NuxtI18nRoutingCustomProperties } from '../types'
+
+export default defineNuxtPlugin<{
+  i18n: ExportedGlobalComposer & Composer & NuxtI18nRoutingCustomProperties & I18nRoutingCustomProperties
+}>(() => {
+  __DEBUG__ && console.log('load $i18n type definition plugin for composition mode')
+  // return {
+  //   provide: {
+  //     i18n: nuxt.__i18n.global
+  //   }
+  // }
+})
+
+declare module '#app' {
+  interface NuxtApp {
+    // @ts-ignore
+    $i18n: ExportedGlobalComposer & Composer & NuxtI18nRoutingCustomProperties & I18nRoutingCustomProperties
+  }
+}
+
+/*
+// @ts-ignore
+declare module 'nuxt/dist/app/nuxt' {
+  interface NuxtApp {
+    $i18n: ExportedGlobalComposer & Composer & NuxtI18nRoutingCustomProperties & I18nRoutingCustomProperties
+  }
+}
+//*/

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -32,6 +32,7 @@ import {
   getBrowserLocale as _getBrowserLocale,
   getLocaleCookie as _getLocaleCookie,
   setLocaleCookie as _setLocaleCookie
+  // proxyNuxt
 } from '#build/i18n.internal.mjs'
 
 import type { Composer, I18nOptions, Locale } from 'vue-i18n'
@@ -44,7 +45,13 @@ type LocaleRoute = typeof localeRoute
 type LocaleHead = typeof localeHead
 type SwitchLocalePath = typeof switchLocalePath
 
-export default defineNuxtPlugin(async nuxt => {
+export default defineNuxtPlugin<{
+  getRouteBaseName: (...args: Parameters<GetRouteBaseName>) => ReturnType<GetRouteBaseName>
+  localePath: (...args: Parameters<LocalePath>) => ReturnType<LocalePath>
+  localeRoute: (...args: Parameters<LocaleRoute>) => ReturnType<LocaleRoute>
+  localeHead: (...args: Parameters<LocaleHead>) => ReturnType<LocaleHead>
+  switchLocalePath: (...args: Parameters<SwitchLocalePath>) => ReturnType<SwitchLocalePath>
+}>(async nuxt => {
   const router = useRouter()
   const route = useRoute()
   const { vueApp: app } = nuxt
@@ -82,9 +89,7 @@ export default defineNuxtPlugin(async nuxt => {
   // so global options is reffered by `vue-i18n-routing`
   registerGlobalOptions(router, {
     ...nuxtI18nOptions,
-    dynamicRouteParamsKey: isBoolean(nuxtI18nOptions.dynamicRouteParams)
-      ? 'nuxtI18n'
-      : nuxtI18nOptions.dynamicRouteParams,
+    dynamicRouteParamsKey: 'nuxtI18n',
     switchLocalePathIntercepter: extendSwitchLocalePathIntercepter(differentDomains, normalizedLocales, nuxtContext),
     prefixable: extendPrefixable(differentDomains)
   })
@@ -390,6 +395,27 @@ export default defineNuxtPlugin(async nuxt => {
     }),
     { global: true }
   )
+
+  // getRouteBaseName: (...args: Parameters<GetRouteBaseName>) => ReturnType<GetRouteBaseName>
+  // localePath: (...args: Parameters<LocalePath>) => ReturnType<LocalePath>
+  // localeRoute: (...args: Parameters<LocaleRoute>) => ReturnType<LocaleRoute>
+  // localeHead: (...args: Parameters<LocaleHead>) => ReturnType<LocaleHead>
+  // switchLocalePath: (...args: Parameters<SwitchLocalePath>) => ReturnType<SwitchLocalePath>
+  // return {
+  //   provide: {
+  //     getRouteBaseName: proxyNuxt(nuxt, getRouteBaseName) as unknown as (
+  //       ...args: Parameters<GetRouteBaseName>
+  //     ) => ReturnType<GetRouteBaseName>,
+  //     localePath: proxyNuxt(nuxt, localePath) as unknown as (...args: Parameters<LocalePath>) => ReturnType<LocalePath>,
+  //     localeRoute: proxyNuxt(nuxt, localeRoute) as unknown as (
+  //       ...args: Parameters<LocaleRoute>
+  //     ) => ReturnType<LocaleRoute>,
+  //     localeHead: proxyNuxt(nuxt, localeHead) as unknown as (...args: Parameters<LocaleHead>) => ReturnType<LocaleHead>,
+  //     switchLocalePath: proxyNuxt(nuxt, switchLocalePath) as unknown as (
+  //       ...args: Parameters<SwitchLocalePath>
+  //     ) => ReturnType<SwitchLocalePath>
+  //   }
+  // }
 })
 
 declare module '#app' {
@@ -402,6 +428,7 @@ declare module '#app' {
   }
 }
 
+/*
 // @ts-ignore
 declare module 'nuxt/dist/app/nuxt' {
   interface NuxtApp {
@@ -412,3 +439,4 @@ declare module 'nuxt/dist/app/nuxt' {
     $switchLocalePath: (...args: Parameters<SwitchLocalePath>) => ReturnType<SwitchLocalePath>
   }
 }
+//*/

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -1,4 +1,3 @@
-import { isBoolean } from '@intlify/shared'
 import { computed } from 'vue'
 import { createI18n } from 'vue-i18n'
 import {
@@ -32,7 +31,6 @@ import {
   getBrowserLocale as _getBrowserLocale,
   getLocaleCookie as _getLocaleCookie,
   setLocaleCookie as _setLocaleCookie
-  // proxyNuxt
 } from '#build/i18n.internal.mjs'
 
 import type { Composer, I18nOptions, Locale } from 'vue-i18n'
@@ -45,13 +43,7 @@ type LocaleRoute = typeof localeRoute
 type LocaleHead = typeof localeHead
 type SwitchLocalePath = typeof switchLocalePath
 
-export default defineNuxtPlugin<{
-  getRouteBaseName: (...args: Parameters<GetRouteBaseName>) => ReturnType<GetRouteBaseName>
-  localePath: (...args: Parameters<LocalePath>) => ReturnType<LocalePath>
-  localeRoute: (...args: Parameters<LocaleRoute>) => ReturnType<LocaleRoute>
-  localeHead: (...args: Parameters<LocaleHead>) => ReturnType<LocaleHead>
-  switchLocalePath: (...args: Parameters<SwitchLocalePath>) => ReturnType<SwitchLocalePath>
-}>(async nuxt => {
+export default defineNuxtPlugin(async nuxt => {
   const router = useRouter()
   const route = useRoute()
   const { vueApp: app } = nuxt
@@ -395,27 +387,6 @@ export default defineNuxtPlugin<{
     }),
     { global: true }
   )
-
-  // getRouteBaseName: (...args: Parameters<GetRouteBaseName>) => ReturnType<GetRouteBaseName>
-  // localePath: (...args: Parameters<LocalePath>) => ReturnType<LocalePath>
-  // localeRoute: (...args: Parameters<LocaleRoute>) => ReturnType<LocaleRoute>
-  // localeHead: (...args: Parameters<LocaleHead>) => ReturnType<LocaleHead>
-  // switchLocalePath: (...args: Parameters<SwitchLocalePath>) => ReturnType<SwitchLocalePath>
-  // return {
-  //   provide: {
-  //     getRouteBaseName: proxyNuxt(nuxt, getRouteBaseName) as unknown as (
-  //       ...args: Parameters<GetRouteBaseName>
-  //     ) => ReturnType<GetRouteBaseName>,
-  //     localePath: proxyNuxt(nuxt, localePath) as unknown as (...args: Parameters<LocalePath>) => ReturnType<LocalePath>,
-  //     localeRoute: proxyNuxt(nuxt, localeRoute) as unknown as (
-  //       ...args: Parameters<LocaleRoute>
-  //     ) => ReturnType<LocaleRoute>,
-  //     localeHead: proxyNuxt(nuxt, localeHead) as unknown as (...args: Parameters<LocaleHead>) => ReturnType<LocaleHead>,
-  //     switchLocalePath: proxyNuxt(nuxt, switchLocalePath) as unknown as (
-  //       ...args: Parameters<SwitchLocalePath>
-  //     ) => ReturnType<SwitchLocalePath>
-  //   }
-  // }
 })
 
 declare module '#app' {
@@ -427,16 +398,3 @@ declare module '#app' {
     $switchLocalePath: (...args: Parameters<SwitchLocalePath>) => ReturnType<SwitchLocalePath>
   }
 }
-
-/*
-// @ts-ignore
-declare module 'nuxt/dist/app/nuxt' {
-  interface NuxtApp {
-    $getRouteBaseName: (...args: Parameters<GetRouteBaseName>) => ReturnType<GetRouteBaseName>
-    $localePath: (...args: Parameters<LocalePath>) => ReturnType<LocalePath>
-    $localeRoute: (...args: Parameters<LocaleRoute>) => ReturnType<LocaleRoute>
-    $localeHead: (...args: Parameters<LocaleHead>) => ReturnType<LocaleHead>
-    $switchLocalePath: (...args: Parameters<SwitchLocalePath>) => ReturnType<SwitchLocalePath>
-  }
-}
-//*/

--- a/src/runtime/plugins/legacy.ts
+++ b/src/runtime/plugins/legacy.ts
@@ -4,15 +4,8 @@ import type { VueI18n } from 'vue-i18n'
 import type { I18nRoutingCustomProperties } from 'vue-i18n-routing/dist/vue-i18n'
 import type { NuxtI18nRoutingCustomProperties } from '../types'
 
-export default defineNuxtPlugin<{
-  i18n: VueI18n & NuxtI18nRoutingCustomProperties & I18nRoutingCustomProperties
-}>(() => {
+export default defineNuxtPlugin(() => {
   __DEBUG__ && console.log('load $i18n type definition plugin for legacy mode')
-  // return {
-  //   provide: {
-  //     i18n: nuxt.__i18n.global
-  //   }
-  // }
 })
 
 declare module '#app' {
@@ -21,12 +14,3 @@ declare module '#app' {
     $i18n: VueI18n & NuxtI18nRoutingCustomProperties & I18nRoutingCustomProperties
   }
 }
-
-/*
-// @ts-ignore
-declare module 'nuxt/dist/app/nuxt' {
-  interface NuxtApp {
-    $i18n: VueI18n & NuxtI18nRoutingCustomProperties & I18nRoutingCustomProperties
-  }
-}
-*/

--- a/src/runtime/plugins/legacy.ts
+++ b/src/runtime/plugins/legacy.ts
@@ -1,0 +1,32 @@
+import { defineNuxtPlugin } from '#imports'
+
+import type { VueI18n } from 'vue-i18n'
+import type { I18nRoutingCustomProperties } from 'vue-i18n-routing/dist/vue-i18n'
+import type { NuxtI18nRoutingCustomProperties } from '../types'
+
+export default defineNuxtPlugin<{
+  i18n: VueI18n & NuxtI18nRoutingCustomProperties & I18nRoutingCustomProperties
+}>(() => {
+  __DEBUG__ && console.log('load $i18n type definition plugin for legacy mode')
+  // return {
+  //   provide: {
+  //     i18n: nuxt.__i18n.global
+  //   }
+  // }
+})
+
+declare module '#app' {
+  interface NuxtApp {
+    // @ts-ignore
+    $i18n: VueI18n & NuxtI18nRoutingCustomProperties & I18nRoutingCustomProperties
+  }
+}
+
+/*
+// @ts-ignore
+declare module 'nuxt/dist/app/nuxt' {
+  interface NuxtApp {
+    $i18n: VueI18n & NuxtI18nRoutingCustomProperties & I18nRoutingCustomProperties
+  }
+}
+*/

--- a/src/runtime/plugins/meta.ts
+++ b/src/runtime/plugins/meta.ts
@@ -1,0 +1,12 @@
+import { defineNuxtPlugin } from '#imports'
+
+export default defineNuxtPlugin(() => {
+  __DEBUG__ && console.log('load Meta type definition plugin')
+})
+
+// @ts-ignore
+declare module 'nuxt/dist/pages/runtime' {
+  interface PageMeta {
+    nuxtI18n?: Record<string, any> // eslint-disable-line @typescript-eslint/no-explicit-any
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,7 +65,7 @@ export type NuxtI18nOptions<Context = unknown> = {
   vueI18n?: I18nOptions | string
   types?: 'composition' | 'legacy'
   debug?: boolean
-  dynamicRouteParams?: boolean | string
+  dynamicRouteParams?: boolean
 } & Pick<
   I18nRoutingOptions<Context>,
   | 'baseUrl'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolves #1704
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR is to ensure that interpolation for fields injected into the nuxt app also works for injections by Nuxt and the user's plugins provided.

The old way was to generate the type in the Nuxt template dynamically, but that way overwrites the existing type, which was as described in #1704.

This PR is for the same issue, although PageMeta's type generation also involves a destructive change.
It's fixed to `nuxtI18n` only, but that key rarely conflicts with user-defined keys in PageMeta.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
