### PR TITLE
docs: fix extending messages example code

### DIFF
--- a/docs/content/2.guide/13.extend-messages.md
+++ b/docs/content/2.guide/13.extend-messages.md
@@ -16,8 +16,8 @@ Example:
 import { defineNuxtModule } from '@nuxt/kit'
 
 export default defineNuxtModule({
-  async setup(options, nuxt) {
-    nuxt.hook('i18n:extend-messages', (additionalMessages, localeCodes) => {
+  setup(options, nuxt) {
+    nuxt.hook('i18n:extend-messages', async (additionalMessages, localeCodes) => {
       additionalMessages.push({
         en: {
           'my-module-exemple': {
@@ -32,7 +32,8 @@ export default defineNuxtModule({
       })
     })
   }
-}
+})
+
 ```
 
 Now the project has access to new messages and can use them through `$t('my-module-exemple.hello')`.


### PR DESCRIPTION
This commit moves `async` definition to the `i18n:extend-messages` callback for a propper typing and adds missing parenthesis at the end of code example

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

There is no open issues, but I can open if it's necessary
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
