### PR TITLE
fix: don't expose full project path throuh `langDir` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@babel/traverse": "^7.18.10",
     "@intlify/vue-i18n-extensions": "^1.0.2",
     "@intlify/vue-i18n-loader": "^1.1.0",
-    "@nuxt/utils": "2.15.8",
+    "@nuxt/utils": "2.x",
     "cookie": "^0.5.0",
     "devalue": "^2.0.1",
     "is-https": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "@babel/traverse": "^7.18.10",
     "@intlify/vue-i18n-extensions": "^1.0.2",
     "@intlify/vue-i18n-loader": "^1.1.0",
+    "@nuxt/utils": "2.15.8",
     "cookie": "^0.5.0",
     "devalue": "^2.0.1",
     "is-https": "^4.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -27,13 +27,14 @@ export default async function (moduleOptions) {
   /** @type {Record<string, string>} */
   const localeFileMap = {}
 
-  /**
-   * Helper for `langDir` resources resolving
-   * @param {any[]} args
-   */
-  const relativeToBuild = (...args) => relativeTo(this.options.buildDir, ...args)
-
   if (options.langDir) {
+    /**
+     * Helper for `langDir` resources resolving
+     * @param {any[]} args
+     */
+    const relativeToBuild = (...args) => relativeTo(this.options.buildDir, ...args)
+    const resolvedLangDir = this.nuxt.resolver.resolveAlias(options.langDir)
+
     if (!options.locales.length || typeof options.locales[0] === 'string') {
       throw new Error(formatMessage('When using the "langDir" option the "locales" must be a list of objects.'))
     }
@@ -41,12 +42,7 @@ export default async function (moduleOptions) {
       if (typeof (locale) === 'string' || !locale.file) {
         throw new Error(formatMessage(`All locales must be objects and have the "file" property set when using "langDir".\nFound none in:\n${JSON.stringify(locale, null, 2)}.`))
       }
-    }
-    const resolvedLangDir = this.nuxt.resolver.resolveAlias(options.langDir)
-    for (const locale of options.locales) {
-      if (typeof locale !== 'string' && locale.file) {
-        localeFileMap[String(locale.file)] = relativeToBuild(resolvedLangDir, locale.file)
-      }
+      localeFileMap[String(locale.file)] = relativeToBuild(resolvedLangDir, locale.file)
     }
   }
 

--- a/src/templates/options.d.ts
+++ b/src/templates/options.d.ts
@@ -18,3 +18,4 @@ export const localeMessages: Record<string, () => Promise<LocaleFileExport>>
 export const Constants: ModuleConstants
 export const nuxtOptions: ModuleNuxtOptions
 export const options: ResolvedOptions
+export const localeFiles: string

--- a/src/templates/options.js
+++ b/src/templates/options.js
@@ -3,6 +3,7 @@ const { lazy, locales, langDir, vueI18n } = options.options
 const { fallbackLocale } = vueI18n || {}
 const syncLocaleFiles = new Set()
 const asyncLocaleFiles = new Set()
+const localeFiles = JSON.parse(options.localeFiles)
 
 if (langDir) {
   if (fallbackLocale && typeof (fallbackLocale) === 'string') {
@@ -17,7 +18,7 @@ if (langDir) {
     }
   }
   for (const file of syncLocaleFiles) {
-%>import locale<%= hash(file) %> from '<%= `../${relativeToBuild(langDir, file)}` %>'
+%>import locale<%= hash(file) %> from '<%= `../${localeFiles[file]}` %>'
 <%
   }
 }
@@ -62,7 +63,7 @@ export const localeMessages = {
   <%= `'${file}': () => Promise.resolve(locale${hash(file)}),` %><%
   }
   for (const file of asyncLocaleFiles) {%>
-  <%= `'${file}': () => import('../${relativeToBuild(langDir, file)}' /* webpackChunkName: "lang-${file}" */),` %><%
+  <%= `'${file}': () => import('../${localeFiles[file]}' /* webpackChunkName: "lang-${file}" */),` %><%
   }
 %>
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1752,7 +1752,7 @@
     "@types/webpack-hot-middleware" "2.25.4"
     sass-loader "10.1.1"
 
-"@nuxt/utils@2.15.8":
+"@nuxt/utils@2.15.8", "@nuxt/utils@2.x":
   version "2.15.8"
   resolved "https://registry.yarnpkg.com/@nuxt/utils/-/utils-2.15.8.tgz#0c3594f01be63ab521583904cafd32215b719d4c"
   integrity sha512-e0VBarUbPiQ4ZO1T58puoFIuXme7L5gk1QfwyxOONlp2ryE7aRyZ8X/mryuOiIeyP64c4nwSUtN7q9EUWRb7Lg==


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

From e-mail:

An absolute path to the language directory may be exposed in build artifacts if you specify `langDir` option.

Nuxt-i18n expands `langDir` during build process.
https://github.com/nuxt-modules/i18n/blob/c4f7465a289b76d6985b9ac65dfb5908d36daff4/src/index.js#L34

#### Steps to reproduce

```sh
yarn create nuxt-app my-nuxt-app
cd my-nuxt-app
yarn add @nuxtjs/i18n
# After this, you have to modify nuxt.config.ts to use `langDir` option.
yarn run generate
grep -r "${PWD}" dist/ 
# Then the path which contains your current directory will be outputted.
```

#### Affected versions

this behavior is introduced in #1084
So, versions from v6.20.5 to v7.3.0 may be affected.

https://github.com/nuxt-modules/i18n/pull/1084/files
https://github.com/nuxt-modules/i18n/compare/v6.20.4...v6.20.5


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
