### PR TITLE
breaking: `useRouteBaseName` composable does not return function

### DIFF
--- a/docs/content/4.API/1.composables.md
+++ b/docs/content/4.API/1.composables.md
@@ -126,22 +126,28 @@ An object accepting the following optional fields:
 
 ## `useRouteBaseName`
 
-The `useRouteBaseName` composable returns the route base name. `useRouteBaseName` is powered by [vue-i18n-routing](https://github.com/intlify/routing/tree/main/packages/vue-i18n-routing).
+The `useRouteBaseName` composable returns function that get the route base name.  `useRouteBaseName` is powered by [vue-i18n-routing](https://github.com/intlify/routing/tree/main/packages/vue-i18n-routing).
+
+example:
+```vue
+<script setup>
+const route = useRoute()
+const getRouteBaseName = useRouteBaseName()
+const baseRouteName = computed(() => {
+  return getRouteBaseNmae(route)
+})
+</script>
+
+<template>
+  <p>route base name: {{ baseRouteName }}
+</template>
+```
 
 ### Type
 
 ```ts
-declare function useRouteBaseName(route?: Route | RouteLocationNormalizedLoaded): string | undefined;
+declare function useRouteBaseName(): (givenRoute?: Route | RouteLocationNormalizedLoaded) => string | undefined;
 ```
-
-### Parameters
-
-- `route`
-  
-  **Type**: `Route | RouteLocationNormalizedLoaded`
-
-  A route object. if not provided, the route is returned with `useRoute` will be used internal
-
 
 ## `useBrowserLocale`
 

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "ufo": "^1.0.1",
     "unplugin": "^1.0.1",
     "vue-i18n": "9.3.0-beta.16",
-    "vue-i18n-routing": "^0.11.0"
+    "vue-i18n-routing": "^0.12.1"
   },
   "devDependencies": {
     "@babel/parser": "^7.20.15",

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -58,7 +58,8 @@ export default defineNuxtConfig({
     defaultLocale: 'en',
     // strategy: 'no_prefix',
     // strategy: 'prefix',
-    strategy: 'prefix_and_default',
+    // strategy: 'prefix_and_default',
+    strategy: 'prefix_except_default',
     // rootRedirect: '/ja/about-ja',
     dynamicRouteParams: true,
     // customRoutes: 'config',
@@ -68,17 +69,15 @@ export default defineNuxtConfig({
       }
     },
     // differentDomains: true,
-    skipSettingLocaleOnNavigate: true,
+    // skipSettingLocaleOnNavigate: true,
     detectBrowserLanguage: false,
-    /*
-    detectBrowserLanguage: {
-      useCookie: true,
-      // alwaysRedirect: true,
-      cookieKey: 'i18n_redirected',
-      // cookieKey: 'my_custom_cookie_name',
-      redirectOn: 'root'
-    },
-    //*/
+    // detectBrowserLanguage: {
+    //   useCookie: true,
+    //   // alwaysRedirect: true
+    //   // cookieKey: 'i18n_redirected',
+    //   // // cookieKey: 'my_custom_cookie_name',
+    //   // redirectOn: 'root'
+    // },
     onBeforeLanguageSwitch: (oldLocale: string, newLocale: string, initial: boolean, nuxt: NuxtApp) => {
       console.log('onBeforeLanguageSwitch', oldLocale, newLocale, initial)
     },

--- a/playground/pages/[...catch].vue
+++ b/playground/pages/[...catch].vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
-import { LocaleObject, useI18n } from '#i18n'
+import { LocaleObject } from '#i18n'
 
 const route = useRoute()
 const { locale, locales } = useI18n()

--- a/playground/pages/blog.vue
+++ b/playground/pages/blog.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import { useI18n } from '#i18n'
-
 defineI18nRoute({
   paths: {
     en: '/blog-us',

--- a/playground/pages/category/[id].vue
+++ b/playground/pages/category/[id].vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
-import { LocaleObject, useI18n } from '#i18n'
+import { LocaleObject } from '#i18n'
 
 const route = useRoute()
 const { locale, locales } = useI18n()

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -2,17 +2,19 @@
 import { computed } from 'vue'
 
 // import { useLocalePath, useSwitchLocalePath, useLocaleHead, useBrowserLocale } from '#i18n'
-import { LocaleObject, useI18n } from '#i18n'
+import { LocaleObject } from '#i18n'
 
 const route = useRoute()
 const { t, strategy, locale, locales, localeProperties, setLocale, finalizePendingLocaleChange } = useI18n()
 const localePath = useLocalePath()
 const switchLocalePath = useSwitchLocalePath()
+const getRouteBaseName = useRouteBaseName()
 
 // route.meta.pageTransition.onBeforeEnter = async () => {
 //   await finalizePendingLocaleChange()
 // }
 
+console.log('route base name', getRouteBaseName())
 console.log('useBrowserLocale', useBrowserLocale())
 console.log('localeProperties', localeProperties)
 console.log('foo', t('foo'))

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  // https://v3.nuxtjs.org/concepts/typescript
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
       vitest: ^0.26.2
       vue: ^3.2.47
       vue-i18n: 9.3.0-beta.16
-      vue-i18n-routing: ^0.11.0
+      vue-i18n-routing: ^0.12.1
       yorkie: ^2.0.0
     dependencies:
       '@intlify/bundle-utils': 4.0.0_vue-i18n@9.3.0-beta.16
@@ -76,7 +76,7 @@ importers:
       ufo: 1.0.1
       unplugin: 1.0.1
       vue-i18n: 9.3.0-beta.16_vue@3.2.47
-      vue-i18n-routing: 0.11.0_nojl5tq4gemnzytwc7cf7ndqfm
+      vue-i18n-routing: 0.12.1_nojl5tq4gemnzytwc7cf7ndqfm
     devDependencies:
       '@babel/parser': 7.20.15
       '@babel/plugin-syntax-import-assertions': 7.20.0
@@ -9281,8 +9281,8 @@ packages:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
     dev: true
 
-  /vue-i18n-routing/0.11.0_nojl5tq4gemnzytwc7cf7ndqfm:
-    resolution: {integrity: sha512-SK+9bt7T+QAJK4R3CjFEFH0VCY2Er5sDC5h2oTSPxilSHXLpj5Sto9Ph24fHjPl/gpjN9sa/ZbVBZL7vUElsjg==}
+  /vue-i18n-routing/0.12.1_nojl5tq4gemnzytwc7cf7ndqfm:
+    resolution: {integrity: sha512-gWeew7/xxmd9dIY03mINlXXiiP+ewYLAQ5BJxt2dFJAComFid8iqZZ9PL92KYuZ5wjR89ZiyobD8dc+ITINioQ==}
     engines: {node: '>= 14.6'}
     peerDependencies:
       '@vue/composition-api': ^1.0.0-rc.1

--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -18,23 +18,25 @@ export type { LocaleObject } from 'vue-i18n-routing'
 import type { Locale } from 'vue-i18n'
 
 /**
- * The `useRouteBaseName` composable returns the route base name.
+ * The `useRouteBaseName` composable returns function that get the route base name.
  *
  * @remarks
- * The `useRouteBaseName` is the composable function which is {@link getRouteBaseName} wrapper.
+ * The function returned by `useRouteBaseName` is the wrapper function with the same signature as {@link getRouteBaseName}.
  *
  * `useRouteBaseName` is powered by [vue-i18n-routing](https://github.com/intlify/routing/tree/main/packages/vue-i18n-routing).
  *
  * @param route - A route object. if not provided, the route is returned with `useRoute` will be used internally
  *
- * @returns The route base name, if route name is not defined, return `null`.
+ * @returns A {@link RouteBaseNameFunction}.
  *
  * @public
  */
-export function useRouteBaseName(
-  route: NonNullable<Parameters<typeof _useRouteBaseName>[0]> = useRoute()
-): ReturnType<typeof _useRouteBaseName> {
-  return _useRouteBaseName(route, { router: useRouter() })
+export function useRouteBaseName(): ReturnType<typeof _useRouteBaseName> {
+  return _useRouteBaseName({
+    route: useRoute(),
+    router: useRouter(),
+    i18n: getComposer(useNuxtApp().$i18n)
+  })
 }
 
 /**


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

resolve #1862 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

issue said:
> Changes useRouteBaseName composable to return a function that can be used to get the route base name, preventing useRoute and useRouter invocation on every call. 

`useRouteBaseName` is composable to return a function that can be used to get the route base name, not return directly to the route base name.

The reason is that you need a context environment (e.g. setup) in which you can run Vue Composition API such as useRoute internally.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
