### PR TITLE
fix: alwaysRedirect does not work with redirectOn 'all' and 'no prefix'

### DIFF
--- a/specs/browser_language_detection/always_redirect/prefix_and_default_all.spec.ts
+++ b/specs/browser_language_detection/always_redirect/prefix_and_default_all.spec.ts
@@ -31,6 +31,7 @@ test('alwaysRedirect: all', async () => {
   expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('fr')
 
   // go to `en` home page
-  await page.goto(url('/en'))
+  await page.goto(blog)
+  expect(page.url().endsWith('/fr/blog/article'))
   expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('fr')
 })

--- a/specs/browser_language_detection/always_redirect/prefix_and_default_all.spec.ts
+++ b/specs/browser_language_detection/always_redirect/prefix_and_default_all.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, url, createPage } from '@nuxt/test-utils'
+import { getText } from '../../helper'
+
+await setup({
+  rootDir: fileURLToPath(new URL(`../../fixtures/basic`, import.meta.url)),
+  browser: true,
+  // overrides
+  nuxtConfig: {
+    i18n: {
+      strategy: 'prefix_and_default',
+      detectBrowserLanguage: {
+        alwaysRedirect: true,
+        redirectOn: 'all'
+      }
+    }
+  }
+})
+
+test('alwaysRedirect: all', async () => {
+  const blog = url('/blog/article')
+  const page = await createPage(undefined, { locale: 'en' }) // set browser locale
+  await page.goto(blog)
+
+  // detect locale from navigator language
+  expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('en')
+
+  // click `fr` lang switch link
+  await page.locator('#set-locale-link-fr').click()
+  expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('fr')
+
+  // go to `en` home page
+  await page.goto(url('/en'))
+  expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('fr')
+})

--- a/specs/browser_language_detection/always_redirect/prefix_and_default_no_prefix.spec.ts
+++ b/specs/browser_language_detection/always_redirect/prefix_and_default_no_prefix.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, url, createPage } from '@nuxt/test-utils'
+import { getText } from '../../helper'
+
+await setup({
+  rootDir: fileURLToPath(new URL(`../../fixtures/basic`, import.meta.url)),
+  browser: true,
+  // overrides
+  nuxtConfig: {
+    i18n: {
+      strategy: 'prefix_and_default',
+      detectBrowserLanguage: {
+        alwaysRedirect: true,
+        redirectOn: 'no prefix'
+      }
+    }
+  }
+})
+
+test('alwaysRedirect: no prefix', async () => {
+  const blog = url('/blog/article')
+  const page = await createPage(undefined, { locale: 'en' }) // set browser locale
+  await page.goto(blog)
+
+  // detect locale from navigator language
+  expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('en')
+
+  // click `fr` lang switch link
+  await page.locator('#set-locale-link-fr').click()
+  expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('fr')
+
+  // go to `en` home page
+  await page.goto(url('/ja/blog/article'))
+  expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('ja')
+})

--- a/specs/browser_language_detection/always_redirect/prefix_and_default_no_prefix.spec.ts
+++ b/specs/browser_language_detection/always_redirect/prefix_and_default_no_prefix.spec.ts
@@ -4,7 +4,7 @@ import { setup, url, createPage } from '@nuxt/test-utils'
 import { getText } from '../../helper'
 
 await setup({
-  rootDir: fileURLToPath(new URL(`../../fixtures/basic`, import.meta.url)),
+  rootDir: fileURLToPath(new URL(`../../fixtures/fallback`, import.meta.url)),
   browser: true,
   // overrides
   nuxtConfig: {
@@ -19,7 +19,7 @@ await setup({
 })
 
 test('alwaysRedirect: no prefix', async () => {
-  const blog = url('/blog/article')
+  const blog = url('/about')
   const page = await createPage(undefined, { locale: 'en' }) // set browser locale
   await page.goto(blog)
 
@@ -31,6 +31,11 @@ test('alwaysRedirect: no prefix', async () => {
   expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('fr')
 
   // go to `en` home page
-  await page.goto(url('/ja/blog/article'))
+  await page.goto(url('/ja/about'))
+  expect(page.url().endsWith('/ja/about'))
+  expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('ja')
+
+  await page.goto(url('/about'))
+  expect(page.url().endsWith('/ja/about'))
   expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('ja')
 })

--- a/specs/fixtures/basic/nuxt.config.ts
+++ b/specs/fixtures/basic/nuxt.config.ts
@@ -17,6 +17,11 @@ export default defineNuxtConfig({
         code: 'fr',
         iso: 'fr-FR',
         name: 'Français'
+      },
+      {
+        code: 'ja',
+        iso: 'ja-JP',
+        name: 'Japanese'
       }
     ],
     defaultLocale: 'en',

--- a/specs/fixtures/basic/nuxt.config.ts
+++ b/specs/fixtures/basic/nuxt.config.ts
@@ -17,11 +17,6 @@ export default defineNuxtConfig({
         code: 'fr',
         iso: 'fr-FR',
         name: 'Français'
-      },
-      {
-        code: 'ja',
-        iso: 'ja-JP',
-        name: 'Japanese'
       }
     ],
     defaultLocale: 'en',

--- a/src/runtime/internal.ts
+++ b/src/runtime/internal.ts
@@ -406,8 +406,11 @@ export function detectBrowserLanguage<Context extends NuxtApp = NuxtApp>(
       if (finalLocale !== vueI18nLocale /* && path !== '/'*/) {
         __DEBUG__ && console.log('detectBrowserLanguage: finalLocale !== vueI18nLocale', finalLocale)
         return { locale: finalLocale, stat: true, from: localeFrom }
-      } else {
-        if (alwaysRedirect && path === '/') {
+      } else if (alwaysRedirect) {
+        const redirectOnRoot = path === '/'
+        const redirectOnAll = redirectOn === 'all'
+        const redirectOnNoPrefix = redirectOn === 'no prefix' && !path.match(getLocalesRegex(localeCodes as string[]))
+        if (redirectOnRoot || redirectOnAll || redirectOnNoPrefix) {
           return { locale: finalLocale, stat: true, from: localeFrom }
         }
       }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#1859 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
When the strategy is set to anything except 'no_prefix' and with alwaysRedirect enabled, redirection only happens on the root path. This change modifies the check when alwaysRedirect is set to check redirectOn strategy before choosing to redirect.

Previously, going to a page like '/about' would not redirect to '/fr/about' because it is not the root. This fix will allow us to redirect correctly so that '/about' and '/ja/about' will redirect to '/fr/about' when using 'all', and redirect '/about' to '/fr/about' when using 'no prefix'

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
