### PR TITLE
fix: defineI18nRoute do not work client-side

### DIFF
--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -292,6 +292,10 @@ export function detectRedirect<Context extends NuxtApp = NuxtApp>(
   let redirectPath = ''
   const isStaticGenerate = isSSG && process.server
 
+  if (!isI18nRouteDefined(route)) {
+    return redirectPath
+  }
+
   // decide whether we should redirect to a different route.
   if (
     !isStaticGenerate &&
@@ -495,6 +499,10 @@ export function extendBaseUrl<Context extends NuxtApp = NuxtApp>(
 
     return baseUrl
   }
+}
+function isI18nRouteDefined(route: Route | RouteLocationNormalized | RouteLocationNormalizedLoaded): boolean {
+  const i18nLocales = route.matched[0]?.meta.nuxtI18n
+  return i18nLocales ? Object.keys(i18nLocales).length > 0 : false
 }
 
 /* eslint-enable @typescript-eslint/no-explicit-any */


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue
#1889 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
When attempting to check redirection, the detectRedirect function matches a non-defined i18n route back to the root path. 

The detectRedirect function was modified to detect whether the route matched by the router is an i18n route. If it is, we will continue with the logic as-is. If it is not, we will skip redirection.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
