### PR TITLE
docs: update nuxt links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -7,7 +7,7 @@ body:
       value: |
         The reporting guideline of nuxt-modules/i18n is compliant with Nuxt too.
         Please carefully read the contribution docs before creating a bug report.
-        👉 https://v3.nuxtjs.org/community/reporting-bugs
+        👉 https://nuxt.com/docs/community/reporting-bugs
 
         Please use a template below to create a minimal reproduction, and provide to us your issue cases
         👉 https://stackblitz.com/github/nuxt/starter/tree/v3-stackblitz
@@ -24,7 +24,7 @@ body:
     id: reproduction
     attributes:
       label: Reproduction
-      description: Please provide a link to a repo that can reproduce the problem you ran into. A [**minimal reproduction**](https://v3.nuxtjs.org/community/reporting-bugs#create-a-minimal-reproduction) is required unless you are absolutely sure that the issue is obvious and the provided information is enough to understand the problem. If a report is vague (e.g. just a generic error message) and has no reproduction, it will receive a "need reproduction" label. If no reproduction is provided we might close it.
+      description: Please provide a link to a repo that can reproduce the problem you ran into. A [**minimal reproduction**](https://nuxt.com/docs/community/reporting-bugs#create-a-minimal-reproduction) is required unless you are absolutely sure that the issue is obvious and the provided information is enough to understand the problem. If a report is vague (e.g. just a generic error message) and has no reproduction, it will receive a "need reproduction" label. If no reproduction is provided we might close it.
       placeholder: Reproduction
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -9,7 +9,7 @@ body:
 
         Please carefully read the contribution docs before suggesting a new feature.
         (The feature request guideline of nuxt-modules/i18n is compliant with Nuxt too)
-        👉 https://v3.nuxtjs.org/community/contribution/#creating-an-issue
+        👉 https://nuxt.com/docs/community/contribution#creating-an-issue
   - type: textarea
     id: feature-description
     attributes:
@@ -32,7 +32,7 @@ body:
       label: Final checks
       description: Before submitting, please make sure you do the following
       options:
-        - label: Read the [contribution guide](https://v3.nuxtjs.org/community/contribution) (The contribution guideline of nuxt-modules/i18n is compliant with Nuxt too).
+        - label: Read the [contribution guide](https://nuxt.com/docs/community/contribution) (The contribution guideline of nuxt-modules/i18n is compliant with Nuxt too).
           required: true
-        - label: Check existing [discussions](https://github.com/nuxt-modules/i18n/discussions) and [issues](https://github.com/nuxt/framework/issues).
+        - label: Check existing [discussions](https://github.com/nuxt-modules/i18n/discussions) and [issues](https://github.com/nuxt/nuxt/issues).
           required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 ☝️ PR title should follow conventional commits (https://conventionalcommits.org)
 
 Please carefully read the contribution docs before creating a pull request
- 👉 https://v3.nuxtjs.org/community/contribution
+ 👉 https://nuxtjs.com/docs/community/contribution
 -->
 
 ### 🔗 Linked issue

--- a/docs/content/1.getting-started/1.setup.md
+++ b/docs/content/1.getting-started/1.setup.md
@@ -9,7 +9,7 @@
 ::
 
 ::alert{type="info"}
-Check the [Nuxt.js documentation](https://v3.nuxtjs.org/guide/features/modules) for more information about installing and using modules in Nuxt.js.
+Check the [Nuxt.js documentation](https://nuxt.com/docs/guide/concepts/modules) for more information about installing and using modules in Nuxt.js.
 ::
 
 Add `@nuxtjs/i18n` dependency to your project:

--- a/docs/content/1.getting-started/2.basic-usage.md
+++ b/docs/content/1.getting-started/2.basic-usage.md
@@ -59,13 +59,13 @@ const { locale } = useI18n()
 
 ::alert{type="info"}
 
-The code demonstrated in this chapter is illustrated using Nuxt [Pages](https://v3.nuxtjs.org/guide/directory-structure/pages). 
+The code demonstrated in this chapter is illustrated using Nuxt [Pages](https://nuxt.com/docs/guide/directory-structure/pages). 
 
 ::
 
 ::alert{type="info"}
 
-Some composable functions provided by @nuxtjs/i18n such as `useI18n` are [auto-imported by Nuxt](https://v3.nuxtjs.org/guide/concepts/auto-imports#auto-imports)
+Some composable functions provided by @nuxtjs/i18n such as `useI18n` are [auto-imported by Nuxt](https://nuxt.com/docs/guide/concepts/auto-imports#auto-imports)
 
 If you want to import them explicitly, you can use `#imports` as follows:
 
@@ -149,7 +149,7 @@ const localePath = useLocalePath()
 </template>
 ```
 
-Note that `localePath` can use the route's unprefixed path, which must start with `'/'` or the route's base name to generate the localized URL. The base name corresponds to the names Nuxt generates when parsing your `pages` directory, more info in [Nuxt's doc](https://v3.nuxtjs.org/guide/directory-structure/pages).
+Note that `localePath` can use the route's unprefixed path, which must start with `'/'` or the route's base name to generate the localized URL. The base name corresponds to the names Nuxt generates when parsing your `pages` directory, more info in [Nuxt's doc](https://nuxt.com/docs/guide/directory-structure/pages).
 
 ::alert{type="info"}
 

--- a/docs/content/1.index.md
+++ b/docs/content/1.index.md
@@ -22,7 +22,7 @@ snippet: npm install @nuxtjs/i18n@next --save-dev
 Nuxt [I18n]{.text-primary-400}
 
 #description
-[I18n module](https://github.com/nuxt-community/i18n-module) for [Nuxt](https://nuxt.com)
+[I18n module](https://github.com/nuxt-modules/i18n) for [Nuxt](https://nuxt.com)
 
 #extra
   ::list

--- a/docs/content/2.guide/7.seo.md
+++ b/docs/content/2.guide/7.seo.md
@@ -64,15 +64,15 @@ export default defineNuxtConfig({
 
 ## Setup
 
-The `useLocaleHead` is a composable function, Calling that composable function returns a function that returns metadata that is handled by [Head management](https://v3.nuxtjs.org/guide/features/head-management#head-management) that is integrated within Nuxt. That metadata can be specified the `setup` function in various places within Nuxt:
+The `useLocaleHead` is a composable function, Calling that composable function returns a function that returns metadata that is handled by [Head management](https://nuxt.com/docs/getting-started/seo-meta) that is integrated within Nuxt. That metadata can be specified the `setup` function in various places within Nuxt:
 
-- [`app.vue`](https://v3.nuxtjs.org/guide/directory-structure/app)
-- Vue components of [`pages`](https://v3.nuxtjs.org/guide/directory-structure/pages) directory
-- Vue components of [`layouts`](https://v3.nuxtjs.org/guide/directory-structure/layouts) directory
+- [`app.vue`](https://nuxt.com/docs/guide/directory-structure/app)
+- Vue components of [`pages`](https://nuxt.com/docs/guide/directory-structure/pages) directory
+- Vue components of [`layouts`](https://nuxt.com/docs/guide/directory-structure/layouts) directory
 
 To enable SEO metadata, declare a `setup` function in one of the places specified above and make it return the result of a `useLocaleHead` function call.
 
-To avoid duplicating the code, it's recommended to set globally with [Meta Components](https://v3.nuxtjs.org/guide/features/head-management#meta-components) in [layout components](https://v3.nuxtjs.org/guide/directory-structure/layouts) and override some values per-page Vue component like [`definePageMeta`](https://v3.nuxtjs.org/guide/directory-structure/pages#page-metadata), if necessary.
+To avoid duplicating the code, it's recommended to set globally with [Meta Components](https://nuxt.com/docs/getting-started/seo-meta#components) in [layout components](https://nuxt.com/docs/guide/directory-structure/layouts) and override some values per-page Vue component like [`definePageMeta`](https://nuxt.com/docs/guide/directory-structure/pages#page-metadata), if necessary.
 
 ::code-group
 ```vue {}[app.vue]

--- a/docs/content/2.guide/9.lang-switcher.md
+++ b/docs/content/2.guide/9.lang-switcher.md
@@ -147,7 +147,7 @@ To work around the issue, you can set the option [`skipSettingLocaleOnNavigate`]
 
 ### Global transition
 
-If you would like to transition the entire Nuxt app, you can use the [`transition` of `NuxtPage`](https://v3.nuxtjs.org/getting-started/transitions#transition-with-nuxtpage) to control it as follows:
+If you would like to transition the entire Nuxt app, you can use the [`transition` of `NuxtPage`](https://nuxt.com/docs/getting-started/transitions#transition-with-nuxtpage) to control it as follows:
 
 ```ts {}[nuxt.config.ts]
 export default defineNuxtConfig({
@@ -189,7 +189,7 @@ const onBeforeEnter = async () => {
 </style>
 ```
 
-Optional, wait for locale before scrolling for a smoother transition with [Router Options](https://v3.nuxtjs.org/guide/directory-structure/pages#router-options):
+Optional, wait for locale before scrolling for a smoother transition with [Router Options](https://nuxt.com/docs/guide/directory-structure/pages#router-options):
 
 ```ts {}[app/router.options.ts]
 import type { RouterConfig } from '@nuxt/schema'
@@ -212,7 +212,7 @@ export default <RouterConfig>{
 
 ### Per page component transition
 
-If you have a specific transition defined in a page component with [`definePageMeta`](https://v3.nuxtjs.org/guide/directory-structure/pages/#page-metadata) and need to add `finalizePendingLocaleChange` at `onBeforeEnter` hook for `pageTransition`.
+If you have a specific transition defined in a page component with [`definePageMeta`](https://nuxt.com/docs/guide/directory-structure/pages#page-metadata) and need to add `finalizePendingLocaleChange` at `onBeforeEnter` hook for `pageTransition`.
 
 Example:
 

--- a/docs/content/4.API/2.compiler-macros.md
+++ b/docs/content/4.API/2.compiler-macros.md
@@ -6,7 +6,7 @@ Compiler Macros for Nuxt i18n module.
 
 ## `defineI18nRoute`
 
-`defineI18nRoute` is a compiler macro that you can use to set custom route paths for your **page** components located in the `pages/` directory (unless [set otherwise](https://v3.nuxtjs.org/api/configuration/nuxt.config#pages)). This way you can set custom route paths for each static or dynamic route of your Nuxt application.
+`defineI18nRoute` is a compiler macro that you can use to set custom route paths for your **page** components located in the `pages/` directory (unless [set otherwise](https://nuxt.com/docs/api/configuration/nuxt-config#pages-1)). This way you can set custom route paths for each static or dynamic route of your Nuxt application.
 
 ```vue [pages/some-page.vue]
 <script setup>

--- a/docs/content/4.API/5.nuxt.md
+++ b/docs/content/4.API/5.nuxt.md
@@ -12,7 +12,7 @@ The following APIs are exposed both on `NuxtApp`.
 
 - **Type**: [`VueI18n` | `Composer`]
 
-See also [NuxtApp](https://v3.nuxtjs.org/guide/going-further/nuxt-app/#accessing-nuxtapp)
+See also [NuxtApp](https://nuxt.com/docs/guide/going-further/nuxt-app#accessing-nuxtapp)
 
 `$i18n` is the global `Composer` or global `VueI18n` instance of Vue I18n. See about details [here](https://vue-i18n.intlify.dev/api/general.html#i18n)
 

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,7 +1,7 @@
 import Module1 from './module1'
 import type { NuxtApp } from 'nuxt/dist/app/index'
 
-// https://v3.nuxtjs.org/docs/directory-structure/nuxt.config
+// https://nuxt.com/docs/guide/directory-structure/nuxt.config
 export default defineNuxtConfig({
   modules: [Module1, '@nuxtjs/i18n'],
 

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  // https://v3.nuxtjs.org/concepts/typescript
-  "extends": "./.nuxt/tsconfig.json"
+	// https://nuxt.com/docs/guide/concepts/typescript
+	"extends": "./.nuxt/tsconfig.json"
 }

--- a/specs/fixtures/basic/nuxt.config.ts
+++ b/specs/fixtures/basic/nuxt.config.ts
@@ -1,6 +1,6 @@
 import CustomModule from './module'
 
-// https://v3.nuxtjs.org/docs/directory-structure/nuxt.config
+// https://nuxt.com/docs/guide/directory-structure/nuxt.config
 export default defineNuxtConfig({
   modules: [CustomModule, '@nuxtjs/i18n'],
 

--- a/specs/fixtures/basic_usage/nuxt.config.ts
+++ b/specs/fixtures/basic_usage/nuxt.config.ts
@@ -1,4 +1,4 @@
-// https://v3.nuxtjs.org/docs/directory-structure/nuxt.config
+// https://nuxt.com/docs/guide/directory-structure/nuxt.config
 export default defineNuxtConfig({
   modules: ['@nuxtjs/i18n'],
 

--- a/specs/fixtures/fallback/nuxt.config.ts
+++ b/specs/fixtures/fallback/nuxt.config.ts
@@ -1,4 +1,4 @@
-// https://v3.nuxtjs.org/docs/directory-structure/nuxt.config
+// https://nuxt.com/docs/guide/directory-structure/nuxt.config
 export default defineNuxtConfig({
   modules: ['@nuxtjs/i18n'],
 

--- a/specs/fixtures/head/nuxt.config.ts
+++ b/specs/fixtures/head/nuxt.config.ts
@@ -1,4 +1,4 @@
-// https://v3.nuxtjs.org/docs/directory-structure/nuxt.config
+// https://nuxt.com/docs/guide/directory-structure/nuxt.config
 export default defineNuxtConfig({
   modules: ['@nuxtjs/i18n'],
 

--- a/specs/fixtures/issues/1740/nuxt.config.ts
+++ b/specs/fixtures/issues/1740/nuxt.config.ts
@@ -1,4 +1,4 @@
-// https://v3.nuxtjs.org/api/configuration/nuxt.config
+// https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   extends: './playground'
 })

--- a/specs/fixtures/lazy/nuxt.config.ts
+++ b/specs/fixtures/lazy/nuxt.config.ts
@@ -1,4 +1,4 @@
-// https://v3.nuxtjs.org/docs/directory-structure/nuxt.config
+// https://nuxt.com/docs/guide/directory-structure/nuxt.config
 export default defineNuxtConfig({
   modules: ['@nuxtjs/i18n'],
 

--- a/specs/fixtures/switcher/nuxt.config.ts
+++ b/specs/fixtures/switcher/nuxt.config.ts
@@ -1,4 +1,4 @@
-// https://v3.nuxtjs.org/docs/directory-structure/nuxt.config
+// https://nuxt.com/docs/guide/directory-structure/nuxt.config
 export default defineNuxtConfig({
   modules: ['@nuxtjs/i18n'],
 

--- a/specs/fixtures/vue_i18n_options_loader/nuxt.config.ts
+++ b/specs/fixtures/vue_i18n_options_loader/nuxt.config.ts
@@ -1,4 +1,4 @@
-// https://v3.nuxtjs.org/docs/directory-structure/nuxt.config
+// https://nuxt.com/docs/guide/directory-structure/nuxt.config
 export default defineNuxtConfig({
   modules: ['@nuxtjs/i18n'],
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://v3.nuxtjs.org/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
At the moment most links referencing the old Nuxt v3 (v3.nuxtjs.org) documents redirect to the new updated docs (nuxt.com), some do not (e.g. the info notice referencing the docs about modules on https://v8.i18n.nuxtjs.org/getting-started/setup/). I replaced all links to the location where possible, some docs have been renamed or moved elsewhere so I pointed it to the most appropriate info.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
