### PR TITLE
fix: detect langDir absolute path and refer to docs

### DIFF
--- a/docs/content/3.options/3.lazy.md
+++ b/docs/content/3.options/3.lazy.md
@@ -36,4 +36,10 @@ Whether the translation messages for the current locale should be injected into 
 - type: `string` or `null`
 - default: `null`
 
-Directory that contains translation files to load. Can be used with or without lazy-loading (the `lazy` option). Use Webpack paths like `~/locales/` (with trailing slash).
+A relative path to a directory containing translation files to load. Can be used with or without lazy-loading (the `lazy` option). 
+
+The path is resolved relative to the project `srcDir` (project root by default).
+
+::alert{type="warning"}
+Absolute paths will fail in production (eg. `/locales` should be changed into either `locales` or `./locales`)
+::

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,7 @@
 import createDebug from 'debug'
 import { isBoolean, isObject, isString } from '@intlify/shared'
 import { defineNuxtModule, isNuxt2, isNuxt3, getNuxtVersion, addPlugin, addTemplate, addImports } from '@nuxt/kit'
-import { resolve, relative } from 'pathe'
+import { resolve, relative, isAbsolute } from 'pathe'
 import { setupAlias, resolveVueI18nAlias } from './alias'
 import { setupPages } from './pages'
 import { extendMessages } from './messages'
@@ -64,6 +64,13 @@ export default defineNuxtModule<NuxtI18nOptions>({
      * resolve lang directory
      */
 
+    if (isString(options.langDir) && isAbsolute(options.langDir)) {
+      console.warn(
+        formatMessage(
+          `\`langdir\` is set to an absolute path (${options.langDir}) but should be set a path relative to \`srcDir\` (${nuxt.options.srcDir}). Absolute paths will not work in production, see https://v8.i18n.nuxtjs.org/options/lazy#langdir for more details.`
+        )
+      )
+    }
     const langPath = isString(options.langDir) ? resolve(nuxt.options.srcDir, options.langDir) : null
     debug('langDir path', langPath)
 


### PR DESCRIPTION
### 🔗 Linked issue
#1913 
#1890 
#1900 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change
- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
It seems the current behaviour is unclear which can be seen in the linked issues.
* Changes documentation for `langDir` option to clarify that a relative path should be used.
* Detects and logs a warning if `langDir` is set to an absolute path and refers to updated documentation.
* Resolves #1913 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
