### PR TITLE
fix: defineI18nRoute not working outside setup sugar syntax pages

### DIFF
--- a/src/pages.ts
+++ b/src/pages.ts
@@ -245,16 +245,19 @@ function readComponent(target: string) {
   try {
     const content = fs.readFileSync(target, 'utf8').toString()
     const { descriptor } = parseSFC(content)
-    if (!descriptor.scriptSetup) {
+
+    if (!content.includes('defineI18nRoute')) {
       return options
     }
+
     const desc = compileScript(descriptor, { id: target })
-    const { scriptSetupAst } = desc
+    const { scriptSetupAst, scriptAst } = desc
 
     let extract = ''
-    if (scriptSetupAst) {
+    const genericSetupAst = scriptSetupAst || scriptAst
+    if (genericSetupAst) {
       const s = new MagicString(desc.loc.source)
-      scriptSetupAst.forEach(ast => {
+      genericSetupAst.forEach(ast => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         walk(ast as any, {
           enter(_node) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
#1928 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #1928

It looks like `defineI18nRoute` was only checked  in components/pages using the setup sugar syntax, maybe as an optimization? I changed the logic to use work with either approaches.

In case it was an optimization I have added a simple check whether the content of the file includes `defineI18nRoute` before continuing, it may be too simple so I can remove that if needed.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
