### PR TITLE
fix: rm locale has already  loaded warning.

### DIFF
--- a/src/runtime/internal.ts
+++ b/src/runtime/internal.ts
@@ -182,7 +182,9 @@ export async function loadLocale(
       }
     }
   } else {
-    console.warn(formatMessage('Could not find ' + locale + ' locale code in localeMessages'))
+    if (!loadedLocales.includes(locale)) {
+      console.warn(formatMessage('Could not find ' + locale + ' locale code in localeMessages'))
+    }
   }
 }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue

closes https://github.com/nuxt-modules/i18n/issues/1947

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

when toggle locale use `setLocale`,it shows can not found en locale warning for locale message has already loaded.it's confusing.It should be removed or replaced with correct message. 
