### PR TITLE
fix: `format is not defined` in generated options

### DIFF
--- a/src/transform/proxy.ts
+++ b/src/transform/proxy.ts
@@ -87,7 +87,7 @@ export default async function(context, locale) {
         m => m.default || m
       )
     } catch (e) {
-      console.error(format(e.message))
+      console.error(formatMessage(e.message))
     }
     return mod || {}
   }
@@ -126,7 +126,7 @@ export default async function(context) {
         m => m.default || m
       )
     } catch (e) {
-      console.error(format(e.message))
+      console.error(formatMessage(e.message))
     }
     config.messages = messages || {}
     return config


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
Related/mentioned in #1990 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Fixes generated i18n.options trying to use `format` instead of imported `formatMessage` to format errors.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
