### PR TITLE
docs: update `defineI18nLocale` parameters in lazy-load-translations

### DIFF
--- a/docs/content/2.guide/8.lazy-load-translations.md
+++ b/docs/content/2.guide/8.lazy-load-translations.md
@@ -58,7 +58,7 @@ export default defineNuxtConfig({
 ```
 
 ```ts {}[lang/fr-FR.ts]
-export default defineI18nLocale(async (context, locale) => {
+export default defineI18nLocale(async (locale) => {
   return {
     welcome: 'Welcome'
   }
@@ -92,7 +92,7 @@ If you want to use it, you must set the `experimental.jsTsFormatResource` module
 If the function returns an Object available in nuxt i18n module, you can configure the dynamic locale messages, like the API (including external API) or back-end, via fetch:
 
 ```js
-export default defineI18nLocale((context, locale) => {
+export default defineI18nLocale((locale) => {
   // for example, fetch locale messages from nuxt server
   return $fetch(`/api/${locale}`)
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The type of `defineI18nLocale` has been changed according to https://v8.i18n.nuxtjs.org/api/composables/#type-8

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
