### PR TITLE
feat: add configurable runtime only setting

### DIFF
--- a/docs/content/3.options/6.misc.md
+++ b/docs/content/3.options/6.misc.md
@@ -7,7 +7,7 @@ Miscellaneous options.
 ## `experimental`
 
 - type: `object`
-- default: `{ jsTsFormatResource: false }`
+- default: `{ jsTsFormatResource: false, runtimeOnlyVueI18nBundle: true }`
 
 Configure the flag for experimental features of the nuxt i18n module.
 
@@ -21,6 +21,7 @@ Supported properties:
 
 - `jsTsFormatResource` (default: `false`) - Allow the format `js` and `ts` for locale messages in lazy load translation.
 
+- `runtimeOnlyVueI18nBundle` (default: `true`) - Optimization for bundle size. If you need to load dynamic translations at runtime, set to false.
 
 ## `precompile`
 

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -31,7 +31,8 @@ export default defineNuxtConfig({
   debug: false,
   i18n: {
     experimental: {
-      jsTsFormatResource: true
+      jsTsFormatResource: true,
+      runtimeOnlyVueI18nBundle: true
     },
     precompile: {
       strictMessage: false,

--- a/specs/fixtures/issues/2000/nuxt.config.ts
+++ b/specs/fixtures/issues/2000/nuxt.config.ts
@@ -10,7 +10,8 @@ export default defineNuxtConfig({
 
   i18n: {
     experimental: {
-      jsTsFormatResource: true
+      jsTsFormatResource: true,
+      runtimeOnlyVueI18nBundle: true
     },
     defaultLocale: 'en',
     langDir: 'locales',

--- a/specs/lazy_load/basic.spec.ts
+++ b/specs/lazy_load/basic.spec.ts
@@ -11,7 +11,8 @@ describe('basic', async () => {
     nuxtConfig: {
       i18n: {
         experimental: {
-          jsTsFormatResource: true
+          jsTsFormatResource: true,
+          runtimeOnlyVueI18nBundle: true
         },
         precompile: {
           strictMessage: false

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -72,7 +72,7 @@ export async function extendBundler(
     const webpack = await import('webpack').then(m => m.default || m)
 
     const webpackPluginOptions: PluginOptions = {
-      runtimeOnly: true,
+      runtimeOnly: nuxtOptions.experimental.runtimeOnlyVueI18nBundle,
       allowDynamic: true,
       strictMessage: nuxtOptions.precompile.strictMessage,
       escapeHtml: nuxtOptions.precompile.escapeHtml
@@ -107,7 +107,7 @@ export async function extendBundler(
    */
 
   const vitePluginOptions: PluginOptions = {
-    runtimeOnly: true,
+    runtimeOnly: nuxtOptions.experimental.runtimeOnlyVueI18nBundle,
     allowDynamic: true,
     strictMessage: nuxtOptions.precompile.strictMessage,
     escapeHtml: nuxtOptions.precompile.escapeHtml

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,7 +31,8 @@ export const COMPONENT_OPTIONS_KEY = 'nuxtI18n'
 
 export const DEFAULT_OPTIONS = {
   experimental: {
-    jsTsFormatResource: false
+    jsTsFormatResource: false,
+    runtimeOnlyVueI18nBundle: true
   },
   precompile: {
     strictMessage: true,

--- a/src/module.ts
+++ b/src/module.ts
@@ -68,6 +68,10 @@ export default defineNuxtModule<NuxtI18nOptions>({
       logger.warn('JS / TS extension format is experimental')
     }
 
+    if (!options.experimental.runtimeOnlyVueI18nBundle) {
+      logger.warn('Disabled runtimeOnlyVueI18nBundle is experimental')
+    }
+
     /**
      * Check vertions
      */

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,7 @@ export type CustomRoutePages = {
 
 export interface ExperimentalFeatures {
   jsTsFormatResource?: boolean
+  runtimeOnlyVueI18nBundle: boolean
 }
 
 export interface LocaleMessagePrecompileOptions {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt-modules/i18n/issues/2075

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Added `runtimeOnlyVueI18nBundle` under the experimental flag as described in the linked task. This flag is true by default, so it shouldn't affect current behaviour.
I faced lazy loading limitations, we need to load translations at runtime because they change quite often. I found some workarounds with empty messages at build time and setting dynamic messages at runtime with` i18n.setLocaleMessage.` But with runtime only vue-i18n we can't use any params in translations. I hope this feature helps to solve this limitation.

Partially resolved #2075
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
