### PR TITLE
fix(alias): do not use runtime version during nuxt prepare

### DIFF
--- a/src/alias.ts
+++ b/src/alias.ts
@@ -52,7 +52,7 @@ export async function setupAlias(nuxt: Nuxt) {
 
 export async function resolveVueI18nAlias(pkgModulesDir: string, nuxt: Nuxt, pkgMgr: PackageManager) {
   const { rootDir, workspaceDir } = nuxt.options
-  const modulePath = nuxt.options.dev
+  const modulePath = nuxt.options.dev || nuxt.options._prepare
     ? `${VUE_I18N_PKG}/dist/vue-i18n.mjs`
     : `${VUE_I18N_PKG}/dist/vue-i18n.runtime.mjs`
   const targets = [

--- a/src/alias.ts
+++ b/src/alias.ts
@@ -52,9 +52,10 @@ export async function setupAlias(nuxt: Nuxt) {
 
 export async function resolveVueI18nAlias(pkgModulesDir: string, nuxt: Nuxt, pkgMgr: PackageManager) {
   const { rootDir, workspaceDir } = nuxt.options
-  const modulePath = nuxt.options.dev || nuxt.options._prepare
-    ? `${VUE_I18N_PKG}/dist/vue-i18n.mjs`
-    : `${VUE_I18N_PKG}/dist/vue-i18n.runtime.mjs`
+  const modulePath =
+    nuxt.options.dev || nuxt.options._prepare
+      ? `${VUE_I18N_PKG}/dist/vue-i18n.mjs`
+      : `${VUE_I18N_PKG}/dist/vue-i18n.runtime.mjs`
   const targets = [
     // for Nuxt layer
     ...getLayerRootDirs(nuxt).map(root => resolve(root, 'node_modules', modulePath)),


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Using `vue-i18n` runtime version only in dev mode results in wrong/no types when running `nuxt prepare`. This PR fixes it.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
