### PR TITLE
fix: registerModule hook not working for js/ts format resources

### DIFF
--- a/playground/module-experimental/index.ts
+++ b/playground/module-experimental/index.ts
@@ -1,0 +1,36 @@
+import { defineNuxtModule, addPlugin, createResolver } from '@nuxt/kit'
+
+// Module options TypeScript interface definition
+export interface ModuleOptions {}
+
+export default defineNuxtModule<ModuleOptions>({
+  meta: {
+    name: 'module-experimental',
+    configKey: 'moduleExperimental'
+  },
+  // Default configuration options of the Nuxt module
+  defaults: {},
+  setup(options, nuxt) {
+    const resolver = createResolver(import.meta.url)
+
+    // @ts-ignore
+    nuxt.hook('i18n:registerModule', (register: any) => {
+      register({
+        // langDir path needs to be resolved
+        langDir: resolver.resolve('./lang'),
+        locales: [
+          {
+            code: 'de',
+            iso: 'de-DE',
+            file: 'de.ts'
+          },
+          {
+            code: 'en',
+            iso: 'en-US',
+            file: 'en.ts'
+          }
+        ]
+      })
+    })
+  }
+})

--- a/playground/module-experimental/lang/de.ts
+++ b/playground/module-experimental/lang/de.ts
@@ -1,0 +1,5 @@
+export default defineI18nLocale(locale => {
+  return {
+    goodDay: 'Guten Tag'
+  }
+})

--- a/playground/module-experimental/lang/en.ts
+++ b/playground/module-experimental/lang/en.ts
@@ -1,0 +1,5 @@
+export default defineI18nLocale(locale => {
+  return {
+    goodDay: 'Good day'
+  }
+})

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,5 +1,6 @@
 import Module1 from './module1'
 import LayerModule from './layer-module'
+import ModuleExperimental from './module-experimental'
 import type { NuxtApp } from 'nuxt/dist/app/index'
 
 // https://nuxt.com/docs/guide/directory-structure/nuxt.config
@@ -10,6 +11,7 @@ export default defineNuxtConfig({
       console.log(nuxt.options._installedModules)
     },
     Module1,
+    ModuleExperimental,
     LayerModule,
     /*
     [

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -5,7 +5,18 @@ import { computed } from 'vue'
 import { LocaleObject } from '#i18n'
 
 const route = useRoute()
-const { t, rt, tm, strategy, locale, locales, localeProperties, setLocale, defaultLocale, finalizePendingLocaleChange } = useI18n()
+const {
+  t,
+  rt,
+  tm,
+  strategy,
+  locale,
+  locales,
+  localeProperties,
+  setLocale,
+  defaultLocale,
+  finalizePendingLocaleChange
+} = useI18n()
 const localePath = useLocalePath()
 const switchLocalePath = useSwitchLocalePath()
 const getRouteBaseName = useRouteBaseName()
@@ -20,6 +31,7 @@ console.log('localeProperties', localeProperties)
 console.log('foo', t('foo'))
 console.log('message if local layer merged:', t('layerText'))
 console.log('message if github layer merged:', t('layer-test-key'))
+console.log('experimental module', t('goodDay'))
 
 function getLocaleName(code: string) {
   const locale = (locales.value as LocaleObject[]).find(i => i.code === code)

--- a/specs/fixtures/basic_layer/layer-module/index.ts
+++ b/specs/fixtures/basic_layer/layer-module/index.ts
@@ -22,7 +22,7 @@ export default defineNuxtModule({
           {
             code: 'nl',
             iso: 'nl-NL',
-            file: 'nl.json',
+            file: 'nl.ts',
             name: 'Nederlands'
           }
         ]

--- a/specs/fixtures/basic_layer/layer-module/locales/nl.json
+++ b/specs/fixtures/basic_layer/layer-module/locales/nl.json
@@ -1,3 +1,0 @@
-{
-  "moduleLayerText": "This is a merged module layer locale key in Dutch"
-}

--- a/specs/fixtures/basic_layer/layer-module/locales/nl.ts
+++ b/specs/fixtures/basic_layer/layer-module/locales/nl.ts
@@ -1,0 +1,3 @@
+export default defineI18nLocale(locale => ({
+  moduleLayerText: 'This is a merged module layer locale key in Dutch'
+}))

--- a/specs/fixtures/basic_layer/layer-module/nuxt.config.ts
+++ b/specs/fixtures/basic_layer/layer-module/nuxt.config.ts
@@ -25,7 +25,7 @@ export default defineNuxtConfig({
       {
         code: 'nl',
         iso: 'nl-NL',
-        file: 'nl.json',
+        file: 'nl.ts',
         // domain: 'localhost',
         name: 'Nederlands'
       }

--- a/specs/fixtures/basic_layer/nuxt.config.ts
+++ b/specs/fixtures/basic_layer/nuxt.config.ts
@@ -30,6 +30,9 @@ export default defineNuxtConfig({
     lazy: true,
     langDir: 'lang',
     defaultLocale: 'en',
+    experimental: {
+      jsTsFormatResource: true
+    },
     locales: [
       {
         code: 'en',

--- a/specs/fixtures/basic_layer/pages/index.vue
+++ b/specs/fixtures/basic_layer/pages/index.vue
@@ -64,6 +64,9 @@ function onClick() {
         <li class="switch-to-fr">
           <NuxtLink :to="switchLocalePath('fr')">Français</NuxtLink>
         </li>
+        <li class="switch-to-nl">
+          <NuxtLink :to="switchLocalePath('nl')">Nederlands</NuxtLink>
+        </li>
       </ul>
     </section>
     <section id="locale-route-usages">

--- a/specs/register_module.spec.ts
+++ b/specs/register_module.spec.ts
@@ -21,4 +21,10 @@ test('register module hook', async () => {
   await page.locator('.switch-to-fr a').click()
 
   expect(await getText(page, '#register-module')).toEqual('This is a merged module layer locale key in French')
+
+  // click `nl` lang switch link
+  await page.locator('.switch-to-nl a').click()
+  await page.waitForLoadState('networkidle')
+
+  expect(await getText(page, '#register-module')).toEqual('This is a merged module layer locale key in Dutch')
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,7 +59,8 @@ export function getNormalizedLocales(locales: NuxtI18nOptions['locales']): Local
 }
 
 export async function resolveLocales(path: string, locales: LocaleObject[]): Promise<LocaleInfo[]> {
-  const files = await resolveFiles(path, '**/*{json,json5,yaml,yml,js,cjs,mjs,ts,cts,mts}')
+  const files = await Promise.all(locales.flatMap(x => (x.file ? [x.file] : x.files ?? [])).map(x => resolve(path, x)))
+
   const find = (f: string) => files.find(file => file === resolve(path, f))
   return (locales as LocaleInfo[]).map(locale => {
     if (locale.file) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
#2141 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
It seems that only locales within the project `langDir` were being resolved in the following line: https://github.com/nuxt-modules/i18n/blob/next/src/utils.ts#L62C1-L62C92

This results in locales added via the `i18n:registerModule` hook and possibly layers too would not get a `type` or `types` assigned to it, which as far as I understand is required for js/ts format locales (I'm still catching up with the changes made in the last few months 😅). 

Note that my changes removes the file extension check/filter in the resolve function, I could add a basic matcher to ensure each file has the correct extension if needed.


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
