### PR TITLE
breaking: deprecate `parsePages` option

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 - For Official release
   - [ ] remove `i18n:extends-messages` hook logic
-  - [ ] remove `parsePage` option logic
+  - [x] remove `parsePage` option logic
   - [ ] update `@intlify/**` and vue-i18-\* pkgs for latest version
 - Refactoring
   - [ ] module alias, langs option, etc should be resolved with `createResolver`

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -1,7 +1,7 @@
 import createDebug from 'debug'
 import { extendPages } from '@nuxt/kit'
 import { I18nRoute, localizeRoutes, DefaultLocalizeRoutesPrefixable } from 'vue-i18n-routing'
-import { isString, isBoolean } from '@intlify/shared'
+import { isString } from '@intlify/shared'
 import { parse as parseSFC, compileScript } from '@vue/compiler-sfc'
 import { walk } from 'estree-walker'
 import MagicString from 'magic-string'
@@ -117,21 +117,11 @@ export function analyzeNuxtPages(ctx: NuxtPageAnalizeContext, pages: NuxtPage[],
 
 export function getRouteOptionsResolver(
   ctx: NuxtPageAnalizeContext,
-  options: Pick<Required<NuxtI18nOptions>, 'pages' | 'defaultLocale' | 'parsePages' | 'customRoutes'>
+  options: Pick<Required<NuxtI18nOptions>, 'pages' | 'defaultLocale' | 'customRoutes'>
 ): RouteOptionsResolver {
-  const { pages, defaultLocale, parsePages, customRoutes } = options
+  const { pages, defaultLocale, customRoutes } = options
 
-  let useConfig = false
-  if (isBoolean(parsePages)) {
-    console.warn(
-      formatMessage(
-        `'parsePages' option is deprecated. Please use 'customRoutes' option instead. We will remove it in v8 official release.`
-      )
-    )
-    useConfig = !parsePages
-  } else {
-    useConfig = customRoutes === 'config'
-  }
+  const useConfig = customRoutes === 'config'
   debug('getRouteOptionsResolver useConfig', useConfig)
 
   return (route, localeCodes): ComputedRouteOptions | null => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,10 +81,6 @@ export type NuxtI18nOptions<Context = unknown> = {
    * @internal
    */
   i18nModules?: { langDir?: string | null; locales?: I18nRoutingOptions<Context>['locales'] }[]
-  /**
-   * @deprecated `'parsePages' option is deprecated. Please use 'customRoutes' option instead. We will remove it in v8 official release.`
-   */
-  parsePages?: boolean
   rootRedirect?: string | null | RootRedirectOptions
   routesNameSeparator?: string
   skipSettingLocaleOnNavigate?: boolean


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

Drop for v8 RC release

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

https://v8.i18n.nuxtjs.org/guide/migrating#deprecated-parsepages-option

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
