### PR TITLE
docs: escape `]` in code-block filename

### DIFF
--- a/docs/content/2.guide/4.custom-paths.md
+++ b/docs/content/2.guide/4.custom-paths.md
@@ -217,7 +217,7 @@ defineI18nRoute({
 
 To configure a custom path for a dynamic route, you need to use it in double square brackets in the paths similarly to how you would do it in [Nuxt Dynamic Routes](https://nuxt.com/docs/guide/directory-structure/pages#dynamic-routes):
 
-```html {}[pages/articles/[name].vue]
+```html {}[pages/articles/[name\\].vue]
 <script setup>
 defineI18nRoute({
   paths: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->


Adds `\\` to every code-block filename with `]` to escape it. This prevents the filename from being cropped.

Currently, the filename `pages/articles/[name].vue` is displayed as `pages/articles/[name` because it is cropped incorrectly.

---

#### Related & Info

See this PR https://github.com/nuxt/content/pull/2169, released in `nuxt/content` since [`v2.7.2`](https://github.com/nuxt/content/releases/tag/v2.7.2), to fix this with an escape character

The fix was shipped in [Docus `v1.14.4`](https://github.com/nuxt-themes/docus/releases/tag/v1.14.4) with https://github.com/nuxt-themes/docus/commit/44aefd545b170f105b525a619a3f3475ae25e1f0.

**So this will work after #1989 was merged.**

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
