### PR TITLE
fix(module): correct runtime nuxt hook module path

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -382,7 +382,7 @@ declare module '@nuxt/schema' {
   }
 }
 
-declare module '#app' {
+declare module '#app/nuxt' {
   interface RuntimeNuxtHooks {
     'i18n:beforeLocaleSwitch': <Context = unknown>(
       params: LocaleSwitch & {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     "paths": {
       "#app": ["./node_modules/nuxt/dist/app"],
+      "#app/*": ["./node_modules/nuxt/dist/app/*"],
       "#imports": ["./.nuxt/imports.d.ts"],
       "#pages": ["./node_modules/nuxt/dist/pages/runtime/index.d.ts"],
       "#head": ["./node_modules/nuxt/dist/index.d.ts"],


### PR DESCRIPTION
### 🔗 Linked issue

n/a

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hooks like `i18n:localeSwitched` as used in https://v8.i18n.nuxtjs.org/guide/runtime-hooks#usage lead to a linter error for me when used together with @harlan-zw's `nuxt-seo-kit-module` unless I make the module declaration path more specific as done in this PR. Could the reason be that Harlan's declaration is more specific and shadows the currently used declaration somehow?

See for context: https://github.com/harlan-zw/nuxt-seo-experiments/blob/c6ae207dd1aac9c519f26dff8ce1713cce1048b9/src/templates.ts#L19

I'll setup a minimal reproduction if necessary :heart: 

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
