### PR TITLE
feat: project relative layer locale resolution

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,13 +14,13 @@ importers:
         version: 9.3.0-beta.24
       '@intlify/unplugin-vue-i18n':
         specifier: ^0.12.2
-        version: 0.12.2(rollup@3.27.0)(vue-i18n@9.3.0-beta.24)
+        version: 0.12.2(rollup@3.28.0)(vue-i18n@9.3.0-beta.24)
       '@mizchi/sucrase':
         specifier: ^4.1.0
         version: 4.1.0
       '@nuxt/kit':
         specifier: ^3.6.5
-        version: 3.6.5(rollup@3.27.0)
+        version: 3.6.5(rollup@3.28.0)
       '@vue/compiler-sfc':
         specifier: ^3.3.4
         version: 3.3.4
@@ -65,7 +65,7 @@ importers:
         version: 1.3.2
       unstorage:
         specifier: ^1.5.0
-        version: 1.5.0
+        version: 1.9.0
       vue-i18n:
         specifier: 9.3.0-beta.24
         version: 9.3.0-beta.24(vue@3.3.4)
@@ -87,7 +87,7 @@ importers:
         version: 0.4.0(@nuxt/kit@3.6.5)(nuxi@3.6.5)
       '@nuxt/schema':
         specifier: ^3.6.5
-        version: 3.6.5(rollup@3.27.0)
+        version: 3.6.5(rollup@3.28.0)
       '@types/debug':
         specifier: ^4.1.8
         version: 4.1.8
@@ -135,7 +135,7 @@ importers:
         version: 4.1.5
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
       ofetch:
         specifier: ^1.1.1
         version: 1.1.1
@@ -162,22 +162,22 @@ importers:
     devDependencies:
       '@nuxt-themes/docus':
         specifier: 1.14.3
-        version: 1.14.3(nuxt@3.6.5)(postcss@8.4.27)(rollup@3.27.0)(vue-component-type-helpers@1.3.12)(vue@3.3.4)
+        version: 1.14.3(nuxt@3.6.5)(postcss@8.4.27)(rollup@3.28.0)(vue-component-type-helpers@1.3.12)(vue@3.3.4)
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   playground:
     devDependencies:
       '@nuxt/devtools':
         specifier: latest
-        version: 0.7.4(debug@4.3.4)(nuxt@3.6.5)(rollup@3.27.0)(vite@4.4.7)
+        version: 0.7.5(debug@4.3.4)(nuxt@3.6.5)(rollup@3.28.0)(vite@4.4.9)
       '@nuxtjs/i18n':
         specifier: link:..
         version: link:..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/base_url:
     devDependencies:
@@ -186,7 +186,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/base_url_runtime:
     devDependencies:
@@ -195,7 +195,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/basic:
     devDependencies:
@@ -204,7 +204,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/basic_layer:
     devDependencies:
@@ -213,7 +213,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/basic_pages:
     devDependencies:
@@ -222,7 +222,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/basic_usage:
     devDependencies:
@@ -231,7 +231,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/component:
     devDependencies:
@@ -240,7 +240,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/custom_route_paths_component:
     devDependencies:
@@ -249,7 +249,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/custom_route_paths_module_configration:
     devDependencies:
@@ -258,7 +258,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/different_domains:
     devDependencies:
@@ -267,7 +267,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/domain:
     devDependencies:
@@ -276,7 +276,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/fallback:
     devDependencies:
@@ -285,7 +285,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/head:
     devDependencies:
@@ -294,7 +294,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/ignore_disable_component:
     devDependencies:
@@ -303,7 +303,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/ignore_disable_module_configration:
     devDependencies:
@@ -312,7 +312,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/ignore_pick_component:
     devDependencies:
@@ -321,7 +321,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/ignore_pick_module_configration:
     devDependencies:
@@ -330,7 +330,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/inline_options:
     devDependencies:
@@ -339,7 +339,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/layer_consumer:
     devDependencies:
@@ -348,7 +348,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/lazy:
     devDependencies:
@@ -357,7 +357,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/meta_component:
     devDependencies:
@@ -366,7 +366,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/routing_no_prefix:
     devDependencies:
@@ -375,7 +375,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/routing_prefix:
     devDependencies:
@@ -384,7 +384,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/routing_prefix_and_default:
     devDependencies:
@@ -393,7 +393,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/routing_prefix_except_default:
     devDependencies:
@@ -402,7 +402,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/routing_root_redirect:
     devDependencies:
@@ -411,7 +411,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/runtime_hook:
     devDependencies:
@@ -420,7 +420,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/switcher:
     devDependencies:
@@ -429,7 +429,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/use_head:
     devDependencies:
@@ -438,7 +438,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
   specs/fixtures/vue_i18n_options:
     devDependencies:
@@ -447,7 +447,7 @@ importers:
         version: link:../../..
       nuxt:
         specifier: ^3.6.5
-        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
 
 packages:
 
@@ -819,8 +819,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm64@0.18.17:
-    resolution: {integrity: sha512-9np+YYdNDed5+Jgr1TdWBsozZ85U1Oa3xW0c7TWqH0y2aGghXtZsuT8nYRbzOMcl0bXZXjOGbksoTtVOlWrRZg==}
+  /@esbuild/android-arm64@0.18.20:
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -837,8 +837,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm@0.18.17:
-    resolution: {integrity: sha512-wHsmJG/dnL3OkpAcwbgoBTTMHVi4Uyou3F5mf58ZtmUyIKfcdA7TROav/6tCzET4A3QW2Q2FC+eFneMU+iyOxg==}
+  /@esbuild/android-arm@0.18.20:
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -855,8 +855,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-x64@0.18.17:
-    resolution: {integrity: sha512-O+FeWB/+xya0aLg23hHEM2E3hbfwZzjqumKMSIqcHbNvDa+dza2D0yLuymRBQQnC34CWrsJUXyH2MG5VnLd6uw==}
+  /@esbuild/android-x64@0.18.20:
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -873,8 +873,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.18.17:
-    resolution: {integrity: sha512-M9uJ9VSB1oli2BE/dJs3zVr9kcCBBsE883prage1NWz6pBS++1oNn/7soPNS3+1DGj0FrkSvnED4Bmlu1VAE9g==}
+  /@esbuild/darwin-arm64@0.18.20:
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -891,8 +891,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-x64@0.18.17:
-    resolution: {integrity: sha512-XDre+J5YeIJDMfp3n0279DFNrGCXlxOuGsWIkRb1NThMZ0BsrWXoTg23Jer7fEXQ9Ye5QjrvXpxnhzl3bHtk0g==}
+  /@esbuild/darwin-x64@0.18.20:
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -909,8 +909,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.18.17:
-    resolution: {integrity: sha512-cjTzGa3QlNfERa0+ptykyxs5A6FEUQQF0MuilYXYBGdBxD3vxJcKnzDlhDCa1VAJCmAxed6mYhA2KaJIbtiNuQ==}
+  /@esbuild/freebsd-arm64@0.18.20:
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -927,8 +927,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-x64@0.18.17:
-    resolution: {integrity: sha512-sOxEvR8d7V7Kw8QqzxWc7bFfnWnGdaFBut1dRUYtu+EIRXefBc/eIsiUiShnW0hM3FmQ5Zf27suDuHsKgZ5QrA==}
+  /@esbuild/freebsd-x64@0.18.20:
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -945,8 +945,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm64@0.18.17:
-    resolution: {integrity: sha512-c9w3tE7qA3CYWjT+M3BMbwMt+0JYOp3vCMKgVBrCl1nwjAlOMYzEo+gG7QaZ9AtqZFj5MbUc885wuBBmu6aADQ==}
+  /@esbuild/linux-arm64@0.18.20:
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -963,8 +963,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm@0.18.17:
-    resolution: {integrity: sha512-2d3Lw6wkwgSLC2fIvXKoMNGVaeY8qdN0IC3rfuVxJp89CRfA3e3VqWifGDfuakPmp90+ZirmTfye1n4ncjv2lg==}
+  /@esbuild/linux-arm@0.18.20:
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -981,8 +981,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ia32@0.18.17:
-    resolution: {integrity: sha512-1DS9F966pn5pPnqXYz16dQqWIB0dmDfAQZd6jSSpiT9eX1NzKh07J6VKR3AoXXXEk6CqZMojiVDSZi1SlmKVdg==}
+  /@esbuild/linux-ia32@0.18.20:
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -999,8 +999,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-loong64@0.18.17:
-    resolution: {integrity: sha512-EvLsxCk6ZF0fpCB6w6eOI2Fc8KW5N6sHlIovNe8uOFObL2O+Mr0bflPHyHwLT6rwMg9r77WOAWb2FqCQrVnwFg==}
+  /@esbuild/linux-loong64@0.18.20:
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -1017,8 +1017,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.18.17:
-    resolution: {integrity: sha512-e0bIdHA5p6l+lwqTE36NAW5hHtw2tNRmHlGBygZC14QObsA3bD4C6sXLJjvnDIjSKhW1/0S3eDy+QmX/uZWEYQ==}
+  /@esbuild/linux-mips64el@0.18.20:
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -1035,8 +1035,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ppc64@0.18.17:
-    resolution: {integrity: sha512-BAAilJ0M5O2uMxHYGjFKn4nJKF6fNCdP1E0o5t5fvMYYzeIqy2JdAP88Az5LHt9qBoUa4tDaRpfWt21ep5/WqQ==}
+  /@esbuild/linux-ppc64@0.18.20:
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -1053,8 +1053,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.18.17:
-    resolution: {integrity: sha512-Wh/HW2MPnC3b8BqRSIme/9Zhab36PPH+3zam5pqGRH4pE+4xTrVLx2+XdGp6fVS3L2x+DrsIcsbMleex8fbE6g==}
+  /@esbuild/linux-riscv64@0.18.20:
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -1071,8 +1071,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-s390x@0.18.17:
-    resolution: {integrity: sha512-j/34jAl3ul3PNcK3pfI0NSlBANduT2UO5kZ7FCaK33XFv3chDhICLY8wJJWIhiQ+YNdQ9dxqQctRg2bvrMlYgg==}
+  /@esbuild/linux-s390x@0.18.20:
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -1089,8 +1089,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-x64@0.18.17:
-    resolution: {integrity: sha512-QM50vJ/y+8I60qEmFxMoxIx4de03pGo2HwxdBeFd4nMh364X6TIBZ6VQ5UQmPbQWUVWHWws5MmJXlHAXvJEmpQ==}
+  /@esbuild/linux-x64@0.18.20:
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -1107,8 +1107,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/netbsd-x64@0.18.17:
-    resolution: {integrity: sha512-/jGlhWR7Sj9JPZHzXyyMZ1RFMkNPjC6QIAan0sDOtIo2TYk3tZn5UDrkE0XgsTQCxWTTOcMPf9p6Rh2hXtl5TQ==}
+  /@esbuild/netbsd-x64@0.18.20:
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -1125,8 +1125,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/openbsd-x64@0.18.17:
-    resolution: {integrity: sha512-rSEeYaGgyGGf4qZM2NonMhMOP/5EHp4u9ehFiBrg7stH6BYEEjlkVREuDEcQ0LfIl53OXLxNbfuIj7mr5m29TA==}
+  /@esbuild/openbsd-x64@0.18.20:
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -1143,8 +1143,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/sunos-x64@0.18.17:
-    resolution: {integrity: sha512-Y7ZBbkLqlSgn4+zot4KUNYst0bFoO68tRgI6mY2FIM+b7ZbyNVtNbDP5y8qlu4/knZZ73fgJDlXID+ohY5zt5g==}
+  /@esbuild/sunos-x64@0.18.20:
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -1161,8 +1161,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-arm64@0.18.17:
-    resolution: {integrity: sha512-bwPmTJsEQcbZk26oYpc4c/8PvTY3J5/QK8jM19DVlEsAB41M39aWovWoHtNm78sd6ip6prilxeHosPADXtEJFw==}
+  /@esbuild/win32-arm64@0.18.20:
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -1179,8 +1179,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-ia32@0.18.17:
-    resolution: {integrity: sha512-H/XaPtPKli2MhW+3CQueo6Ni3Avggi6hP/YvgkEe1aSaxw+AeO8MFjq8DlgfTd9Iz4Yih3QCZI6YLMoyccnPRg==}
+  /@esbuild/win32-ia32@0.18.20:
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -1197,8 +1197,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-x64@0.18.17:
-    resolution: {integrity: sha512-fGEb8f2BSA3CW7riJVurug65ACLuQAzKq0SSqkY2b2yHHH0MzDfbLyKIGzHwOI/gkHcxM/leuSW6D5w/LMNitA==}
+  /@esbuild/win32-x64@0.18.20:
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -1346,7 +1346,7 @@ packages:
     engines: {node: '>= 16'}
     dev: false
 
-  /@intlify/unplugin-vue-i18n@0.12.2(rollup@3.27.0)(vue-i18n@9.3.0-beta.24):
+  /@intlify/unplugin-vue-i18n@0.12.2(rollup@3.28.0)(vue-i18n@9.3.0-beta.24):
     resolution: {integrity: sha512-IIgzLRSPUKZM1FBdUAZ9NwVPiLUr4ea5g/HLWe2lB7gNtPDz4FOfUNUllIT504hT+3pDoJmjaYJ6pyqT7F4Wuw==}
     engines: {node: '>= 14.16'}
     peerDependencies:
@@ -1363,7 +1363,7 @@ packages:
     dependencies:
       '@intlify/bundle-utils': 7.0.2(vue-i18n@9.3.0-beta.24)
       '@intlify/shared': 9.3.0-beta.24
-      '@rollup/pluginutils': 5.0.2(rollup@3.27.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.28.0)
       '@vue/compiler-sfc': 3.3.4
       debug: 4.3.4
       fast-glob: 3.3.0
@@ -1600,16 +1600,16 @@ packages:
       - supports-color
     dev: true
 
-  /@nuxt-themes/docus@1.14.3(nuxt@3.6.5)(postcss@8.4.27)(rollup@3.27.0)(vue-component-type-helpers@1.3.12)(vue@3.3.4):
+  /@nuxt-themes/docus@1.14.3(nuxt@3.6.5)(postcss@8.4.27)(rollup@3.28.0)(vue-component-type-helpers@1.3.12)(vue@3.3.4):
     resolution: {integrity: sha512-GNTyyZSvNjWK7y0efIME7xY9YfV7kkDM8uWqeq5rCwHVUoYtwNFmhKEuBbCssmaGwx0kl031PuQOkLnUMdC2Dg==}
     dependencies:
-      '@nuxt-themes/elements': 0.9.4(postcss@8.4.27)(rollup@3.27.0)(vue@3.3.4)
-      '@nuxt-themes/tokens': 1.9.1(postcss@8.4.27)(rollup@3.27.0)(vue@3.3.4)
-      '@nuxt-themes/typography': 0.11.0(postcss@8.4.27)(rollup@3.27.0)(vue@3.3.4)
-      '@nuxt/content': 2.7.0(rollup@3.27.0)
-      '@nuxthq/studio': 0.13.4(rollup@3.27.0)(vue-component-type-helpers@1.3.12)
+      '@nuxt-themes/elements': 0.9.4(postcss@8.4.27)(rollup@3.28.0)(vue@3.3.4)
+      '@nuxt-themes/tokens': 1.9.1(postcss@8.4.27)(rollup@3.28.0)(vue@3.3.4)
+      '@nuxt-themes/typography': 0.11.0(postcss@8.4.27)(rollup@3.28.0)(vue@3.3.4)
+      '@nuxt/content': 2.7.0(rollup@3.28.0)
+      '@nuxthq/studio': 0.13.4(rollup@3.28.0)(vue-component-type-helpers@1.3.12)
       '@vueuse/integrations': 10.2.1(focus-trap@7.5.2)(fuse.js@6.6.2)(vue@3.3.4)
-      '@vueuse/nuxt': 10.2.1(nuxt@3.6.5)(rollup@3.27.0)(vue@3.3.4)
+      '@vueuse/nuxt': 10.2.1(nuxt@3.6.5)(rollup@3.28.0)(vue@3.3.4)
       focus-trap: 7.5.2
       fuse.js: 6.6.2
     transitivePeerDependencies:
@@ -1619,6 +1619,7 @@ packages:
       - '@azure/identity'
       - '@azure/keyvault-secrets'
       - '@azure/storage-blob'
+      - '@capacitor/preferences'
       - '@planetscale/database'
       - '@upstash/redis'
       - '@vercel/kv'
@@ -1644,10 +1645,10 @@ packages:
       - vue-component-type-helpers
     dev: true
 
-  /@nuxt-themes/elements@0.9.4(postcss@8.4.27)(rollup@3.27.0)(vue@3.3.4):
+  /@nuxt-themes/elements@0.9.4(postcss@8.4.27)(rollup@3.28.0)(vue@3.3.4):
     resolution: {integrity: sha512-d7XgHc/gjMpre26+N76APL1vlnQHiZTOk61GC4I/ZYQuioSfoKuoIP+Ixrr0QgM22j4MRBtAaBnDAg1wRJrDCQ==}
     dependencies:
-      '@nuxt-themes/tokens': 1.9.1(postcss@8.4.27)(rollup@3.27.0)(vue@3.3.4)
+      '@nuxt-themes/tokens': 1.9.1(postcss@8.4.27)(rollup@3.28.0)(vue@3.3.4)
       '@vueuse/core': 9.13.0(vue@3.3.4)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -1658,10 +1659,10 @@ packages:
       - vue
     dev: true
 
-  /@nuxt-themes/tokens@1.9.1(postcss@8.4.27)(rollup@3.27.0)(vue@3.3.4):
+  /@nuxt-themes/tokens@1.9.1(postcss@8.4.27)(rollup@3.28.0)(vue@3.3.4):
     resolution: {integrity: sha512-5C28kfRvKnTX8Tux+xwyaf+2pxKgQ53dC9l6C33sZwRRyfUJulGDZCFjKbuNq4iqVwdGvkFSQBYBYjFAv6t75g==}
     dependencies:
-      '@nuxtjs/color-mode': 3.2.0(rollup@3.27.0)
+      '@nuxtjs/color-mode': 3.2.0(rollup@3.28.0)
       '@vueuse/core': 9.13.0(vue@3.3.4)
       pinceau: 0.18.9(postcss@8.4.27)
     transitivePeerDependencies:
@@ -1673,12 +1674,12 @@ packages:
       - vue
     dev: true
 
-  /@nuxt-themes/typography@0.11.0(postcss@8.4.27)(rollup@3.27.0)(vue@3.3.4):
+  /@nuxt-themes/typography@0.11.0(postcss@8.4.27)(rollup@3.28.0)(vue@3.3.4):
     resolution: {integrity: sha512-TqyvD7sDWnqGmL00VtuI7JdmNTPL5/g957HCAWNzcNp+S20uJjW/FXSdkM76d4JSVDHvBqw7Wer3RsqVhqvA4w==}
     dependencies:
-      '@nuxtjs/color-mode': 3.2.0(rollup@3.27.0)
-      nuxt-config-schema: 0.4.6(rollup@3.27.0)
-      nuxt-icon: 0.3.3(rollup@3.27.0)(vue@3.3.4)
+      '@nuxtjs/color-mode': 3.2.0(rollup@3.28.0)
+      nuxt-config-schema: 0.4.6(rollup@3.28.0)
+      nuxt-icon: 0.3.3(rollup@3.28.0)(vue@3.3.4)
       pinceau: 0.18.9(postcss@8.4.27)
       ufo: 1.2.0
     transitivePeerDependencies:
@@ -1689,17 +1690,17 @@ packages:
       - vue
     dev: true
 
-  /@nuxt/content@2.7.0(rollup@3.27.0):
+  /@nuxt/content@2.7.0(rollup@3.28.0):
     resolution: {integrity: sha512-3vv3Rbpf6NH7RRuy7PLVmpQCt8C9DgV4aTWLmTCdnWpmlNsX+0wQT8bA/ypqmh8zrJ6BXWztFM35WVESkNvDvQ==}
     dependencies:
-      '@nuxt/kit': 3.6.5(rollup@3.27.0)
+      '@nuxt/kit': 3.6.5(rollup@3.28.0)
       consola: 3.2.3
       defu: 6.1.2
       destr: 1.2.2
       detab: 3.0.2
       json5: 2.2.3
       knitwork: 1.0.0
-      listhen: 1.1.2
+      listhen: 1.2.2
       mdast-util-to-hast: 12.3.0
       mdurl: 1.0.1
       ohash: 1.1.2
@@ -1726,7 +1727,7 @@ packages:
       unist-util-position: 4.0.4
       unist-util-stringify-position: 3.0.3
       unist-util-visit: 4.1.2
-      unstorage: 1.8.0
+      unstorage: 1.9.0
       ws: 8.13.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -1735,10 +1736,12 @@ packages:
       - '@azure/identity'
       - '@azure/keyvault-secrets'
       - '@azure/storage-blob'
+      - '@capacitor/preferences'
       - '@planetscale/database'
       - '@upstash/redis'
       - '@vercel/kv'
       - bufferutil
+      - idb-keyval
       - rollup
       - supports-color
       - utf-8-validate
@@ -1748,24 +1751,24 @@ packages:
     resolution: {integrity: sha512-GBzP8zOc7CGWyFQS6dv1lQz8VVpz5C2yRszbXufwG/9zhStTIH50EtD87NmWbTMwXDvZLNg8GIpb1UFdH93JCA==}
     dev: true
 
-  /@nuxt/devtools-kit@0.7.4(nuxt@3.6.5)(rollup@3.27.0)(vite@4.4.7):
-    resolution: {integrity: sha512-+CKSSqalyW3elK364FamcHtXm6F03Iarfs9ftBiWmj3CdCTuv9aGpJFi0FKzXKzq/xlCtbWvIrqcaf2Iy//6NQ==}
+  /@nuxt/devtools-kit@0.7.5(nuxt@3.6.5)(rollup@3.28.0)(vite@4.4.9):
+    resolution: {integrity: sha512-Zadd4s2vHlFQYRBLqmCADLMs1qxht8KKCZzfdhEdCAHby/s3EkfnYIuRUBlrfuAuNxa4cyExKFpeDpQ67N5fIQ==}
     peerDependencies:
       nuxt: ^3.6.5
       vite: '*'
     dependencies:
-      '@nuxt/kit': 3.6.5(rollup@3.27.0)
-      '@nuxt/schema': 3.6.5(rollup@3.27.0)
+      '@nuxt/kit': 3.6.5(rollup@3.28.0)
+      '@nuxt/schema': 3.6.5(rollup@3.28.0)
       execa: 7.2.0
-      nuxt: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
-      vite: 4.4.7(@types/node@20.4.5)
+      nuxt: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
+      vite: 4.4.9(@types/node@20.4.5)
     transitivePeerDependencies:
       - rollup
       - supports-color
     dev: true
 
-  /@nuxt/devtools-wizard@0.7.4:
-    resolution: {integrity: sha512-Ga+OgxTEZu0AnOmak5eMPrFThvLdoFVB5kEyyCrnBNdkTvX5Dtr8FvVAL+6jV0ALmqhWSXp99op2+QwHg7kgDg==}
+  /@nuxt/devtools-wizard@0.7.5:
+    resolution: {integrity: sha512-A8Urgy3hJBi3MSDEsr3yzOhO1jHoE80cQHmQUqAD8sD2e2fQSOwaH5CZMVGPbnSCWDfbchy+1cCwJ30JuEfeKg==}
     hasBin: true
     dependencies:
       consola: 3.2.3
@@ -1781,16 +1784,16 @@ packages:
       semver: 7.5.4
     dev: true
 
-  /@nuxt/devtools@0.7.4(debug@4.3.4)(nuxt@3.6.5)(rollup@3.27.0)(vite@4.4.7):
-    resolution: {integrity: sha512-uaKvVIYWuJ5L1NasXYiZfOh3w2HkHwaMyyVCceabVsOh27PBIeV7rzF5zyMrkyO3vivmWUuXcoZo3M0JO41sqg==}
+  /@nuxt/devtools@0.7.5(debug@4.3.4)(nuxt@3.6.5)(rollup@3.28.0)(vite@4.4.9):
+    resolution: {integrity: sha512-Uxjow3J0QcYnbgMA8XR/1myr6Nw8P5vA/PMxTTj8LKqSZhd2+BgjnAg1gRUmMeKQCvkUfNOD+AqTK2HOBdHaBw==}
     hasBin: true
     peerDependencies:
       nuxt: ^3.6.5
       vite: '*'
     dependencies:
-      '@nuxt/devtools-kit': 0.7.4(nuxt@3.6.5)(rollup@3.27.0)(vite@4.4.7)
-      '@nuxt/devtools-wizard': 0.7.4
-      '@nuxt/kit': 3.6.5(rollup@3.27.0)
+      '@nuxt/devtools-kit': 0.7.5(nuxt@3.6.5)(rollup@3.28.0)(vite@4.4.9)
+      '@nuxt/devtools-wizard': 0.7.5
+      '@nuxt/kit': 3.6.5(rollup@3.28.0)
       birpc: 0.2.12
       boxen: 7.1.1
       consola: 3.2.3
@@ -1807,7 +1810,7 @@ packages:
       launch-editor: 2.6.0
       local-pkg: 0.4.3
       magicast: 0.2.10
-      nuxt: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+      nuxt: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
       nypm: 0.2.2
       pacote: 15.2.0
       pathe: 1.1.1
@@ -1817,10 +1820,10 @@ packages:
       rc9: 2.1.1
       semver: 7.5.4
       sirv: 2.0.3
-      unimport: 3.1.0(rollup@3.27.0)
-      vite: 4.4.7(@types/node@20.4.5)
-      vite-plugin-inspect: 0.7.35(@nuxt/kit@3.6.5)(rollup@3.27.0)(vite@4.4.7)
-      vite-plugin-vue-inspector: 3.5.0(vite@4.4.7)
+      unimport: 3.1.3(rollup@3.28.0)
+      vite: 4.4.9(@types/node@20.4.5)
+      vite-plugin-inspect: 0.7.35(@nuxt/kit@3.6.5)(rollup@3.28.0)(vite@4.4.9)
+      vite-plugin-vue-inspector: 3.5.0(vite@4.4.9)
       wait-on: 7.0.1(debug@4.3.4)
       which: 3.0.1
       ws: 8.13.0
@@ -1833,11 +1836,11 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@nuxt/kit@3.6.5(rollup@3.27.0):
+  /@nuxt/kit@3.6.5(rollup@3.28.0):
     resolution: {integrity: sha512-uBI5I2Zx6sk+vRHU+nBmifwxg/nyXCGZ1g5hUKrUfgv1ZfiKB8JkN5T9iRoduDOaqbwM6XSnEl1ja73iloDcrw==}
     engines: {node: ^14.18.0 || >=16.10.0}
     dependencies:
-      '@nuxt/schema': 3.6.5(rollup@3.27.0)
+      '@nuxt/schema': 3.6.5(rollup@3.28.0)
       c12: 1.4.2
       consola: 3.2.3
       defu: 6.1.2
@@ -1852,7 +1855,7 @@ packages:
       scule: 1.0.0
       semver: 7.5.4
       unctx: 2.3.1
-      unimport: 3.1.0(rollup@3.27.0)
+      unimport: 3.1.3(rollup@3.28.0)
       untyped: 1.4.0
     transitivePeerDependencies:
       - rollup
@@ -1865,7 +1868,7 @@ packages:
       '@nuxt/kit': ^3.5.0
       nuxi: ^3.5.0
     dependencies:
-      '@nuxt/kit': 3.6.5(rollup@3.27.0)
+      '@nuxt/kit': 3.6.5(rollup@3.28.0)
       consola: 3.2.3
       mlly: 1.4.0
       mri: 1.2.0
@@ -1877,7 +1880,7 @@ packages:
       - supports-color
     dev: true
 
-  /@nuxt/schema@3.6.5(rollup@3.27.0):
+  /@nuxt/schema@3.6.5(rollup@3.28.0):
     resolution: {integrity: sha512-UPUnMB0W5TZ/Pi1fiF71EqIsPlj8LGZqzhSf8wOeh538KHwxbA9r7cuvEUU92eXRksOZaylbea3fJxZWhOITVw==}
     engines: {node: ^14.18.0 || >=16.10.0}
     dependencies:
@@ -1887,24 +1890,24 @@ packages:
       pkg-types: 1.0.3
       postcss-import-resolver: 2.0.0
       std-env: 3.3.3
-      ufo: 1.1.2
-      unimport: 3.1.0(rollup@3.27.0)
+      ufo: 1.2.0
+      unimport: 3.1.3(rollup@3.28.0)
       untyped: 1.4.0
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  /@nuxt/telemetry@2.3.2(rollup@3.27.0):
+  /@nuxt/telemetry@2.3.2(rollup@3.28.0):
     resolution: {integrity: sha512-S2sF4hLQWS48lWPpRT8xqVUFuwFGTgeKvojp8vL/iP79fWxudua2DWXR15T8C2zpauYwNgEpEWJmy6vxY2ZQeg==}
     hasBin: true
     dependencies:
-      '@nuxt/kit': 3.6.5(rollup@3.27.0)
+      '@nuxt/kit': 3.6.5(rollup@3.28.0)
       chalk: 5.3.0
       ci-info: 3.8.0
       consola: 3.2.3
       create-require: 1.1.1
       defu: 6.1.2
-      destr: 2.0.0
+      destr: 2.0.1
       dotenv: 16.3.1
       fs-extra: 11.1.1
       git-url-parse: 13.1.0
@@ -1926,14 +1929,14 @@ packages:
     resolution: {integrity: sha512-5gc02Pu1HycOVUWJ8aYsWeeXcSTPe8iX8+KIrhyEtEoOSkY0eMBuo0ssljB8wALuEmepv31DlYe5gpiRwkjESA==}
     dev: true
 
-  /@nuxt/vite-builder@3.6.5(@types/node@20.4.5)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)(vue@3.3.4):
+  /@nuxt/vite-builder@3.6.5(@types/node@20.4.5)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)(vue@3.3.4):
     resolution: {integrity: sha512-pwSpt257ApCp3XWUs8vrC7X9QHeHUv5PbbIR3+5w0n5f95XPNOQWDJa2fTPX/H6oaRJCPYAsBPqiQhQ7qW/NZQ==}
     engines: {node: ^14.18.0 || >=16.10.0}
     peerDependencies:
       vue: ^3.3.4
     dependencies:
-      '@nuxt/kit': 3.6.5(rollup@3.27.0)
-      '@rollup/plugin-replace': 5.0.2(rollup@3.27.0)
+      '@nuxt/kit': 3.6.5(rollup@3.28.0)
+      '@rollup/plugin-replace': 5.0.2(rollup@3.28.0)
       '@vitejs/plugin-vue': 4.2.3(vite@4.3.9)(vue@3.3.4)
       '@vitejs/plugin-vue-jsx': 3.0.1(vite@4.3.9)(vue@3.3.4)
       autoprefixer: 10.4.14(postcss@8.4.27)
@@ -1941,7 +1944,7 @@ packages:
       consola: 3.2.3
       cssnano: 6.0.1(postcss@8.4.27)
       defu: 6.1.2
-      esbuild: 0.18.17
+      esbuild: 0.18.20
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
       externality: 1.0.2
@@ -1958,9 +1961,9 @@ packages:
       postcss: 8.4.27
       postcss-import: 15.1.0(postcss@8.4.27)
       postcss-url: 10.1.3(postcss@8.4.27)
-      rollup-plugin-visualizer: 5.9.2(rollup@3.27.0)
+      rollup-plugin-visualizer: 5.9.2(rollup@3.28.0)
       std-env: 3.3.3
-      strip-literal: 1.0.1
+      strip-literal: 1.3.0
       ufo: 1.2.0
       unplugin: 1.4.0
       vite: 4.3.9(@types/node@20.4.5)
@@ -1988,13 +1991,13 @@ packages:
       - vue-tsc
     dev: true
 
-  /@nuxthq/studio@0.13.4(rollup@3.27.0)(vue-component-type-helpers@1.3.12):
+  /@nuxthq/studio@0.13.4(rollup@3.28.0)(vue-component-type-helpers@1.3.12):
     resolution: {integrity: sha512-+Jn0iN6TvRTTtTBX4qXWhtOMLL4rsyUIX3/9HM+eBAwr5/cELLw3RuI1tgp942QteTi7PvI5Av4nEi6BlLBr+A==}
     dependencies:
-      '@nuxt/kit': 3.6.5(rollup@3.27.0)
+      '@nuxt/kit': 3.6.5(rollup@3.28.0)
       defu: 6.1.2
-      nuxt-component-meta: 0.5.1(rollup@3.27.0)(vue-component-type-helpers@1.3.12)
-      nuxt-config-schema: 0.4.6(rollup@3.27.0)
+      nuxt-component-meta: 0.5.1(rollup@3.28.0)(vue-component-type-helpers@1.3.12)
+      nuxt-config-schema: 0.4.6(rollup@3.28.0)
       socket.io-client: 4.7.1
       ufo: 1.2.0
     transitivePeerDependencies:
@@ -2005,16 +2008,24 @@ packages:
       - vue-component-type-helpers
     dev: true
 
-  /@nuxtjs/color-mode@3.2.0(rollup@3.27.0):
+  /@nuxtjs/color-mode@3.2.0(rollup@3.28.0):
     resolution: {integrity: sha512-isDR01yfadopiHQ/VEVUpyNSPrk5PCjUHS4t1qYRZwuRGefU4s9Iaxf6H9nmr1QFzoMgTm+3T0r/54jLwtpZbA==}
     dependencies:
-      '@nuxt/kit': 3.6.5(rollup@3.27.0)
+      '@nuxt/kit': 3.6.5(rollup@3.28.0)
       lodash.template: 4.5.0
       pathe: 1.1.1
     transitivePeerDependencies:
       - rollup
       - supports-color
     dev: true
+
+  /@parcel/watcher-wasm@2.3.0-alpha.1:
+    resolution: {integrity: sha512-wo6065l1MQ6SJPPchYw/q8J+pFL40qBXLu4Td2CXeQ/+mUk8NenNqC75P/P1Cyvpam0kfk91iszd+XL+xKDQww==}
+    engines: {node: '>= 10.0.0'}
+    dependencies:
+      is-glob: 4.0.3
+      micromatch: 4.0.5
+      napi-wasm: 1.1.0
 
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -2027,7 +2038,7 @@ packages:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
     dev: true
 
-  /@rollup/plugin-alias@5.0.0(rollup@3.27.0):
+  /@rollup/plugin-alias@5.0.0(rollup@3.28.0):
     resolution: {integrity: sha512-l9hY5chSCjuFRPsnRm16twWBiSApl2uYFLsepQYwtBuAxNMQ/1dJqADld40P0Jkqm65GRTLy/AC6hnpVebtLsA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2036,11 +2047,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.27.0
+      rollup: 3.28.0
       slash: 4.0.0
     dev: true
 
-  /@rollup/plugin-commonjs@24.1.0(rollup@3.27.0):
+  /@rollup/plugin-commonjs@24.1.0(rollup@3.28.0):
     resolution: {integrity: sha512-eSL45hjhCWI0jCCXcNtLVqM5N1JlBGvlFfY0m6oOYnLCJ6N0qEXoZql4sY2MOUArzhH4SA/qBpTxvvZp2Sc+DQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2049,16 +2060,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.27.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.28.0)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.27.0
-      rollup: 3.27.0
+      rollup: 3.28.0
     dev: true
 
-  /@rollup/plugin-commonjs@25.0.3(rollup@3.27.0):
+  /@rollup/plugin-commonjs@25.0.3(rollup@3.28.0):
     resolution: {integrity: sha512-uBdtWr/H3BVcgm97MUdq2oJmqBR23ny1hOrWe2PKo9FTbjsGqg32jfasJUKYAI5ouqacjRnj65mBB/S79F+GQA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2067,16 +2078,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.27.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.28.0)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.27.0
-      rollup: 3.27.0
+      rollup: 3.28.0
     dev: true
 
-  /@rollup/plugin-inject@5.0.3(rollup@3.27.0):
+  /@rollup/plugin-inject@5.0.3(rollup@3.28.0):
     resolution: {integrity: sha512-411QlbL+z2yXpRWFXSmw/teQRMkXcAAC8aYTemc15gwJRpvEVDQwoe+N/HTFD8RFG8+88Bme9DK2V9CVm7hJdA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2085,13 +2096,13 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.27.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.28.0)
       estree-walker: 2.0.2
       magic-string: 0.27.0
-      rollup: 3.27.0
+      rollup: 3.28.0
     dev: true
 
-  /@rollup/plugin-json@6.0.0(rollup@3.27.0):
+  /@rollup/plugin-json@6.0.0(rollup@3.28.0):
     resolution: {integrity: sha512-i/4C5Jrdr1XUarRhVu27EEwjt4GObltD7c+MkCIpO2QIbojw8MUs+CCTqOphQi3Qtg1FLmYt+l+6YeoIf51J7w==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2100,11 +2111,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.27.0)
-      rollup: 3.27.0
+      '@rollup/pluginutils': 5.0.2(rollup@3.28.0)
+      rollup: 3.28.0
     dev: true
 
-  /@rollup/plugin-node-resolve@15.1.0(rollup@3.27.0):
+  /@rollup/plugin-node-resolve@15.1.0(rollup@3.28.0):
     resolution: {integrity: sha512-xeZHCgsiZ9pzYVgAo9580eCGqwh/XCEUM9q6iQfGNocjgkufHAqC3exA+45URvhiYV8sBF9RlBai650eNs7AsA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2113,16 +2124,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.27.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.28.0)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.2
-      rollup: 3.27.0
+      rollup: 3.28.0
     dev: true
 
-  /@rollup/plugin-replace@5.0.2(rollup@3.27.0):
+  /@rollup/plugin-replace@5.0.2(rollup@3.28.0):
     resolution: {integrity: sha512-M9YXNekv/C/iHHK+cvORzfRYfPbq0RDD8r0G+bMiTXjNGKulPnCT9O3Ss46WfhI6ZOCgApOP7xAdmCQJ+U2LAA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2131,12 +2142,12 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.27.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.28.0)
       magic-string: 0.27.0
-      rollup: 3.27.0
+      rollup: 3.28.0
     dev: true
 
-  /@rollup/plugin-terser@0.4.3(rollup@3.27.0):
+  /@rollup/plugin-terser@0.4.3(rollup@3.28.0):
     resolution: {integrity: sha512-EF0oejTMtkyhrkwCdg0HJ0IpkcaVg1MMSf2olHb2Jp+1mnLM04OhjpJWGma4HobiDTF0WCyViWuvadyE9ch2XA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2145,13 +2156,13 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.27.0
+      rollup: 3.28.0
       serialize-javascript: 6.0.1
       smob: 1.4.0
       terser: 5.19.2
     dev: true
 
-  /@rollup/plugin-wasm@6.1.3(rollup@3.27.0):
+  /@rollup/plugin-wasm@6.1.3(rollup@3.28.0):
     resolution: {integrity: sha512-7ItTTeyauE6lwdDtQWceEHZ9+txbi4RRy0mYPFn9BW7rD7YdgBDu7HTHsLtHrRzJc313RM/1m6GKgV3np/aEaw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2160,7 +2171,7 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: 3.27.0
+      rollup: 3.28.0
     dev: true
 
   /@rollup/pluginutils@4.2.1:
@@ -2171,7 +2182,7 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /@rollup/pluginutils@5.0.2(rollup@3.27.0):
+  /@rollup/pluginutils@5.0.2(rollup@3.28.0):
     resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -2183,7 +2194,7 @@ packages:
       '@types/estree': 1.0.1
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: 3.27.0
+      rollup: 3.28.0
 
   /@sideway/address@4.1.4:
     resolution: {integrity: sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==}
@@ -2299,10 +2310,6 @@ packages:
 
   /@types/ms@0.7.31:
     resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
-    dev: true
-
-  /@types/node@18.16.19:
-    resolution: {integrity: sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==}
     dev: true
 
   /@types/node@20.4.5:
@@ -2467,42 +2474,42 @@ packages:
       eslint-visitor-keys: 3.4.1
     dev: true
 
-  /@unhead/dom@1.1.35:
-    resolution: {integrity: sha512-/VAwHHiZGHAKS9V0JaYBWxIBc8OpPMfjVk0TRcKoerFCmYRMsuWtpWauWx644j177kCbzCCT1HOA2fB7R07uXQ==}
+  /@unhead/dom@1.2.2:
+    resolution: {integrity: sha512-ohganmg4i1Dd4wwQ2A9oLWEkJNpJRoERJNmFgzmScw9Vi3zMqoS4gPIofT20zUR5rhyyAsFojuDPojJ5vKcmqw==}
     dependencies:
-      '@unhead/schema': 1.1.35
-      '@unhead/shared': 1.1.35
+      '@unhead/schema': 1.2.2
+      '@unhead/shared': 1.2.2
     dev: true
 
-  /@unhead/schema@1.1.35:
-    resolution: {integrity: sha512-hB1uHbK38+WoZn2PHRl0eJJ2Lip374+eHHxUbHY4rFQeL4mTgxAFL0KltpMZr5Eo7ZMV/zNL7LZ89KBd9L43Zg==}
+  /@unhead/schema@1.2.2:
+    resolution: {integrity: sha512-cGtNvadL76eGl7QxGjWHZxFqLv9a2VrmRpeEb1d7sm0cvnN0bWngdXDTdUyXzn7RVv/Um+/yae6eiT6A+pyQOw==}
     dependencies:
       hookable: 5.5.3
       zhead: 2.0.10
     dev: true
 
-  /@unhead/shared@1.1.35:
-    resolution: {integrity: sha512-SmR2tyAVYfvN+bPp71Bp4igHpv19X6VAoVP14qq3Yqdw1nWJKknla2QEkpqAgygit9b69Gyu+Wi5WABpZKUA+A==}
+  /@unhead/shared@1.2.2:
+    resolution: {integrity: sha512-bWRjRyVzFsunih9GbHctvS8Aenj6KBe5ycql1JE4LawBL/NRYvCYUCPpdK5poVOqjYr0yDAf9m4JGaM2HwpVLw==}
     dependencies:
-      '@unhead/schema': 1.1.35
+      '@unhead/schema': 1.2.2
     dev: true
 
-  /@unhead/ssr@1.1.35:
-    resolution: {integrity: sha512-VFIWcqGX358v05tzEPgZ8N7YhAhrrGxeecmRVE/jHtwimKCXa/xsQnhHe5ytswDiuTCTd/qBHEqVTVg8tGseUg==}
+  /@unhead/ssr@1.2.2:
+    resolution: {integrity: sha512-mpWSNNbrQFJZolAfdVInPPiSGUva08bK9UbNV1zgDScUz+p+FnRg4cj77X+PpVeJ0+KPgjXfOsI8VQKYt+buYA==}
     dependencies:
-      '@unhead/schema': 1.1.35
-      '@unhead/shared': 1.1.35
+      '@unhead/schema': 1.2.2
+      '@unhead/shared': 1.2.2
     dev: true
 
-  /@unhead/vue@1.1.35(vue@3.3.4):
-    resolution: {integrity: sha512-U0iM9B8pq06FS1DLK7g25+ddMqDnQkqy+fgQyC0Gv+e4m8XEKsI7JKSbzAjFnsG69orCKd8M6jvcOyst8gvn5g==}
+  /@unhead/vue@1.2.2(vue@3.3.4):
+    resolution: {integrity: sha512-AxOmY5JPn4fS34ovaivPnqg2my+InIkZDNSxCKfRkmbBtstFre/Fyf0d92Qfx0u8PJiSRPOjthEHx5vKDgTEJQ==}
     peerDependencies:
       vue: '>=2.7 || >=3'
     dependencies:
-      '@unhead/schema': 1.1.35
-      '@unhead/shared': 1.1.35
+      '@unhead/schema': 1.2.2
+      '@unhead/shared': 1.2.2
       hookable: 5.5.3
-      unhead: 1.1.35
+      unhead: 1.2.2
       vue: 3.3.4
     dev: true
 
@@ -2622,7 +2629,7 @@ packages:
       vue-template-compiler: 2.7.14
     dev: true
 
-  /@vue-macros/common@1.6.0(rollup@3.27.0)(vue@3.3.4):
+  /@vue-macros/common@1.6.0(rollup@3.28.0)(vue@3.3.4):
     resolution: {integrity: sha512-sgDo9qN5DI0y7FJ+E0qOxhcsrBlVNp0erW5mfLzYtGYRFfuuIS5hEanNao7QZWVmK39kvmNOPbPOV1oiWBMrng==}
     engines: {node: '>=16.14.0'}
     peerDependencies:
@@ -2632,9 +2639,9 @@ packages:
         optional: true
     dependencies:
       '@babel/types': 7.22.5
-      '@rollup/pluginutils': 5.0.2(rollup@3.27.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.28.0)
       '@vue/compiler-sfc': 3.3.4
-      ast-kit: 0.9.4(rollup@3.27.0)
+      ast-kit: 0.9.4(rollup@3.28.0)
       local-pkg: 0.4.3
       magic-string-ast: 0.2.0
       vue: 3.3.4
@@ -2824,16 +2831,16 @@ packages:
     resolution: {integrity: sha512-gdU7TKNAUVlXXLbaF+ZCfte8BjRJQWPCa2J55+7/h+yDtzw3vOoGQDRXzI6pyKyo6bXFT5/QoPE4hAknExjRLQ==}
     dev: true
 
-  /@vueuse/nuxt@10.2.1(nuxt@3.6.5)(rollup@3.27.0)(vue@3.3.4):
+  /@vueuse/nuxt@10.2.1(nuxt@3.6.5)(rollup@3.28.0)(vue@3.3.4):
     resolution: {integrity: sha512-01iDXnjZFDaGZnEL0nvlmSTNV0EG6WY+VSFyWnBji9lbxdQwOn4DHvLou3ePe8ipaoQVtY58WcL0OHIFa4+fBA==}
     peerDependencies:
       nuxt: ^3.0.0
     dependencies:
-      '@nuxt/kit': 3.6.5(rollup@3.27.0)
+      '@nuxt/kit': 3.6.5(rollup@3.28.0)
       '@vueuse/core': 10.2.1(vue@3.3.4)
       '@vueuse/metadata': 10.2.1
       local-pkg: 0.4.3
-      nuxt: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+      nuxt: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)
       vue-demi: 0.14.5(vue@3.3.4)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -3101,12 +3108,12 @@ packages:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: true
 
-  /ast-kit@0.9.4(rollup@3.27.0):
+  /ast-kit@0.9.4(rollup@3.28.0):
     resolution: {integrity: sha512-UrZHsdj87OS6NM+IXRii+asdAUA/P0SMa4r1NrZvsUy72hDvCYwk8c9PsbKf1MvJ0BvP+rF1B8tFP54eT370Tg==}
     engines: {node: '>=16.14.0'}
     dependencies:
       '@babel/parser': 7.22.7
-      '@rollup/pluginutils': 5.0.2(rollup@3.27.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.28.0)
       pathe: 1.1.1
     transitivePeerDependencies:
       - rollup
@@ -3622,7 +3629,6 @@ packages:
     resolution: {integrity: sha512-Me9nf0/BEmMOnuQzMOVXgpzkMUNbd0Am8lTl/13p0aRGAoLGk5T5sdet/42CrIGmWdG67BgHUhcKK1my1ujUEg==}
     dependencies:
       consola: 3.2.3
-    dev: true
 
   /clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -4134,9 +4140,13 @@ packages:
 
   /destr@1.2.2:
     resolution: {integrity: sha512-lrbCJwD9saUQrqUfXvl6qoM+QN3W7tLV5pAOs+OqOmopCCz/JkE05MHedJR1xfk4IAnZuJXPVuN5+7jNA2ZCiA==}
+    dev: true
 
   /destr@2.0.0:
     resolution: {integrity: sha512-FJ9RDpf3GicEBvzI3jxc2XhHzbqD8p4ANw/1kPsFBfTvP1b7Gn/Lg1vO7R9J4IVgoMbyUmFrFGZafJ1hPZpvlg==}
+
+  /destr@2.0.1:
+    resolution: {integrity: sha512-M1Ob1zPSIvlARiJUkKqvAZ3VAqQY6Jcuth/pBKQ2b1dX/Qx0OnJ8Vux6J2H5PTMQeRzWrrbTu70VxBfv/OPDJA==}
 
   /destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
@@ -4372,7 +4382,7 @@ packages:
       is-regex: 1.1.4
       is-shared-array-buffer: 1.0.2
       is-string: 1.0.7
-      is-typed-array: 1.1.12
+      is-typed-array: 1.1.10
       is-weakref: 1.0.2
       object-inspect: 1.12.3
       object-keys: 1.1.1
@@ -4384,7 +4394,7 @@ packages:
       string.prototype.trimstart: 1.0.6
       typed-array-length: 1.0.4
       unbox-primitive: 1.0.2
-      which-typed-array: 1.1.11
+      which-typed-array: 1.1.9
     dev: true
 
   /es-set-tostringtag@2.0.1:
@@ -4439,34 +4449,34 @@ packages:
       '@esbuild/win32-x64': 0.17.19
     dev: true
 
-  /esbuild@0.18.17:
-    resolution: {integrity: sha512-1GJtYnUxsJreHYA0Y+iQz2UEykonY66HNWOb0yXYZi9/kNrORUEHVg87eQsCtqh59PEJ5YVZJO98JHznMJSWjg==}
+  /esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
     engines: {node: '>=12'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@esbuild/android-arm': 0.18.17
-      '@esbuild/android-arm64': 0.18.17
-      '@esbuild/android-x64': 0.18.17
-      '@esbuild/darwin-arm64': 0.18.17
-      '@esbuild/darwin-x64': 0.18.17
-      '@esbuild/freebsd-arm64': 0.18.17
-      '@esbuild/freebsd-x64': 0.18.17
-      '@esbuild/linux-arm': 0.18.17
-      '@esbuild/linux-arm64': 0.18.17
-      '@esbuild/linux-ia32': 0.18.17
-      '@esbuild/linux-loong64': 0.18.17
-      '@esbuild/linux-mips64el': 0.18.17
-      '@esbuild/linux-ppc64': 0.18.17
-      '@esbuild/linux-riscv64': 0.18.17
-      '@esbuild/linux-s390x': 0.18.17
-      '@esbuild/linux-x64': 0.18.17
-      '@esbuild/netbsd-x64': 0.18.17
-      '@esbuild/openbsd-x64': 0.18.17
-      '@esbuild/sunos-x64': 0.18.17
-      '@esbuild/win32-arm64': 0.18.17
-      '@esbuild/win32-ia32': 0.18.17
-      '@esbuild/win32-x64': 0.18.17
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
     dev: true
 
   /escalade@3.1.1:
@@ -5251,11 +5261,23 @@ packages:
     dependencies:
       cookie-es: 1.0.0
       defu: 6.1.2
-      destr: 2.0.0
+      destr: 2.0.1
       iron-webcrypto: 0.7.1
       radix3: 1.0.1
       ufo: 1.2.0
       uncrypto: 0.1.3
+
+  /h3@1.8.0-rc.3:
+    resolution: {integrity: sha512-NhDCNXhrJkt42BDQF57787yXJa2eX2Hl4OMlu+Ym9QBdBaOByUjBrovYaBc+27mtIhHvs2IqPf56to8qcNBI7Q==}
+    dependencies:
+      cookie-es: 1.0.0
+      defu: 6.1.2
+      destr: 2.0.1
+      iron-webcrypto: 0.8.0
+      radix3: 1.0.1
+      ufo: 1.2.0
+      uncrypto: 0.1.3
+      unenv: 1.7.1
 
   /has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
@@ -5605,17 +5627,15 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /ip-regex@5.0.0:
-    resolution: {integrity: sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dev: false
-
   /ip@2.0.0:
     resolution: {integrity: sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==}
     dev: true
 
   /iron-webcrypto@0.7.1:
     resolution: {integrity: sha512-K/UmlEhPCPXEHV5hAtH5C0tI5JnFuOrv4yO/j7ODPl3HaiiHBLbOLTde+ieUaAyfCATe4LoAnclyF+hmSCOVmQ==}
+
+  /iron-webcrypto@0.8.0:
+    resolution: {integrity: sha512-gScdcWHjTGclCU15CIv2r069NoQrys1UeUFFfaO1hL++ytLHkVw7N5nXJmFf3J2LEDMz1PkrvC0m62JEeu1axQ==}
 
   /is-absolute-url@4.0.1:
     resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
@@ -5646,7 +5666,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       get-intrinsic: 1.2.0
-      is-typed-array: 1.1.12
+      is-typed-array: 1.1.10
     dev: true
 
   /is-arrayish@0.2.1:
@@ -5880,6 +5900,17 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
+    dev: true
+
+  /is-typed-array@1.1.10:
+    resolution: {integrity: sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      available-typed-arrays: 1.0.5
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      gopd: 1.0.1
+      has-tostringtag: 1.0.0
     dev: true
 
   /is-typed-array@1.1.12:
@@ -6122,35 +6153,23 @@ packages:
       - supports-color
     dev: true
 
-  /listhen@1.0.4:
-    resolution: {integrity: sha512-r94k7kmXHb8e8wpv7+UP/qqhhD+j/9TgX19QKim2cEJuWCLwlTw+5BkCFmYyjhQ7Bt8KdVun/2DcD7MF2Fe3+g==}
-    dependencies:
-      clipboardy: 3.0.0
-      colorette: 2.0.20
-      defu: 6.1.2
-      get-port-please: 3.0.1
-      http-shutdown: 1.2.2
-      ip-regex: 5.0.0
-      node-forge: 1.3.1
-      ufo: 1.2.0
-    dev: false
-
-  /listhen@1.1.2:
-    resolution: {integrity: sha512-rLX5V57oonazmc6zoZ2LzfbSOfGzDOLdQ/eTEh/d3f1xYMACH1yIU8nr0YGl2WiR+l31o3QCN4/VH2dUNyYvTA==}
+  /listhen@1.2.2:
+    resolution: {integrity: sha512-fQaXe+DAQ5QiYP1B4uXfAgwqIwNS+0WMIwRd5l2a3npQAEhlCJ1pN11d41yHtbeReE7oRtfL+h6Nzxq+Wc4vIg==}
     hasBin: true
     dependencies:
+      '@parcel/watcher-wasm': 2.3.0-alpha.1
       citty: 0.1.2
       clipboardy: 3.0.0
       consola: 3.2.3
       defu: 6.1.2
       get-port-please: 3.0.1
+      h3: 1.8.0-rc.3
       http-shutdown: 1.2.2
       jiti: 1.19.1
       mlly: 1.4.0
       node-forge: 1.3.1
       pathe: 1.1.1
       ufo: 1.2.0
-    dev: true
 
   /listr2@5.0.8:
     resolution: {integrity: sha512-mC73LitKHj9w6v30nLNGPetZIlfpUniNSsxxrbaPcWOjDb92SHPzJPi/t+v1YC/lxKz/AJ9egOjww0qUuFxBpA==}
@@ -6283,7 +6302,6 @@ packages:
   /lru-cache@10.0.0:
     resolution: {integrity: sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==}
     engines: {node: 14 || >=16.14}
-    dev: true
 
   /lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -6300,11 +6318,6 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
     dev: true
-
-  /lru-cache@9.1.1:
-    resolution: {integrity: sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==}
-    engines: {node: 14 || >=16.14}
-    dev: false
 
   /magic-string-ast@0.2.0:
     resolution: {integrity: sha512-GHev7SFZZrIFy+ZyNJOJpK88KoGSn6FUOhGJXSdHhPt7Q6htJKTiKkdGcJFKp9Tt3P4SIL/P+ro0jZ7BSV8KMw==}
@@ -6833,7 +6846,6 @@ packages:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
     hasBin: true
-    dev: true
 
   /mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -6976,7 +6988,7 @@ packages:
     dependencies:
       citty: 0.1.2
       defu: 6.1.2
-      esbuild: 0.18.17
+      esbuild: 0.18.20
       fs-extra: 11.1.1
       globby: 13.2.2
       jiti: 1.19.1
@@ -7038,6 +7050,9 @@ packages:
     hasBin: true
     dev: true
 
+  /napi-wasm@1.1.0:
+    resolution: {integrity: sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==}
+
   /natural-compare-lite@1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
     dev: true
@@ -7062,15 +7077,15 @@ packages:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.0
       '@netlify/functions': 1.6.0
-      '@rollup/plugin-alias': 5.0.0(rollup@3.27.0)
-      '@rollup/plugin-commonjs': 25.0.3(rollup@3.27.0)
-      '@rollup/plugin-inject': 5.0.3(rollup@3.27.0)
-      '@rollup/plugin-json': 6.0.0(rollup@3.27.0)
-      '@rollup/plugin-node-resolve': 15.1.0(rollup@3.27.0)
-      '@rollup/plugin-replace': 5.0.2(rollup@3.27.0)
-      '@rollup/plugin-terser': 0.4.3(rollup@3.27.0)
-      '@rollup/plugin-wasm': 6.1.3(rollup@3.27.0)
-      '@rollup/pluginutils': 5.0.2(rollup@3.27.0)
+      '@rollup/plugin-alias': 5.0.0(rollup@3.28.0)
+      '@rollup/plugin-commonjs': 25.0.3(rollup@3.28.0)
+      '@rollup/plugin-inject': 5.0.3(rollup@3.28.0)
+      '@rollup/plugin-json': 6.0.0(rollup@3.28.0)
+      '@rollup/plugin-node-resolve': 15.1.0(rollup@3.28.0)
+      '@rollup/plugin-replace': 5.0.2(rollup@3.28.0)
+      '@rollup/plugin-terser': 0.4.3(rollup@3.28.0)
+      '@rollup/plugin-wasm': 6.1.3(rollup@3.28.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.28.0)
       '@types/http-proxy': 1.17.11
       '@vercel/nft': 0.22.6
       archiver: 5.3.1
@@ -7081,9 +7096,9 @@ packages:
       consola: 3.2.3
       cookie-es: 1.0.0
       defu: 6.1.2
-      destr: 2.0.0
+      destr: 2.0.1
       dot-prop: 7.2.0
-      esbuild: 0.18.17
+      esbuild: 0.18.20
       escape-string-regexp: 5.0.0
       etag: 1.8.1
       fs-extra: 11.1.1
@@ -7097,7 +7112,7 @@ packages:
       jiti: 1.19.1
       klona: 2.0.6
       knitwork: 1.0.0
-      listhen: 1.1.2
+      listhen: 1.2.2
       magic-string: 0.30.2
       mime: 3.0.0
       mlly: 1.4.0
@@ -7105,14 +7120,14 @@ packages:
       node-fetch-native: 1.2.0
       ofetch: 1.1.1
       ohash: 1.1.2
-      openapi-typescript: 6.3.9
+      openapi-typescript: 6.4.3
       pathe: 1.1.1
       perfect-debounce: 1.0.0
       pkg-types: 1.0.3
       pretty-bytes: 6.1.1
       radix3: 1.0.1
-      rollup: 3.27.0
-      rollup-plugin-visualizer: 5.9.2(rollup@3.27.0)
+      rollup: 3.28.0
+      rollup-plugin-visualizer: 5.9.2(rollup@3.28.0)
       scule: 1.0.0
       semver: 7.5.4
       serve-placeholder: 2.0.1
@@ -7121,9 +7136,9 @@ packages:
       std-env: 3.3.3
       ufo: 1.2.0
       uncrypto: 0.1.3
-      unenv: 1.5.2
-      unimport: 3.1.0(rollup@3.27.0)
-      unstorage: 1.8.0
+      unenv: 1.7.1
+      unimport: 3.1.3(rollup@3.28.0)
+      unstorage: 1.9.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -7131,11 +7146,13 @@ packages:
       - '@azure/identity'
       - '@azure/keyvault-secrets'
       - '@azure/storage-blob'
+      - '@capacitor/preferences'
       - '@planetscale/database'
       - '@upstash/redis'
       - '@vercel/kv'
       - debug
       - encoding
+      - idb-keyval
       - supports-color
     dev: true
 
@@ -7160,10 +7177,6 @@ packages:
   /node-fetch-native@0.1.8:
     resolution: {integrity: sha512-ZNaury9r0NxaT2oL65GvdGDy+5PlSaHTovT6JV5tOW07k1TQmgC0olZETa4C9KZg0+6zBr99ctTYa3Utqj9P/Q==}
     dev: true
-
-  /node-fetch-native@1.1.0:
-    resolution: {integrity: sha512-nl5goFCig93JZ9FIV8GHT9xpNqXbxQUzkOmKIMKmncsBH9jhg7qKex8hirpymkBFmNQ114chEEG5lS4wgK2I+Q==}
-    dev: false
 
   /node-fetch-native@1.2.0:
     resolution: {integrity: sha512-5IAMBTl9p6PaAjYCnMv5FmqIF6GcZnawAVnzaCG0rX2aYZJ4CxEkZNtVPuTRug7fL7wyM5BQYTlAzcyMPi6oTQ==}
@@ -7388,10 +7401,10 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /nuxt-component-meta@0.5.1(rollup@3.27.0)(vue-component-type-helpers@1.3.12):
+  /nuxt-component-meta@0.5.1(rollup@3.28.0)(vue-component-type-helpers@1.3.12):
     resolution: {integrity: sha512-vwx5wySyVX+QbFrNb3wLYNMPlADho8E66MO45d5i5fTlEkmhopVpQ9YXwlAvM3pLCPjupxG3R3D5rKpLDeitkw==}
     dependencies:
-      '@nuxt/kit': 3.6.5(rollup@3.27.0)
+      '@nuxt/kit': 3.6.5(rollup@3.28.0)
       scule: 1.0.0
       typescript: 5.1.6
       vue-component-meta: 1.4.4(typescript@5.1.6)(vue-component-type-helpers@1.3.12)
@@ -7401,10 +7414,10 @@ packages:
       - vue-component-type-helpers
     dev: true
 
-  /nuxt-config-schema@0.4.6(rollup@3.27.0):
+  /nuxt-config-schema@0.4.6(rollup@3.28.0):
     resolution: {integrity: sha512-kHLWJFynj5QrxVZ1MjY2xmDaTSN1BCMLGExA+hMMLoCb3wn9TJlDVqnE/nSdUJPMRkNn/NQ5WP9NLA9vlAXRUw==}
     dependencies:
-      '@nuxt/kit': 3.6.5(rollup@3.27.0)
+      '@nuxt/kit': 3.6.5(rollup@3.28.0)
       defu: 6.1.2
       jiti: 1.19.1
       pathe: 1.1.1
@@ -7414,19 +7427,19 @@ packages:
       - supports-color
     dev: true
 
-  /nuxt-icon@0.3.3(rollup@3.27.0)(vue@3.3.4):
+  /nuxt-icon@0.3.3(rollup@3.28.0)(vue@3.3.4):
     resolution: {integrity: sha512-KdhJAigBGTP8/YIFZ3orwetk40AgLq6VQ5HRYuDLmv5hiDptor9Ro+WIdZggHw7nciRxZvDdQkEwi9B5G/jrkQ==}
     dependencies:
       '@iconify/vue': 4.1.1(vue@3.3.4)
-      '@nuxt/kit': 3.6.5(rollup@3.27.0)
-      nuxt-config-schema: 0.4.6(rollup@3.27.0)
+      '@nuxt/kit': 3.6.5(rollup@3.28.0)
+      nuxt-config-schema: 0.4.6(rollup@3.28.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - vue
     dev: true
 
-  /nuxt@3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6):
+  /nuxt@3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6):
     resolution: {integrity: sha512-0A7V8B1HrIXX9IlqPc2w+5ZPXi+7MYa9QVhtuGYuLvjRKoSFANhCoMPRP6pKdoxigM1MBxhLue2VmHA/VbtJCw==}
     engines: {node: ^14.18.0 || >=16.10.0}
     hasBin: true
@@ -7438,23 +7451,23 @@ packages:
         optional: true
     dependencies:
       '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 3.6.5(rollup@3.27.0)
-      '@nuxt/schema': 3.6.5(rollup@3.27.0)
-      '@nuxt/telemetry': 2.3.2(rollup@3.27.0)
+      '@nuxt/kit': 3.6.5(rollup@3.28.0)
+      '@nuxt/schema': 3.6.5(rollup@3.28.0)
+      '@nuxt/telemetry': 2.3.2(rollup@3.28.0)
       '@nuxt/ui-templates': 1.3.1
-      '@nuxt/vite-builder': 3.6.5(@types/node@20.4.5)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)(vue@3.3.4)
+      '@nuxt/vite-builder': 3.6.5(@types/node@20.4.5)(eslint@8.44.0)(rollup@3.28.0)(typescript@5.1.6)(vue@3.3.4)
       '@types/node': 20.4.5
-      '@unhead/ssr': 1.1.35
-      '@unhead/vue': 1.1.35(vue@3.3.4)
+      '@unhead/ssr': 1.2.2
+      '@unhead/vue': 1.2.2(vue@3.3.4)
       '@vue/shared': 3.3.4
       acorn: 8.10.0
       c12: 1.4.2
       chokidar: 3.5.3
       cookie-es: 1.0.0
       defu: 6.1.2
-      destr: 2.0.0
+      destr: 2.0.1
       devalue: 4.3.2
-      esbuild: 0.18.17
+      esbuild: 0.18.20
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
       fs-extra: 11.1.1
@@ -7476,15 +7489,15 @@ packages:
       perfect-debounce: 1.0.0
       prompts: 2.4.2
       scule: 1.0.0
-      strip-literal: 1.0.1
+      strip-literal: 1.3.0
       ufo: 1.2.0
       ultrahtml: 1.3.0
       uncrypto: 0.1.3
       unctx: 2.3.1
-      unenv: 1.5.2
-      unimport: 3.1.0(rollup@3.27.0)
+      unenv: 1.7.1
+      unimport: 3.1.3(rollup@3.28.0)
       unplugin: 1.4.0
-      unplugin-vue-router: 0.6.4(rollup@3.27.0)(vue-router@4.2.4)(vue@3.3.4)
+      unplugin-vue-router: 0.6.4(rollup@3.28.0)(vue-router@4.2.4)(vue@3.3.4)
       untyped: 1.4.0
       vue: 3.3.4
       vue-bundle-renderer: 1.0.3
@@ -7497,12 +7510,14 @@ packages:
       - '@azure/identity'
       - '@azure/keyvault-secrets'
       - '@azure/storage-blob'
+      - '@capacitor/preferences'
       - '@planetscale/database'
       - '@upstash/redis'
       - '@vercel/kv'
       - debug
       - encoding
       - eslint
+      - idb-keyval
       - less
       - lightningcss
       - meow
@@ -7627,15 +7642,15 @@ packages:
       is-wsl: 2.2.0
     dev: true
 
-  /openapi-typescript@6.3.9:
-    resolution: {integrity: sha512-1+IHZIhkPjOjS9WQ3YF8lJq7/ZuFBoDOQfCFI2r5mJ4n2+xQ4aQbFw+mTqBl2pYSIb1cB+LWb2T8ig0K/VwI7A==}
+  /openapi-typescript@6.4.3:
+    resolution: {integrity: sha512-GbAkQkiadlLRFRfPoIrETa1vwyOUah8NWnW221ykp5eEG+B1la67Ci1gfdIJggCYKueYqj9dISXswRWX3+LmUw==}
     hasBin: true
     dependencies:
       ansi-colors: 4.1.3
       fast-glob: 3.3.1
       js-yaml: 4.1.0
       supports-color: 9.4.0
-      undici: 5.22.1
+      undici: 5.23.0
       yargs-parser: 21.1.1
     dev: true
 
@@ -8155,7 +8170,7 @@ packages:
       postcss: ^8.2.15
     dependencies:
       postcss: 8.4.27
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
     dev: true
 
   /postcss-nested@6.0.1(postcss@8.4.27):
@@ -8324,7 +8339,7 @@ packages:
       postcss: ^8.2.15
     dependencies:
       postcss: 8.4.27
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
     dev: true
 
   /postcss-url@10.1.3(postcss@8.4.27):
@@ -8351,15 +8366,6 @@ packages:
       nanoid: 3.3.6
       picocolors: 1.0.0
       source-map-js: 1.0.2
-
-  /postcss@8.4.24:
-    resolution: {integrity: sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==}
-    engines: {node: ^10 || ^12 || >=14}
-    dependencies:
-      nanoid: 3.3.6
-      picocolors: 1.0.0
-      source-map-js: 1.0.2
-    dev: true
 
   /postcss@8.4.27:
     resolution: {integrity: sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==}
@@ -8485,7 +8491,7 @@ packages:
     resolution: {integrity: sha512-lNeOl38Ws0eNxpO3+wD1I9rkHGQyj1NU1jlzv4go2CtEnEQEUfqnIvZG7W+bC/aXdJ27n5x/yUjb6RoT9tko+Q==}
     dependencies:
       defu: 6.1.2
-      destr: 2.0.0
+      destr: 2.0.1
       flat: 5.0.2
 
   /react-is@18.2.0:
@@ -8775,7 +8781,7 @@ packages:
       glob: 7.2.3
     dev: true
 
-  /rollup-plugin-dts@5.3.1(rollup@3.27.0)(typescript@5.1.6):
+  /rollup-plugin-dts@5.3.1(rollup@3.28.0)(typescript@5.1.6):
     resolution: {integrity: sha512-gusMi+Z4gY/JaEQeXnB0RUdU82h1kF0WYzCWgVmV4p3hWXqelaKuCvcJawfeg+EKn2T1Ie+YWF2OiN1/L8bTVg==}
     engines: {node: '>=v14.21.3'}
     peerDependencies:
@@ -8783,13 +8789,13 @@ packages:
       typescript: ^4.1 || ^5.0
     dependencies:
       magic-string: 0.30.2
-      rollup: 3.27.0
+      rollup: 3.28.0
       typescript: 5.1.6
     optionalDependencies:
       '@babel/code-frame': 7.22.5
     dev: true
 
-  /rollup-plugin-visualizer@5.9.2(rollup@3.27.0):
+  /rollup-plugin-visualizer@5.9.2(rollup@3.28.0):
     resolution: {integrity: sha512-waHktD5mlWrYFrhOLbti4YgQCn1uR24nYsNuXxg7LkPH8KdTXVWR9DNY1WU0QqokyMixVXJS4J04HNrVTMP01A==}
     engines: {node: '>=14'}
     hasBin: true
@@ -8801,13 +8807,13 @@ packages:
     dependencies:
       open: 8.4.2
       picomatch: 2.3.1
-      rollup: 3.27.0
+      rollup: 3.28.0
       source-map: 0.7.4
       yargs: 17.7.1
     dev: true
 
-  /rollup@3.27.0:
-    resolution: {integrity: sha512-aOltLCrYZ0FhJDm7fCqwTjIUEVjWjcydKBV/Zeid6Mn8BWgDCUBBWT5beM5ieForYNo/1ZHuGJdka26kvQ3Gzg==}
+  /rollup@3.28.0:
+    resolution: {integrity: sha512-d7zhvo1OUY2SXSM6pfNjgD5+d0Nz87CUp4mt8l/GgVP3oBsPwzNvSzyu1me6BSG9JIgWNTVcafIXBIyM8yQ3yw==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -8832,7 +8838,7 @@ packages:
   /rxjs@7.8.0:
     resolution: {integrity: sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==}
     dependencies:
-      tslib: 2.6.1
+      tslib: 2.5.0
     dev: true
 
   /rxjs@7.8.1:
@@ -9343,8 +9349,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /strip-literal@1.0.1:
-    resolution: {integrity: sha512-QZTsipNpa2Ppr6v1AmJHESqJ3Uz247MUS0OjrnnZjFAvEoWqxuyFuXn2xLgMtRnijJShAa1HL0gtJyUs7u7n3Q==}
+  /strip-literal@1.3.0:
+    resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
     dependencies:
       acorn: 8.10.0
 
@@ -9597,6 +9603,10 @@ packages:
       typescript: 5.1.6
     dev: true
 
+  /tslib@2.5.0:
+    resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
+    dev: true
+
   /tslib@2.6.1:
     resolution: {integrity: sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==}
     dev: true
@@ -9661,7 +9671,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       for-each: 0.3.3
-      is-typed-array: 1.1.12
+      is-typed-array: 1.1.10
     dev: true
 
   /typesafe-path@0.2.2:
@@ -9701,12 +9711,12 @@ packages:
     resolution: {integrity: sha512-J4efk69Aye43tWcBPCsLK7TIRppGrEN4pAlDzRKo3HSE6MgTSTBxSEuE3ccx7ixc62JvGQ/CoFXYqqF2AHozow==}
     hasBin: true
     dependencies:
-      '@rollup/plugin-alias': 5.0.0(rollup@3.27.0)
-      '@rollup/plugin-commonjs': 24.1.0(rollup@3.27.0)
-      '@rollup/plugin-json': 6.0.0(rollup@3.27.0)
-      '@rollup/plugin-node-resolve': 15.1.0(rollup@3.27.0)
-      '@rollup/plugin-replace': 5.0.2(rollup@3.27.0)
-      '@rollup/pluginutils': 5.0.2(rollup@3.27.0)
+      '@rollup/plugin-alias': 5.0.0(rollup@3.28.0)
+      '@rollup/plugin-commonjs': 24.1.0(rollup@3.28.0)
+      '@rollup/plugin-json': 6.0.0(rollup@3.28.0)
+      '@rollup/plugin-node-resolve': 15.1.0(rollup@3.28.0)
+      '@rollup/plugin-replace': 5.0.2(rollup@3.28.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.28.0)
       chalk: 5.3.0
       consola: 3.2.3
       defu: 6.1.2
@@ -9721,8 +9731,8 @@ packages:
       pathe: 1.1.1
       pkg-types: 1.0.3
       pretty-bytes: 6.1.1
-      rollup: 3.27.0
-      rollup-plugin-dts: 5.3.1(rollup@3.27.0)(typescript@5.1.6)
+      rollup: 3.28.0
+      rollup-plugin-dts: 5.3.1(rollup@3.28.0)(typescript@5.1.6)
       scule: 1.0.0
       typescript: 5.1.6
       untyped: 1.4.0
@@ -9756,29 +9766,28 @@ packages:
       busboy: 1.6.0
     dev: true
 
-  /undici@5.22.1:
-    resolution: {integrity: sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==}
+  /undici@5.23.0:
+    resolution: {integrity: sha512-1D7w+fvRsqlQ9GscLBwcAJinqcZGHUKjbOmXdlE/v8BvEGXjeWAax+341q44EuTcHXXnfyKNbKRq4Lg7OzhMmg==}
     engines: {node: '>=14.0'}
     dependencies:
       busboy: 1.6.0
     dev: true
 
-  /unenv@1.5.2:
-    resolution: {integrity: sha512-fpQW0nx3hGx0q0wq/35+ng9Dm4m1/2V00UmU5Jxdr1woyrMbT4RydQn5eh/hZyM81HKAPzaf50TKX0XfYpBaqg==}
+  /unenv@1.7.1:
+    resolution: {integrity: sha512-iINrdDcqoAjGqoIeOW85TIfI13KGgW1VWwqNO/IzcvvZ/JGBApMAQPZhWcKhE5oC/woFSpCSXg5lc7r1UaLPng==}
     dependencies:
       consola: 3.2.3
       defu: 6.1.2
       mime: 3.0.0
       node-fetch-native: 1.2.0
       pathe: 1.1.1
-    dev: true
 
-  /unhead@1.1.35:
-    resolution: {integrity: sha512-YEHXxJeSM313yPRcJdBQOSCnkcck1uhg7e2ZoEO+X0KVLuhqV1iYXU+tzvLU+ZId6IZOcEVDfsJ0hHfLkM6Itw==}
+  /unhead@1.2.2:
+    resolution: {integrity: sha512-9wDuiso7YWNe0BTA5NGsHR0dtqn0YrL/5+NumfuXDxxYykavc6N27pzZxTXiuvVHbod8tFicsxA6pC9WhQvzqg==}
     dependencies:
-      '@unhead/dom': 1.1.35
-      '@unhead/schema': 1.1.35
-      '@unhead/shared': 1.1.35
+      '@unhead/dom': 1.2.2
+      '@unhead/schema': 1.2.2
+      '@unhead/shared': 1.2.2
       hookable: 5.5.3
     dev: true
 
@@ -9794,10 +9803,10 @@ packages:
       vfile: 5.3.7
     dev: true
 
-  /unimport@3.1.0(rollup@3.27.0):
-    resolution: {integrity: sha512-ybK3NVWh30MdiqSyqakrrQOeiXyu5507tDA0tUf7VJHrsq4DM6S43gR7oAsZaFojM32hzX982Lqw02D3yf2aiA==}
+  /unimport@3.1.3(rollup@3.28.0):
+    resolution: {integrity: sha512-up4TE2yA+nMyyErGTjbYGVw95MriGa2hVRXQ3/JRp7984cwwqULcnBjHaovVpsO8tZc2j0fvgGu9yiBKOyxvYw==}
     dependencies:
-      '@rollup/pluginutils': 5.0.2(rollup@3.27.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.28.0)
       escape-string-regexp: 5.0.0
       fast-glob: 3.3.1
       local-pkg: 0.4.3
@@ -9806,7 +9815,7 @@ packages:
       pathe: 1.1.1
       pkg-types: 1.0.3
       scule: 1.0.0
-      strip-literal: 1.0.1
+      strip-literal: 1.3.0
       unplugin: 1.4.0
     transitivePeerDependencies:
       - rollup
@@ -9878,7 +9887,7 @@ packages:
     engines: {node: '>= 10.0.0'}
     dev: true
 
-  /unplugin-vue-router@0.6.4(rollup@3.27.0)(vue-router@4.2.4)(vue@3.3.4):
+  /unplugin-vue-router@0.6.4(rollup@3.28.0)(vue-router@4.2.4)(vue@3.3.4):
     resolution: {integrity: sha512-9THVhhtbVFxbsIibjK59oPwMI1UCxRWRPX7azSkTUABsxovlOXJys5SJx0kd/0oKIqNJuYgkRfAgPuO77SqCOg==}
     peerDependencies:
       vue-router: ^4.1.0
@@ -9887,8 +9896,8 @@ packages:
         optional: true
     dependencies:
       '@babel/types': 7.22.5
-      '@rollup/pluginutils': 5.0.2(rollup@3.27.0)
-      '@vue-macros/common': 1.6.0(rollup@3.27.0)(vue@3.3.4)
+      '@rollup/pluginutils': 5.0.2(rollup@3.28.0)
+      '@vue-macros/common': 1.6.0(rollup@3.28.0)(vue@3.3.4)
       ast-walker-scope: 0.4.2
       chokidar: 3.5.3
       fast-glob: 3.3.1
@@ -9922,49 +9931,8 @@ packages:
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.5.0
 
-  /unstorage@1.5.0:
-    resolution: {integrity: sha512-bL6sHwTKp2ns0SAGNHAbLP9LwmtPGMtaOVrHRA4V8ngQMHQR18q0uRgkeGB4qF84XSDu/o8ebv54p/HBJESXFA==}
-    peerDependencies:
-      '@azure/app-configuration': ^1.3.1
-      '@azure/cosmos': ^3.17.3
-      '@azure/data-tables': ^13.2.2
-      '@azure/identity': ^3.1.4
-      '@azure/keyvault-secrets': ^4.7.0
-      '@azure/storage-blob': ^12.14.0
-      '@planetscale/database': ^1.7.0
-    peerDependenciesMeta:
-      '@azure/app-configuration':
-        optional: true
-      '@azure/cosmos':
-        optional: true
-      '@azure/data-tables':
-        optional: true
-      '@azure/identity':
-        optional: true
-      '@azure/keyvault-secrets':
-        optional: true
-      '@azure/storage-blob':
-        optional: true
-      '@planetscale/database':
-        optional: true
-    dependencies:
-      anymatch: 3.1.3
-      chokidar: 3.5.3
-      destr: 1.2.2
-      h3: 1.7.1
-      ioredis: 5.3.2
-      listhen: 1.0.4
-      lru-cache: 9.1.1
-      mri: 1.2.0
-      node-fetch-native: 1.1.0
-      ofetch: 1.1.1
-      ufo: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /unstorage@1.8.0:
-    resolution: {integrity: sha512-Wl6a0fYIIPx8yWIHAVNzsNRcIpagVnBV05UXeIFCNqPZ5tu0w0MPE+eTjpRe/yxCD60K7qX55K5Px/PeKvNntw==}
+  /unstorage@1.9.0:
+    resolution: {integrity: sha512-VpD8ZEYc/le8DZCrny3bnqKE4ZjioQxBRnWE+j5sGNvziPjeDlaS1NaFFHzl/kkXaO3r7UaF8MGQrs14+1B4pQ==}
     peerDependencies:
       '@azure/app-configuration': ^1.4.1
       '@azure/cosmos': ^3.17.3
@@ -9972,9 +9940,11 @@ packages:
       '@azure/identity': ^3.2.3
       '@azure/keyvault-secrets': ^4.7.0
       '@azure/storage-blob': ^12.14.0
-      '@planetscale/database': ^1.7.0
-      '@upstash/redis': ^1.21.0
+      '@capacitor/preferences': ^5.0.0
+      '@planetscale/database': ^1.8.0
+      '@upstash/redis': ^1.22.0
       '@vercel/kv': ^0.2.2
+      idb-keyval: ^6.2.1
     peerDependenciesMeta:
       '@azure/app-configuration':
         optional: true
@@ -9988,19 +9958,23 @@ packages:
         optional: true
       '@azure/storage-blob':
         optional: true
+      '@capacitor/preferences':
+        optional: true
       '@planetscale/database':
         optional: true
       '@upstash/redis':
         optional: true
       '@vercel/kv':
         optional: true
+      idb-keyval:
+        optional: true
     dependencies:
       anymatch: 3.1.3
       chokidar: 3.5.3
-      destr: 2.0.0
+      destr: 2.0.1
       h3: 1.7.1
       ioredis: 5.3.2
-      listhen: 1.1.2
+      listhen: 1.2.2
       lru-cache: 10.0.0
       mri: 1.2.0
       node-fetch-native: 1.2.0
@@ -10008,7 +9982,6 @@ packages:
       ufo: 1.2.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /untildify@4.0.0:
     resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}
@@ -10125,7 +10098,7 @@ packages:
       vfile-message: 3.1.4
     dev: true
 
-  /vite-node@0.32.4(@types/node@18.16.19):
+  /vite-node@0.32.4(@types/node@20.4.5):
     resolution: {integrity: sha512-L2gIw+dCxO0LK14QnUMoqSYpa9XRGnTTTDjW2h19Mr+GR0EFj4vx52W41gFXfMLqpA00eK4ZjOVYo1Xk//LFEw==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -10135,10 +10108,11 @@ packages:
       mlly: 1.4.0
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.3.1(@types/node@18.16.19)
+      vite: 4.4.9(@types/node@20.4.5)
     transitivePeerDependencies:
       - '@types/node'
       - less
+      - lightningcss
       - sass
       - stylus
       - sugarss
@@ -10156,7 +10130,7 @@ packages:
       mlly: 1.4.0
       pathe: 1.1.1
       picocolors: 1.0.0
-      vite: 4.4.7(@types/node@20.4.5)
+      vite: 4.4.9(@types/node@20.4.5)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -10221,7 +10195,7 @@ packages:
       vscode-uri: 3.0.7
     dev: true
 
-  /vite-plugin-inspect@0.7.35(@nuxt/kit@3.6.5)(rollup@3.27.0)(vite@4.4.7):
+  /vite-plugin-inspect@0.7.35(@nuxt/kit@3.6.5)(rollup@3.28.0)(vite@4.4.9):
     resolution: {integrity: sha512-e5w5dJAj3vDcHTxn8hHbiH+mVqYs17gaW00f3aGuMTXiqUog+T1Lsxr9Jb4WRiip84cpuhR0KFFBT1egtXboiA==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -10232,20 +10206,20 @@ packages:
         optional: true
     dependencies:
       '@antfu/utils': 0.7.5
-      '@nuxt/kit': 3.6.5(rollup@3.27.0)
-      '@rollup/pluginutils': 5.0.2(rollup@3.27.0)
+      '@nuxt/kit': 3.6.5(rollup@3.28.0)
+      '@rollup/pluginutils': 5.0.2(rollup@3.28.0)
       debug: 4.3.4
       fs-extra: 11.1.1
       open: 9.1.0
       picocolors: 1.0.0
       sirv: 2.0.3
-      vite: 4.4.7(@types/node@20.4.5)
+      vite: 4.4.9(@types/node@20.4.5)
     transitivePeerDependencies:
       - rollup
       - supports-color
     dev: true
 
-  /vite-plugin-vue-inspector@3.5.0(vite@4.4.7):
+  /vite-plugin-vue-inspector@3.5.0(vite@4.4.9):
     resolution: {integrity: sha512-dDoxEi5VWkfsKflVUYxElC3XD/MOn8s/6mjCqWRDlFIQ+OsY0cW5PNTbqxGllbBBCr5SDnDmPWFS1vMJxrLVEw==}
     peerDependencies:
       vite: ^3.0.0-0 || ^4.0.0-0
@@ -10259,42 +10233,9 @@ packages:
       kolorist: 1.8.0
       magic-string: 0.30.2
       shell-quote: 1.8.1
-      vite: 4.4.7(@types/node@20.4.5)
+      vite: 4.4.9(@types/node@20.4.5)
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /vite@4.3.1(@types/node@18.16.19):
-    resolution: {integrity: sha512-EPmfPLAI79Z/RofuMvkIS0Yr091T2ReUoXQqc5ppBX/sjFRhHKiPPF/R46cTdoci/XgeQpB23diiJxq5w30vdg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 18.16.19
-      esbuild: 0.17.19
-      postcss: 8.4.24
-      rollup: 3.27.0
-    optionalDependencies:
-      fsevents: 2.3.2
     dev: true
 
   /vite@4.3.9(@types/node@20.4.5):
@@ -10325,13 +10266,13 @@ packages:
       '@types/node': 20.4.5
       esbuild: 0.17.19
       postcss: 8.4.27
-      rollup: 3.27.0
+      rollup: 3.28.0
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
 
-  /vite@4.4.7(@types/node@20.4.5):
-    resolution: {integrity: sha512-6pYf9QJ1mHylfVh39HpuSfMPojPSKVxZvnclX1K1FyZ1PXDOcLBibdq5t1qxJSnL63ca8Wf4zts6mD8u8oc9Fw==}
+  /vite@4.4.9(@types/node@20.4.5):
+    resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -10359,9 +10300,9 @@ packages:
         optional: true
     dependencies:
       '@types/node': 20.4.5
-      esbuild: 0.18.17
+      esbuild: 0.18.20
       postcss: 8.4.27
-      rollup: 3.27.0
+      rollup: 3.28.0
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
@@ -10399,32 +10340,33 @@ packages:
     dependencies:
       '@types/chai': 4.3.5
       '@types/chai-subset': 1.3.3
-      '@types/node': 18.16.19
+      '@types/node': 20.4.5
       '@vitest/expect': 0.32.4
       '@vitest/runner': 0.32.4
       '@vitest/snapshot': 0.32.4
       '@vitest/spy': 0.32.4
       '@vitest/utils': 0.32.4
-      acorn: 8.9.0
+      acorn: 8.10.0
       acorn-walk: 8.2.0
       cac: 6.7.14
       chai: 4.3.7
       debug: 4.3.4
       jsdom: 21.1.2
       local-pkg: 0.4.3
-      magic-string: 0.30.1
+      magic-string: 0.30.2
       pathe: 1.1.1
       picocolors: 1.0.0
       playwright: 1.35.1
       std-env: 3.3.3
-      strip-literal: 1.0.1
+      strip-literal: 1.3.0
       tinybench: 2.5.0
       tinypool: 0.5.0
-      vite: 4.3.1(@types/node@18.16.19)
-      vite-node: 0.32.4(@types/node@18.16.19)
+      vite: 4.4.9(@types/node@20.4.5)
+      vite-node: 0.32.4(@types/node@20.4.5)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
+      - lightningcss
       - sass
       - stylus
       - sugarss
@@ -10689,6 +10631,18 @@ packages:
       for-each: 0.3.3
       gopd: 1.0.1
       has-tostringtag: 1.0.0
+    dev: true
+
+  /which-typed-array@1.1.9:
+    resolution: {integrity: sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      available-typed-arrays: 1.0.5
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      gopd: 1.0.1
+      has-tostringtag: 1.0.0
+      is-typed-array: 1.1.10
     dev: true
 
   /which@1.3.1:

--- a/specs/fixtures/basic_pages/nuxt.config.ts
+++ b/specs/fixtures/basic_pages/nuxt.config.ts
@@ -11,14 +11,12 @@ export default defineNuxtConfig({
       {
         code: 'en',
         iso: 'en',
-        name: 'English',
-        file: 'en-US.json'
+        name: 'English'
       },
       {
         code: 'fr',
         iso: 'fr-FR',
-        name: 'Français',
-        file: 'fr-FR.json'
+        name: 'Français'
       }
     ],
     defaultLocale: 'en',

--- a/specs/fixtures/different_domains/nuxt.config.ts
+++ b/specs/fixtures/different_domains/nuxt.config.ts
@@ -28,7 +28,7 @@ export default defineNuxtConfig({
       {
         code: 'nl',
         iso: 'nl-NL',
-        file: 'nl.json',
+        // file: 'nl.json',
         domain: undefined,
         name: 'Nederlands'
       }

--- a/specs/fixtures/layers/layer-domain/nuxt.config.ts
+++ b/specs/fixtures/layers/layer-domain/nuxt.config.ts
@@ -5,7 +5,7 @@ export default defineNuxtConfig({
     differentDomains: true,
     defaultLocale: 'en',
     strategy: 'prefix_except_default',
-    // langDir: 'locales',
+    langDir: 'locales',
     locales: [
       {
         code: 'en',

--- a/specs/fixtures/layers/layer-pages/nuxt.config.ts
+++ b/specs/fixtures/layers/layer-pages/nuxt.config.ts
@@ -5,20 +5,17 @@ export default defineNuxtConfig({
       {
         code: 'en',
         iso: 'en-US',
-        name: 'English',
-        file: 'en-US.json'
+        name: 'English'
       },
       {
         code: 'fr',
         iso: 'fr-FR',
-        name: 'Français',
-        file: 'fr-FR.json'
+        name: 'Français'
       },
       {
         code: 'nl',
         iso: 'nl-NL',
-        name: 'Nederlands',
-        file: 'nl-NL.json'
+        name: 'Nederlands'
       }
     ]
   }

--- a/specs/utils/setup/index.ts
+++ b/specs/utils/setup/index.ts
@@ -1,5 +1,5 @@
 import { createTestContext, setTestContext } from '../context'
-import { buildFixture, loadFixture, clearDir } from '../nuxt'
+import { buildFixture, loadFixture } from '../nuxt'
 import { startServer, stopServer } from '../server'
 import { createBrowser } from '../browser'
 import type { TestHooks, TestOptions } from '../types'
@@ -68,6 +68,16 @@ export function createTest(options: Partial<TestOptions>): TestHooks {
 }
 
 export async function setup(options: Partial<TestOptions> = {}) {
+  // Our layer support handles each layer individually (ignoring merged options)
+  // `nuxtConfig` overrides are not applied to `_layers` but passed to merged options
+  // `i18n.overrides` are applied at project layer to support overrides from tests
+
+  // @ts-ignore
+  if (options?.nuxtConfig?.i18n != null) {
+    // @ts-ignore
+    options.nuxtConfig.i18n = { ...options.nuxtConfig.i18n, overrides: options.nuxtConfig.i18n }
+  }
+
   const hooks = createTest(options)
 
   const setupFn = setupMaps[hooks.ctx.options.runner]

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -19,16 +19,13 @@ export async function extendBundler(
   options: {
     nuxtOptions: Required<NuxtI18nOptions>
     hasLocaleFiles: boolean
-    langPath: string | null
   }
 ) {
   const { nuxtOptions, hasLocaleFiles } = options
   const langPaths = getLayerLangPaths(nuxt)
   debug('langPaths -', langPaths)
   const i18nModulePaths =
-    nuxt.options._layers[0].config.i18n?.i18nModules?.map(module =>
-      resolve(nuxt.options._layers[0].config.rootDir, module.langDir ?? '')
-    ) ?? []
+    nuxtOptions?.i18nModules?.map(module => resolve(nuxt.options._layers[0].config.rootDir, module.langDir ?? '')) ?? []
   debug('i18nModulePaths -', i18nModulePaths)
   const localePaths = [...langPaths, ...i18nModulePaths]
 

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -68,10 +68,7 @@ export function generateLoaderOptions(
     const { root, dir, base, ext } = parsePath(relativePath)
     const key = makeImportKey(root, dir, base)
     if (!generatedImports.has(key)) {
-      let loadPath = relativePath
-      if (langDir) {
-        loadPath = resolveLocaleRelativePath(localesRelativeBase, langDir, relativePath)
-      }
+      const loadPath = resolveLocaleRelativePath(localesRelativeBase, relativePath)
       const assertFormat = ext.slice(1)
       const variableName = genSafeVariableName(`locale_${convertToImportId(key)}`)
       gen += `${genImport(
@@ -98,11 +95,9 @@ export function generateLoaderOptions(
   /**
    * Prepare locale files for synthetic or asynthetic
    */
-  if (langDir) {
-    for (const locale of localeInfo) {
-      if (!syncLocaleFiles.has(locale) && !asyncLocaleFiles.has(locale)) {
-        ;(lazy ? asyncLocaleFiles : syncLocaleFiles).add(locale)
-      }
+  for (const locale of localeInfo) {
+    if (!syncLocaleFiles.has(locale) && !asyncLocaleFiles.has(locale)) {
+      ;(lazy ? asyncLocaleFiles : syncLocaleFiles).add(locale)
     }
   }
 
@@ -236,7 +231,6 @@ export function generateLoaderOptions(
       }).join(`,`)}})\n`
     } else if (rootKey === 'localeInfo') {
       let codes = `export const localeMessages = {\n`
-      if (langDir) {
         for (const { code, file, files} of syncLocaleFiles) {
           const syncPaths = file ? [file] : files|| []
           codes += `  ${toCode(code)}: [${syncPaths.map(filepath => {
@@ -249,16 +243,15 @@ export function generateLoaderOptions(
           codes += `  ${toCode(localeInfo.code)}: [${convertToPairs(localeInfo).map(({ file, path, hash, type }) => {
             const { root, dir, base, ext } = parsePath(file)
             const key = makeImportKey(root, dir, base)
-            const loadPath = resolveLocaleRelativePath(localesRelativeBase, langDir, file)
+            const loadPath = resolveLocaleRelativePath(localesRelativeBase, file)
             return `{ key: ${toCode(loadPath)}, load: ${genDynamicImport(genImportSpecifier(loadPath, ext, path, type, { hash, query: { locale: localeInfo.code } }), { comment: `webpackChunkName: "lang_${normalizeWithUnderScore(key)}"` })} }`
           })}],\n`
         }
-      }
       codes += `}\n`
       return codes
-	  } else {
-	    return `export const ${rootKey} = ${toCode(rootValue)}\n`
-	  }
+    } else {
+      return `export const ${rootKey} = ${toCode(rootValue)}\n`
+    }
   }).join('\n')}`
 
   /**
@@ -314,15 +307,15 @@ function convertToImportId(file: string) {
     return IMPORT_ID_CACHES.get(file)
   }
 
-  const { name } = parsePath(file)
-  const id = normalizeWithUnderScore(name)
+  const { name, dir } = parsePath(file)
+  const id = normalizeWithUnderScore(`${dir}/${name}`)
   IMPORT_ID_CACHES.set(file, id)
 
   return id
 }
 
-function resolveLocaleRelativePath(relativeBase: string, langDir: string, file: string) {
-  return normalize(`${relativeBase}/${langDir}/${file}`)
+function resolveLocaleRelativePath(relativeBase: string, file: string) {
+  return normalize(`${relativeBase}/${file}`)
 }
 
 /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -25,7 +25,6 @@ const debug = createDebug('@nuxtjs/i18n:gen')
 
 export function generateLoaderOptions(
   lazy: NonNullable<NuxtI18nOptions['lazy']>,
-  langDir: NuxtI18nOptions['langDir'],
   localesRelativeBase: string,
   vueI18nConfigPathInfo: VueI18nConfigPathInfo,
   vueI18nConfigPaths: VueI18nConfigPathInfo[],

--- a/src/layers.ts
+++ b/src/layers.ts
@@ -1,10 +1,70 @@
 import createDebug from 'debug'
-import { getLayerI18n, getProjectPath, mergeConfigLocales, resolveVueI18nConfigInfo, LocaleConfig } from './utils'
+import {
+  getLayerI18n,
+  getProjectPath,
+  mergeConfigLocales,
+  resolveVueI18nConfigInfo,
+  LocaleConfig,
+  formatMessage
+} from './utils'
+
+import { useLogger } from '@nuxt/kit'
+import { isAbsolute, resolve } from 'pathe'
+import { isString } from '@intlify/shared'
+import { NUXT_I18N_MODULE_ID } from './constants'
 
 import type { Nuxt } from '@nuxt/schema'
 import type { NuxtI18nOptions } from './types'
 
 const debug = createDebug('@nuxtjs/i18n:layers')
+
+export const checkLayerOptions = (options: NuxtI18nOptions, nuxt: Nuxt) => {
+  const logger = useLogger(NUXT_I18N_MODULE_ID)
+  const project = nuxt.options._layers[0]
+  const layers = nuxt.options._layers
+
+  for (const layer of layers) {
+    const layerI18n = getLayerI18n(layer)
+    if (layerI18n == null) continue
+
+    const configLocation = project.config.rootDir === layer.config.rootDir ? 'project layer' : 'extended layer'
+    const layerHint = `In ${configLocation} (\`${resolve(project.config.rootDir, layer.configFile)}\`) -`
+
+    try {
+      // check `lazy` and `langDir` option
+      if (layerI18n.lazy && !layerI18n.langDir) {
+        throw new Error('When using the `lazy`option you must also set the `langDir` option.')
+      }
+
+      // check `langDir` option
+      if (layerI18n.langDir) {
+        const locales = layerI18n.locales || []
+        if (!locales.length || locales.some(locale => isString(locale))) {
+          throw new Error('When using the `langDir` option the `locales` must be a list of objects.')
+        }
+
+        if (isString(layerI18n.langDir) && isAbsolute(layerI18n.langDir)) {
+          logger.warn(
+            `${layerHint} \`langdir\` is set to an absolute path (\`${layerI18n.langDir}\`) but should be set a path relative to \`srcDir\` (\`${layer.config.srcDir}\`). ` +
+              `Absolute paths will not work in production, see https://v8.i18n.nuxtjs.org/options/lazy#langdir for more details.`
+          )
+        }
+
+        for (const locale of locales) {
+          if (isString(locale) || !(locale.file || locale.files)) {
+            throw new Error(
+              'All locales must have the `file` or `files` property set when using `langDir`.\n' +
+                `Found none in:\n${JSON.stringify(locale, null, 2)}.`
+            )
+          }
+        }
+      }
+    } catch (err) {
+      if (!(err instanceof Error)) throw err
+      throw new Error(formatMessage(`${layerHint} ${err.message}`))
+    }
+  }
+}
 
 export const applyLayerOptions = (options: NuxtI18nOptions, nuxt: Nuxt) => {
   const project = nuxt.options._layers[0]

--- a/src/layers.ts
+++ b/src/layers.ts
@@ -1,9 +1,7 @@
 import createDebug from 'debug'
-import { resolve } from 'pathe'
-import { getLayerI18n, getProjectPath, mergeConfigLocales, resolveVueI18nConfigInfo } from './utils'
+import { getLayerI18n, getProjectPath, mergeConfigLocales, resolveVueI18nConfigInfo, LocaleConfig } from './utils'
 
 import type { Nuxt } from '@nuxt/schema'
-import type { LocaleObject } from 'vue-i18n-routing'
 import type { NuxtI18nOptions } from './types'
 
 const debug = createDebug('@nuxtjs/i18n:layers')
@@ -12,13 +10,10 @@ export const applyLayerOptions = (options: NuxtI18nOptions, nuxt: Nuxt) => {
   const project = nuxt.options._layers[0]
   const layers = nuxt.options._layers
 
-  // No layers to merge
-  if (layers.length === 1) return
-
   const resolvedLayerPaths = layers.map(l => resolve(project.config.rootDir, l.config.rootDir))
   debug('using layers at paths', resolvedLayerPaths)
 
-  const mergedLocales = mergeLayerLocales(nuxt)
+  const mergedLocales = mergeLayerLocales(options, nuxt)
   debug('merged locales', mergedLocales)
 
   options.locales = mergedLocales
@@ -38,94 +33,27 @@ export const mergeLayerPages = (analyzer: (pathOverride: string) => void, nuxt: 
   }
 }
 
-export const mergeLayerLocales = (nuxt: Nuxt) => {
-  const projectLayer = nuxt.options._layers[0]
-  const projectI18n = getLayerI18n(projectLayer)
+export const mergeLayerLocales = (options: NuxtI18nOptions, nuxt: Nuxt) => {
+  debug('project layer `lazy` option', options.lazy)
+  const projectLangDir = getProjectPath(nuxt, nuxt.options.srcDir)
+  options.locales ??= []
 
-  if (projectI18n == null) {
-    debug('project layer `i18n` configuration is required')
-    return []
-  }
-  debug('project layer `lazy` option', projectI18n.lazy)
-
-  /**
-   * Merge locales when `lazy: false`
-   */
-  const mergeSimpleLocales = () => {
-    if (projectI18n.locales == null) return []
-
-    const firstI18nLayer = nuxt.options._layers.find(layer => {
+  const configs: LocaleConfig[] = nuxt.options._layers
+    .filter(layer => {
       const i18n = getLayerI18n(layer)
-      return i18n?.locales && i18n?.locales?.length > 0
+      return i18n?.locales != null
     })
-    if (firstI18nLayer == null) return []
-
-    const localeType = typeof getLayerI18n(firstI18nLayer)?.locales?.at(0)
-    const isStringLocales = (val: unknown): val is string[] => localeType === 'string'
-
-    const mergedLocales: string[] | LocaleObject[] = []
-
-    /*
-      Layers need to be reversed to ensure that the original first layer (project)
-      has the highest priority in merging (because in the reversed array it gets merged last)
-    */
-    const reversedLayers = [...nuxt.options._layers].reverse()
-    for (const layer of reversedLayers) {
+    .map(layer => {
       const i18n = getLayerI18n(layer)
-      debug('layer.config.i18n.locales', i18n?.locales)
-      if (i18n?.locales == null) continue
-
-      for (const locale of i18n.locales) {
-        if (isStringLocales(mergedLocales)) {
-          if (typeof locale !== 'string') continue
-          if (mergedLocales.includes(locale)) continue
-
-          mergedLocales.push(locale)
-          continue
-        }
-
-        if (typeof locale === 'string') continue
-        const localeEntry = mergedLocales.find(x => x.code === locale.code)
-
-        if (localeEntry == null) {
-          mergedLocales.push(locale)
-        } else {
-          Object.assign(localeEntry, locale, localeEntry)
-        }
+      return {
+        ...i18n,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        langDir: resolve(layer.config.srcDir, i18n?.langDir ?? layer.config.srcDir),
+        projectLangDir
       }
-    }
+    })
 
-    return mergedLocales
-  }
-
-  const mergeLazyLocales = () => {
-    if (projectI18n.langDir == null) {
-      debug('project layer `i18n.langDir` is required')
-      return []
-    }
-
-    const projectLangDir = getProjectPath(nuxt, projectI18n.langDir)
-    debug('project path', getProjectPath(nuxt))
-
-    const configs = nuxt.options._layers
-      .filter(layer => {
-        const i18n = getLayerI18n(layer)
-        return i18n?.locales != null && i18n?.langDir != null
-      })
-      .map(layer => {
-        const i18n = getLayerI18n(layer)
-        return {
-          ...i18n,
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          langDir: resolve(layer.config.rootDir, i18n!.langDir!),
-          projectLangDir
-        }
-      })
-
-    return mergeConfigLocales(configs)
-  }
-
-  return projectI18n.lazy ? mergeLazyLocales() : mergeSimpleLocales()
+  return mergeConfigLocales(configs)
 }
 
 /**

--- a/src/module.ts
+++ b/src/module.ts
@@ -36,7 +36,7 @@ import {
   applyOptionOverrides
 } from './utils'
 import { distDir, runtimeDir, pkgModulesDir } from './dirs'
-import { applyLayerOptions, resolveLayerVueI18nConfigInfo } from './layers'
+import { applyLayerOptions, checkLayerOptions, resolveLayerVueI18nConfigInfo } from './layers'
 
 import type { NuxtI18nOptions } from './types'
 
@@ -74,10 +74,10 @@ export default defineNuxtModule<NuxtI18nOptions>({
     }
 
     /**
-     * Check vertions
+     * Check versions
      */
 
-    checkOptions(options)
+    checkLayerOptions(options, nuxt)
 
     if (isNuxt2(nuxt)) {
       throw new Error(
@@ -115,19 +115,6 @@ export default defineNuxtModule<NuxtI18nOptions>({
       baseUrl: options.baseUrl
       // TODO: we should support more i18n module options. welcome PRs :-)
     })
-
-    /**
-     * resolve lang directory
-     */
-
-    if (isString(options.langDir) && isAbsolute(options.langDir)) {
-      logger.warn(
-        `\`langdir\` is set to an absolute path (${options.langDir}) but should be set a path relative to \`srcDir\` (${nuxt.options.srcDir}). ` +
-          `Absolute paths will not work in production, see https://v8.i18n.nuxtjs.org/options/lazy#langdir for more details.`
-      )
-    }
-    const langPath = isString(options.langDir) ? resolve(nuxt.options.srcDir, options.langDir) : null
-    debug('langDir path', langPath)
 
     /**
      * resolve locale info
@@ -333,32 +320,6 @@ export default defineNuxtModule<NuxtI18nOptions>({
     nuxt.options.vite.optimizeDeps.exclude.push('vue-i18n')
   }
 })
-
-function checkOptions(options: NuxtI18nOptions) {
-  // check `lazy` and `langDir` option
-  if (options.lazy && !options.langDir) {
-    throw new Error(formatMessage('When using the "lazy" option you must also set the "langDir" option.'))
-  }
-
-  // check `langDir` option
-  if (options.langDir) {
-    const locales = options.locales || []
-    if (!locales.length || isString(locales[0])) {
-      throw new Error(formatMessage('When using the "langDir" option the "locales" must be a list of objects.'))
-    }
-    for (const locale of locales) {
-      if (isString(locale) || !(locale.file || locale.files)) {
-        throw new Error(
-          formatMessage(
-            `All locales must be objects and have the "file" or "files" property set when using "langDir".` +
-              '\n' +
-              `Found none in:\n${JSON.stringify(locale, null, 2)}.`
-          )
-        )
-      }
-    }
-  }
-}
 
 type MaybePromise<T> = T | Promise<T>
 type LocaleSwitch<T extends string = string> = { oldLocale: T; newLocale: T }

--- a/src/module.ts
+++ b/src/module.ts
@@ -211,7 +211,6 @@ export default defineNuxtModule<NuxtI18nOptions>({
       getContents: () => {
         return generateLoaderOptions(
           options.lazy,
-          options.langDir,
           localesRelativeBasePath,
           vueI18nConfigPathInfo,
           layerVueI18nConfigPaths,

--- a/src/module.ts
+++ b/src/module.ts
@@ -32,7 +32,8 @@ import {
   resolveLocales,
   getPackageManagerType,
   mergeI18nModules,
-  resolveVueI18nConfigInfo
+  resolveVueI18nConfigInfo,
+  applyOptionOverrides
 } from './utils'
 import { distDir, runtimeDir, pkgModulesDir } from './dirs'
 import { applyLayerOptions, resolveLayerVueI18nConfigInfo } from './layers'
@@ -57,6 +58,7 @@ export default defineNuxtModule<NuxtI18nOptions>({
     const logger = useLogger(NUXT_I18N_MODULE_ID)
 
     const options = i18nOptions as Required<NuxtI18nOptions>
+    applyOptionOverrides(options, nuxt)
     debug('options', options)
 
     if (options.experimental.jsTsFormatResource) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,5 @@
 import createDebug from 'debug'
-import { isObject, isString } from '@intlify/shared'
+import { isObject } from '@intlify/shared'
 import {
   defineNuxtModule,
   isNuxt2,
@@ -11,7 +11,7 @@ import {
   addImports,
   useLogger
 } from '@nuxt/kit'
-import { resolve, relative, isAbsolute } from 'pathe'
+import { resolve, relative } from 'pathe'
 import { defu } from 'defu'
 import { setupAlias, resolveVueI18nAlias } from './alias'
 import { setupPages } from './pages'
@@ -93,8 +93,8 @@ export default defineNuxtModule<NuxtI18nOptions>({
       throw new Error(formatMessage(`Cannot support nuxt version: ${getNuxtVersion(nuxt)}`))
     }
 
-    await mergeI18nModules(options, nuxt)
     applyLayerOptions(options, nuxt)
+    await mergeI18nModules(options, nuxt)
 
     if (options.strategy === 'no_prefix' && options.differentDomains) {
       console.warn(
@@ -136,7 +136,7 @@ export default defineNuxtModule<NuxtI18nOptions>({
     const normalizedLocales = getNormalizedLocales(options.locales)
     const hasLocaleFiles = normalizedLocales.length > 0
     const localeCodes = normalizedLocales.map(locale => locale.code)
-    const localeInfo = langPath != null ? await resolveLocales(langPath, normalizedLocales) : []
+    const localeInfo = await resolveLocales(resolve(nuxt.options.srcDir), normalizedLocales)
     debug('localeInfo', localeInfo)
 
     /**
@@ -273,8 +273,7 @@ export default defineNuxtModule<NuxtI18nOptions>({
 
     await extendBundler(nuxt, {
       nuxtOptions: options as Required<NuxtI18nOptions>,
-      hasLocaleFiles,
-      langPath
+      hasLocaleFiles
     })
 
     /**

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -59,7 +59,6 @@ export default defineNuxtPlugin(async nuxt => {
     differentDomains,
     skipSettingLocaleOnNavigate,
     lazy,
-    langDir,
     routesNameSeparator,
     defaultLocaleRouteNameSuffix,
     strategy,
@@ -192,8 +191,7 @@ export default defineNuxtPlugin(async nuxt => {
             differentDomains,
             initial: localeSetup,
             skipSettingLocaleOnNavigate,
-            lazy,
-            langDir
+            lazy
           })
 
           if (modified && localeSetup) {
@@ -440,8 +438,7 @@ export default defineNuxtPlugin(async nuxt => {
         differentDomains,
         initial: localeSetup,
         skipSettingLocaleOnNavigate,
-        lazy,
-        langDir
+        lazy
       })
 
       if (modified && localeSetup) {

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -107,22 +107,21 @@ export async function loadInitialMessages<Context extends NuxtApp = NuxtApp>(
     localeCodes: string[]
   }
 ): Promise<Record<string, any>> {
-  const { defaultLocale, initialLocale, localeCodes, fallbackLocale, langDir, lazy } = options
+  const { defaultLocale, initialLocale, localeCodes, fallbackLocale, lazy } = options
   const setter = (locale: Locale, message: Record<string, any>) => {
     const base = messages[locale] || {}
     messages[locale] = { ...base, ...message }
   }
 
-  if (langDir) {
-    // load fallback messages
-    if (lazy && fallbackLocale) {
-      const fallbackLocales = makeFallbackLocaleCodes(fallbackLocale, [defaultLocale, initialLocale])
-      await Promise.all(fallbackLocales.map(locale => loadLocale(context, locale, setter)))
-    }
-    // load initial messages
-    const locales = lazy ? [...new Set<Locale>().add(defaultLocale).add(initialLocale)] : localeCodes
-    await Promise.all(locales.map(locale => loadLocale(context, locale, setter)))
+  // load fallback messages
+  if (lazy && fallbackLocale) {
+    const fallbackLocales = makeFallbackLocaleCodes(fallbackLocale, [defaultLocale, initialLocale])
+    await Promise.all(fallbackLocales.map(locale => loadLocale(context, locale, setter)))
   }
+
+  // load initial messages
+  const locales = lazy ? [...new Set<Locale>().add(defaultLocale).add(initialLocale)] : localeCodes
+  await Promise.all(locales.map(locale => loadLocale(context, locale, setter)))
 
   return messages
 }
@@ -137,6 +136,7 @@ export async function loadAndSetLocale<Context extends NuxtApp = NuxtApp>(
     differentDomains = nuxtI18nOptionsDefault.differentDomains,
     initial = false,
     lazy = false,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     langDir = null
   }: Pick<DetectBrowserLanguageOptions, 'useCookie'> &
     Pick<NuxtI18nOptions<Context>, 'lazy' | 'langDir' | 'skipSettingLocaleOnNavigate' | 'differentDomains'> & {
@@ -169,16 +169,14 @@ export async function loadAndSetLocale<Context extends NuxtApp = NuxtApp>(
     newLocale = localeOverride
   }
 
-  if (langDir) {
-    const i18nFallbackLocales = getVueI18nPropertyValue<FallbackLocale>(i18n, 'fallbackLocale')
-    if (lazy) {
-      const setter = (locale: Locale, message: Record<string, any>) => mergeLocaleMessage(i18n, locale, message)
-      if (i18nFallbackLocales) {
-        const fallbackLocales = makeFallbackLocaleCodes(i18nFallbackLocales, [newLocale])
-        await Promise.all(fallbackLocales.map(locale => loadLocale(context, locale, setter)))
-      }
-      await loadLocale(context, newLocale, setter)
+  const i18nFallbackLocales = getVueI18nPropertyValue<FallbackLocale>(i18n, 'fallbackLocale')
+  if (lazy) {
+    const setter = (locale: Locale, message: Record<string, any>) => mergeLocaleMessage(i18n, locale, message)
+    if (i18nFallbackLocales) {
+      const fallbackLocales = makeFallbackLocaleCodes(i18nFallbackLocales, [newLocale])
+      await Promise.all(fallbackLocales.map(locale => loadLocale(context, locale, setter)))
     }
+    await loadLocale(context, newLocale, setter)
   }
 
   if (skipSettingLocaleOnNavigate) {

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -135,11 +135,9 @@ export async function loadAndSetLocale<Context extends NuxtApp = NuxtApp>(
     skipSettingLocaleOnNavigate = nuxtI18nOptionsDefault.skipSettingLocaleOnNavigate,
     differentDomains = nuxtI18nOptionsDefault.differentDomains,
     initial = false,
-    lazy = false,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    langDir = null
+    lazy = false
   }: Pick<DetectBrowserLanguageOptions, 'useCookie'> &
-    Pick<NuxtI18nOptions<Context>, 'lazy' | 'langDir' | 'skipSettingLocaleOnNavigate' | 'differentDomains'> & {
+    Pick<NuxtI18nOptions<Context>, 'lazy' | 'skipSettingLocaleOnNavigate' | 'differentDomains'> & {
       initial?: boolean
     } = {}
 ): Promise<[boolean, string]> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,7 @@ export type NuxtI18nOptions<Context = unknown> = {
   /**
    * @internal
    */
+  overrides?: Omit<NuxtI18nOptions, 'overrides'>
   i18nModules?: { langDir?: string | null; locales?: I18nRoutingOptions<Context>['locales'] }[]
   rootRedirect?: string | null | RootRedirectOptions
   routesNameSeparator?: string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -378,20 +378,21 @@ export function parseSegment(segment: string) {
 
 export const resolveRelativeLocales = (
   relativeFileResolver: (files: string[]) => string[],
-  locale: LocaleObject,
-  merged: LocaleObject | undefined
+  locale: LocaleObject | string,
+  merged: LocaleObject | string | undefined
 ) => {
-  if (typeof locale === 'string') return merged
+  if (typeof locale === 'string') return merged ?? locale
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { file, files, ...entry } = locale
 
   const fileEntries = getLocaleFiles(locale)
   const relativeFiles = relativeFileResolver(fileEntries)
+  const mergedLocaleObject = typeof merged === 'string' ? undefined : merged
   return {
     ...entry,
-    ...merged,
-    files: [...relativeFiles, ...(merged?.files ?? [])]
+    ...mergedLocaleObject,
+    files: [...(relativeFiles ?? []), ...(mergedLocaleObject?.files ?? [])]
   }
 }
 
@@ -401,7 +402,7 @@ export const getLocaleFiles = (locale: LocaleObject): string[] => {
   return []
 }
 
-export const localeFilesToRelative = (projectLangDir: string, layerLangDir: string, files: string[]) => {
+export const localeFilesToRelative = (projectLangDir: string, layerLangDir: string = '', files: string[] = []) => {
   const absoluteFiles = files.map(file => resolve(layerLangDir, file))
   const relativeFiles = absoluteFiles.map(file => relative(projectLangDir, file))
 
@@ -414,9 +415,9 @@ export const getProjectPath = (nuxt: Nuxt, ...target: string[]) => {
 }
 
 export type LocaleConfig = {
-  projectLangDir?: string | null
+  projectLangDir: string
   langDir?: string | null
-  locales?: (string | LocaleObject)[]
+  locales?: string[] | LocaleObject[]
 }
 /**
  * Generically merge LocaleObject locales
@@ -425,32 +426,29 @@ export type LocaleConfig = {
  * @param baseLocales optional array of locale objects to merge configs into
  */
 export const mergeConfigLocales = (configs: LocaleConfig[], baseLocales: LocaleObject[] = []) => {
-  const mergedLocales = new Map<string, LocaleObject>()
+  const mergedLocales = new Map<string, LocaleObject | string>()
   baseLocales.forEach(locale => mergedLocales.set(locale.code, locale))
+
+  const getLocaleCode = (val: string | LocaleObject) => (typeof val === 'string' ? val : val.code)
 
   for (const { locales, langDir, projectLangDir } of configs) {
     if (locales == null) continue
-    if (langDir == null) continue
-    if (projectLangDir == null) continue
 
     for (const locale of locales) {
-      if (typeof locale === 'string') continue
-
-      const filesResolver = (files: string[]) => localeFilesToRelative(projectLangDir, langDir, files)
-      const resolvedLocale = resolveRelativeLocales(filesResolver, locale, mergedLocales.get(locale.code))
-      if (resolvedLocale != null) mergedLocales.set(locale.code, resolvedLocale)
+      const code = getLocaleCode(locale)
+      const filesResolver = (files: string[]) => localeFilesToRelative(projectLangDir, langDir ?? '', files)
+      const resolvedLocale = resolveRelativeLocales(filesResolver, locale, mergedLocales.get(code))
+      if (resolvedLocale != null) mergedLocales.set(code, resolvedLocale)
     }
   }
 
-  return Array.from(mergedLocales.values())
+  return Array.from(mergedLocales.values()) as string[] | LocaleObject[]
 }
 
 /**
  * Merges project layer locales with registered i18n modules
  */
 export const mergeI18nModules = async (options: NuxtI18nOptions, nuxt: Nuxt) => {
-  const projectLayer = nuxt.options._layers[0]
-  const projectI18n = getLayerI18n(projectLayer)
   if (options) options.i18nModules = []
 
   const registerI18nModule = (config: Pick<NuxtI18nOptions, 'langDir' | 'locales'>) => {
@@ -460,7 +458,7 @@ export const mergeI18nModules = async (options: NuxtI18nOptions, nuxt: Nuxt) => 
 
   await nuxt.callHook('i18n:registerModule', registerI18nModule)
   const modules = options?.i18nModules ?? []
-  const projectLangDir = getProjectPath(nuxt, projectI18n?.langDir ?? '')
+  const projectLangDir = getProjectPath(nuxt, nuxt.options.rootDir)
 
   if (modules.length > 0) {
     const baseLocales: LocaleObject[] = []

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto'
 import { resolvePath } from '@nuxt/kit'
 import { parse as parsePath, resolve, relative } from 'pathe'
 import { parse as _parseCode } from '@babel/parser'
+import { defu } from 'defu'
 import { encodePath } from 'ufo'
 import { resolveLockfile } from 'pkg-types'
 // @ts-ignore
@@ -509,4 +510,15 @@ export function getLayerI18n(configLayer: NuxtConfigLayer) {
   }
 
   return layerInlineOptions
+}
+
+export const applyOptionOverrides = (options: NuxtI18nOptions, nuxt: Nuxt) => {
+  const project = nuxt.options._layers[0]
+  const { overrides, ...mergedOptions } = options
+
+  if (overrides) {
+    delete options.overrides
+    project.config.i18n = defu(overrides, project.config.i18n)
+    Object.assign(options, defu(overrides, mergedOptions))
+  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -504,7 +504,7 @@ export function getLayerI18n(configLayer: NuxtConfigLayer) {
   )?.[1]
 
   if (configLayer.config.i18n) {
-    return { ...layerInlineOptions, ...configLayer.config.i18n }
+    return defu(configLayer.config.i18n, layerInlineOptions)
   }
 
   return layerInlineOptions

--- a/test/__snapshots__/gen.test.ts.snap
+++ b/test/__snapshots__/gen.test.ts.snap
@@ -1,15 +1,15 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`basic 1`] = `
-"import locale_en from \\"../locales/en.json\\" assert { type: \\"json\\" };
-import locale_ja from \\"../locales/ja.json\\" assert { type: \\"json\\" };
-import locale_fr from \\"../locales/fr.json\\" assert { type: \\"json\\" };
+"import locale_en_json_en from \\"../en.json\\" assert { type: \\"json\\" };
+import locale_ja_json_ja from \\"../ja.json\\" assert { type: \\"json\\" };
+import locale_fr_json_fr from \\"../fr.json\\" assert { type: \\"json\\" };
 export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\"]
 
 export const localeMessages = {
-  \\"en\\": [{ key: \\"../locales/en.json\\", load: () => Promise.resolve(locale_en) }],
-  \\"ja\\": [{ key: \\"../locales/ja.json\\", load: () => Promise.resolve(locale_ja) }],
-  \\"fr\\": [{ key: \\"../locales/fr.json\\", load: () => Promise.resolve(locale_fr) }],
+  \\"en\\": [{ key: \\"../en.json\\", load: () => Promise.resolve(locale_en_json_en) }],
+  \\"ja\\": [{ key: \\"../ja.json\\", load: () => Promise.resolve(locale_ja_json_ja) }],
+  \\"fr\\": [{ key: \\"../fr.json\\", load: () => Promise.resolve(locale_fr_json_fr) }],
 }
 
 export const resolveNuxtI18nOptions = async (context) => {
@@ -30,9 +30,9 @@ exports[`lazy 1`] = `
 "export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\"]
 
 export const localeMessages = {
-  \\"en\\": [{ key: \\"../locales/en.json\\", load: () => import(\\"../locales/en.json\\" /* webpackChunkName: \\"lang_en_json_en_json\\" */) }],
-  \\"ja\\": [{ key: \\"../locales/ja.json\\", load: () => import(\\"../locales/ja.json\\" /* webpackChunkName: \\"lang_ja_json_ja_json\\" */) }],
-  \\"fr\\": [{ key: \\"../locales/fr.json\\", load: () => import(\\"../locales/fr.json\\" /* webpackChunkName: \\"lang_fr_json_fr_json\\" */) }],
+  \\"en\\": [{ key: \\"../en.json\\", load: () => import(\\"../en.json\\" /* webpackChunkName: \\"lang_en_json_en_json\\" */) }],
+  \\"ja\\": [{ key: \\"../ja.json\\", load: () => import(\\"../ja.json\\" /* webpackChunkName: \\"lang_ja_json_ja_json\\" */) }],
+  \\"fr\\": [{ key: \\"../fr.json\\", load: () => import(\\"../fr.json\\" /* webpackChunkName: \\"lang_fr_json_fr_json\\" */) }],
 }
 
 export const resolveNuxtI18nOptions = async (context) => {
@@ -51,9 +51,9 @@ exports[`locale file in nested 1`] = `
 "export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\"]
 
 export const localeMessages = {
-  \\"en\\": [{ key: \\"../locales/en/main.json\\", load: () => import(\\"../locales/en/main.json\\" /* webpackChunkName: \\"lang_en_en_main_json\\" */) }],
-  \\"ja\\": [{ key: \\"../locales/ja/main.json\\", load: () => import(\\"../locales/ja/main.json\\" /* webpackChunkName: \\"lang_ja_ja_main_json\\" */) }],
-  \\"fr\\": [{ key: \\"../locales/fr/main.json\\", load: () => import(\\"../locales/fr/main.json\\" /* webpackChunkName: \\"lang_fr_fr_main_json\\" */) }],
+  \\"en\\": [{ key: \\"../en/main.json\\", load: () => import(\\"../en/main.json\\" /* webpackChunkName: \\"lang_en_en_main_json\\" */) }],
+  \\"ja\\": [{ key: \\"../ja/main.json\\", load: () => import(\\"../ja/main.json\\" /* webpackChunkName: \\"lang_ja_ja_main_json\\" */) }],
+  \\"fr\\": [{ key: \\"../fr/main.json\\", load: () => import(\\"../fr/main.json\\" /* webpackChunkName: \\"lang_fr_fr_main_json\\" */) }],
 }
 
 export const resolveNuxtI18nOptions = async (context) => {
@@ -72,11 +72,11 @@ exports[`multiple files 1`] = `
 "export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\",\\"es\\",\\"es-AR\\"]
 
 export const localeMessages = {
-  \\"en\\": [{ key: \\"../locales/en.json\\", load: () => import(\\"../locales/en.json\\" /* webpackChunkName: \\"lang_en_json_en_json\\" */) }],
-  \\"ja\\": [{ key: \\"../locales/ja.json\\", load: () => import(\\"../locales/ja.json\\" /* webpackChunkName: \\"lang_ja_json_ja_json\\" */) }],
-  \\"fr\\": [{ key: \\"../locales/fr.json\\", load: () => import(\\"../locales/fr.json\\" /* webpackChunkName: \\"lang_fr_json_fr_json\\" */) }],
-  \\"es\\": [{ key: \\"../locales/es.json\\", load: () => import(\\"../locales/es.json\\" /* webpackChunkName: \\"lang_es_json_es_json\\" */) }],
-  \\"es-AR\\": [{ key: \\"../locales/es.json\\", load: () => import(\\"../locales/es.json\\" /* webpackChunkName: \\"lang_es_json_es_json\\" */) },{ key: \\"../locales/es-AR.json\\", load: () => import(\\"../locales/es-AR.json\\" /* webpackChunkName: \\"lang_es_AR_json_es_AR_json\\" */) }],
+  \\"en\\": [{ key: \\"../en.json\\", load: () => import(\\"../en.json\\" /* webpackChunkName: \\"lang_en_json_en_json\\" */) }],
+  \\"ja\\": [{ key: \\"../ja.json\\", load: () => import(\\"../ja.json\\" /* webpackChunkName: \\"lang_ja_json_ja_json\\" */) }],
+  \\"fr\\": [{ key: \\"../fr.json\\", load: () => import(\\"../fr.json\\" /* webpackChunkName: \\"lang_fr_json_fr_json\\" */) }],
+  \\"es\\": [{ key: \\"../es.json\\", load: () => import(\\"../es.json\\" /* webpackChunkName: \\"lang_es_json_es_json\\" */) }],
+  \\"es-AR\\": [{ key: \\"../es.json\\", load: () => import(\\"../es.json\\" /* webpackChunkName: \\"lang_es_json_es_json\\" */) },{ key: \\"../es-AR.json\\", load: () => import(\\"../es-AR.json\\" /* webpackChunkName: \\"lang_es_AR_json_es_AR_json\\" */) }],
 }
 
 export const resolveNuxtI18nOptions = async (context) => {
@@ -140,15 +140,15 @@ export const isSSG = false
 `;
 
 exports[`vueI18n option 1`] = `
-"import locale_en from \\"../locales/en.json\\" assert { type: \\"json\\" };
-import locale_ja from \\"../locales/ja.json\\" assert { type: \\"json\\" };
-import locale_fr from \\"../locales/fr.json\\" assert { type: \\"json\\" };
+"import locale_en_json_en from \\"../en.json\\" assert { type: \\"json\\" };
+import locale_ja_json_ja from \\"../ja.json\\" assert { type: \\"json\\" };
+import locale_fr_json_fr from \\"../fr.json\\" assert { type: \\"json\\" };
 export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\"]
 
 export const localeMessages = {
-  \\"en\\": [{ key: \\"../locales/en.json\\", load: () => Promise.resolve(locale_en) }],
-  \\"ja\\": [{ key: \\"../locales/ja.json\\", load: () => Promise.resolve(locale_ja) }],
-  \\"fr\\": [{ key: \\"../locales/fr.json\\", load: () => Promise.resolve(locale_fr) }],
+  \\"en\\": [{ key: \\"../en.json\\", load: () => Promise.resolve(locale_en_json_en) }],
+  \\"ja\\": [{ key: \\"../ja.json\\", load: () => Promise.resolve(locale_ja_json_ja) }],
+  \\"fr\\": [{ key: \\"../fr.json\\", load: () => Promise.resolve(locale_fr_json_fr) }],
 }
 
 export const resolveNuxtI18nOptions = async (context) => {

--- a/test/gen.test.ts
+++ b/test/gen.test.ts
@@ -70,7 +70,6 @@ test('basic', async () => {
   const { generateLoaderOptions } = await import('../src/gen')
   const code = generateLoaderOptions(
     false,
-    'locales',
     '..',
     NUXT_I18N_VUE_I18N_CONFIG,
     [],
@@ -90,7 +89,6 @@ test('basic', async () => {
 test('lazy', () => {
   const code = generateLoaderOptions(
     true,
-    'locales',
     '..',
     NUXT_I18N_VUE_I18N_CONFIG,
     [],
@@ -109,7 +107,6 @@ test('lazy', () => {
 test('multiple files', () => {
   const code = generateLoaderOptions(
     true,
-    'locales',
     '..',
     NUXT_I18N_VUE_I18N_CONFIG,
     [],
@@ -142,7 +139,6 @@ test('multiple files', () => {
 test('locale file in nested', () => {
   const code = generateLoaderOptions(
     true,
-    'locales',
     '..',
     NUXT_I18N_VUE_I18N_CONFIG,
     [],
@@ -177,7 +173,6 @@ test('locale file in nested', () => {
 test('vueI18n option', () => {
   const code = generateLoaderOptions(
     false,
-    'locales',
     '..',
     NUXT_I18N_VUE_I18N_CONFIG,
     [
@@ -211,7 +206,6 @@ test('vueI18n option', () => {
 test('toCode: function (arrow)', () => {
   const code = generateLoaderOptions(
     false,
-    'locales',
     '..',
     NUXT_I18N_VUE_I18N_CONFIG,
     [],
@@ -236,7 +230,7 @@ test('toCode: function (arrow)', () => {
 })
 
 test('toCode: function (named)', () => {
-  const code = generateLoaderOptions(false, 'locales', '..', NUXT_I18N_VUE_I18N_CONFIG, [], {
+  const code = generateLoaderOptions(false, '..', NUXT_I18N_VUE_I18N_CONFIG, [], {
     localeCodes: LOCALE_CODES,
     nuxtI18nOptions: {
       ...NUXT_I18N_OPTIONS,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
#2206 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change
These changes fix some unintuitive behaviors we have regarding layer support, it could be seen as a bug fix or feature enhancement.
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
> ~I'm making this PR a draft as I'm not confident whether this PR is non breaking, would appreciate some extra eyes on this. Maybe it's better to delay this until v9?~ It seems to be working.

At this moment projects are required to do some configuring to be able to make use of extended i18n layers. All locale files are resolved relative to the main project's `langDir` so the directory has to exist and be defined at `i18n.langDir`, which in turn requires `i18n.locales` to contain `LocaleObject` entries. (see [related issue discussion](https://github.com/nuxt-modules/i18n/issues/2206#issuecomment-1627676007) and [related PR discussion](https://github.com/nuxt-modules/i18n/pull/2268))

This PR changes the way the locales are resolved by looping through all layers (project and extended) and resolving all locale files relative to the main project, which should make extending i18n layers easier.

~I believe this may make some breaking edge cases possible, I still need to test what happens when mixing `lazy` and non `lazy` layers or mixing layers with `string` locales vs `LocaleObject` locales.~ The final merged value of `lazy` is used to treat all provided locales as either lazy or not, this seems to work fine.

Extending a project's `i18n` config with locales and messages is getting easier and easier, should we think of ways for projects to filter out locales as well?

⚠️ Important note ⚠️
I have added a workaround/hack to be able to properly test our layer implementation, I did this by changing the `setup` function inside `@nuxt/test-utils` included in this repo (`specs/utils`). The changes made to the test-utils can be removed, but we will have to be mindful to use the added `overrides` property to set project layer configurations.

The `@nuxt/test-utils` package does not apply `nuxtConfig` overrides to the project/first layer (`nuxt.options._layers[0]`), overrides are only applied to the fully merged options. The layer implementation intentionally ignores merged options as files need to be handled/resolved per layer. To work around this I have added an `overrides` key, essentially implementing our own override approach, which is handled/applied by the module itself. if there is a better way to do this please let me know. 

Some tests had to be changed as the layer implementation incorrectly allowed some broken configurations. Also, the `gen.test.ts` unit tests results are now technically faulty as the `langDir` locale paths are not resolved inside `gen.ts` but beforehand.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
