### PR TITLE
fix: inline options i18n module locale resolution

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,7 +171,7 @@ importers:
     devDependencies:
       '@nuxt/devtools':
         specifier: latest
-        version: 0.7.3(debug@4.3.4)(nuxt@3.6.5)(rollup@3.27.0)(vite@4.4.7)
+        version: 0.7.4(debug@4.3.4)(nuxt@3.6.5)(rollup@3.27.0)(vite@4.4.7)
       '@nuxtjs/i18n':
         specifier: link:..
         version: link:..
@@ -324,6 +324,15 @@ importers:
         version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
 
   specs/fixtures/ignore_pick_module_configration:
+    devDependencies:
+      '@nuxtjs/i18n':
+        specifier: link:../../..
+        version: link:../../..
+      nuxt:
+        specifier: ^3.6.5
+        version: 3.6.5(@types/node@20.4.5)(debug@4.3.4)(eslint@8.44.0)(rollup@3.27.0)(typescript@5.1.6)
+
+  specs/fixtures/inline_options:
     devDependencies:
       '@nuxtjs/i18n':
         specifier: link:../../..
@@ -1332,6 +1341,11 @@ packages:
     engines: {node: '>= 16'}
     dev: false
 
+  /@intlify/shared@9.3.0-beta.25:
+    resolution: {integrity: sha512-Zg+ECV9RPdp227tCJOgvPb+S3i651nf4kKHsMojSyWCppVK/4NFuDrBG2lIQSQL6Iq5LKVr5MkezHCW2NBTQRg==}
+    engines: {node: '>= 16'}
+    dev: false
+
   /@intlify/unplugin-vue-i18n@0.12.2(rollup@3.27.0)(vue-i18n@9.3.0-beta.24):
     resolution: {integrity: sha512-IIgzLRSPUKZM1FBdUAZ9NwVPiLUr4ea5g/HLWe2lB7gNtPDz4FOfUNUllIT504hT+3pDoJmjaYJ6pyqT7F4Wuw==}
     engines: {node: '>= 14.16'}
@@ -1734,8 +1748,8 @@ packages:
     resolution: {integrity: sha512-GBzP8zOc7CGWyFQS6dv1lQz8VVpz5C2yRszbXufwG/9zhStTIH50EtD87NmWbTMwXDvZLNg8GIpb1UFdH93JCA==}
     dev: true
 
-  /@nuxt/devtools-kit@0.7.3(nuxt@3.6.5)(rollup@3.27.0)(vite@4.4.7):
-    resolution: {integrity: sha512-Sh88eXF5m/nL9LmkONIAb1VrsM15QBp378eAQhpsWUFjKWZ1PjvHXWvcq/Nq5+SZGFVegUSuHrN5m6WQHFsrKQ==}
+  /@nuxt/devtools-kit@0.7.4(nuxt@3.6.5)(rollup@3.27.0)(vite@4.4.7):
+    resolution: {integrity: sha512-+CKSSqalyW3elK364FamcHtXm6F03Iarfs9ftBiWmj3CdCTuv9aGpJFi0FKzXKzq/xlCtbWvIrqcaf2Iy//6NQ==}
     peerDependencies:
       nuxt: ^3.6.5
       vite: '*'
@@ -1750,8 +1764,8 @@ packages:
       - supports-color
     dev: true
 
-  /@nuxt/devtools-wizard@0.7.3:
-    resolution: {integrity: sha512-NEdQ5F5D5wCQf2IhjqSapoUP8DuJk33UlQi6juFe0pm8t4/VsavYZ62wHQRn16Lap16aIMK74FjA4VbJ/RflAA==}
+  /@nuxt/devtools-wizard@0.7.4:
+    resolution: {integrity: sha512-Ga+OgxTEZu0AnOmak5eMPrFThvLdoFVB5kEyyCrnBNdkTvX5Dtr8FvVAL+6jV0ALmqhWSXp99op2+QwHg7kgDg==}
     hasBin: true
     dependencies:
       consola: 3.2.3
@@ -1767,15 +1781,15 @@ packages:
       semver: 7.5.4
     dev: true
 
-  /@nuxt/devtools@0.7.3(debug@4.3.4)(nuxt@3.6.5)(rollup@3.27.0)(vite@4.4.7):
-    resolution: {integrity: sha512-ZZsjwna8UJQd7r7Ua7QoTPgdkTvzPqiePGcNvI1X4b2kalvHrct880E++ROZJGvGSbdugA0vA3Va0ybsRc8Wvw==}
+  /@nuxt/devtools@0.7.4(debug@4.3.4)(nuxt@3.6.5)(rollup@3.27.0)(vite@4.4.7):
+    resolution: {integrity: sha512-uaKvVIYWuJ5L1NasXYiZfOh3w2HkHwaMyyVCceabVsOh27PBIeV7rzF5zyMrkyO3vivmWUuXcoZo3M0JO41sqg==}
     hasBin: true
     peerDependencies:
       nuxt: ^3.6.5
       vite: '*'
     dependencies:
-      '@nuxt/devtools-kit': 0.7.3(nuxt@3.6.5)(rollup@3.27.0)(vite@4.4.7)
-      '@nuxt/devtools-wizard': 0.7.3
+      '@nuxt/devtools-kit': 0.7.4(nuxt@3.6.5)(rollup@3.27.0)(vite@4.4.7)
+      '@nuxt/devtools-wizard': 0.7.4
       '@nuxt/kit': 3.6.5(rollup@3.27.0)
       birpc: 0.2.12
       boxen: 7.1.1
@@ -10559,7 +10573,7 @@ packages:
       vue-router:
         optional: true
     dependencies:
-      '@intlify/shared': 9.3.0-beta.24
+      '@intlify/shared': 9.3.0-beta.25
       '@intlify/vue-i18n-bridge': 0.8.0(vue-i18n@9.3.0-beta.24)
       '@intlify/vue-router-bridge': 0.8.0(vue@3.3.4)
       ufo: 1.1.2

--- a/specs/fixtures/external_module/i18n-module/index.ts
+++ b/specs/fixtures/external_module/i18n-module/index.ts
@@ -1,0 +1,26 @@
+import { createResolver, defineNuxtModule } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  async setup(options, nuxt) {
+    const { resolve } = createResolver(import.meta.url)
+    nuxt.hook('i18n:registerModule', register => {
+      register({
+        langDir: resolve('./locales'),
+        locales: [
+          {
+            code: 'fr',
+            iso: 'fr-FR',
+            file: 'locale-file-module-fr.json',
+            name: 'Francais'
+          },
+          {
+            code: 'nl',
+            iso: 'nl-NL',
+            file: 'locale-file-module-nl.ts',
+            name: 'Nederlands'
+          }
+        ]
+      })
+    })
+  }
+})

--- a/specs/fixtures/external_module/i18n-module/locales/locale-file-module-fr.json
+++ b/specs/fixtures/external_module/i18n-module/locales/locale-file-module-fr.json
@@ -1,0 +1,3 @@
+{
+  "moduleLayerText": "This is a merged i18n module locale key in French"
+}

--- a/specs/fixtures/external_module/i18n-module/locales/locale-file-module-nl.ts
+++ b/specs/fixtures/external_module/i18n-module/locales/locale-file-module-nl.ts
@@ -1,0 +1,3 @@
+export default defineI18nLocale(locale => ({
+  moduleLayerText: 'This is a merged i18n module locale key in Dutch'
+}))

--- a/specs/fixtures/inline_options/app.vue
+++ b/specs/fixtures/inline_options/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <NuxtPage />
+  </div>
+</template>

--- a/specs/fixtures/inline_options/components/BasicUsage.vue
+++ b/specs/fixtures/inline_options/components/BasicUsage.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import { navigateTo } from '#imports'
+import { useLocalePath, useSwitchLocalePath, useLocaleRoute, useI18n } from '#i18n'
+
+const { locale } = useI18n()
+const localePath = useLocalePath()
+const switchLocalePath = useSwitchLocalePath()
+const localeRoute = useLocaleRoute()
+
+const category = ref({
+  title: 'Kirby',
+  slug: 'nintendo'
+})
+
+function onClick() {
+  const route = localeRoute({ name: 'user-profile', query: { foo: '1' } })
+  if (route) {
+    return navigateTo(route.fullPath)
+  }
+}
+</script>
+
+<template>
+  <div id="basic-usage-section">
+    <h2>Docs Basic usages</h2>
+    <section id="vue-i18n-usage">
+      <h3>vue-i18n</h3>
+      <div class="vue-i18n">
+        <form>
+          <select v-model="locale">
+            <option value="en">en</option>
+            <option value="fr">fr</option>
+          </select>
+          <p>{{ $t('welcome') }}</p>
+        </form>
+      </div>
+    </section>
+    <section id="locale-path-usages">
+      <h3>localePath</h3>
+      <ul>
+        <li class="name">
+          <NuxtLink :to="localePath('index')">{{ $t('home') }}</NuxtLink>
+        </li>
+        <li class="path">
+          <NuxtLink :to="localePath('/')">{{ $t('home') }}</NuxtLink>
+        </li>
+        <li class="named-with-locale">
+          <NuxtLink :to="localePath('index', 'en')">Homepage in English</NuxtLink>
+        </li>
+        <li class="nest-path">
+          <NuxtLink :to="localePath('/user/profile')">Route by path to: {{ $t('profile') }}</NuxtLink>
+        </li>
+        <li class="nest-named">
+          <NuxtLink :to="localePath('user-profile')">Route by name to: {{ $t('profile') }}</NuxtLink>
+        </li>
+        <li class="object-with-named">
+          <NuxtLink :to="localePath({ name: 'category-slug', params: { slug: category.slug } })">
+            {{ category.title }}
+          </NuxtLink>
+        </li>
+      </ul>
+    </section>
+    <section id="switch-locale-path-usages">
+      <h3>switchLocalePath</h3>
+      <ul>
+        <li class="switch-to-en">
+          <NuxtLink :to="switchLocalePath('en')">English</NuxtLink>
+        </li>
+        <li class="switch-to-fr">
+          <NuxtLink :to="switchLocalePath('fr')">Français</NuxtLink>
+        </li>
+      </ul>
+    </section>
+    <section id="locale-route-usages">
+      <h3>localeRoute</h3>
+      <button @click="onClick">Show profile</button>
+    </section>
+  </div>
+</template>

--- a/specs/fixtures/inline_options/components/LangSwitcher.vue
+++ b/specs/fixtures/inline_options/components/LangSwitcher.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { useI18n, useSwitchLocalePath } from '#i18n'
+
+const { locales, locale, setLocale } = useI18n()
+const switchLocalePath = useSwitchLocalePath()
+
+const localesExcludingCurrent = computed(() => {
+  return locales.value.filter(i => i.code !== locale.value)
+})
+</script>
+
+<template>
+  <div>
+    <section id="lang-switcher-with-nuxt-link">
+      <strong>Using <code>NuxtLink</code></strong
+      >:
+      <NuxtLink
+        v-for="(locale, index) in locales"
+        :key="index"
+        :exact="true"
+        :class="`switch-to-${locale.code}`"
+        :to="switchLocalePath(locale.code)"
+        >{{ locale.name }}</NuxtLink
+      >
+    </section>
+    <section id="lang-switcher-with-set-locale">
+      <strong>Using <code>setLocale()</code></strong
+      >:
+      <a
+        v-for="(locale, index) in locales"
+        :id="`set-locale-link-${locale.code}`"
+        :key="`b-${index}`"
+        href="javascript:void(0)"
+        @click.prevent="setLocale(locale.code)"
+        >{{ locale.name }}</a
+      >
+    </section>
+    <section id="lang-switcher-current-locale">
+      <strong
+        >Current Locale: <code>{{ locale }}</code></strong
+      >:
+    </section>
+  </div>
+</template>

--- a/specs/fixtures/inline_options/lang/locale-file-en.json
+++ b/specs/fixtures/inline_options/lang/locale-file-en.json
@@ -1,0 +1,6 @@
+{
+  "home": "Homepage",
+  "about": "About us",
+  "posts": "Posts",
+  "dynamic": "Dynamic"
+}

--- a/specs/fixtures/inline_options/lang/locale-file-ja.json
+++ b/specs/fixtures/inline_options/lang/locale-file-ja.json
@@ -1,0 +1,6 @@
+{
+  "home": "Homepage in Japanese",
+  "about": "About us in Japanese",
+  "posts": "Posts in Japanese",
+  "dynamic": "Dynamic in Japanese"
+}

--- a/specs/fixtures/inline_options/nuxt.config.ts
+++ b/specs/fixtures/inline_options/nuxt.config.ts
@@ -1,0 +1,40 @@
+import i18nModule from '../external_module/i18n-module'
+
+// https://nuxt.com/docs/guide/directory-structure/nuxt.config
+export default defineNuxtConfig({
+  modules: [
+    i18nModule,
+    [
+      '@nuxtjs/i18n',
+      {
+        debug: false,
+        lazy: false,
+        langDir: 'lang',
+        defaultLocale: 'en',
+        experimental: {
+          jsTsFormatResource: true
+        },
+        detectBrowserLanguage: false,
+        locales: [
+          {
+            code: 'en',
+            iso: 'en-US',
+            file: 'locale-file-en.json',
+            name: 'English'
+          }
+        ]
+      }
+    ]
+  ],
+  debug: false,
+  i18n: {
+    locales: [
+      {
+        code: 'ja',
+        iso: 'ja-JP',
+        file: 'locale-file-ja.json',
+        name: 'Japanese'
+      }
+    ]
+  }
+})

--- a/specs/fixtures/inline_options/package.json
+++ b/specs/fixtures/inline_options/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "nuxt3-test-basic-usage-layers",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "nuxi dev",
+    "build": "nuxt build",
+    "start": "node .output/server/index.mjs"
+  },
+  "devDependencies": {
+    "@nuxtjs/i18n": "latest",
+    "nuxt": "latest"
+  }
+}

--- a/specs/fixtures/inline_options/pages/category/[slug].vue
+++ b/specs/fixtures/inline_options/pages/category/[slug].vue
@@ -1,0 +1,3 @@
+<template>
+  <p>This is cateory page on '{{ $route.params.slug }}'</p>
+</template>

--- a/specs/fixtures/inline_options/pages/index.vue
+++ b/specs/fixtures/inline_options/pages/index.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { watchEffect } from 'vue'
+import { useAsyncData, useHead, useRouter } from '#imports'
+import { useI18n, useLocalePath, useLocaleHead } from '#i18n'
+import BasicUsage from '../components/BasicUsage.vue'
+import LangSwitcher from '../components/LangSwitcher.vue'
+
+const { t } = useI18n()
+const localePath = useLocalePath()
+const i18nHead = useLocaleHead({
+  addDirAttribute: true,
+  identifierAttribute: 'id',
+  addSeoAttributes: { canonicalQueries: ['page'] },
+  router: useRouter()
+})
+const { data, refresh } = useAsyncData('home', () =>
+  Promise.resolve({
+    aboutPath: localePath('about'),
+    aboutTranslation: t('about')
+  })
+)
+
+watchEffect(() => {
+  refresh()
+})
+
+useHead({
+  title: t('home'),
+  htmlAttrs: {
+    lang: i18nHead.value.htmlAttrs!.lang,
+    dir: i18nHead.value.htmlAttrs!.dir
+  },
+  link: [...(i18nHead.value.link || [])],
+  meta: [...(i18nHead.value.meta || [])]
+})
+</script>
+
+<template>
+  <div>
+    <h1 id="home-header">{{ $t('home') }}</h1>
+    <!-- <BasicUsage /> -->
+    <LangSwitcher />
+    <section>
+      <strong>resolve with <code>useAsyncData</code></strong
+      >:
+      <code id="home-use-async-data">{{ data }}</code>
+    </section>
+    <section>
+      <strong><code>useHead</code> with <code>useLocaleHead</code></strong
+      >:
+      <code id="home-use-locale-head">{{ i18nHead }}</code>
+    </section>
+    <section>
+      <code id="extend-message">{{ t('my-module-exemple.hello') }}</code>
+    </section>
+    <NuxtLink id="link-about" exact :to="localePath('about')">{{ $t('about') }}</NuxtLink>
+    <NuxtLink id="link-blog" :to="localePath('blog')">{{ $t('blog') }}</NuxtLink>
+    <NuxtLink id="link-ignore-disable" :to="localePath('/ignore-routes/disable')"
+      >go to ignoring localized disable route</NuxtLink
+    >
+    <NuxtLink id="link-ignore-pick" :to="localePath('/ignore-routes/pick')"
+      >go to ignoring localized pick route</NuxtLink
+    >
+  </div>
+</template>

--- a/specs/fixtures/inline_options/pages/user/profile.vue
+++ b/specs/fixtures/inline_options/pages/user/profile.vue
@@ -1,0 +1,3 @@
+<template>
+  <p id="profile-page">This is profile page</p>
+</template>

--- a/specs/inline_options.spec.ts
+++ b/specs/inline_options.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect, describe } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, url, createPage } from './utils'
+// import { getText, getData } from './helper'
+
+describe('inline options are handled correctly', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL(`./fixtures/inline_options`, import.meta.url)),
+    browser: true
+  })
+
+  test('inline options are handled correctly', async () => {
+    const home = url('/')
+    const page = await createPage()
+    page.goto(home)
+
+    // Inline options provide `en` locale
+    expect(await page.locator('#lang-switcher-with-nuxt-link .switch-to-en').getAttribute('href')).toEqual('/')
+
+    // `i18n` options provides `ja` locale
+    expect(await page.locator('#lang-switcher-with-nuxt-link .switch-to-ja').getAttribute('href')).toEqual('/ja')
+
+    // I18n module provides `fr` and `nl` locales and are resolved using `langDir` from inline options
+    expect(await page.locator('#lang-switcher-with-nuxt-link .switch-to-fr').getAttribute('href')).toEqual('/fr')
+    expect(await page.locator('#lang-switcher-with-nuxt-link .switch-to-nl').getAttribute('href')).toEqual('/nl')
+  })
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
#2141 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Fixes #2141 

Inline options of layers were not being used for i18n module locale resolution.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
