### PR TITLE
ci: fix release edge conditional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,9 +167,9 @@ jobs:
       - name: Release Edge
         if: |
           github.event_name == 'push' &&
-          !contains(github.event.head_commit.message, '[skip-release]') &&
-          !contains(github.event.head_commit.message, 'chore') &&
-          !contains(github.event.head_commit.message, 'docs')
+          !startsWith(github.event.head_commit.message, '[skip-release]') &&
+          !startsWith(github.event.head_commit.message, 'chore') &&
+          !startsWith(github.event.head_commit.message, 'docs')
         run: ./scripts/release-edge.sh
         env:
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Changes the CI release edge conditional to only check whether the commit message `startsWith`, instead of checking whether the commit message `contains` one the following:
* `[skip-release]` 
* `chore` 
* `docs`

This way squashed PRs will still be released even when one of the (squashed) commits contains one of the keywords listed (as mentioned on Discord).

I tested in on my fork:
* [edge-release triggered with commit message containing `chore`](https://github.com/BobbieGoede/i18n-module/actions/runs/5809736513) (ignore failure - due to missing npm config)
* [edge-release skipped with commit message starting with `chore`](https://github.com/BobbieGoede/i18n-module/actions/runs/5809863292)

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
