### PR TITLE
fix: normalise `sourcemap` option to boolean

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -31,11 +31,11 @@ export async function extendBundler(
 
   // extract macros from components
   const macroOptions: TransformMacroPluginOptions = {
-    sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client
+    sourcemap: !!nuxt.options.sourcemap.server || !!nuxt.options.sourcemap.client
   }
 
   const resourceOptions: ResourcePluginOptions = {
-    sourcemap: nuxt.options.sourcemap.server || nuxt.options.sourcemap.client
+    sourcemap: !!nuxt.options.sourcemap.server || !!nuxt.options.sourcemap.client
   }
 
   /**


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue

https://github.com/nuxt/nuxt/pull/22787

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This respects the new `inline` value for sourcemaps. This isn't an urgent fix as v3.7 shouldn't break anything for users but will break this module's build/CI when Nuxt 3.7 lands.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
