### PR TITLE
fix: i18n layer vue i18n resolution

### DIFF
--- a/src/layers.ts
+++ b/src/layers.ts
@@ -140,9 +140,11 @@ export async function resolveLayerVueI18nConfigInfo(nuxt: Nuxt, buildDir: string
   const layers = [...nuxt.options._layers]
   layers.shift()
   return await Promise.all(
-    layers.map(layer => {
-      const i18n = getLayerI18n(layer)
-      return resolveVueI18nConfigInfo(i18n || {}, buildDir, layer.config.rootDir)
-    })
+    layers
+      .filter(layer => getLayerI18n(layer))
+      .map(layer => {
+        const i18n = getLayerI18n(layer)
+        return resolveVueI18nConfigInfo(i18n || {}, buildDir, layer.config.rootDir)
+      })
   )
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
#2343 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This changes `resolveLayerVueI18nConfigInfo` to only try to resolve Vue I18n configuration paths for layers that contain configuration for `@nuxtjs/i18n`. 

@kazupon would this be correct or is it possible and should we take into account layers could have an `i18n.config` file without using `@nuxtjs/i18n`?
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
