### PR TITLE
feat: disable caching for dynamic locale messages

### DIFF
--- a/docs/content/2.guide/8.lazy-load-translations.md
+++ b/docs/content/2.guide/8.lazy-load-translations.md
@@ -78,10 +78,7 @@ About `defineI18nLocale` details, see the [here](/api/composables#defineI18nLoca
 ::
 
 ::alert{type="warn"}
-
-The js / ts format is currently an experimental feature and is disabled by default. 
-
-If you want to use it, you must set the `experimental.jsTsFormatResource` module option to `true`.
+Support for JS/TS format resources is an experimental feature and is disabled by default, to enable this set the `experimental.jsTsFormatResource` module option to `true`.
 ::
 
 ::alert{type="info"}
@@ -176,5 +173,11 @@ In the example above, only two files are defined for `files`, of course you can 
 By taking advantage of the characteristic that locale messages are overridden in sequence, it's possible to manage locale messages by defining them on a differential basis. By adding shared (common) locale messages as the first entry of `files`, followed by file entries of regional/dialectal locale messages, it's possible to manage resources while avoiding the duplication of locale messages.
 
 ::alert{type="info"}
-Lazy loaded locale messages are cached by filename, when the same filename is used in the `files` array of other `locales`, once loaded, it will be used from cache.
+Lazy loaded locale messages are cached based on their filename, `file` and `files` shared across locales will be used from cache once loaded.
+::
+
+::alert{type="warn"}
+Please note that caching for JS/TS format resources is disabled by default as these files can return messages dynamically.
+
+Support for enabling/disabling caching on a per file basis is currently in development.
 ::

--- a/specs/fixtures/lazy/i18n-module/locales/lazy-locale-module-nl.ts
+++ b/specs/fixtures/lazy/i18n-module/locales/lazy-locale-module-nl.ts
@@ -1,3 +1,4 @@
 export default defineI18nLocale(locale => ({
-  moduleLayerText: 'This is a merged module layer locale key in Dutch'
+  moduleLayerText: 'This is a merged module layer locale key in Dutch',
+  dynamicTime: new Date().toISOString()
 }))

--- a/specs/fixtures/lazy/lang/lazy-locale-en.json
+++ b/specs/fixtures/lazy/lang/lazy-locale-en.json
@@ -3,5 +3,6 @@
   "about": "About us",
   "posts": "Posts",
   "dynamic": "Dynamic",
-  "html": "<span>This is the danger</span>"
+  "html": "<span>This is the danger</span>",
+  "dynamicTime": "Not dynamic"
 }

--- a/specs/fixtures/lazy/lang/lazy-locale-fr.json5
+++ b/specs/fixtures/lazy/lang/lazy-locale-fr.json5
@@ -2,5 +2,6 @@
   home: 'Accueil',
   about: 'À propos',
   posts: 'Articles',
-  dynamic: 'Dynamique'
+  dynamic: 'Dynamique',
+  dynamicTime: 'Not dynamic'
 }

--- a/specs/fixtures/lazy/pages/index.vue
+++ b/specs/fixtures/lazy/pages/index.vue
@@ -46,5 +46,6 @@ useHead({
     <p id="profile-js">{{ $t('settings.nest.foo.bar.profile') }}</p>
     <p id="profile-ts">{{ $t('settings_nest_foo_bar_profile') }}</p>
     <p id="html-message" v-html="$t('html')"></p>
+    <p id="dynamic-time">{{ $t('dynamicTime') }}</p>
   </div>
 </template>

--- a/specs/helper.ts
+++ b/specs/helper.ts
@@ -75,3 +75,7 @@ export function validateSyntax(code: string): boolean {
   }
   return ret
 }
+
+export async function waitForMs(ms = 1000) {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}

--- a/specs/lazy_load/basic_lazy_load.spec.ts
+++ b/specs/lazy_load/basic_lazy_load.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, describe } from 'vitest'
 import { fileURLToPath } from 'node:url'
 import { setup, url, createPage } from '../utils'
-import { getText, getData } from '../helper'
+import { getText, getData, waitForMs } from '../helper'
 
 describe('basic lazy loading', async () => {
   await setup({
@@ -9,7 +9,25 @@ describe('basic lazy loading', async () => {
     browser: true
   })
 
-  // TODO: fix lazy loading
+  test('dynamic locale files are not cached', async () => {
+    const home = url('/nl')
+    const page = await createPage()
+    await page.goto(home)
+
+    // capture dynamicTime - simulates changing api response
+    const dynamicTime = await getText(page, '#dynamic-time')
+
+    await page.click('#lang-switcher-with-nuxt-link-fr')
+    expect(await getText(page, '#dynamic-time')).toEqual('Not dynamic')
+
+    // dynamicTime depends on passage of some time
+    await waitForMs(100)
+
+    // dynamicTime does not match captured dynamicTime
+    await page.click('#lang-switcher-with-nuxt-link-nl')
+    expect(await getText(page, '#dynamic-time')).to.not.equal(dynamicTime)
+  })
+
   test('locales are fetched on demand', async () => {
     const home = url('/')
     const page = await createPage()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
#2185 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This changes the messages caching behaviour, only message file keys are used to store and retrieve cached messages. If a message loader is dynamic (ie. a function) then its key and messages are not used for caching. 

As described in https://github.com/nuxt-modules/i18n/issues/2185#issuecomment-1695083083 we want to disable caching by default for `js` and `ts` files, this PR is a step into that direction but does not offer control over caching yet.

It may be preferred to delay this until I have made a solution that provides control over the caching via a `cache` property.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
