### PR TITLE
FIX protocol inside function getDomainFromLocale with differentDomain:true

### DIFF
--- a/src/runtime/internal.ts
+++ b/src/runtime/internal.ts
@@ -491,11 +491,11 @@ export function getDomainFromLocale(localeCode: Locale, locales: LocaleObject[],
       const {
         node: { req }
       } = useRequestEvent(nuxt)
-      protocol = req && isHTTPS(req) ? 'https' : 'http'
+      protocol = req && isHTTPS(req) ? 'https:' : 'http:'
     } else {
       protocol = new URL(window.location.origin).protocol
     }
-    return protocol + '://' + lang.domain
+    return protocol + '//' + lang.domain
   }
 
   console.warn(formatMessage('Could not find domain name for locale ' + localeCode))


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

I fixed the function getDomainFromLocale which sometimes return an URL that begin with `https:://` (that contains 2 ":" instead of 1). This issue happens because the function `URL(window.localtion.origin).protocol` will return the protocol with a ":" at the end. So we don't need to add them again when we return the URL.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
