### PR TITLE
fix: layer VueI18n configuration should not deep copy primitives

### DIFF
--- a/specs/fixtures/layer_consumer/i18n.config.ts
+++ b/specs/fixtures/layer_consumer/i18n.config.ts
@@ -1,4 +1,5 @@
 export default {
+  fallbackLocale: 'nl',
   messages: {
     nl: {
       about: 'Over deze site',

--- a/specs/fixtures/layer_consumer/layer-simple/i18n.config.ts
+++ b/specs/fixtures/layer_consumer/layer-simple/i18n.config.ts
@@ -1,11 +1,13 @@
 export default {
+  fallbackLocale: 'en',
   messages: {
     fr: {
       thanks: 'Merci!',
       about: 'Should be overridden'
     },
     nl: {
-      thanks: 'Bedankt!'
+      thanks: 'Bedankt!',
+      uniqueTranslation: 'Unieke vertaling'
     },
     en: {
       about: 'About this site',

--- a/specs/fixtures/layer_consumer/pages/index.vue
+++ b/specs/fixtures/layer_consumer/pages/index.vue
@@ -22,6 +22,7 @@ useHead({
     <div id="layer-message">{{ $t('thanks') }}</div>
     <div id="snake-case">{{ $t('snakeCaseText') }}</div>
     <div id="pascal-case">{{ $t('pascalCaseText') }}</div>
+    <div id="fallback-message">{{ $t('uniqueTranslation') }}</div>
     <LangSwitcher />
     <section>
       <strong><code>useHead</code> with <code>useLocaleHead</code></strong

--- a/specs/layers/layers_vuei18n_options.spec.ts
+++ b/specs/layers/layers_vuei18n_options.spec.ts
@@ -36,9 +36,11 @@ describe('nuxt layers vuei18n options', async () => {
     await page.click(`#set-locale-link-en`)
     expect(await getText(page, '#snake-case')).toEqual('About-this-site')
     expect(await getText(page, '#pascal-case')).toEqual('AboutThisSite')
+    expect(await getText(page, '#fallback-message')).toEqual('Unieke vertaling')
 
     await page.click(`#set-locale-link-fr`)
     expect(await getText(page, '#snake-case')).toEqual('À-propos-de-ce-site')
     expect(await getText(page, '#pascal-case')).toEqual('ÀProposDeCeSite')
+    expect(await getText(page, '#fallback-message')).toEqual('Unieke vertaling')
   })
 })

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -202,7 +202,7 @@ export function generateLoaderOptions(
           const skipped = ['messages']
 
           for (const [k, v] of Object.entries(cfg).filter(([k]) => !skipped.includes(k))) {
-            if(nuxtI18nOptions.vueI18n?.[k] === undefined) {
+            if(nuxtI18nOptions.vueI18n?.[k] === undefined || typeof nuxtI18nOptions.vueI18n?.[k] !== 'object') {
               nuxtI18nOptions.vueI18n[k] = v
             } else {
               deepCopy(v, nuxtI18nOptions.vueI18n[k])

--- a/test/__snapshots__/gen.test.ts.snap
+++ b/test/__snapshots__/gen.test.ts.snap
@@ -214,7 +214,7 @@ export const resolveNuxtI18nOptions = async (context) => {
           const skipped = ['messages']
 
           for (const [k, v] of Object.entries(cfg).filter(([k]) => !skipped.includes(k))) {
-            if(nuxtI18nOptions.vueI18n?.[k] === undefined) {
+            if(nuxtI18nOptions.vueI18n?.[k] === undefined || typeof nuxtI18nOptions.vueI18n?.[k] !== 'object') {
               nuxtI18nOptions.vueI18n[k] = v
             } else {
               deepCopy(v, nuxtI18nOptions.vueI18n[k])


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #2375

Fixes regression introduced by #2358, VueI18n properties with primitive as values would break a project. Tests have been improved to catch this case.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
