### PR TITLE
Fixed Incorrect locale returned when using different domains

### DIFF
--- a/specs/fixtures/issues/2374/app.vue
+++ b/specs/fixtures/issues/2374/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <NuxtPage />
+  </div>
+</template>

--- a/specs/fixtures/issues/2374/lang/en/pc.js
+++ b/specs/fixtures/issues/2374/lang/en/pc.js
@@ -1,0 +1,3 @@
+export default {
+  welcome: 'test issue 2374'
+}

--- a/specs/fixtures/issues/2374/lang/zh/pc.js
+++ b/specs/fixtures/issues/2374/lang/zh/pc.js
@@ -1,0 +1,3 @@
+export default {
+  welcome: '测试问题2374'
+}

--- a/specs/fixtures/issues/2374/nuxt.config.ts
+++ b/specs/fixtures/issues/2374/nuxt.config.ts
@@ -1,0 +1,26 @@
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/i18n'],
+  i18n: {
+    locales: [
+      {
+        code: 'en',
+        name: 'English',
+        iso: 'en',
+        file: 'en/pc.js',
+        domain: 'en.nuxt-app.localhost'
+      },
+      {
+        code: 'zh-CN',
+        name: '简体中文',
+        iso: 'zh',
+        file: 'zh/pc.js',
+        domain: 'zh.nuxt-app.localhost'
+      }
+    ],
+    differentDomains: true,
+    detectBrowserLanguage: false,
+    defaultLocale: 'en',
+    langDir: 'lang/'
+  }
+})

--- a/specs/fixtures/issues/2374/package.json
+++ b/specs/fixtures/issues/2374/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "nuxt3-test-issues-2374",
+  "private": true,
+  "scripts": {
+    "build": "nuxt build",
+    "dev": "nuxt dev",
+    "generate": "nuxt generate",
+    "preview": "nuxt preview"
+  },
+  "devDependencies": {
+    "@nuxtjs/i18n": "latest",
+    "nuxt": "latest"
+  }
+}

--- a/specs/fixtures/issues/2374/pages/index.vue
+++ b/specs/fixtures/issues/2374/pages/index.vue
@@ -1,0 +1,11 @@
+<script lang="ts" setup>
+const { t } = useI18n()
+</script>
+
+<template>
+  <div>
+    <div id="content">{{ t('welcome') }}</div>
+  </div>
+</template>
+
+<style scoped></style>

--- a/specs/issues/2374.spec.ts
+++ b/specs/issues/2374.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect, describe } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, $fetch } from '../utils'
+import { getDom } from '../helper'
+
+describe('#2374', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL(`../fixtures/issues/2374`, import.meta.url))
+  })
+
+  describe('detection issues 2374 with host on server', () => {
+    test.each([
+      ['en.nuxt-app.localhost', 'test issue 2374'],
+      ['zh.nuxt-app.localhost', '测试问题2374']
+    ])('%s host', async (host, header) => {
+      const html = await $fetch('/', {
+        headers: {
+          Host: host
+        }
+      })
+      const dom = getDom(html)
+      expect(dom.querySelector('#content').textContent).toEqual(header)
+    })
+  })
+
+  test('detection issues 2374  with x-forwarded-host on server', async () => {
+    const html = await $fetch('/', {
+      headers: {
+        'X-Forwarded-Host': 'zh.nuxt-app.localhost'
+      }
+    })
+    const dom = getDom(html)
+
+    expect(dom.querySelector('#content').textContent).toEqual('测试问题2374')
+  })
+})

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export const NUXT_I18N_MODULE_ID = '@nuxtjs/i18n' as const
 export const VUE_I18N_PKG = 'vue-i18n' as const
 export const SHARED_PKG = '@intlify/shared' as const
 export const MESSAGE_COMPILER_PKG = '@intlify/message-compiler' as const
+export const CORE_BASE_PKG = '@intlify/core-base' as const
 export const VUE_I18N_BRIDGE_PKG = '@intlify/vue-i18n-bridge' as const
 export const VUE_ROUTER_BRIDGE_PKG = '@intlify/vue-router-bridge' as const
 export const VUE_I18N_ROUTING_PKG = 'vue-i18n-routing' as const

--- a/src/runtime/internal.ts
+++ b/src/runtime/internal.ts
@@ -470,11 +470,14 @@ export function getLocaleDomain(locales: LocaleObject[]): string {
   let host = getHost() || ''
   if (host) {
     const matchingLocale = locales.find(locale => {
-      let domain = locale.domain
-      if (hasProtocol(locale.domain)) {
-        domain = locale.domain.replace(/(http|https):\/\//, '')
+      if (locale && locale.domain) {
+        let domain = locale.domain
+        if (hasProtocol(locale.domain)) {
+          domain = locale.domain.replace(/(http|https):\/\//, '')
+        }
+        return domain === host
       }
-      return domain === host
+      return false
     })
     if (matchingLocale) {
       return matchingLocale.code

--- a/src/runtime/internal.ts
+++ b/src/runtime/internal.ts
@@ -470,14 +470,11 @@ export function getLocaleDomain(locales: LocaleObject[]): string {
   let host = getHost() || ''
   if (host) {
     const matchingLocale = locales.find(locale => {
-      if (locale && locale.domain) {
-        let domain = locale.domain
-        if (hasProtocol(locale.domain)) {
-          domain = locale.domain.replace(/(http|https):\/\//, '')
-        }
-        return domain === host
+      let domain = locale.domain
+      if (hasProtocol(locale.domain)) {
+        domain = locale.domain.replace(/(http|https):\/\//, '')
       }
-      return false
+      return domain === host
     })
     if (matchingLocale) {
       return matchingLocale.code

--- a/src/runtime/internal.ts
+++ b/src/runtime/internal.ts
@@ -469,7 +469,13 @@ export function getHost() {
 export function getLocaleDomain(locales: LocaleObject[]): string {
   let host = getHost() || ''
   if (host) {
-    const matchingLocale = locales.find(locale => locale.domain === host)
+    const matchingLocale = locales.find(locale => {
+      let domain = locale.domain
+      if (hasProtocol(locale.domain)) {
+        domain = locale.domain.replace(/(http|https):\/\//, '')
+      }
+      return domain === host
+    })
     if (matchingLocale) {
       return matchingLocale.code
     } else {


### PR DESCRIPTION
[…differentDomains: true and locale.domain is set with a protocol header.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
https://volta.net/nuxt-modules/i18n/issues/2374

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
Fixed Incorrect locale returned when using different domains
<!-- Why is this change required? What problem does it solve? -->
When using different domains, setting the domain to http://zh.nuxt-app.localhost or https://en.nuxt-app.localhost does not correctly retrieve the locale.code. I fixed this bug.
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Resolves #2374

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
](https://volta.net/nuxt-modules/i18n/issues/2374)