### PR TITLE
fix: disable typescript check for generated `i18n.options.mjs`

### DIFF
--- a/src/gen.ts
+++ b/src/gen.ts
@@ -100,7 +100,7 @@ export function generateLoaderOptions(
     })
   }
 
-  let genCode = ''
+  let genCode = '// @ts-nocheck\n'
   const localeInfo = options.localeInfo || []
   const syncLocaleFiles = new Set<LocaleInfo>()
   const asyncLocaleFiles = new Set<LocaleInfo>()

--- a/test/__snapshots__/gen.test.ts.snap
+++ b/test/__snapshots__/gen.test.ts.snap
@@ -1,7 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`basic 1`] = `
-"import locale_en_json_en from \\"../en.json\\" assert { type: \\"json\\" };
+"// @ts-nocheck
+import locale_en_json_en from \\"../en.json\\" assert { type: \\"json\\" };
 import locale_ja_json_ja from \\"../ja.json\\" assert { type: \\"json\\" };
 import locale_fr_json_fr from \\"../fr.json\\" assert { type: \\"json\\" };
 export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\"]
@@ -28,7 +29,8 @@ export const parallelPlugin = false
 `;
 
 exports[`files with cache configuration 1`] = `
-"export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\",\\"es\\",\\"es-AR\\"]
+"// @ts-nocheck
+export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\",\\"es\\",\\"es-AR\\"]
 
 export const localeMessages = {
   \\"en\\": [{ key: \\"../en.json\\", load: () => import(\\"../en.json\\" /* webpackChunkName: \\"lang_en_json_en_json\\" */), cache: true }],
@@ -52,7 +54,8 @@ export const parallelPlugin = false
 `;
 
 exports[`lazy 1`] = `
-"export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\"]
+"// @ts-nocheck
+export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\"]
 
 export const localeMessages = {
   \\"en\\": [{ key: \\"../en.json\\", load: () => import(\\"../en.json\\" /* webpackChunkName: \\"lang_en_json_en_json\\" */), cache: true }],
@@ -74,7 +77,8 @@ export const parallelPlugin = false
 `;
 
 exports[`locale file in nested 1`] = `
-"export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\"]
+"// @ts-nocheck
+export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\"]
 
 export const localeMessages = {
   \\"en\\": [{ key: \\"../en/main.json\\", load: () => import(\\"../en/main.json\\" /* webpackChunkName: \\"lang_en_en_main_json\\" */), cache: true }],
@@ -96,7 +100,8 @@ export const parallelPlugin = false
 `;
 
 exports[`multiple files 1`] = `
-"export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\",\\"es\\",\\"es-AR\\"]
+"// @ts-nocheck
+export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\",\\"es\\",\\"es-AR\\"]
 
 export const localeMessages = {
   \\"en\\": [{ key: \\"../en.json\\", load: () => import(\\"../en.json\\" /* webpackChunkName: \\"lang_en_json_en_json\\" */), cache: true }],
@@ -120,7 +125,8 @@ export const parallelPlugin = false
 `;
 
 exports[`toCode: function (arrow) 1`] = `
-"export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\"]
+"// @ts-nocheck
+export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\"]
 
 export const resolveNuxtI18nOptions = async (context) => {
   const nuxtI18nOptions = Object({})
@@ -145,7 +151,8 @@ export const parallelPlugin = false
 `;
 
 exports[`toCode: function (named) 1`] = `
-"export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\"]
+"// @ts-nocheck
+export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\"]
 
 export const resolveNuxtI18nOptions = async (context) => {
   const nuxtI18nOptions = Object({})
@@ -170,7 +177,8 @@ export const parallelPlugin = false
 `;
 
 exports[`vueI18n option 1`] = `
-"import locale_en_json_en from \\"../en.json\\" assert { type: \\"json\\" };
+"// @ts-nocheck
+import locale_en_json_en from \\"../en.json\\" assert { type: \\"json\\" };
 import locale_ja_json_ja from \\"../ja.json\\" assert { type: \\"json\\" };
 import locale_fr_json_fr from \\"../fr.json\\" assert { type: \\"json\\" };
 export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\"]


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
#2392 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #2392 

Adds `// @ts-nocheck` to the start of `i18n.options.mjs` to prevent `checkJs` from checking it, it feels like a lazy fix, but if I understand correctly the end-user should not use this file directly. 

At first I tried adding a declaration file but I don't know how typescript decides whether to use a declaration file to use as types for a `js,mjs` file. As always, I'm open to suggestions!
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
