### PR TITLE
refactor: reduce option generation complexity

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -14,14 +14,7 @@ import type { NuxtI18nOptions } from './types'
 
 const debug = createDebug('@nuxtjs/i18n:bundler')
 
-export async function extendBundler(
-  nuxt: Nuxt,
-  options: {
-    nuxtOptions: Required<NuxtI18nOptions>
-    hasLocaleFiles: boolean
-  }
-) {
-  const { nuxtOptions, hasLocaleFiles } = options
+export async function extendBundler(nuxt: Nuxt, nuxtOptions: Required<NuxtI18nOptions>) {
   const langPaths = getLayerLangPaths(nuxt)
   debug('langPaths -', langPaths)
   const i18nModulePaths =
@@ -56,7 +49,7 @@ export async function extendBundler(
       escapeHtml: nuxtOptions.compilation.escapeHtml
     }
 
-    if (hasLocaleFiles && localePaths.length > 0) {
+    if (localePaths.length > 0) {
       webpackPluginOptions.include = localePaths.map(x => resolve(x, './**'))
     }
 
@@ -102,7 +95,7 @@ export async function extendBundler(
     defaultSFCLang: nuxtOptions.customBlocks.defaultSFCLang,
     globalSFCScope: nuxtOptions.customBlocks.globalSFCScope
   }
-  if (hasLocaleFiles && localePaths.length > 0) {
+  if (localePaths.length > 0) {
     vitePluginOptions.include = localePaths.map(x => resolve(x, './**'))
   }
 

--- a/src/layers.ts
+++ b/src/layers.ts
@@ -13,7 +13,7 @@ import { isAbsolute, resolve } from 'pathe'
 import { isString } from '@intlify/shared'
 import { NUXT_I18N_MODULE_ID } from './constants'
 
-import type { Nuxt } from '@nuxt/schema'
+import type { Nuxt, NuxtConfigLayer } from '@nuxt/schema'
 import type { NuxtI18nOptions } from './types'
 
 const debug = createDebug('@nuxtjs/i18n:layers')
@@ -133,18 +133,14 @@ export const getLayerLangPaths = (nuxt: Nuxt) => {
 }
 
 export async function resolveLayerVueI18nConfigInfo(nuxt: Nuxt, buildDir: string) {
-  if (nuxt.options._layers.length === 1) {
-    return []
-  }
-
   const layers = [...nuxt.options._layers]
-  layers.shift()
+  const project = layers.shift() as NuxtConfigLayer
+  const i18nLayers = [project, ...layers.filter(layer => getLayerI18n(layer))]
+
   return await Promise.all(
-    layers
-      .filter(layer => getLayerI18n(layer))
-      .map(layer => {
-        const i18n = getLayerI18n(layer)
-        return resolveVueI18nConfigInfo(i18n || {}, buildDir, layer.config.rootDir)
-      })
+    i18nLayers.map(layer => {
+      const i18n = getLayerI18n(layer)
+      return resolveVueI18nConfigInfo(i18n || {}, buildDir, layer.config.rootDir)
+    })
   )
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type { Strategies, I18nRoutingOptions, LocaleObject } from 'vue-i18n-routing'
 import type { Locale, I18nOptions } from 'vue-i18n'
 import type { PluginOptions } from '@intlify/unplugin-vue-i18n'
+import type { ParsedPath } from 'path'
 
 export type RedirectOnOptions = 'all' | 'root' | 'no prefix'
 
@@ -34,7 +35,16 @@ export type LocaleInfo = {
   paths?: string[]
   hashes?: string[]
   types?: LocaleType[]
-} & Omit<LocaleObject, 'file' | 'files'> & { files: LocaleFile[] }
+} & Omit<LocaleObject, 'file' | 'files'> & { files: LocaleFile[]; meta?: (FileMeta & { file: LocaleFile })[] }
+
+export type FileMeta = {
+  path: string
+  loadPath: string
+  hash: string
+  type: LocaleType
+  parsed: ParsedPath
+  key: string
+}
 
 export type VueI18nConfigPathInfo = {
   relative?: string
@@ -43,6 +53,7 @@ export type VueI18nConfigPathInfo = {
   type?: LocaleType
   rootDir: string
   relativeBase: string
+  meta: FileMeta
 }
 
 export interface RootRedirectOptions {

--- a/test/__snapshots__/gen.test.ts.snap
+++ b/test/__snapshots__/gen.test.ts.snap
@@ -2,15 +2,15 @@
 
 exports[`basic 1`] = `
 "// @ts-nocheck
-import locale_en_json_en from \\"../en.json\\" assert { type: \\"json\\" };
-import locale_ja_json_ja from \\"../ja.json\\" assert { type: \\"json\\" };
-import locale_fr_json_fr from \\"../fr.json\\" assert { type: \\"json\\" };
+import locale__test_srcDir_en_json from \\"../en.json\\" assert { type: \\"json\\" };
+import locale__test_srcDir_ja_json from \\"../ja.json\\" assert { type: \\"json\\" };
+import locale__test_srcDir_fr_json from \\"../fr.json\\" assert { type: \\"json\\" };
 export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\"]
 
 export const localeMessages = {
-  \\"en\\": [{ key: \\"../en.json\\", load: () => Promise.resolve(locale_en_json_en), cache: true }],
-  \\"ja\\": [{ key: \\"../ja.json\\", load: () => Promise.resolve(locale_ja_json_ja), cache: true }],
-  \\"fr\\": [{ key: \\"../fr.json\\", load: () => Promise.resolve(locale_fr_json_fr), cache: true }],
+  \\"en\\": [{ key: \\"../en.json\\", load: () => Promise.resolve(locale__test_srcDir_en_json), cache: true }],
+  \\"ja\\": [{ key: \\"../ja.json\\", load: () => Promise.resolve(locale__test_srcDir_ja_json), cache: true }],
+  \\"fr\\": [{ key: \\"../fr.json\\", load: () => Promise.resolve(locale__test_srcDir_fr_json), cache: true }]
 }
 
 export const resolveNuxtI18nOptions = async (context) => {
@@ -33,11 +33,11 @@ exports[`files with cache configuration 1`] = `
 export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\",\\"es\\",\\"es-AR\\"]
 
 export const localeMessages = {
-  \\"en\\": [{ key: \\"../en.json\\", load: () => import(\\"../en.json\\" /* webpackChunkName: \\"lang_en_json_en_json\\" */), cache: true }],
-  \\"ja\\": [{ key: \\"../ja.json\\", load: () => import(\\"../ja.json\\" /* webpackChunkName: \\"lang_ja_json_ja_json\\" */), cache: true }],
-  \\"fr\\": [{ key: \\"../fr.json\\", load: () => import(\\"../fr.json\\" /* webpackChunkName: \\"lang_fr_json_fr_json\\" */), cache: true }],
-  \\"es\\": [{ key: \\"../es.json\\", load: () => import(\\"../es.json\\" /* webpackChunkName: \\"lang_es_json_es_json\\" */), cache: false }],
-  \\"es-AR\\": [{ key: \\"../es.json\\", load: () => import(\\"../es.json\\" /* webpackChunkName: \\"lang_es_json_es_json\\" */), cache: false },{ key: \\"../es-AR.json\\", load: () => import(\\"../es-AR.json\\" /* webpackChunkName: \\"lang_es_AR_json_es_AR_json\\" */), cache: true }],
+  \\"en\\": [{ key: \\"../en.json\\", load: () => import(\\"../en.json\\" /* webpackChunkName: \\"locale__test_srcDir_en_json\\" */), cache: true }],
+  \\"ja\\": [{ key: \\"../ja.json\\", load: () => import(\\"../ja.json\\" /* webpackChunkName: \\"locale__test_srcDir_ja_json\\" */), cache: true }],
+  \\"fr\\": [{ key: \\"../fr.json\\", load: () => import(\\"../fr.json\\" /* webpackChunkName: \\"locale__test_srcDir_fr_json\\" */), cache: true }],
+  \\"es\\": [{ key: \\"../es.json\\", load: () => import(\\"../es.json\\" /* webpackChunkName: \\"locale__test_srcDir_es_json\\" */), cache: false }],
+  \\"es-AR\\": [{ key: \\"../es.json\\", load: () => import(\\"../es.json\\" /* webpackChunkName: \\"locale__test_srcDir_es_json\\" */), cache: false },{ key: \\"../es-AR.json\\", load: () => import(\\"../es-AR.json\\" /* webpackChunkName: \\"locale__test_srcDir_es_AR_json\\" */), cache: true }]
 }
 
 export const resolveNuxtI18nOptions = async (context) => {
@@ -58,9 +58,9 @@ exports[`lazy 1`] = `
 export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\"]
 
 export const localeMessages = {
-  \\"en\\": [{ key: \\"../en.json\\", load: () => import(\\"../en.json\\" /* webpackChunkName: \\"lang_en_json_en_json\\" */), cache: true }],
-  \\"ja\\": [{ key: \\"../ja.json\\", load: () => import(\\"../ja.json\\" /* webpackChunkName: \\"lang_ja_json_ja_json\\" */), cache: true }],
-  \\"fr\\": [{ key: \\"../fr.json\\", load: () => import(\\"../fr.json\\" /* webpackChunkName: \\"lang_fr_json_fr_json\\" */), cache: true }],
+  \\"en\\": [{ key: \\"../en.json\\", load: () => import(\\"../en.json\\" /* webpackChunkName: \\"locale__test_srcDir_en_json\\" */), cache: true }],
+  \\"ja\\": [{ key: \\"../ja.json\\", load: () => import(\\"../ja.json\\" /* webpackChunkName: \\"locale__test_srcDir_ja_json\\" */), cache: true }],
+  \\"fr\\": [{ key: \\"../fr.json\\", load: () => import(\\"../fr.json\\" /* webpackChunkName: \\"locale__test_srcDir_fr_json\\" */), cache: true }]
 }
 
 export const resolveNuxtI18nOptions = async (context) => {
@@ -81,9 +81,9 @@ exports[`locale file in nested 1`] = `
 export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\"]
 
 export const localeMessages = {
-  \\"en\\": [{ key: \\"../en/main.json\\", load: () => import(\\"../en/main.json\\" /* webpackChunkName: \\"lang_en_en_main_json\\" */), cache: true }],
-  \\"ja\\": [{ key: \\"../ja/main.json\\", load: () => import(\\"../ja/main.json\\" /* webpackChunkName: \\"lang_ja_ja_main_json\\" */), cache: true }],
-  \\"fr\\": [{ key: \\"../fr/main.json\\", load: () => import(\\"../fr/main.json\\" /* webpackChunkName: \\"lang_fr_fr_main_json\\" */), cache: true }],
+  \\"en\\": [{ key: \\"../en/main.json\\", load: () => import(\\"../en/main.json\\" /* webpackChunkName: \\"locale__test_srcDir_en_main_json\\" */), cache: true }],
+  \\"ja\\": [{ key: \\"../ja/main.json\\", load: () => import(\\"../ja/main.json\\" /* webpackChunkName: \\"locale__test_srcDir_ja_main_json\\" */), cache: true }],
+  \\"fr\\": [{ key: \\"../fr/main.json\\", load: () => import(\\"../fr/main.json\\" /* webpackChunkName: \\"locale__test_srcDir_fr_main_json\\" */), cache: true }]
 }
 
 export const resolveNuxtI18nOptions = async (context) => {
@@ -104,11 +104,11 @@ exports[`multiple files 1`] = `
 export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\",\\"es\\",\\"es-AR\\"]
 
 export const localeMessages = {
-  \\"en\\": [{ key: \\"../en.json\\", load: () => import(\\"../en.json\\" /* webpackChunkName: \\"lang_en_json_en_json\\" */), cache: true }],
-  \\"ja\\": [{ key: \\"../ja.json\\", load: () => import(\\"../ja.json\\" /* webpackChunkName: \\"lang_ja_json_ja_json\\" */), cache: true }],
-  \\"fr\\": [{ key: \\"../fr.json\\", load: () => import(\\"../fr.json\\" /* webpackChunkName: \\"lang_fr_json_fr_json\\" */), cache: true }],
-  \\"es\\": [{ key: \\"../es.json\\", load: () => import(\\"../es.json\\" /* webpackChunkName: \\"lang_es_json_es_json\\" */), cache: true }],
-  \\"es-AR\\": [{ key: \\"../es.json\\", load: () => import(\\"../es.json\\" /* webpackChunkName: \\"lang_es_json_es_json\\" */), cache: true },{ key: \\"../es-AR.json\\", load: () => import(\\"../es-AR.json\\" /* webpackChunkName: \\"lang_es_AR_json_es_AR_json\\" */), cache: true }],
+  \\"en\\": [{ key: \\"../en.json\\", load: () => import(\\"../en.json\\" /* webpackChunkName: \\"locale__test_srcDir_en_json\\" */), cache: true }],
+  \\"ja\\": [{ key: \\"../ja.json\\", load: () => import(\\"../ja.json\\" /* webpackChunkName: \\"locale__test_srcDir_ja_json\\" */), cache: true }],
+  \\"fr\\": [{ key: \\"../fr.json\\", load: () => import(\\"../fr.json\\" /* webpackChunkName: \\"locale__test_srcDir_fr_json\\" */), cache: true }],
+  \\"es\\": [{ key: \\"../es.json\\", load: () => import(\\"../es.json\\" /* webpackChunkName: \\"locale__test_srcDir_es_json\\" */), cache: true }],
+  \\"es-AR\\": [{ key: \\"../es.json\\", load: () => import(\\"../es.json\\" /* webpackChunkName: \\"locale__test_srcDir_es_json\\" */), cache: true },{ key: \\"../es-AR.json\\", load: () => import(\\"../es-AR.json\\" /* webpackChunkName: \\"locale__test_srcDir_es_AR_json\\" */), cache: true }]
 }
 
 export const resolveNuxtI18nOptions = async (context) => {
@@ -131,11 +131,11 @@ export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\"]
 export const resolveNuxtI18nOptions = async (context) => {
   const nuxtI18nOptions = Object({})
   nuxtI18nOptions.defaultLocale = \\"en\\"
-  nuxtI18nOptions.locales = [Object({\\"code\\":\\"en\\",\\"files\\":[\\"en.json\\"],\\"testFunc\\":((prop) => {
+  nuxtI18nOptions.locales = [Object({\\"code\\":\\"en\\",\\"files\\":[\\"en.json\\"],\\"paths\\":[\\"/path/to/en.json\\"],\\"testFunc\\":((prop) => {
             return \`Hello \${prop}\`;
-          })}),Object({\\"code\\":\\"ja\\",\\"files\\":[\\"ja.json\\"],\\"testFunc\\":((prop) => {
+          })}),Object({\\"code\\":\\"ja\\",\\"files\\":[\\"ja.json\\"],\\"paths\\":[\\"/path/to/ja.json\\"],\\"testFunc\\":((prop) => {
             return \`Hello \${prop}\`;
-          })}),Object({\\"code\\":\\"fr\\",\\"files\\":[\\"fr.json\\"],\\"testFunc\\":((prop) => {
+          })}),Object({\\"code\\":\\"fr\\",\\"files\\":[\\"fr.json\\"],\\"paths\\":[\\"/path/to/fr.json\\"],\\"testFunc\\":((prop) => {
             return \`Hello \${prop}\`;
           })})]
   return nuxtI18nOptions
@@ -157,11 +157,11 @@ export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\"]
 export const resolveNuxtI18nOptions = async (context) => {
   const nuxtI18nOptions = Object({})
   nuxtI18nOptions.defaultLocale = \\"en\\"
-  nuxtI18nOptions.locales = [Object({\\"code\\":\\"en\\",\\"files\\":[\\"en.json\\"],\\"testFunc\\":(function (prop) {
+  nuxtI18nOptions.locales = [Object({\\"code\\":\\"en\\",\\"files\\":[\\"en.json\\"],\\"paths\\":[\\"/path/to/en.json\\"],\\"testFunc\\":(function (prop) {
           return \`Hello \${prop}\`;
-        })}),Object({\\"code\\":\\"ja\\",\\"files\\":[\\"ja.json\\"],\\"testFunc\\":(function (prop) {
+        })}),Object({\\"code\\":\\"ja\\",\\"files\\":[\\"ja.json\\"],\\"paths\\":[\\"/path/to/ja.json\\"],\\"testFunc\\":(function (prop) {
           return \`Hello \${prop}\`;
-        })}),Object({\\"code\\":\\"fr\\",\\"files\\":[\\"fr.json\\"],\\"testFunc\\":(function (prop) {
+        })}),Object({\\"code\\":\\"fr\\",\\"files\\":[\\"fr.json\\"],\\"paths\\":[\\"/path/to/fr.json\\"],\\"testFunc\\":(function (prop) {
           return \`Hello \${prop}\`;
         })})]
   return nuxtI18nOptions
@@ -178,15 +178,15 @@ export const parallelPlugin = false
 
 exports[`vueI18n option 1`] = `
 "// @ts-nocheck
-import locale_en_json_en from \\"../en.json\\" assert { type: \\"json\\" };
-import locale_ja_json_ja from \\"../ja.json\\" assert { type: \\"json\\" };
-import locale_fr_json_fr from \\"../fr.json\\" assert { type: \\"json\\" };
+import locale__test_srcDir_en_json from \\"../en.json\\" assert { type: \\"json\\" };
+import locale__test_srcDir_ja_json from \\"../ja.json\\" assert { type: \\"json\\" };
+import locale__test_srcDir_fr_json from \\"../fr.json\\" assert { type: \\"json\\" };
 export const localeCodes = [\\"en\\",\\"ja\\",\\"fr\\"]
 
 export const localeMessages = {
-  \\"en\\": [{ key: \\"../en.json\\", load: () => Promise.resolve(locale_en_json_en), cache: true }],
-  \\"ja\\": [{ key: \\"../ja.json\\", load: () => Promise.resolve(locale_ja_json_ja), cache: true }],
-  \\"fr\\": [{ key: \\"../fr.json\\", load: () => Promise.resolve(locale_fr_json_fr), cache: true }],
+  \\"en\\": [{ key: \\"../en.json\\", load: () => Promise.resolve(locale__test_srcDir_en_json), cache: true }],
+  \\"ja\\": [{ key: \\"../ja.json\\", load: () => Promise.resolve(locale__test_srcDir_ja_json), cache: true }],
+  \\"fr\\": [{ key: \\"../fr.json\\", load: () => Promise.resolve(locale__test_srcDir_fr_json), cache: true }]
 }
 
 export const resolveNuxtI18nOptions = async (context) => {
@@ -197,43 +197,46 @@ export const resolveNuxtI18nOptions = async (context) => {
             if (typeof config === 'function') return await config()
             return {}
           }
-  nuxtI18nOptions.vueI18n = Object({\\"messages\\":Object({})})
-  const deepCopy = (src, des, predicate) => {
-          for (const key in src) {
-            if (typeof src[key] === 'object') {
-              if (!(typeof des[key] === 'object')) des[key] = {}
-              deepCopy(src[key], des[key], predicate)
-            } else {
-              if (predicate) {
-                if (predicate(src[key], des[key])) {
+          const deepCopy = (src, des, predicate) => {
+            for (const key in src) {
+              if (typeof src[key] === 'object') {
+                if (!(typeof des[key] === 'object')) des[key] = {}
+                deepCopy(src[key], des[key], predicate)
+              } else {
+                if (predicate) {
+                  if (predicate(src[key], des[key])) {
+                    des[key] = src[key]
+                  }
+                } else {
                   des[key] = src[key]
                 }
-              } else {
-                des[key] = src[key]
               }
             }
           }
-        }
 
-        const mergeVueI18nConfigs = async (configuredMessages, loader) => {
-          const layerConfig = await vueI18nConfigLoader(loader)
-          const cfg = layerConfig || {}
-          cfg.messages ??= {}
-          const skipped = ['messages']
+          const mergeVueI18nConfigs = async (configuredMessages, loader) => {
+            const layerConfig = await vueI18nConfigLoader(loader)
+            const cfg = layerConfig || {}
+            cfg.messages ??= {}
+            const skipped = ['messages']
 
-          for (const [k, v] of Object.entries(cfg).filter(([k]) => !skipped.includes(k))) {
-            if(nuxtI18nOptions.vueI18n?.[k] === undefined || typeof nuxtI18nOptions.vueI18n?.[k] !== 'object') {
-              nuxtI18nOptions.vueI18n[k] = v
-            } else {
-              deepCopy(v, nuxtI18nOptions.vueI18n[k])
+            for (const [k, v] of Object.entries(cfg).filter(([k]) => !skipped.includes(k))) {
+              if(nuxtI18nOptions.vueI18n?.[k] === undefined || typeof nuxtI18nOptions.vueI18n?.[k] !== 'object') {
+                nuxtI18nOptions.vueI18n[k] = v
+              } else {
+                deepCopy(v, nuxtI18nOptions.vueI18n[k])
+              }
+            }
+
+            for (const [locale, message] of Object.entries(cfg.messages)) {
+              configuredMessages[locale] ??= {}
+              deepCopy(message, configuredMessages[locale])
             }
           }
-
-          for (const [locale, message] of Object.entries(cfg.messages)) {
-            configuredMessages[locale] ??= {}
-            deepCopy(message, configuredMessages[locale])
-          }
-        }
+  nuxtI18nOptions.vueI18n = Object({\\"messages\\":Object({})})
+  await mergeVueI18nConfigs(nuxtI18nOptions.vueI18n.messages, (() => import(\\"../foo/layer2/vue-i18n.options.js?hash=84df1640&config=1\\" /* webpackChunkName: vue_i18n_options_js_84df1640 */)))
+  await mergeVueI18nConfigs(nuxtI18nOptions.vueI18n.messages, (() => import(\\"../layer1/i18n.custom.ts?hash=faa288dc&config=1\\" /* webpackChunkName: i18n_custom_ts_faa288dc */)))
+  await mergeVueI18nConfigs(nuxtI18nOptions.vueI18n.messages, (() => import(\\"../to/i18n.config.ts?hash=42902d1e&config=1\\" /* webpackChunkName: i18n_config_ts_42902d1e */)))
   return nuxtI18nOptions
 }
 

--- a/test/gen.test.ts
+++ b/test/gen.test.ts
@@ -1,10 +1,16 @@
 import { parse } from '@babel/parser'
 import { DEFAULT_OPTIONS } from '../src/constants'
 import { generateLoaderOptions } from '../src/gen'
+import { resolveLocales, resolveVueI18nConfigInfo } from '../src/utils'
 
 import type { NuxtI18nOptions, NuxtI18nInternalOptions, VueI18nConfigPathInfo } from '../src/types'
 
 vi.mock('node:fs')
+
+vi.mock('pathe', async () => {
+  const mod = await vi.importActual<typeof import('pathe')>('pathe')
+  return { ...mod, resolve: vi.fn((...args: string[]) => mod.normalize(args.join('/'))) }
+})
 
 beforeEach(async () => {
   vi.spyOn(await import('node:fs'), 'readFileSync').mockReturnValue('export default {}')
@@ -49,7 +55,7 @@ const NUXT_I18N_VUE_I18N_CONFIG = {
   relative: 'i18n.config.ts',
   rootDir: '/path/to',
   relativeBase: '..'
-} as VueI18nConfigPathInfo
+} as Required<VueI18nConfigPathInfo>
 
 function validateSyntax(code: string): boolean {
   let ret = false
@@ -68,14 +74,14 @@ function validateSyntax(code: string): boolean {
 
 test('basic', async () => {
   const { generateLoaderOptions } = await import('../src/gen')
+  const localeInfo = await resolveLocales('/test/srcDir', LOCALE_INFO, '..')
+  const vueI18nConfig = await resolveVueI18nConfigInfo({ vueI18n: NUXT_I18N_VUE_I18N_CONFIG.relative }, '.nuxt', '.')
   const code = generateLoaderOptions(
     false,
-    '..',
-    NUXT_I18N_VUE_I18N_CONFIG,
-    [],
+    [vueI18nConfig],
     {
       localeCodes: LOCALE_CODES,
-      localeInfo: LOCALE_INFO,
+      localeInfo,
       nuxtI18nOptions: NUXT_I18N_OPTIONS,
       nuxtI18nOptionsDefault: DEFAULT_OPTIONS,
       nuxtI18nInternalOptions: NUXT_I18N_INTERNAL_OPTIONS
@@ -86,15 +92,15 @@ test('basic', async () => {
   expect(code).toMatchSnapshot()
 })
 
-test('lazy', () => {
+test('lazy', async () => {
+  const localeInfo = await resolveLocales('/test/srcDir', LOCALE_INFO, '..')
+  const vueI18nConfig = await resolveVueI18nConfigInfo({ vueI18n: NUXT_I18N_VUE_I18N_CONFIG.relative }, '.nuxt', '.')
   const code = generateLoaderOptions(
     true,
-    '..',
-    NUXT_I18N_VUE_I18N_CONFIG,
-    [],
+    [vueI18nConfig],
     {
       localeCodes: LOCALE_CODES,
-      localeInfo: LOCALE_INFO,
+      localeInfo,
       nuxtI18nOptions: NUXT_I18N_OPTIONS,
       nuxtI18nInternalOptions: NUXT_I18N_INTERNAL_OPTIONS
     },
@@ -104,116 +110,130 @@ test('lazy', () => {
   expect(code).toMatchSnapshot()
 })
 
-test('multiple files', () => {
-  const code = generateLoaderOptions(
-    true,
-    '..',
-    NUXT_I18N_VUE_I18N_CONFIG,
-    [],
-    {
-      localeCodes: [...LOCALE_CODES, 'es', 'es-AR'],
-      localeInfo: [
-        ...LOCALE_INFO,
-        ...[
-          {
-            code: 'es',
-            files: [{ path: 'es.json', cache: true }],
-            paths: ['/path/to/es.json']
-          },
-          {
-            code: 'es-AR',
-            files: [
-              { path: 'es.json', cache: true },
-              { path: 'es-AR.json', cache: true }
-            ],
-            paths: ['/path/to/es.json', '/path/to/es-AR.json']
-          }
-        ]
-      ],
-      nuxtI18nOptions: NUXT_I18N_OPTIONS,
-      nuxtI18nInternalOptions: NUXT_I18N_INTERNAL_OPTIONS
-    },
-    { ssg: false, dev: true, parallelPlugin: false }
-  )
-  expect(validateSyntax(code)).toBe(true)
-  expect(code).toMatchSnapshot()
-})
-
-test('files with cache configuration', () => {
-  const code = generateLoaderOptions(
-    true,
-    '..',
-    NUXT_I18N_VUE_I18N_CONFIG,
-    [],
-    {
-      localeCodes: [...LOCALE_CODES, 'es', 'es-AR'],
-      localeInfo: [
-        ...LOCALE_INFO,
-        ...[
-          {
-            code: 'es',
-            files: [{ path: 'es.json', cache: false }],
-            paths: ['/path/to/es.json']
-          },
-          {
-            code: 'es-AR',
-            files: [
-              { path: 'es.json', cache: false },
-              { path: 'es-AR.json', cache: true }
-            ],
-            paths: ['/path/to/es.json', '/path/to/es-AR.json']
-          }
-        ]
-      ],
-      nuxtI18nOptions: NUXT_I18N_OPTIONS,
-      nuxtI18nInternalOptions: NUXT_I18N_INTERNAL_OPTIONS
-    },
-    { ssg: false, dev: true, parallelPlugin: false }
-  )
-  expect(validateSyntax(code)).toBe(true)
-  expect(code).toMatchSnapshot()
-})
-
-test('locale file in nested', () => {
-  const code = generateLoaderOptions(
-    true,
-    '..',
-    NUXT_I18N_VUE_I18N_CONFIG,
-    [],
-    {
-      localeCodes: LOCALE_CODES,
-      localeInfo: [
-        {
-          code: 'en',
-          files: [{ path: 'en/main.json', cache: true }],
-          paths: ['/path/to/en.json']
-        },
-        {
-          code: 'ja',
-          files: [{ path: 'ja/main.json', cache: true }],
-          paths: ['/path/to/ja.json']
-        },
-        {
-          code: 'fr',
-          files: [{ path: 'fr/main.json', cache: true }],
-          paths: ['/path/to/fr.json']
-        }
-      ],
-      nuxtI18nOptions: NUXT_I18N_OPTIONS,
-      nuxtI18nInternalOptions: NUXT_I18N_INTERNAL_OPTIONS
-    },
-    { ssg: false, dev: true, parallelPlugin: false }
-  )
-  expect(validateSyntax(code)).toBe(true)
-  expect(code).toMatchSnapshot()
-})
-
-test('vueI18n option', () => {
-  const code = generateLoaderOptions(
-    false,
-    '..',
-    NUXT_I18N_VUE_I18N_CONFIG,
+test('multiple files', async () => {
+  const localeInfo = await resolveLocales(
+    '/test/srcDir',
     [
+      ...LOCALE_INFO,
+      ...[
+        {
+          code: 'es',
+          files: [{ path: 'es.json', cache: true }],
+          paths: ['/path/to/es.json']
+        },
+        {
+          code: 'es-AR',
+          files: [
+            { path: 'es.json', cache: true },
+            { path: 'es-AR.json', cache: true }
+          ],
+          paths: ['/path/to/es.json', '/path/to/es-AR.json']
+        }
+      ]
+    ],
+    '..'
+  )
+  const vueI18nConfig = await resolveVueI18nConfigInfo({ vueI18n: NUXT_I18N_VUE_I18N_CONFIG.relative }, '.nuxt', '.')
+
+  const code = generateLoaderOptions(
+    true,
+    [vueI18nConfig],
+    {
+      localeCodes: [...LOCALE_CODES, 'es', 'es-AR'],
+      localeInfo,
+      nuxtI18nOptions: NUXT_I18N_OPTIONS,
+      nuxtI18nInternalOptions: NUXT_I18N_INTERNAL_OPTIONS
+    },
+    { ssg: false, dev: true, parallelPlugin: false }
+  )
+  expect(validateSyntax(code)).toBe(true)
+  expect(code).toMatchSnapshot()
+})
+
+test('files with cache configuration', async () => {
+  const localeInfo = await resolveLocales(
+    '/test/srcDir',
+    [
+      ...LOCALE_INFO,
+      ...[
+        {
+          code: 'es',
+          files: [{ path: 'es.json', cache: false }],
+          paths: ['/path/to/es.json']
+        },
+        {
+          code: 'es-AR',
+          files: [
+            { path: 'es.json', cache: false },
+            { path: 'es-AR.json', cache: true }
+          ],
+          paths: ['/path/to/es.json', '/path/to/es-AR.json']
+        }
+      ]
+    ],
+    '..'
+  )
+  const vueI18nConfig = await resolveVueI18nConfigInfo({ vueI18n: NUXT_I18N_VUE_I18N_CONFIG.relative }, '.nuxt', '.')
+
+  const code = generateLoaderOptions(
+    true,
+    [vueI18nConfig],
+    {
+      localeCodes: [...LOCALE_CODES, 'es', 'es-AR'],
+      localeInfo,
+      nuxtI18nOptions: NUXT_I18N_OPTIONS,
+      nuxtI18nInternalOptions: NUXT_I18N_INTERNAL_OPTIONS
+    },
+    { ssg: false, dev: true, parallelPlugin: false }
+  )
+  expect(validateSyntax(code)).toBe(true)
+  expect(code).toMatchSnapshot()
+})
+
+test('locale file in nested', async () => {
+  const localeInfo = await resolveLocales(
+    '/test/srcDir',
+    [
+      {
+        code: 'en',
+        files: [{ path: 'en/main.json', cache: true }],
+        paths: ['/path/to/en.json']
+      },
+      {
+        code: 'ja',
+        files: [{ path: 'ja/main.json', cache: true }],
+        paths: ['/path/to/ja.json']
+      },
+      {
+        code: 'fr',
+        files: [{ path: 'fr/main.json', cache: true }],
+        paths: ['/path/to/fr.json']
+      }
+    ],
+    '..'
+  )
+
+  const vueI18nConfig = await resolveVueI18nConfigInfo({ vueI18n: NUXT_I18N_VUE_I18N_CONFIG.relative }, '.nuxt', '.')
+  const code = generateLoaderOptions(
+    true,
+    [vueI18nConfig],
+    {
+      localeCodes: LOCALE_CODES,
+      localeInfo,
+      nuxtI18nOptions: NUXT_I18N_OPTIONS,
+      nuxtI18nInternalOptions: NUXT_I18N_INTERNAL_OPTIONS
+    },
+    { ssg: false, dev: true, parallelPlugin: false }
+  )
+  expect(validateSyntax(code)).toBe(true)
+  expect(code).toMatchSnapshot()
+})
+
+test('vueI18n option', async () => {
+  const localeInfo = await resolveLocales('/test/srcDir', LOCALE_INFO, '..')
+  const vueI18nConfigs = await Promise.all(
+    [
+      NUXT_I18N_VUE_I18N_CONFIG,
       {
         absolute: '/path/layer1/i18n.custom.ts',
         relative: 'i18n.custom.ts',
@@ -226,10 +246,14 @@ test('vueI18n option', () => {
         rootDir: '/path/foo/layer2',
         relativeBase: '../../..'
       }
-    ],
+    ].map(x => resolveVueI18nConfigInfo({ vueI18n: x.relative }, '/path/.nuxt', x.rootDir))
+  )
+  const code = generateLoaderOptions(
+    false,
+    vueI18nConfigs as Required<VueI18nConfigPathInfo>[],
     {
       localeCodes: LOCALE_CODES,
-      localeInfo: LOCALE_INFO,
+      localeInfo,
       nuxtI18nOptions: {
         vueI18n: 'vue-i18n.config.ts'
       },
@@ -241,12 +265,11 @@ test('vueI18n option', () => {
   expect(code).toMatchSnapshot()
 })
 
-test('toCode: function (arrow)', () => {
+test('toCode: function (arrow)', async () => {
+  const vueI18nConfig = await resolveVueI18nConfigInfo({ vueI18n: NUXT_I18N_VUE_I18N_CONFIG.relative }, '.nuxt', '.')
   const code = generateLoaderOptions(
     false,
-    '..',
-    NUXT_I18N_VUE_I18N_CONFIG,
-    [],
+    [vueI18nConfig],
     {
       localeCodes: LOCALE_CODES,
       nuxtI18nOptions: {
@@ -267,8 +290,9 @@ test('toCode: function (arrow)', () => {
   expect(code).toMatchSnapshot()
 })
 
-test('toCode: function (named)', () => {
-  const code = generateLoaderOptions(false, '..', NUXT_I18N_VUE_I18N_CONFIG, [], {
+test('toCode: function (named)', async () => {
+  const vueI18nConfig = await resolveVueI18nConfigInfo({ vueI18n: NUXT_I18N_VUE_I18N_CONFIG.relative }, '.nuxt', '.')
+  const code = generateLoaderOptions(false, [vueI18nConfig], {
     localeCodes: LOCALE_CODES,
     nuxtI18nOptions: {
       ...NUXT_I18N_OPTIONS,

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,11 @@
 import { parseSegment, getRoutePath, resolveLocales } from '../src/utils'
 import type { LocaleObject } from 'vue-i18n-routing'
 
+vi.mock('pathe', async () => {
+  const mod = await vi.importActual<typeof import('pathe')>('pathe')
+  return { ...mod, resolve: vi.fn((...args: string[]) => mod.normalize(args.join('/'))) }
+})
+
 vi.mock('@nuxt/kit', () => {
   const resolveFiles = () => {
     return [
@@ -30,15 +35,15 @@ test('resolveLocales', async () => {
   const locales = [
     {
       code: 'en',
-      file: 'en.json'
+      files: ['en.json']
     },
     {
       code: 'ja',
-      file: 'ja.json'
+      files: ['ja.json']
     },
     {
       code: 'es',
-      file: 'es.json'
+      files: ['es.json']
     },
     {
       code: 'es-AR',
@@ -46,48 +51,133 @@ test('resolveLocales', async () => {
     },
     {
       code: 'nl',
-      file: 'nl.js'
+      files: ['nl.js']
     }
   ] as LocaleObject[]
-  const resolvedLocales = await resolveLocales('/path/to/project/locales', locales)
+  const resolvedLocales = await resolveLocales('/path/to/project/locales', locales, '..')
   expect(resolvedLocales).toEqual([
     {
-      paths: ['/path/to/project/locales/en.json'],
       code: 'en',
-      files: [{ cache: true, path: 'en.json' }],
-      hashes: ['18f36abf'],
-      types: ['static']
+      files: [{ path: 'en.json', cache: true }],
+      meta: [
+        {
+          path: '/path/to/project/locales/en.json',
+          loadPath: '../en.json',
+          type: 'static',
+          hash: '18f36abf',
+          parsed: {
+            root: '/',
+            dir: '/path/to/project/locales',
+            base: 'en.json',
+            ext: '.json',
+            name: 'en'
+          },
+          key: 'locale__path_to_project_locales_en_json',
+          file: { path: 'en.json', cache: true }
+        }
+      ]
     },
     {
-      paths: ['/path/to/project/locales/ja.json'],
       code: 'ja',
       files: [{ path: 'ja.json', cache: true }],
-      hashes: ['147c88eb'],
-      types: ['static']
+      meta: [
+        {
+          path: '/path/to/project/locales/ja.json',
+          loadPath: '../ja.json',
+          type: 'static',
+          hash: '147c88eb',
+          parsed: {
+            root: '/',
+            dir: '/path/to/project/locales',
+            base: 'ja.json',
+            ext: '.json',
+            name: 'ja'
+          },
+          key: 'locale__path_to_project_locales_ja_json',
+          file: { path: 'ja.json', cache: true }
+        }
+      ]
     },
     {
-      paths: ['/path/to/project/locales/es.json'],
       code: 'es',
       files: [{ path: 'es.json', cache: true }],
-      hashes: ['f4490d2c'],
-      types: ['static']
+      meta: [
+        {
+          path: '/path/to/project/locales/es.json',
+          loadPath: '../es.json',
+          type: 'static',
+          hash: 'f4490d2c',
+          parsed: {
+            root: '/',
+            dir: '/path/to/project/locales',
+            base: 'es.json',
+            ext: '.json',
+            name: 'es'
+          },
+          key: 'locale__path_to_project_locales_es_json',
+          file: { path: 'es.json', cache: true }
+        }
+      ]
     },
     {
-      paths: ['/path/to/project/locales/es.json', '/path/to/project/locales/es-AR.json'],
       code: 'es-AR',
       files: [
         { path: 'es.json', cache: true },
         { path: 'es-AR.json', cache: true }
       ],
-      hashes: ['f4490d2c', '96ad3952'],
-      types: ['static', 'static']
+      meta: [
+        {
+          path: '/path/to/project/locales/es.json',
+          loadPath: '../es.json',
+          type: 'static',
+          hash: 'f4490d2c',
+          parsed: {
+            root: '/',
+            dir: '/path/to/project/locales',
+            base: 'es.json',
+            ext: '.json',
+            name: 'es'
+          },
+          key: 'locale__path_to_project_locales_es_json',
+          file: { path: 'es.json', cache: true }
+        },
+        {
+          path: '/path/to/project/locales/es-AR.json',
+          loadPath: '../es-AR.json',
+          type: 'static',
+          hash: '96ad3952',
+          parsed: {
+            root: '/',
+            dir: '/path/to/project/locales',
+            base: 'es-AR.json',
+            ext: '.json',
+            name: 'es-AR'
+          },
+          key: 'locale__path_to_project_locales_es_AR_json',
+          file: { path: 'es-AR.json', cache: true }
+        }
+      ]
     },
     {
-      paths: ['/path/to/project/locales/nl.js'],
       code: 'nl',
       files: [{ path: 'nl.js', cache: false }],
-      hashes: ['68b1a130'],
-      types: ['dynamic']
+      meta: [
+        {
+          path: '/path/to/project/locales/nl.js',
+          loadPath: '../nl.js',
+          type: 'dynamic',
+          hash: '68b1a130',
+          parsed: {
+            root: '/',
+            dir: '/path/to/project/locales',
+            base: 'nl.js',
+            ext: '.js',
+            name: 'nl'
+          },
+          key: 'locale__path_to_project_locales_nl_js',
+          file: { path: 'nl.js', cache: false }
+        }
+      ]
     }
   ])
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I think it would be preferable to use a template for the generated options file instead of constructing it programmatically. This is a step toward that, moving logic outside of the generation script will eventually allow us to replace it with a template.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
