### PR TITLE
chore(deps): remove duplicate `debug` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,6 @@
     "@typescript-eslint/parser": "^6.7.2",
     "bumpp": "^9.2.0",
     "changelogithub": "^0.13.0",
-    "debug": "^4.3.4",
     "eslint": "^8.49.0",
     "eslint-config-prettier": "^9.0.0",
     "execa": "^8.0.1",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
`debug` was both present in `dependencies` as well as `devDependencies`, apparently Bun doesn't like this and refuses to install if this is the case 😅.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
