### PR TITLE
fix: transform resources failing when `autoImport` is disabled

### DIFF
--- a/specs/fixtures/issues/2151/app.vue
+++ b/specs/fixtures/issues/2151/app.vue
@@ -1,0 +1,7 @@
+<template>
+  <div>
+    <NuxtLayout>
+      <NuxtPage />
+    </NuxtLayout>
+  </div>
+</template>

--- a/specs/fixtures/issues/2151/i18n.config.ts
+++ b/specs/fixtures/issues/2151/i18n.config.ts
@@ -1,0 +1,12 @@
+import { defineI18nConfig } from '#i18n'
+
+export default defineI18nConfig(() => ({
+  legacy: false,
+  fallbackLocale: 'en',
+  messages: {
+    en: {},
+    ja: {
+      msg: '日本語のメッセージ'
+    }
+  }
+}))

--- a/specs/fixtures/issues/2151/locales/en.js
+++ b/specs/fixtures/issues/2151/locales/en.js
@@ -1,0 +1,5 @@
+import { defineI18nLocale } from '#i18n'
+
+export default defineI18nLocale(() => ({
+  msg: 'English message'
+}))

--- a/specs/fixtures/issues/2151/locales/ja.js
+++ b/specs/fixtures/issues/2151/locales/ja.js
@@ -1,0 +1,3 @@
+import { defineI18nLocale } from '#i18n'
+
+export default defineI18nLocale(() => ({}))

--- a/specs/fixtures/issues/2151/nuxt.config.ts
+++ b/specs/fixtures/issues/2151/nuxt.config.ts
@@ -1,0 +1,38 @@
+export default defineNuxtConfig({
+  ssr: true,
+  components: true,
+  imports: {
+    autoImport: false
+  },
+  modules: ['@nuxtjs/i18n'],
+  i18n: {
+    lazy: true,
+    langDir: 'locales',
+    locales: [
+      {
+        code: 'en',
+        iso: 'en',
+        name: 'English',
+        file: 'en.js'
+      },
+      {
+        code: 'ja',
+        iso: 'ja-JP',
+        name: '日本語',
+        file: 'ja.js'
+      }
+    ],
+    strategy: 'prefix',
+    defaultLocale: 'en',
+    experimental: {
+      jsTsFormatResource: true
+    },
+    // debug: true,
+    detectBrowserLanguage: {
+      useCookie: true,
+      cookieSecure: true,
+      fallbackLocale: 'en',
+      redirectOn: 'no prefix'
+    }
+  }
+})

--- a/specs/fixtures/issues/2151/package.json
+++ b/specs/fixtures/issues/2151/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "nuxt3-test-issues-5151",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "nuxt build",
+    "dev": "nuxt dev",
+    "generate": "nuxt generate",
+    "start": "node .output/server/index.mjs"
+  },
+  "devDependencies": {
+    "@nuxtjs/i18n": "latest",
+    "nuxt": "latest"
+  }
+}

--- a/specs/fixtures/issues/2151/pages/index.vue
+++ b/specs/fixtures/issues/2151/pages/index.vue
@@ -1,0 +1,10 @@
+<template>
+  <h1 id="msg">
+    {{ $t('msg') }}
+  </h1>
+</template>
+
+<script setup>
+import { useI18n } from '#i18n'
+const { locale } = useI18n()
+</script>

--- a/specs/issues/2151.spec.ts
+++ b/specs/issues/2151.spec.ts
@@ -1,0 +1,22 @@
+import { test, describe, expect } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, createPage, url } from '../utils'
+import { getText } from '../helper'
+
+describe('#2151', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL(`../fixtures/issues/2151`, import.meta.url)),
+    browser: true
+  })
+
+  test('should load resources with `autoImport` disabled', async () => {
+    const home = url('/')
+    const page = await createPage(undefined, { locale: 'ja' }) // set browser locale
+
+    await page.goto(home)
+    expect(await getText(page, '#msg')).toEqual('日本語のメッセージ')
+
+    await page.goto(url('/en'))
+    expect(await getText(page, '#msg')).toEqual('English message')
+  })
+})

--- a/src/transform/resource.ts
+++ b/src/transform/resource.ts
@@ -49,8 +49,9 @@ export const ResourcePlugin = createUnplugin((options: ResourcePluginOptions) =>
       }
 
       const pattern = query.locale ? NUXT_I18N_COMPOSABLE_DEFINE_LOCALE : NUXT_I18N_COMPOSABLE_DEFINE_CONFIG
-      const match = code.match(new RegExp(`\\b${pattern}\\s*`))
-      if (match?.[0]) {
+      const matches = code.matchAll(new RegExp(`\\b${pattern}\\s*`, 'g'))
+
+      for (const match of matches) {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         s.remove(match.index!, match.index! + match[0].length)
       }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
#2151 
#2182 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #2151 
Resolves #2182 

The core of these issues seems to be that `defineI18nLocale` or `defineI18nConfig` are only removed once, but with `autoImport` disabled a file will usually contain the string multiple times.

This happened with `autoImport` disabled.
```diff
import { } from "#i18n";
export default defineI18nConfig(() => ({}));
```

My change results in:
```diff
import { } from "#i18n";
export default (() => ({}));
```

Which still looks odd but seems to work fine!

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
