### PR TITLE
docs: differentiate menu between `v7` and `v8` docs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,5 +6,7 @@ test/fixtures
 coverage
 docs/components/content/Logo.vue
 docs/components/content/VoltaBoard.vue
+docs/components/AppHeader.vue
+docs/components/AppHeaderNavigation.vue
 .eslintcache
 src/runtime/templates

--- a/docs/components/AppHeader.vue
+++ b/docs/components/AppHeader.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+/**
+ * See: https://github.com/nuxt-themes/docus/issues/938
+ * Copied from: https://github.com/nuxt-themes/docus/blob/main/components/app/AppHeader.vue
+ */
+
+const { config } = useDocus()
+const { navigation } = useContent()
+const { hasDocSearch } = useDocSearch()
+
+const route = useRoute()
+const isV7 = computed(() => route.path.startsWith('/v7'))
+const hasDialog = computed(() => navigation.value?.length > 1 || navigation.value?.[0]?.children?.length)
+
+defineProps({
+  ...variants
+})
+</script>
+
+<template>
+  <header :class="{ 'has-dialog': hasDialog }">
+    <Container :fluid="config?.header?.fluid">
+      <div class="section left">
+        <AppHeaderDialog v-if="hasDialog" />
+        <AppHeaderLogo />
+        <Badge type="warning" v-if="isV7" style="font-weight: bold">v7.x</Badge>
+      </div>
+
+      <div class="section center">
+        <AppHeaderLogo v-if="hasDialog" />
+        <AppHeaderNavigation />
+      </div>
+
+      <div class="section right">
+        <AppDocSearch v-if="hasDocSearch" />
+        <AppSearch v-else :fuse="config.fuse" />
+        <ThemeSelect />
+        <div class="social-icons">
+          <AppSocialIcons />
+        </div>
+      </div>
+    </Container>
+  </header>
+</template>
+
+<style scoped lang="ts">
+css({
+  ':deep(.icon)': {
+    width: '{space.4}',
+    height: '{space.4}'
+  },
+
+  '.navbar-logo': {
+    '.left &': {
+      '.has-dialog &': {
+        display: 'none',
+        '@lg': {
+          display: 'block'
+        }
+      }
+    },
+    '.center &': {
+      display: 'block',
+      '@lg': {
+        display: 'none'
+      }
+    }
+  },
+
+  header: {
+    backdropFilter: '{elements.backdrop.filter}',
+    position: 'sticky',
+    top: 0,
+    zIndex: 10,
+    width: '100%',
+    borderBottom: '1px solid {elements.border.primary.static}',
+    backgroundColor: '{elements.backdrop.background}',
+    height: '{docus.header.height}',
+
+    '.container': {
+      display: 'grid',
+      height: '100%',
+      gridTemplateColumns: 'repeat(12, minmax(0, 1fr))',
+      gap: '{space.2}'
+    },
+
+    '.section': {
+      display: 'flex',
+      alignItems: 'center',
+      flex: 'none',
+      '&.left': {
+        gridColumn: 'span 4 / span 4',
+        '@lg': {
+          marginLeft: 0
+        }
+      },
+      '&.center': {
+        gridColumn: 'span 4 / span 4',
+        justifyContent: 'center',
+        flex: '1',
+        zIndex: '1'
+      },
+      '&.right': {
+        display: 'flex',
+        gridColumn: 'span 4 / span 4',
+        justifyContent: 'flex-end',
+        alignItems: 'center',
+        flex: 'none',
+        marginRight: 'calc(0px - {space.4})',
+        '.social-icons': {
+          display: 'none',
+          '@md': {
+            display: 'flex',
+            alignItems: 'center'
+          }
+        }
+      }
+    }
+  }
+})
+</style>

--- a/docs/components/AppHeaderNavigation.vue
+++ b/docs/components/AppHeaderNavigation.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+/**
+ * See: https://github.com/nuxt-themes/docus/issues/938
+ * Copied from: https://github.com/nuxt-themes/docus/blob/main/components/app/AppHeaderNavigation.vue
+ */
+
+const route = useRoute()
+const { navBottomLink } = useContentHelpers()
+const { navigation } = useContent()
+const { config } = useDocus()
+
+const isV7 = computed(() => route.path.startsWith('/v7'))
+const hasNavigation = computed(() => !!config.value.aside?.level)
+
+const filtered = computed(() => [...(config.value.header?.exclude || [])])
+
+const dynamicNavigation = computed(() => {
+  if (isV7.value) return [{ title: 'Switch to v8 Docs', _path: '/' }]
+  return navigation.value
+})
+
+const tree = computed(() => {
+  return (dynamicNavigation.value || []).filter((item: any) => {
+    if (filtered.value.includes(item._path as never)) {
+      return false
+    }
+    return true
+  })
+})
+
+const isActive = (link: any) => (link.exact ? route.fullPath === link._path : route.fullPath.startsWith(link._path))
+</script>
+
+<template>
+  <nav v-if="hasNavigation">
+    <ul>
+      <li v-for="link in tree" :key="link._path">
+        <NuxtLink
+          class="link"
+          :to="link.redirect ? link.redirect : navBottomLink(link)"
+          :class="{ active: isActive(link) }"
+        >
+          <Icon v-if="link.icon && config?.header?.showLinkIcon" :name="link.icon" />
+          {{ link.title }}
+        </NuxtLink>
+      </li>
+    </ul>
+  </nav>
+</template>
+
+<style scoped lang="ts">
+css({
+  nav: {
+    display: 'none',
+    '@lg': {
+      display: 'block'
+    },
+    ul: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flex: '1',
+      maxWidth: '100%',
+      truncate: true,
+
+      '& > * + *': {
+        marginLeft: '{space.2}'
+      },
+
+      li: {
+        display: 'inline-flex',
+        gap: '{space.1}'
+      },
+
+      '.link': {
+        display: 'flex',
+        alignItems: 'center',
+        gap: '{space.2}',
+        padding: '{space.2} {space.4}',
+        fontSize: '{fontSize.sm}',
+        borderRadius: '{radii.md}',
+        outline: 'none',
+        transition: 'background 200ms ease',
+
+        svg: {
+          display: 'inline-block'
+        },
+
+        '&:active,&.active,&:hover': {
+          backgroundColor: '{color.gray.100}',
+          '@dark': {
+            backgroundColor: '{color.gray.900}'
+          }
+        },
+
+        '&.active': {
+          boxShadow: 'inset 0 2px 4px 0 rgb(0 0 0 / 0.05)',
+          fontWeight: '{fontWeight.semibold}'
+        }
+      }
+    }
+  }
+})
+</style>

--- a/docs/content/1.getting-started/1.setup.md
+++ b/docs/content/1.getting-started/1.setup.md
@@ -1,9 +1,8 @@
 # Setup
 
 ::alert{type="warning"}
-❗IMPORTANT
-
-- From this section, this documentation is for Nuxt i18n module (`@nuxtjs/i18n`) v8 RC. If you would like to use v7.x, see [here](../v7/setup)
+You are reading the `v8 RC` documentation compatible with **Nuxt 3**. :br :br
+Checkout the `v7` documentation for Nuxt 2 [here](../v7/setup). 
 ::
 
 ::alert{type="info"}

--- a/docs/content/7.v7/_dir.yml
+++ b/docs/content/7.v7/_dir.yml
@@ -1,1 +1,1 @@
-title: v7
+title: v7 Docs


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Not sure if I should directly commit and push to `docs/v7-on-v8` or if a PR on the branch like this is preferred. I changed the docs so that the menu for `v8` is hidden when viewing `v7` documentation and added a simple indicator. 

Unfortunately right now this only seems to work for the menu viewed on large screens, the mobile menu still shows all documentation right now.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
