### PR TITLE
test: fix flaky tests

### DIFF
--- a/specs/basic_usage.spec.ts
+++ b/specs/basic_usage.spec.ts
@@ -54,7 +54,7 @@ test('basic usage', async () => {
   // URL path with Route object with `useLocaleRoute`
   const button = await page.locator('#locale-route-usages button')
   await button.click()
-  await page.waitForTimeout(100)
+  await page.waitForURL('**/user/profile?foo=1')
   expect(await getText(page, '#profile-page')).toEqual('This is profile page')
   expect(await page.url()).include('/user/profile?foo=1')
 })

--- a/specs/browser_language_detection/cookie.spec.ts
+++ b/specs/browser_language_detection/cookie.spec.ts
@@ -26,7 +26,6 @@ test('detection with cookie', async () => {
   const page = await createPage(undefined, { locale: 'en' })
   await page.goto(home)
   const ctx = await page.context()
-
   // click `fr` lang switch link
   await page.locator('#set-locale-link-fr').click()
   expect(await ctx.cookies()).toMatchObject([
@@ -35,19 +34,15 @@ test('detection with cookie', async () => {
 
   // navigate to about
   await page.goto(url('/about'))
-
   // detect locale from persisted cookie
   expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('fr')
-
   // navigate with home link
   await page.locator('#link-home').click()
-  await page.waitForTimeout(100)
 
   // locale in home
   expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('fr')
 
   // click `fr` lang switch link
   await page.locator('#set-locale-link-en').click()
-  await page.waitForTimeout(100)
   expect(await ctx.cookies()).toMatchObject([{ name: 'my_custom_cookie_name', value: 'en' }])
 })

--- a/specs/browser_language_detection/disable.spec.ts
+++ b/specs/browser_language_detection/disable.spec.ts
@@ -23,7 +23,6 @@ test('disable', async () => {
 
   // click `fr` lang switch link
   await page.locator('#set-locale-link-fr').click()
-  await page.waitForTimeout(100)
   expect(await ctx.cookies()).toMatchObject([])
 
   // navigate to about
@@ -34,11 +33,9 @@ test('disable', async () => {
 
   // click `fr` lang switch link
   await page.locator('#set-locale-link-fr').click()
-  await page.waitForTimeout(100)
 
   // navigate with home link
   await page.locator('#link-home').click()
-  await page.waitForTimeout(100)
 
   // set default locale
   expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('fr')

--- a/specs/custom_route_paths/component.spec.ts
+++ b/specs/custom_route_paths/component.spec.ts
@@ -20,15 +20,17 @@ test('can access to custom route path', async () => {
   await page.goto(home)
 
   await page.locator('#link-blog').click()
-  await page.waitForTimeout(500)
+  await page.waitForURL('**/blog-us')
 
   expect(await page.url()).include('/blog-us')
 
   await page.goBack()
+  await page.waitForURL('**/')
   await page.locator('#lang-switcher-with-nuxt-link a').click()
+  await page.waitForURL('**/fr')
 
   await page.locator('#link-blog').click()
-  await page.waitForTimeout(100)
+  await page.waitForURL('**/fr/a-blog')
 
   expect(await page.url()).include('/fr/a-blog')
 })
@@ -39,15 +41,17 @@ test('can access to custom dynamic route path', async () => {
   await page.goto(home)
 
   await page.locator('#link-category').click()
-  await page.waitForTimeout(100)
+  await page.waitForURL('**/categories/foo')
 
   expect(await page.url()).include('/categories/foo')
 
   await page.goBack()
+  await page.waitForURL('**/')
   await page.locator('#lang-switcher-with-nuxt-link a').click()
+  await page.waitForURL('**/fr')
 
   await page.locator('#link-category').click()
-  await page.waitForTimeout(100)
+  await page.waitForURL('**' + encodeURI('/fr/catégories/foo'))
 
   expect(await page.url()).include(encodeURI('/fr/catégories/foo'))
 })

--- a/specs/custom_route_paths/module_configration.spec.ts
+++ b/specs/custom_route_paths/module_configration.spec.ts
@@ -33,14 +33,14 @@ test('can access to custom route path', async () => {
 
   // click `fr` switching link
   await page.locator('#lang-switcher-with-nuxt-link a').click()
-  await page.waitForTimeout(100)
+  await page.waitForURL('**/fr')
 
   // page path
   expect(await getData(page, '#home-use-async-data')).toMatchObject({ aboutPath: '/fr/about-fr' })
 
   // navigate to about page for `fr`
   await page.locator('#link-about').click()
-  await page.waitForTimeout(100)
+  await page.waitForURL('**/fr/about-fr')
 
   expect(await getText(page, '#about-header')).toEqual('À propos')
   expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('fr')
@@ -54,13 +54,13 @@ test('can access to custom nested route path', async () => {
 
   // navigate to blog index page
   await page.locator('#link-blog').click()
-  await page.waitForTimeout(100)
+  await page.waitForURL('**/news')
 
   expect(await page.url()).include('/news')
 
   // navigate to blog article page
   await page.locator('#link-blog-article').click()
-  await page.waitForTimeout(100)
+  await page.waitForURL('**/news/article')
 
   expect(await page.url()).include('/news/article')
 })

--- a/specs/fixtures/component/app.vue
+++ b/specs/fixtures/component/app.vue
@@ -10,6 +10,7 @@ const onBeforeEnter = async () => {
 <template>
   <NuxtLayout>
     <NuxtPage
+      id="nuxt-page"
       :transition="{
         name: 'my',
         mode: 'out-in',

--- a/specs/fixtures/switcher/app.vue
+++ b/specs/fixtures/switcher/app.vue
@@ -10,6 +10,7 @@ const onBeforeEnter = async () => {
 <template>
   <NuxtLayout>
     <NuxtPage
+      id="nuxt-page"
       :transition="{
         name: 'my',
         mode: 'out-in',

--- a/specs/helper.ts
+++ b/specs/helper.ts
@@ -11,6 +11,10 @@ export async function getData(page: Page, selector: string, options?: Parameters
   return JSON.parse(await page.locator(selector, options).innerText())
 }
 
+export async function waitForTransition(page: Page, selector: string = '#nuxt-page.my-leave-active') {
+  return await page.locator(selector).waitFor({ state: 'detached' })
+}
+
 export async function assetLocaleHead(page: Page, headSelector: string) {
   const localeHeadValue = await getData(page, headSelector)
   const headHandle = await page.locator('head').elementHandle()

--- a/specs/ignoring_localized_route/disable/component.spec.ts
+++ b/specs/ignoring_localized_route/disable/component.spec.ts
@@ -23,7 +23,7 @@ test('can not access to disable route path', async () => {
 
   // click `fr` switching link
   await page.locator('#lang-switcher-with-nuxt-link a').click()
-  await page.waitForTimeout(100)
+  await page.waitForURL('**/fr')
 
   // disalbe href with <NuxtLink>
   expect(await page.locator('#link-ignore-disable').getAttribute('href')).toBe(null)

--- a/specs/ignoring_localized_route/disable/module_configration.spec.ts
+++ b/specs/ignoring_localized_route/disable/module_configration.spec.ts
@@ -32,7 +32,7 @@ test('can not access to disable route path', async () => {
 
   // click `fr` switching link
   await page.locator('#lang-switcher-with-nuxt-link a').click()
-  await page.waitForTimeout(100)
+  await page.waitForURL('**/fr')
 
   // disalbe href with <NuxtLink>
   expect(await page.locator('#link-about').getAttribute('href')).toBe(null)

--- a/specs/ignoring_localized_route/pick/component.spec.ts
+++ b/specs/ignoring_localized_route/pick/component.spec.ts
@@ -21,7 +21,7 @@ test('can not access to pick route path', async () => {
 
   // click `fr` switching link
   await page.locator('#lang-switcher-with-nuxt-link a').click()
-  await page.waitForTimeout(100)
+  await page.waitForURL('**/fr')
 
   // pick href with <NuxtLink>
   expect(await page.locator('#link-ignore-pick').getAttribute('href')).toBe('/fr/ignore-routes/pick')

--- a/specs/ignoring_localized_route/pick/module_configration.spec.ts
+++ b/specs/ignoring_localized_route/pick/module_configration.spec.ts
@@ -34,7 +34,7 @@ test('can not access to pick route path', async () => {
 
   // click `fr` switching link
   await page.locator('#lang-switcher-with-nuxt-link a').click()
-  await page.waitForTimeout(100)
+  await page.waitForURL('**/fr')
 
   // disalbe href with <NuxtLink>
   expect(await page.locator('#link-about').getAttribute('href')).toBe(null)

--- a/specs/issues/2247.spec.ts
+++ b/specs/issues/2247.spec.ts
@@ -14,33 +14,43 @@ describe('#2247', async () => {
     await page.goto(home)
 
     await page.locator('#root-en').click()
+    await page.waitForURL('**/en')
     expect(await getText(page, '#route-path')).include('/en')
 
     await page.locator('#root').click()
+    await page.waitForURL('**/')
     expect(await getText(page, '#route-path')).include('/')
 
     await page.locator('#about-en').click()
+    await page.waitForURL('**/en/about')
     expect(await getText(page, '#route-path')).include('/en/about')
 
     await page.locator('#root').click()
+    await page.waitForURL('**/')
     expect(await getText(page, '#route-path')).include('/')
 
     await page.locator('#about').click()
+    await page.waitForURL('**/about')
     expect(await getText(page, '#route-path')).include('/about')
 
     await page.locator('#about-ar').click()
+    await page.waitForURL('**/ar/about')
     expect(await getText(page, '#route-path')).include('/ar/about')
 
     await page.locator('#root').click()
+    await page.waitForURL('**/')
     expect(await getText(page, '#route-path')).include('/')
 
     await page.locator('#example-ar').click()
+    await page.waitForURL('**/ar/example')
     expect(await getText(page, '#route-path')).include('/ar/example')
 
     await page.locator('#about-ar').click()
+    await page.waitForURL('**/ar/about')
     expect(await getText(page, '#route-path')).include('/ar/about')
 
     await page.locator('#root').click()
+    await page.waitForURL('**/')
     expect(await getText(page, '#route-path')).include('/')
   })
 })

--- a/specs/issues/2288.spec.ts
+++ b/specs/issues/2288.spec.ts
@@ -15,27 +15,27 @@ describe('#2288', async () => {
 
     // goto to `/en/about`
     await page.locator('#about-en').click()
-    await page.waitForTimeout(10)
+    await page.waitForURL('**/en/about')
     expect(await page.url().endsWith('/en/about')).toBe(true)
 
     // change to `ar`
     await page.locator('#ar').click()
-    await page.waitForTimeout(10)
+    await page.waitForURL('**/about')
     expect(await page.url().endsWith('/about')).toBe(true)
 
     // change to `en`
     await page.locator('#en').click()
-    await page.waitForTimeout(10)
+    await page.waitForURL('**/en/about')
     expect(await page.url().endsWith('/en/about')).toBe(true)
 
     // goto to `/ar/example`
     await page.locator('#example-ar').click()
-    await page.waitForTimeout(10)
+    await page.waitForURL('**/ar/example')
     expect(await page.url().endsWith('/ar/example')).toBe(true)
 
     // goto to `/en/example`
     await page.locator('#example-en').click()
-    await page.waitForTimeout(10)
+    await page.waitForURL('**/en/example')
     expect(await page.url().endsWith('/en/example')).toBe(true)
   })
 })

--- a/specs/lang_switcher.spec.ts
+++ b/specs/lang_switcher.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, describe } from 'vitest'
 import { fileURLToPath } from 'node:url'
 import { setup, url, createPage } from './utils'
-import { getText, getData } from './helper'
+import { getText, getData, waitForTransition } from './helper'
 
 await setup({
   rootDir: fileURLToPath(new URL(`./fixtures/switcher`, import.meta.url)),
@@ -22,7 +22,8 @@ test('switching', async () => {
 
   // click `fr` lang switch with `<NuxtLink>`
   await page.locator('#lang-switcher-with-nuxt-link a').click()
-  await page.waitForTimeout(1000)
+  await waitForTransition(page)
+  await page.waitForURL('**/fr')
 
   // `fr` rendering
   expect(await getText(page, '#home-header')).toMatch('Accueil')
@@ -34,7 +35,8 @@ test('switching', async () => {
 
   // click `en` lang switch with `setLocale`
   await page.locator('#set-locale-link-en').click()
-  await page.waitForTimeout(1000)
+  await waitForTransition(page)
+  await page.waitForURL('**/')
 
   // page path
   expect(await getData(page, '#home-use-async-data')).toMatchObject({
@@ -51,11 +53,11 @@ test('retains query parameters', async () => {
   const home = url('/?foo=123')
   const page = await createPage()
   await page.goto(home)
-  await page.waitForTimeout(1000)
   expect(page.url()).include('/?foo=123')
 
   await page.locator('#lang-switcher-with-nuxt-link a').click()
-  await page.waitForTimeout(1000)
+  await waitForTransition(page)
+  await page.waitForURL('**/fr?foo=123')
   expect(page.url()).include('/fr?foo=123')
 })
 
@@ -67,11 +69,13 @@ describe('dynamic route parameter', () => {
 
     // go to dynamic route page
     await page.locator('#link-post').click()
-    await page.waitForTimeout(1000)
+    await waitForTransition(page)
+    await page.waitForURL('**/post/id')
 
     // click `fr` lang switch with `<NuxtLink>`
     await page.locator('#lang-switcher-with-nuxt-link a').click()
-    await page.waitForTimeout(1000)
+    await waitForTransition(page)
+    await page.waitForURL('**/fr/post/mon-article')
     expect(await getText(page, '#post-id')).toMatch('mon-article')
     expect(await page.url()).include('mon-article')
   })
@@ -83,7 +87,8 @@ describe('dynamic route parameter', () => {
 
     // click `fr` lang switch with `<NuxtLink>`
     await page.locator('#lang-switcher-with-nuxt-link a').click()
-    await page.waitForTimeout(1000)
+    await waitForTransition(page)
+    await page.waitForURL('**/fr/mon-article/xyz')
     expect(await getText(page, '#catch-all-id')).toMatch('mon-article/xyz')
     expect(await page.url()).include('mon-article/xyz')
   })
@@ -98,11 +103,13 @@ test('wait for page transition', async () => {
 
   // click `fr` lang switching
   await page.locator('#lang-switcher-with-nuxt-link a').click()
-  await page.waitForTimeout(3000)
+  await waitForTransition(page)
+  await page.waitForURL('**/fr')
   expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('fr')
 
   // click `en` lang switching
   await page.locator('#lang-switcher-with-nuxt-link a').click()
-  await page.waitForTimeout(3000)
+  await waitForTransition(page)
+  await page.waitForURL('**/')
   expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('en')
 })

--- a/specs/layers/layers_vuei18n_options.spec.ts
+++ b/specs/layers/layers_vuei18n_options.spec.ts
@@ -28,17 +28,19 @@ describe('nuxt layers vuei18n options', async () => {
     const home = url('/')
     const page = await createPage(undefined)
     await page.goto(home)
-    await page.waitForTimeout(1000)
+    await page.waitForURL('**/')
 
     expect(await getText(page, '#snake-case')).toEqual('Over-deze-site')
     expect(await getText(page, '#pascal-case')).toEqual('OverDezeSite')
 
     await page.click(`#set-locale-link-en`)
+    await page.waitForURL('**/en')
     expect(await getText(page, '#snake-case')).toEqual('About-this-site')
     expect(await getText(page, '#pascal-case')).toEqual('AboutThisSite')
     expect(await getText(page, '#fallback-message')).toEqual('Unieke vertaling')
 
     await page.click(`#set-locale-link-fr`)
+    await page.waitForURL('**/fr')
     expect(await getText(page, '#snake-case')).toEqual('À-propos-de-ce-site')
     expect(await getText(page, '#pascal-case')).toEqual('ÀProposDeCeSite')
     expect(await getText(page, '#fallback-message')).toEqual('Unieke vertaling')

--- a/specs/lazy_load/basic_lazy_load.spec.ts
+++ b/specs/lazy_load/basic_lazy_load.spec.ts
@@ -23,6 +23,7 @@ describe('basic lazy loading', async () => {
     const dynamicTime = await getText(page, '#dynamic-time')
 
     await page.click('#lang-switcher-with-nuxt-link-fr')
+    await page.waitForURL('**/fr')
     expect(await getText(page, '#dynamic-time')).toEqual('Not dynamic')
 
     // dynamicTime depends on passage of some time
@@ -30,6 +31,7 @@ describe('basic lazy loading', async () => {
 
     // dynamicTime does not match captured dynamicTime
     await page.click('#lang-switcher-with-nuxt-link-nl')
+    await page.waitForURL('**/nl')
     expect(await getText(page, '#dynamic-time')).to.not.equal(dynamicTime)
   })
 

--- a/specs/locale_fallback.spec.ts
+++ b/specs/locale_fallback.spec.ts
@@ -24,6 +24,7 @@ test('fallback to target lang', async () => {
 
   // click `ja` lang switch with `<NuxtLink>`
   await page.locator('#lang-switcher-with-nuxt-link-ja a').click()
+  await page.waitForURL('**/ja')
 
   // fallback to en content translation
   expect(await getText(page, '#home-header')).toEqual('Homepage')

--- a/specs/per_component_translations.spec.ts
+++ b/specs/per_component_translations.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from 'vitest'
 import { fileURLToPath } from 'node:url'
 import { setup, url, createPage } from './utils'
-import { getText } from './helper'
+import { getText, waitForTransition } from './helper'
 
 await setup({
   rootDir: fileURLToPath(new URL(`./fixtures/component`, import.meta.url)),
@@ -21,17 +21,17 @@ test('i18n custom block', async () => {
 
   // click `fr` lang switch with `<NuxtLink>`
   await page.locator('#lang-switcher-with-nuxt-link a').click()
-  await page.waitForTimeout(1000)
+  await waitForTransition(page)
 
   // go to category page
   await page.locator('#link-category').click()
-  await page.waitForTimeout(1000)
+  await waitForTransition(page)
 
   expect(await getText(page, '#per-component-hello')).toMatch('Bonjour!')
 
   // click `en` lang switch with `<NuxtLink>`
   await page.locator('#lang-switcher-with-nuxt-link a').click()
-  await page.waitForTimeout(1000)
+  await waitForTransition(page)
 
   expect(await getText(page, '#per-component-hello')).toMatch('Hello!')
 })

--- a/specs/register_module.spec.ts
+++ b/specs/register_module.spec.ts
@@ -19,12 +19,13 @@ test('register module hook', async () => {
 
   // click `fr` lang switch link
   await page.locator('.switch-to-fr a').click()
+  await page.waitForURL('**/fr')
 
   expect(await getText(page, '#register-module')).toEqual('This is a merged module layer locale key in French')
 
   // click `nl` lang switch link
   await page.locator('.switch-to-nl a').click()
-  await page.waitForLoadState('networkidle')
+  await page.waitForURL('**/nl')
 
   expect(await getText(page, '#register-module')).toEqual('This is a merged module layer locale key in Dutch')
 })

--- a/specs/routing_strategies/no_prefix.spec.ts
+++ b/specs/routing_strategies/no_prefix.spec.ts
@@ -61,7 +61,7 @@ describe('strategy: no_prefix', async () => {
 
     // click `fr` lang switch link (`setLocale`)
     await page.locator('#lang-switcher-with-set-locale a').click()
-    await page.waitForTimeout(100)
+    await page.waitForURL('**/')
 
     // `fr` rendering
     expect(await getText(page, '#home-header')).toEqual('Accueil')

--- a/specs/routing_strategies/prefix.spec.ts
+++ b/specs/routing_strategies/prefix.spec.ts
@@ -97,7 +97,7 @@ describe('strategy: prefix', async () => {
 
     // click `fr` lang switch link
     await page.locator('#lang-switcher-with-nuxt-link a').click()
-    await page.waitForTimeout(100)
+    await page.waitForURL('**/fr')
 
     // `fr` rendering
     expect(await getText(page, '#home-header')).toEqual('Accueil')

--- a/specs/routing_strategies/prefix_and_default.spec.ts
+++ b/specs/routing_strategies/prefix_and_default.spec.ts
@@ -105,7 +105,7 @@ describe('strategy: prefix_and_default', async () => {
 
     // click `fr` lang switch link with NuxtLink
     await page.locator('#lang-switcher-with-nuxt-link a').click()
-    await page.waitForTimeout(100)
+    await page.waitForURL('**/fr')
 
     // `fr` rendering
     expect(await getText(page, '#home-header')).toEqual('Accueil')
@@ -125,9 +125,9 @@ describe('strategy: prefix_and_default', async () => {
 
     // click `en` and `fr` lang switch link with setLocale
     await page.locator('#set-locale-link-en').click()
-    await page.waitForTimeout(100)
+    await page.waitForURL('**/')
     await page.locator('#set-locale-link-fr').click()
-    await page.waitForTimeout(100)
+    await page.waitForURL('**/fr')
 
     // navigation URL
     expect(await page.url()).toEqual(url('/fr'))

--- a/specs/routing_strategies/prefix_except_default.spec.ts
+++ b/specs/routing_strategies/prefix_except_default.spec.ts
@@ -81,7 +81,7 @@ describe('default strategy: prefix_except_default', async () => {
 
     // click `fr` lang switch link with NuxtLink
     await page.locator('#lang-switcher-with-nuxt-link a').click()
-    await page.waitForTimeout(100)
+    await page.waitForURL('**/fr')
 
     // `fr` rendering
     expect(await getText(page, '#home-header')).toEqual('Accueil')
@@ -101,9 +101,9 @@ describe('default strategy: prefix_except_default', async () => {
 
     // click `en` and `fr` lang switch link with setLocale
     await page.locator('#set-locale-link-en').click()
-    await page.waitForTimeout(100)
+    await page.waitForURL('**/')
     await page.locator('#set-locale-link-fr').click()
-    await page.waitForTimeout(100)
+    await page.waitForURL('**/fr')
 
     // navigation URL
     expect(await page.url()).toEqual(url('/fr'))

--- a/specs/runtime_hooks.spec.ts
+++ b/specs/runtime_hooks.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from 'vitest'
+import { test, expect, describe } from 'vitest'
 import { fileURLToPath } from 'node:url'
 import { setup, url, createPage } from './utils'
 import { getText } from './helper'
@@ -35,11 +35,11 @@ describe('beforeLocaleSwitch / localeSwitched', () => {
 
     // navigate to about page
     await page.locator('#link-about').click()
-    await page.waitForTimeout(1000)
+    await page.waitForURL('**/fr/about')
 
     // navigate to home page
     await page.locator('#link-home').click()
-    await page.waitForTimeout(1000)
+    await page.waitForURL('**/fr')
   })
 
   test('setLocale', async () => {

--- a/specs/seo/metaComponent.spec.ts
+++ b/specs/seo/metaComponent.spec.ts
@@ -25,7 +25,7 @@ test('render with meta components', async () => {
 
   // title tag
   expect(await getText(page, 'title')).toMatch('Page - Homepage')
-  await page.waitForTimeout(100)
+  await page.waitForURL('**/')
 
   // html tag `lang` attriute
   expect(await page.getAttribute('html', 'lang')).toMatch('en')
@@ -42,7 +42,7 @@ test('render with meta components', async () => {
 
   // click `fr` lang switch link
   await page.locator('#lang-switcher-with-nuxt-link a').click()
-  await page.waitForTimeout(100)
+  await page.waitForURL('**/fr')
 
   // title tag
   expect(await getText(page, 'title')).toMatch('Page - Accueil')
@@ -59,7 +59,7 @@ test('render with meta components', async () => {
 
   // click about page
   await page.locator('#link-about').click()
-  await page.waitForTimeout(100)
+  await page.waitForURL('**/fr/about')
 
   // title tag
   expect(await getText(page, 'title')).toMatch('Page - À propos')

--- a/specs/seo/useHead.spec.ts
+++ b/specs/seo/useHead.spec.ts
@@ -44,7 +44,7 @@ test('render with useHead', async () => {
 
   // click `fr` lang switch link
   await page.locator('#lang-switcher-with-nuxt-link a').click()
-  await page.waitForTimeout(100)
+  await page.waitForURL('**/fr')
 
   // title tag
   expect(await getText(page, 'title')).toMatch('Accueil')

--- a/specs/utils/server.ts
+++ b/specs/utils/server.ts
@@ -15,32 +15,37 @@ const kit: typeof _kit = _kit.default || _kit
 export async function startServer() {
   const ctx = useTestContext()
   await stopServer()
-  const port = ctx.options.port || (await getRandomPort())
-  ctx.url = 'http://127.0.0.1:' + port
+  const host = '127.0.0.1'
+  const port = ctx.options.port || (await getRandomPort(host))
+  ctx.url = `http://${host}:${port}`
   if (ctx.options.dev) {
     const nuxiCLI = await kit.resolvePath('nuxi/cli')
-    ctx.serverProcess = execa(nuxiCLI, ['dev'], {
+    ctx.serverProcess = execa(nuxiCLI, ['_dev'], {
       cwd: ctx.nuxt!.options.rootDir,
       stdio: 'inherit',
       env: {
         ...process.env,
+        _PORT: String(port), // Used by internal _dev command
         PORT: String(port),
-        NITRO_PORT: String(port),
+        HOST: host,
         NODE_ENV: 'development'
       }
     })
-    await waitForPort(port, { retries: 32 })
-    for (let i = 0; i < 50; i++) {
+    await waitForPort(port, { retries: 32, host }).catch(() => {})
+    let lastError
+    for (let i = 0; i < 150; i++) {
       await new Promise(resolve => setTimeout(resolve, 100))
       try {
         const res = await $fetch(ctx.nuxt!.options.app.baseURL)
         if (!res.includes('__NUXT_LOADING__')) {
           return
         }
-      } catch {}
+      } catch (e) {
+        lastError = e
+      }
     }
     ctx.serverProcess.kill()
-    throw new Error('Timeout waiting for dev server!')
+    throw lastError || new Error('Timeout waiting for dev server!')
   } else if (ctx.options.prerender) {
     const command = `npx serve -s ./dist -p ${port}`
     const [_command, ...commandArgs] = command.split(' ')
@@ -66,11 +71,11 @@ export async function startServer() {
       env: {
         ...process.env,
         PORT: String(port),
-        NITRO_PORT: String(port),
+        HOST: host,
         NODE_ENV: 'test'
       }
     })
-    await waitForPort(port, { retries: 8 })
+    await waitForPort(port, { retries: 20, host })
   }
 }
 

--- a/specs/utils/setup/index.ts
+++ b/specs/utils/setup/index.ts
@@ -5,6 +5,7 @@ import { createBrowser } from '../browser'
 import type { TestHooks, TestOptions } from '../types'
 import setupJest from './jest'
 import setupVitest from './vitest'
+import consola from 'consola'
 
 export const setupMaps = {
   jest: setupJest,
@@ -16,6 +17,7 @@ export function createTest(options: Partial<TestOptions>): TestHooks {
 
   const beforeEach = () => {
     setTestContext(ctx)
+    consola.restoreConsole()
   }
 
   const afterEach = () => {

--- a/specs/utils/types.ts
+++ b/specs/utils/types.ts
@@ -1,6 +1,7 @@
 import type { Nuxt, NuxtConfig } from '@nuxt/schema'
 import type { ExecaChildProcess } from 'execa'
 import type { Browser, LaunchOptions } from 'playwright'
+import type { NuxtI18nOptions } from '../../src/types'
 
 export type TestRunner = 'vitest' | 'jest'
 
@@ -10,7 +11,7 @@ export interface TestOptions {
   configFile: string
   rootDir: string
   buildDir: string
-  nuxtConfig: NuxtConfig
+  nuxtConfig: NuxtConfig & { i18n?: NuxtI18nOptions }
   build: boolean
   dev: boolean
   prerender: boolean // NOTE: this option for `nuxi generate` emulation

--- a/specs/vue_i18n_custom_options.spec.ts
+++ b/specs/vue_i18n_custom_options.spec.ts
@@ -21,11 +21,11 @@ test('load option successfully', async () => {
 
   // click `fr` lang switch link
   await page.locator('#lang-switcher-with-nuxt-link a').click()
-  await page.waitForTimeout(100)
+  await page.waitForURL('**/fr')
   expect(await getText(page, '#home-header')).toEqual('Bonjour-le-monde!')
 
   // click `en` lang switch link
   await page.locator('#lang-switcher-with-nuxt-link a').click()
-  await page.waitForTimeout(100)
+  await page.waitForURL('**/')
   expect(await getText(page, '#home-header')).toEqual('Hello-World!')
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,8 +5,8 @@ export default defineConfig({
     globals: true,
     clearMocks: true,
     restoreMocks: true,
-    threads: false,
     testTimeout: 300000,
+    retry: 1,
     server: {
       deps: {
         inline: [/@nuxt\/test-utils/]


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
#1998
#2446 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
* Resolves #1998 (hopefully)

The playwright docs describe the `page.waitForTimeout` method as 'inherently flaky' and discourage its use. So I have replaced its usage with other more reliable assertions.

Also synced the test-utils I saw in `nuxt/nuxt`.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
