### PR TITLE
test: prevent build collision

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lint": "eslint --cache --ext .js,.ts,.vue,.json .",
     "lint:fix": "pnpm lint --fix",
     "test": "pnpm dev:prepare && run-s test:types test:unit test:spec",
-    "test:types": "tsc --noEmit",
+    "test:types": "tsc --noEmit --project tsconfig.test.json",
     "test:unit": "vitest run test",
     "test:spec": "vitest run specs"
   },

--- a/specs/utils/nuxt.ts
+++ b/specs/utils/nuxt.ts
@@ -3,14 +3,16 @@ import { resolve } from 'node:path'
 import { defu } from 'defu'
 import * as _kit from '@nuxt/kit'
 import { useTestContext } from './context'
-import { parse } from 'pathe'
+import { relative } from 'pathe'
 
 import type { VitestContext } from './types'
 
+const normalizeWithUnderScore = (name: string) => name.replace(/-/g, '_').replace(/\./g, '_').replace(/\//g, '_')
+
 function getTestKey(ctx: VitestContext) {
-  const testPath = ctx.file?.filepath ?? ctx.filepath
-  const testFile = parse(testPath ?? '').base
-  const testKey = testFile.replaceAll('.', '-')
+  const testPath = ctx.file?.filepath ?? ctx.filepath ?? ''
+  const relativePath = relative(__dirname, testPath)
+  const testKey = normalizeWithUnderScore(relativePath)
 
   return testKey
 }

--- a/specs/utils/setup/index.ts
+++ b/specs/utils/setup/index.ts
@@ -2,10 +2,11 @@ import { createTestContext, setTestContext } from '../context'
 import { buildFixture, loadFixture } from '../nuxt'
 import { startServer, stopServer } from '../server'
 import { createBrowser } from '../browser'
-import type { TestHooks, TestOptions } from '../types'
 import setupJest from './jest'
 import setupVitest from './vitest'
 import consola from 'consola'
+
+import type { TestHooks, TestOptions, VitestContext } from '../types'
 
 export const setupMaps = {
   jest: setupJest,
@@ -30,17 +31,19 @@ export function createTest(options: Partial<TestOptions>): TestHooks {
       await stopServer()
       setTestContext(undefined)
     }
+
     if (ctx.nuxt && ctx.nuxt.options.dev) {
       await ctx.nuxt.close()
     }
+
     if (ctx.browser) {
       await ctx.browser.close()
     }
   }
 
-  const setup = async () => {
+  const setup = async (testContext: VitestContext) => {
     if (ctx.options.fixture) {
-      await loadFixture()
+      await loadFixture(testContext)
     }
 
     if (ctx.options.build) {

--- a/specs/utils/types.ts
+++ b/specs/utils/types.ts
@@ -2,6 +2,7 @@ import type { Nuxt, NuxtConfig } from '@nuxt/schema'
 import type { ExecaChildProcess } from 'execa'
 import type { Browser, LaunchOptions } from 'playwright'
 import type { NuxtI18nOptions } from '../../src/types'
+import type { Suite, File } from 'vitest'
 
 export type TestRunner = 'vitest' | 'jest'
 
@@ -42,6 +43,8 @@ export interface TestHooks {
   beforeEach: () => void
   afterEach: () => void
   afterAll: () => void
-  setup: () => void
+  setup: (testContext: VitestContext) => void
   ctx: TestContext
 }
+
+export type VitestContext = Suite | File

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -113,5 +113,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "exclude": ["**/.nuxt/**", "**/*/dist/*", "docs/**", "playground/**", "specs/**", "src/runtime/templates/**"]
+  "exclude": ["**/.nuxt/**", "**/*/dist/*", "docs/**", "playground/**", "specs/**.spec*", "src/runtime/templates/**"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/.nuxt/**", "**/*/dist/*", "docs/**", "playground/**", "specs/**", "src/runtime/templates/**"]
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Our changes to `@nuxt/test-utils` disabled the random numbered subdirectory `buildDir` for tests, this can cause issues when test threads are enabled (which I did in #2452). 

This PR changes the behavior to set the `buildDir` to a subdirectory based on the test filenames, this should make the tests less flaky. It seems the tests run in a random order, so it may be possible that tests failed as they clear and overwrite the build files of other tests when using the same fixtures.

Possibly related to test failures in #2446

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
