### PR TITLE
fix: warn only when vueI18n property is set but not found

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -168,13 +168,6 @@ export default defineNuxtModule<NuxtI18nOptions>({
      */
 
     const vueI18nConfigPaths = await resolveLayerVueI18nConfigInfo(nuxt, nuxt.options.buildDir)
-    for (const vueI18nConfigPath of vueI18nConfigPaths) {
-      if (vueI18nConfigPath.absolute === '') {
-        logger.warn(
-          `Ignore Vue I18n configuration file does not exist at ${vueI18nConfigPath.relative} in ${vueI18nConfigPath.rootDir}. Skipping...`
-        )
-      }
-    }
     debug('VueI18nConfigPaths', vueI18nConfigPaths)
 
     /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -248,24 +248,24 @@ export async function resolveVueI18nConfigInfo(options: NuxtI18nOptions, buildDi
   }
 
   const absolutePath = await resolvePath(configPathInfo.relative, { cwd: rootDir, extensions: EXECUTABLE_EXTENSIONS })
-  if (await isExists(absolutePath)) {
-    const parsed = parsePath(absolutePath)
-    const loadPath = join(configPathInfo.relativeBase, relative(rootDir, absolutePath))
+  if (!(await isExists(absolutePath))) return undefined
 
-    configPathInfo.absolute = absolutePath
-    configPathInfo.type = getLocaleType(absolutePath)
-    configPathInfo.hash = getHash(loadPath)
+  const parsed = parsePath(absolutePath)
+  const loadPath = join(configPathInfo.relativeBase, relative(rootDir, absolutePath))
 
-    const key = `${normalizeWithUnderScore(configPathInfo.relative)}_${configPathInfo.hash}`
+  configPathInfo.absolute = absolutePath
+  configPathInfo.type = getLocaleType(absolutePath)
+  configPathInfo.hash = getHash(loadPath)
 
-    configPathInfo.meta = {
-      path: absolutePath,
-      type: configPathInfo.type,
-      hash: configPathInfo.hash,
-      loadPath,
-      parsed,
-      key
-    }
+  const key = `${normalizeWithUnderScore(configPathInfo.relative)}_${configPathInfo.hash}`
+
+  configPathInfo.meta = {
+    path: absolutePath,
+    type: configPathInfo.type,
+    hash: configPathInfo.hash,
+    loadPath,
+    parsed,
+    key
   }
 
   return configPathInfo

--- a/test/gen.test.ts
+++ b/test/gen.test.ts
@@ -52,7 +52,7 @@ test('basic', async () => {
   const localeInfo = await resolveLocales('/test/srcDir', LOCALE_INFO, '..')
   const vueI18nConfig = await resolveVueI18nConfigInfo({ vueI18n: NUXT_I18N_VUE_I18N_CONFIG.relative }, '.nuxt', '.')
   const code = generateLoaderOptions({
-    vueI18nConfigPaths: [vueI18nConfig],
+    vueI18nConfigPaths: [vueI18nConfig].filter((x): x is Required<VueI18nConfigPathInfo> => x != null),
     localeInfo,
     nuxtI18nOptions: { ...NUXT_I18N_OPTIONS, lazy: false }
   })
@@ -64,7 +64,7 @@ test('lazy', async () => {
   const localeInfo = await resolveLocales('/test/srcDir', LOCALE_INFO, '..')
   const vueI18nConfig = await resolveVueI18nConfigInfo({ vueI18n: NUXT_I18N_VUE_I18N_CONFIG.relative }, '.nuxt', '.')
   const code = generateLoaderOptions({
-    vueI18nConfigPaths: [vueI18nConfig],
+    vueI18nConfigPaths: [vueI18nConfig].filter((x): x is Required<VueI18nConfigPathInfo> => x != null),
     localeInfo,
     nuxtI18nOptions: { ...NUXT_I18N_OPTIONS, lazy: true }
   })
@@ -98,7 +98,7 @@ test('multiple files', async () => {
   const vueI18nConfig = await resolveVueI18nConfigInfo({ vueI18n: NUXT_I18N_VUE_I18N_CONFIG.relative }, '.nuxt', '.')
 
   const code = generateLoaderOptions({
-    vueI18nConfigPaths: [vueI18nConfig],
+    vueI18nConfigPaths: [vueI18nConfig].filter((x): x is Required<VueI18nConfigPathInfo> => x != null),
     localeInfo,
     nuxtI18nOptions: { ...NUXT_I18N_OPTIONS, lazy: true }
   })
@@ -132,7 +132,7 @@ test('files with cache configuration', async () => {
   const vueI18nConfig = await resolveVueI18nConfigInfo({ vueI18n: NUXT_I18N_VUE_I18N_CONFIG.relative }, '.nuxt', '.')
 
   const code = generateLoaderOptions({
-    vueI18nConfigPaths: [vueI18nConfig],
+    vueI18nConfigPaths: [vueI18nConfig].filter((x): x is Required<VueI18nConfigPathInfo> => x != null),
     localeInfo,
     nuxtI18nOptions: { ...NUXT_I18N_OPTIONS, lazy: true }
   })
@@ -165,7 +165,7 @@ test('locale file in nested', async () => {
 
   const vueI18nConfig = await resolveVueI18nConfigInfo({ vueI18n: NUXT_I18N_VUE_I18N_CONFIG.relative }, '.nuxt', '.')
   const code = generateLoaderOptions({
-    vueI18nConfigPaths: [vueI18nConfig],
+    vueI18nConfigPaths: [vueI18nConfig].filter((x): x is Required<VueI18nConfigPathInfo> => x != null),
     localeInfo,
     nuxtI18nOptions: { ...NUXT_I18N_OPTIONS, lazy: true }
   })
@@ -207,7 +207,7 @@ test('vueI18n option', async () => {
 test('toCode: function (arrow)', async () => {
   const vueI18nConfig = await resolveVueI18nConfigInfo({ vueI18n: NUXT_I18N_VUE_I18N_CONFIG.relative }, '.nuxt', '.')
   const code = generateLoaderOptions({
-    vueI18nConfigPaths: [vueI18nConfig],
+    vueI18nConfigPaths: [vueI18nConfig].filter((x): x is Required<VueI18nConfigPathInfo> => x != null),
     localeInfo: [],
     nuxtI18nOptions: {
       ...NUXT_I18N_OPTIONS,
@@ -227,7 +227,7 @@ test('toCode: function (arrow)', async () => {
 test('toCode: function (named)', async () => {
   const vueI18nConfig = await resolveVueI18nConfigInfo({ vueI18n: NUXT_I18N_VUE_I18N_CONFIG.relative }, '.nuxt', '.')
   const code = generateLoaderOptions({
-    vueI18nConfigPaths: [vueI18nConfig],
+    vueI18nConfigPaths: [vueI18nConfig].filter((x): x is Required<VueI18nConfigPathInfo> => x != null),
     localeInfo: [],
     nuxtI18nOptions: {
       ...NUXT_I18N_OPTIONS,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
#2464 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #2464 

Changed the vueI18n config resolution to only warn when `vueI18n` has explicitly been set but could not been found. Users seem to confuse the warning with an error or would like to turn it off as they haven't set the property.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
