### PR TITLE
feat(config): add `site.url` as an alternative to `baseUrl`

### DIFF
--- a/docs/content/2.guide/16.migrating.md
+++ b/docs/content/2.guide/16.migrating.md
@@ -83,9 +83,9 @@ Deprecated for the same reason as the `localeLocation()` Option API.
 
 Use `localeHead()` instead for the Options API style.
 
-### Deprecated `baseUrl` component option
+### `baseUrl` component option
 
-Use `site.url` instead of `i18n.baseUrl`.
+You can use `site.url` instead of `i18n.baseUrl`.
 
 ::alert{type="info"}
 The `site` configuration option stems from [Nuxt SEO's `site-config` module](https://nuxtseo.com/site-config), which `nuxt-i18n` makes use of now.

--- a/docs/content/2.guide/16.migrating.md
+++ b/docs/content/2.guide/16.migrating.md
@@ -16,7 +16,7 @@ You can continue defining `vueI18n` options in `i18n.config`. Refer to the [Vue 
 
 ### Change the route key rules in `pages` option
 
-The key of route set in the `pages` option has been changed to be file-based relative to the `pages/` directory in Nuxt, and **excluding the leading `/`**. 
+The key of route set in the `pages` option has been changed to be file-based relative to the `pages/` directory in Nuxt, and **excluding the leading `/`**.
 
 The reason is that it is more intuitive to match Nuxt file-based routing.
 
@@ -83,6 +83,38 @@ Deprecated for the same reason as the `localeLocation()` Option API.
 
 Use `localeHead()` instead for the Options API style.
 
+### Deprecated `baseUrl` component option
+
+Use `site.url` instead of `i18n.baseUrl`.
+
+::alert{type="info"}
+The `site` configuration option stems from [Nuxt SEO's `site-config` module](https://nuxtseo.com/site-config), which `nuxt-i18n` makes use of now.
+::
+
+Nuxt2:
+```vue {}[nuxt.config.js]
+<script>
+import Vue from 'vue'
+
+export default Vue.extend({
+  nuxtI18n: {
+    baseUrl: 'https://localhost:3000',
+  }
+})
+</script>
+```
+
+Nuxt3:
+```vue {}[nuxt.config.js]
+<script setup>
+defineI18nRoute({
+  site: {
+    url: 'http://localhost:3000'
+  }
+})
+</script>
+```
+
 ### Deprecated `nuxtI18n` component option
 
 Replaced by the `defineI18nRoute()` compiler macro as it can be optimized with bundler.
@@ -122,7 +154,7 @@ Use the `customRoutes` option. because the option name `parsePages` is not intui
    modules: [
      '@nuxtjs/i18n'
    ],
- 
+
    i18n: {
      // ...
 -    parsePages: false,
@@ -141,7 +173,7 @@ Use `dynamicRouteParams` option. Because Vuex is no longer required by the Nuxt 
    modules: [
      '@nuxtjs/i18n'
    ],
- 
+
    i18n: {
      // ...
 -    vuex: true,

--- a/docs/content/2.guide/7.seo.md
+++ b/docs/content/2.guide/7.seo.md
@@ -46,7 +46,7 @@ export default defineNuxtConfig({
 })
 ```
 
-You must also set the `site.url` option to your production domain in order to make alternate URLs fully-qualified:
+You must also set the `baseUrl` or `site.url` option to your production domain in order to make alternate URLs fully-qualified:
 
 ```ts {}[nuxt.config.ts]
 export default defineNuxtConfig({
@@ -70,7 +70,7 @@ export default defineNuxtConfig({
 The `site` configuration option stems from [Nuxt SEO's `site-config` module](https://nuxtseo.com/site-config).
 ::
 
-::alert{type="info"} The site url can also be set using `i18n.baseUrl`. Note that `i18n.baseUrl` can also be set as a function as specified in [`i18n.baseUrl`'s documentation](/options/routing#baseurl).
+::alert{type="info"} Note that `i18n.baseUrl` can also be set as a function as specified in [`i18n.baseUrl`'s documentation](/options/routing#baseurl).
 
 ## Setup
 

--- a/docs/content/2.guide/7.seo.md
+++ b/docs/content/2.guide/7.seo.md
@@ -24,7 +24,7 @@ To leverage the SEO benefits, you must configure the `locales` option as an arra
 ```ts {}[nuxt.config.ts]
 export default defineNuxtConfig({
   // ...
-  
+
   i18n: {
     locales: [
       {
@@ -41,26 +41,35 @@ export default defineNuxtConfig({
       }
     ]
   },
-  
+
   // ...
 })
 ```
 
-You must also set the `baseUrl` option to your production domain in order to make alternate URLs fully-qualified:
+You must also set the `site.url` option to your production domain in order to make alternate URLs fully-qualified:
 
 ```ts {}[nuxt.config.ts]
 export default defineNuxtConfig({
   // ...
 
-  i18n: {
-    baseUrl: 'https://my-nuxt-app.com'
+  site: {
+    url: 'https://my-nuxt-app.com'
   },
-  
+
+  // // this is deprecated
+  // i18n: {
+  //   baseUrl: 'https://my-nuxt-app.com'
+  // },
+
   // ...
 })
 ```
 
-(Note that `baseUrl` can also be set to a function. Check [`baseUrl` documentation](/options/routing#baseurl).)
+::alert{type="info"}
+The `site` configuration option stems from [Nuxt SEO's `site-config` module](https://nuxtseo.com/site-config).
+::
+
+:badge[Deprecated]{type="warning"} The site url can also be set using `i18n.baseUrl`. Note that `i18n.baseUrl` can also be set as a function as specified in [`i18n.baseUrl`'s documentation](/options/routing#baseurl).
 
 ## Setup
 

--- a/docs/content/2.guide/7.seo.md
+++ b/docs/content/2.guide/7.seo.md
@@ -56,10 +56,11 @@ export default defineNuxtConfig({
     url: 'https://my-nuxt-app.com'
   },
 
-  // // this is deprecated
-  // i18n: {
-  //   baseUrl: 'https://my-nuxt-app.com'
-  // },
+  // or
+
+  i18n: {
+    baseUrl: 'https://my-nuxt-app.com'
+  },
 
   // ...
 })
@@ -69,7 +70,7 @@ export default defineNuxtConfig({
 The `site` configuration option stems from [Nuxt SEO's `site-config` module](https://nuxtseo.com/site-config).
 ::
 
-:badge[Deprecated]{type="warning"} The site url can also be set using `i18n.baseUrl`. Note that `i18n.baseUrl` can also be set as a function as specified in [`i18n.baseUrl`'s documentation](/options/routing#baseurl).
+::alert{type="info"} The site url can also be set using `i18n.baseUrl`. Note that `i18n.baseUrl` can also be set as a function as specified in [`i18n.baseUrl`'s documentation](/options/routing#baseurl).
 
 ## Setup
 

--- a/docs/content/3.options/2.routing.md
+++ b/docs/content/3.options/2.routing.md
@@ -4,7 +4,11 @@ Routing and Strategies options.
 
 ---
 
-## `baseUrl`
+## `baseUrl` :badge[Deprecated]{type="warning"}
+
+::alert{type="warning"}
+Use [Nuxt SEO's `site.url`](https://nuxtseo.com/site-config) instead of `i18n.baseUrl`.
+::
 
 - type: `string` or `function`
 - default: `''`
@@ -132,7 +136,7 @@ Set to a path to which you want to redirect users accessing the root URL (`/`). 
 - type: `boolean`
 - default: `false`
 
-Whether to localize dynamic route parameters. 
+Whether to localize dynamic route parameters.
 
 If `true`, you can set the dynamic route parameter to `nuxtI18n` field of `definePageMeta` for each locale:
 

--- a/docs/content/3.options/2.routing.md
+++ b/docs/content/3.options/2.routing.md
@@ -4,10 +4,10 @@ Routing and Strategies options.
 
 ---
 
-## `baseUrl` :badge[Deprecated]{type="warning"}
+## `baseUrl`
 
-::alert{type="warning"}
-Use [Nuxt SEO's `site.url`](https://nuxtseo.com/site-config) instead of `i18n.baseUrl`.
+::alert{type="info"}
+You can use [Nuxt SEO's `site.url`](https://nuxtseo.com/site-config) instead of `i18n.baseUrl`.
 ::
 
 - type: `string` or `function`

--- a/docs/content/3.options/9.runtime-config.md
+++ b/docs/content/3.options/9.runtime-config.md
@@ -46,10 +46,10 @@ The module configuration takes precedence, options set through `runtimeConfig` w
 
 These options can be set using `runtimeConfig`:
 
-### `baseUrl` :badge[Deprecated]{type="warning"}
+### `baseUrl`
 
-::alert{type="warning"}
-Use [Nuxt SEO's `site.url`](https://nuxtseo.com/site-config) instead of `i18n.baseUrl`.
+::alert{type="info"}
+You can use [Nuxt SEO's `site.url`](https://nuxtseo.com/site-config) instead of `i18n.baseUrl`.
 ::
 
 * key: `NUXT_PUBLIC_I18N_BASE_URL`

--- a/docs/content/3.options/9.runtime-config.md
+++ b/docs/content/3.options/9.runtime-config.md
@@ -6,7 +6,7 @@ Some options can be set via the `runtimeConfig`, setting options this way makes 
 
 ## Usage
 
-If you want to use environment variables to change [supported options](#supported-options), you will have to set these in `runtimeConfig.public.i18n`. 
+If you want to use environment variables to change [supported options](#supported-options), you will have to set these in `runtimeConfig.public.i18n`.
 
 ```ts {}[nuxt.config.ts]
 export default defineNuxtConfig({
@@ -15,12 +15,12 @@ export default defineNuxtConfig({
   ],
   i18n: {
     // Leave options unset that you want to set using `runtimeConfig`
-    // baseUrl: 'https://example.com',
+    // defaultLocale: 'en',
   },
   runtimeConfig: {
     public: {
       i18n: {
-        baseUrl: 'https://example.com',
+        defaultLocale: 'en',
         locales: {},
         // other options ...
       }
@@ -46,14 +46,18 @@ The module configuration takes precedence, options set through `runtimeConfig` w
 
 These options can be set using `runtimeConfig`:
 
-### `baseUrl`
+### `baseUrl` :badge[Deprecated]{type="warning"}
+
+::alert{type="warning"}
+Use [Nuxt SEO's `site.url`](https://nuxtseo.com/site-config) instead of `i18n.baseUrl`.
+::
+
 * key: `NUXT_PUBLIC_I18N_BASE_URL`
 
-This runtime config option is the same as the [`baseUrl`](./routing#baseUrl) module option. 
-
+This runtime config option is the same as the [`baseUrl`](./routing#baseUrl) module option.
 
 ::alert{type=warning}
-Note that the `baseUrl` module option allows you to set the function, but the runtime config does not due to limitations.
+Nuxt's runtime config does not allow values to be specified as functions, so you must use the `baseUrl` module option if you need to set the value using a function.
 ::
 
 ### `locales`

--- a/package.json
+++ b/package.json
@@ -88,6 +88,8 @@
     "knitwork": "^1.0.0",
     "magic-string": "^0.30.4",
     "mlly": "^1.4.2",
+    "nuxt-site-config": "^1.4.0",
+    "nuxt-site-config-kit": "^1.4.0",
     "pathe": "^1.1.1",
     "ufo": "^1.3.1",
     "unplugin": "^1.5.0",

--- a/playground/layer-module/nuxt.config.ts
+++ b/playground/layer-module/nuxt.config.ts
@@ -6,7 +6,6 @@ export default defineNuxtConfig({
   i18n: {
     langDir: 'locales',
     lazy: true,
-    baseUrl: 'http://localhost:3000',
     locales: [
       {
         code: 'en',
@@ -30,5 +29,8 @@ export default defineNuxtConfig({
         name: 'Nederlands'
       }
     ]
+  },
+  site: {
+    url: 'http://localhost:3000'
   }
 })

--- a/playground/layers/i18n-layer/nuxt.config.ts
+++ b/playground/layers/i18n-layer/nuxt.config.ts
@@ -6,7 +6,6 @@ export default defineNuxtConfig({
   i18n: {
     langDir: 'locales',
     lazy: true,
-    baseUrl: 'http://localhost:3000',
     customRoutes: 'config',
     pages: {
       history: {
@@ -58,5 +57,8 @@ export default defineNuxtConfig({
       //     name: 'Français'
       //   }
     ]
+  },
+  site: {
+    url: 'http://localhost:3000'
   }
 })

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -26,7 +26,6 @@ export default defineNuxtConfig({
         },
         langDir: 'locales',
         lazy: true,
-        baseUrl: 'http://localhost:3000',
         locales: [
           {
             code: 'en',
@@ -117,7 +116,6 @@ export default defineNuxtConfig({
     },
     langDir: 'locales',
     lazy: true,
-    baseUrl: 'http://localhost:3000',
     locales: [
       {
         code: 'en',
@@ -179,5 +177,8 @@ export default defineNuxtConfig({
     //   // redirectOn: 'root'
     // },
     vueI18n: './vue-i18n.options.ts'
+  },
+  site: {
+    url: 'http://localhost:3000'
   }
 })

--- a/playground/pages/blog.vue
+++ b/playground/pages/blog.vue
@@ -7,10 +7,11 @@ defineI18nRoute({
   }
 })
 
-const { t, locales, baseUrl } = useI18n({
+const { t, locales } = useI18n({
   useScope: 'local'
 })
-console.log('locales', locales, baseUrl)
+const { url } = useSiteConfig()
+console.log('locales', locales, url)
 </script>
 
 <template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,12 @@ importers:
       mlly:
         specifier: ^1.4.2
         version: 1.4.2
+      nuxt-site-config:
+        specifier: ^1.4.0
+        version: 1.4.0(rollup@3.28.1)(vue@3.3.4)
+      nuxt-site-config-kit:
+        specifier: ^1.4.0
+        version: 1.4.0(rollup@3.28.1)(vue@3.3.4)
       pathe:
         specifier: ^1.1.1
         version: 1.1.1
@@ -7917,6 +7923,36 @@ packages:
       - vue
     dev: true
 
+  /nuxt-site-config-kit@1.4.0(rollup@3.28.1)(vue@3.3.4):
+    resolution: {integrity: sha512-zQDlpXMkhLYBTmi4P+dDmHvHdQ7RZC7lVWBxopX27RS9Pf6xRzQR1H7WN2kgjEkbZRVCvYaUS9BsYsVF6Yqu8A==}
+    dependencies:
+      '@nuxt/kit': 3.7.4(rollup@3.28.1)
+      '@nuxt/schema': 3.7.4(rollup@3.28.1)
+      pkg-types: 1.0.3
+      site-config-stack: 1.4.0(vue@3.3.4)
+      std-env: 3.4.3
+      ufo: 1.3.1
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+      - vue
+    dev: false
+
+  /nuxt-site-config@1.4.0(rollup@3.28.1)(vue@3.3.4):
+    resolution: {integrity: sha512-63JJy03qTwn+1tMXAt9Nff41fp3WsBd/NLv3/giAXUPiilgPH7Tdyf/2zKaMacXsZUJ3ySY8KgNHI6t2lJmwaQ==}
+    dependencies:
+      '@nuxt/kit': 3.7.4(rollup@3.28.1)
+      '@nuxt/schema': 3.7.4(rollup@3.28.1)
+      nuxt-site-config-kit: 1.4.0(rollup@3.28.1)(vue@3.3.4)
+      pathe: 1.1.1
+      site-config-stack: 1.4.0(vue@3.3.4)
+      ufo: 1.3.1
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+      - vue
+    dev: false
+
   /nuxt@3.7.0(eslint@8.50.0)(rollup@3.28.1)(typescript@5.2.2):
     resolution: {integrity: sha512-y0/xHYqwuJt20r26xezjpr74FLWR144dMpwSxZ/O2XXUrQUnyO7vHm3fEY4vi+miKbf343YMH5B78GXAELO/Vw==}
     engines: {node: ^14.18.0 || >=16.10.0}
@@ -9531,6 +9567,15 @@ packages:
   /sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
     dev: true
+
+  /site-config-stack@1.4.0(vue@3.3.4):
+    resolution: {integrity: sha512-768t6mk7024SnhtOQJNLWj+eSsUsGLcP5lnmD1ivNQip+mVnF6Xw+7ls08X6J9pF4IWkPdSNP+fR3GTXb7U3Vw==}
+    peerDependencies:
+      vue: ^3
+    dependencies:
+      ufo: 1.3.1
+      vue: 3.3.4
+    dev: false
 
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}

--- a/specs/fixtures/basic/nuxt.config.ts
+++ b/specs/fixtures/basic/nuxt.config.ts
@@ -6,7 +6,6 @@ export default defineNuxtConfig({
 
   i18n: {
     lazy: false,
-    baseUrl: 'http://localhost:3000',
     locales: [
       {
         code: 'en',
@@ -22,5 +21,8 @@ export default defineNuxtConfig({
     defaultLocale: 'en',
     detectBrowserLanguage: false,
     vueI18n: './config/i18n.config.ts'
+  },
+  site: {
+    url: 'http://localhost:3000'
   }
 })

--- a/specs/fixtures/different_domains/nuxt.config.ts
+++ b/specs/fixtures/different_domains/nuxt.config.ts
@@ -6,7 +6,6 @@ export default defineNuxtConfig({
 
   i18n: {
     lazy: false,
-    baseUrl: 'http://localhost:3000',
     locales: [
       {
         code: 'en',
@@ -23,5 +22,8 @@ export default defineNuxtConfig({
     ],
     defaultLocale: 'ja',
     detectBrowserLanguage: false
+  },
+  site: {
+    url: 'http://localhost:3000'
   }
 })

--- a/specs/fixtures/issues/2247/nuxt.config.ts
+++ b/specs/fixtures/issues/2247/nuxt.config.ts
@@ -2,7 +2,6 @@
 export default defineNuxtConfig({
   modules: ['@nuxtjs/i18n'],
   i18n: {
-    baseUrl: 'https://abwaab.com',
     locales: [
       {
         code: 'en',
@@ -27,5 +26,8 @@ export default defineNuxtConfig({
     defaultLocale: 'ar',
     lazy: true,
     langDir: 'i18n/'
+  },
+  site: {
+    url: 'https://abwaab.com'
   }
 })

--- a/specs/fixtures/issues/2288/nuxt.config.ts
+++ b/specs/fixtures/issues/2288/nuxt.config.ts
@@ -2,7 +2,6 @@
 export default defineNuxtConfig({
   modules: ['@nuxtjs/i18n'],
   i18n: {
-    baseUrl: 'https://abwaab.com',
     locales: [
       {
         code: 'en',
@@ -26,5 +25,8 @@ export default defineNuxtConfig({
     defaultLocale: 'ar',
     lazy: true,
     langDir: 'i18n/'
+  },
+  site: {
+    url: 'https://abwaab.com'
   }
 })

--- a/specs/fixtures/lazy/nuxt.config.ts
+++ b/specs/fixtures/lazy/nuxt.config.ts
@@ -4,7 +4,6 @@ import i18nModule from './i18n-module'
 export default defineNuxtConfig({
   modules: [i18nModule, '@nuxtjs/i18n'],
   i18n: {
-    baseUrl: 'http://localhost:3000',
     // langDir: 'lang',
     // defaultLocale: 'fr',
     detectBrowserLanguage: false,
@@ -34,5 +33,8 @@ export default defineNuxtConfig({
         name: 'Français'
       }
     ]
+  },
+  site: {
+    url: 'http://localhost:3000'
   }
 })

--- a/specs/fixtures/meta_component/nuxt.config.ts
+++ b/specs/fixtures/meta_component/nuxt.config.ts
@@ -3,7 +3,6 @@ export default defineNuxtConfig({
   modules: ['@nuxtjs/i18n'],
 
   i18n: {
-    baseUrl: 'http://localhost:3000',
     locales: [
       {
         code: 'en',
@@ -19,5 +18,8 @@ export default defineNuxtConfig({
     defaultLocale: 'en',
     detectBrowserLanguage: false,
     lazy: false
+  },
+  site: {
+    url: 'http://localhost:3000'
   }
 })

--- a/specs/fixtures/switcher/nuxt.config.ts
+++ b/specs/fixtures/switcher/nuxt.config.ts
@@ -13,7 +13,6 @@ export default defineNuxtConfig({
   },
 
   i18n: {
-    baseUrl: 'http://localhost:3000',
     locales: [
       {
         code: 'en',
@@ -29,5 +28,8 @@ export default defineNuxtConfig({
     defaultLocale: 'en',
     skipSettingLocaleOnNavigate: true,
     detectBrowserLanguage: false
+  },
+  site: {
+    url: 'http://localhost:3000'
   }
 })

--- a/specs/seo/siteUrl.spec.ts
+++ b/specs/seo/siteUrl.spec.ts
@@ -3,27 +3,31 @@ import { fileURLToPath } from 'node:url'
 import { setup, $fetch } from '../utils'
 import { getDom, assertLocaleHeadWithDom } from '../helper'
 
+const getUrl = () => {
+  if (process.server) {
+    // @ts-ignore
+    const headers = useRequestHeaders(['x-override-base-url'])
+    const xOverrideBaseUrl = headers['x-override-base-url']
+    console.log('xOverrideBaseUrl', xOverrideBaseUrl)
+    if (Array.isArray(xOverrideBaseUrl)) {
+      return xOverrideBaseUrl[0]
+    }
+    return xOverrideBaseUrl || ''
+  }
+  return ''
+}
+
 await setup({
   rootDir: fileURLToPath(new URL(`../fixtures/basic`, import.meta.url)),
   // overrides
   nuxtConfig: {
+    hooks: {
+      'site-config:resolve': siteConfig => {
+        siteConfig.url = getUrl()
+      }
+    },
     i18n: {
       defaultLocale: 'en'
-    },
-    site: {
-      url: () => {
-        if (process.server) {
-          // @ts-ignore
-          const headers = useRequestHeaders(['x-override-base-url'])
-          const xOverrideBaseUrl = headers['x-override-base-url']
-          console.log('xOverrideBaseUrl', xOverrideBaseUrl)
-          if (Array.isArray(xOverrideBaseUrl)) {
-            return xOverrideBaseUrl[0]
-          }
-          return xOverrideBaseUrl || ''
-        }
-        return ''
-      }
     }
   }
 })

--- a/specs/seo/siteUrl.spec.ts
+++ b/specs/seo/siteUrl.spec.ts
@@ -1,0 +1,39 @@
+import { test } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, $fetch } from '../utils'
+import { getDom, assertLocaleHeadWithDom } from '../helper'
+
+await setup({
+  rootDir: fileURLToPath(new URL(`../fixtures/basic`, import.meta.url)),
+  // overrides
+  nuxtConfig: {
+    i18n: {
+      defaultLocale: 'en'
+    },
+    site: {
+      url: () => {
+        if (process.server) {
+          // @ts-ignore
+          const headers = useRequestHeaders(['x-override-base-url'])
+          const xOverrideBaseUrl = headers['x-override-base-url']
+          console.log('xOverrideBaseUrl', xOverrideBaseUrl)
+          if (Array.isArray(xOverrideBaseUrl)) {
+            return xOverrideBaseUrl[0]
+          }
+          return xOverrideBaseUrl || ''
+        }
+        return ''
+      }
+    }
+  }
+})
+
+test('render seo tags with site.url', async () => {
+  const html = await $fetch('/?noncanonical', {
+    headers: {
+      'X-Override-Base-Url': 'CUSTOM'
+    }
+  })
+  const dom = getDom(html)
+  await assertLocaleHeadWithDom(dom, '#home-use-locale-head')
+})

--- a/specs/seo/siteUrl_runtimeConfig.spec.ts
+++ b/specs/seo/siteUrl_runtimeConfig.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, $fetch } from '../utils'
+import { getDom, getDataFromDom, assertLocaleHeadWithDom } from '../helper'
+
+const configDomain = 'https://runtime-config-domain.com'
+await setup({
+  rootDir: fileURLToPath(new URL(`../fixtures/basic`, import.meta.url)),
+  // overrides
+  nuxtConfig: {
+    runtimeConfig: {
+      public: {
+        site: {
+          url: configDomain
+        }
+      }
+    },
+    i18n: {
+      //   debug: true,
+      defaultLocale: 'en'
+    },
+    site: {
+      url: ''
+    }
+  }
+})
+
+test('render seo tags with site.url', async () => {
+  const html = await $fetch('/?noncanonical')
+  const dom = getDom(html)
+  await assertLocaleHeadWithDom(dom, '#home-use-locale-head')
+
+  const links = getDataFromDom(dom, '#home-use-locale-head').link
+  const i18nCan = links.find(x => x.id === 'i18n-can')
+  expect(i18nCan.href).toContain(configDomain)
+})

--- a/src/module.ts
+++ b/src/module.ts
@@ -66,14 +66,8 @@ export default defineNuxtModule<NuxtI18nOptions>({
     if (!options.compilation.jit) {
       logger.warn(
         'Opt-out JIT compilation. ' +
-        `It's necessary to pre-compile locale messages that are not managed by the nuxt i18n module (e.g. in the case of importing from a specific URL, you will need to precompile them yourself.) ` +
-        `And also, you need to understand that you cannot support use cases where you dynamically compose locale messages from the back-end via an API.`
-      )
-    }
-
-    if (options.baseUrl && options.baseUrl !== '') {
-      logger.warn(
-        "`i18n.baseUrl` is deprecated in favor of `site.url` as nuxt i18n now makes use of Nuxt SEO's site config."
+          `It's necessary to pre-compile locale messages that are not managed by the nuxt i18n module (e.g. in the case of importing from a specific URL, you will need to precompile them yourself.) ` +
+          `And also, you need to understand that you cannot support use cases where you dynamically compose locale messages from the back-end via an API.`
       )
     }
 
@@ -105,7 +99,7 @@ export default defineNuxtModule<NuxtI18nOptions>({
       throw new Error(
         formatMessage(
           '`bundle.compositionOnly` option and `types` option is conflicting: ' +
-          `bundle.compositionOnly: ${options.bundle.compositionOnly}, types: ${JSON.stringify(options.types)}`
+            `bundle.compositionOnly: ${options.bundle.compositionOnly}, types: ${JSON.stringify(options.types)}`
         )
       )
     }
@@ -113,16 +107,16 @@ export default defineNuxtModule<NuxtI18nOptions>({
     if (options.bundle.runtimeOnly && options.compilation.jit) {
       logger.warn(
         '`bundle.runtimeOnly` option and `compilation.jit` option is conflicting: ' +
-        `bundle.runtimeOnly: ${options.bundle.runtimeOnly}, compilation.jit: ${JSON.stringify(
-          options.compilation.jit
-        )}`
+          `bundle.runtimeOnly: ${options.bundle.runtimeOnly}, compilation.jit: ${JSON.stringify(
+            options.compilation.jit
+          )}`
       )
     }
 
     if (options.strategy === 'no_prefix' && options.differentDomains) {
       logger.warn(
         '`differentDomains` option and `no_prefix` strategy are not compatible. ' +
-        'Change strategy or disable `differentDomains` option.'
+          'Change strategy or disable `differentDomains` option.'
       )
     }
 
@@ -350,7 +344,7 @@ export default defineNuxtModule<NuxtI18nOptions>({
 })
 
 // Used by nuxt/module-builder for `types.d.ts` generation
-export interface ModuleOptions extends NuxtI18nOptions { }
+export interface ModuleOptions extends NuxtI18nOptions {}
 
 export interface ModulePublicRuntimeConfig {
   i18n?: Pick<NuxtI18nOptions<unknown>, 'baseUrl'>
@@ -377,7 +371,7 @@ export interface RuntimeModuleHooks {
 
 // Used by module for type inference in source code
 declare module '#app' {
-  interface RuntimeNuxtHooks extends RuntimeModuleHooks { }
+  interface RuntimeNuxtHooks extends RuntimeModuleHooks {}
 }
 
 declare module '@nuxt/schema' {
@@ -387,6 +381,6 @@ declare module '@nuxt/schema' {
   interface NuxtOptions {
     ['i18n']?: ModuleOptions
   }
-  interface NuxtHooks extends ModuleHooks { }
-  interface PublicRuntimeConfig extends ModulePublicRuntimeConfig { }
+  interface NuxtHooks extends ModuleHooks {}
+  interface PublicRuntimeConfig extends ModulePublicRuntimeConfig {}
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -12,7 +12,7 @@ import {
 } from '@nuxt/kit'
 import { resolve, relative } from 'pathe'
 import { defu } from 'defu'
-import { installNuxtSiteConfig, useSiteConfig } from 'nuxt-site-config-kit'
+import { installNuxtSiteConfig } from 'nuxt-site-config-kit'
 import { setupAlias } from './alias'
 import { setupPages } from './pages'
 import { setupNitro } from './nitro'
@@ -130,15 +130,10 @@ export default defineNuxtModule<NuxtI18nOptions>({
 
     /**
      * source baseUrl from Nuxt SEO's `site.url`
-     * TODO: remove i18n's `baseUrl` module option when `site.url` has been in use for a sufficiently long time (starting October 2023)
+     * TODO: remove i18n's `baseUrl` module option when `site.url` has been in use for a sufficiently long time (starting November 2023)
      */
 
     await installNuxtSiteConfig()
-    const siteConfig = useSiteConfig()
-
-    if (siteConfig.url) {
-      options.baseUrl = siteConfig.url
-    }
 
     /**
      * setup runtime config

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -15,7 +15,7 @@ import {
   getComposer,
   useSwitchLocalePath
 } from 'vue-i18n-routing'
-import { navigateTo, useState } from '#imports'
+import { navigateTo, useState, useSiteConfig } from '#imports'
 import { isString, isFunction, isArray, isObject } from '@intlify/shared'
 import { nuxtI18nInternalOptions, nuxtI18nOptionsDefault, NUXT_I18N_MODULE_ID, isSSG } from '#build/i18n.options.mjs'
 import {
@@ -221,7 +221,7 @@ export function detectLocale<Context extends NuxtApp = NuxtApp>(
     reason,
     from
   } = nuxtI18nOptions.detectBrowserLanguage
-    ? detectBrowserLanguage(
+      ? detectBrowserLanguage(
         route,
         context,
         nuxtI18nOptions,
@@ -231,7 +231,7 @@ export function detectLocale<Context extends NuxtApp = NuxtApp>(
         localeCodes,
         initialLocale
       )
-    : DefaultDetectBrowserLanguageFromResult
+      : DefaultDetectBrowserLanguageFromResult
   __DEBUG__ &&
     console.log(
       'detectLocale: detectBrowserLanguage (browserLocale, stat, reason, from) -',
@@ -505,6 +505,12 @@ export function extendBaseUrl<Context extends NuxtApp = NuxtApp>(
   }
 ): BaseUrlResolveHandler<Context> {
   return (context: Context): string => {
+    const siteConfig = useSiteConfig()
+    if (siteConfig.url) {
+      __DEBUG__ && console.log('baseUrl: using site config -', siteConfig.url)
+      return siteConfig.url
+    }
+
     if (isFunction(baseUrl)) {
       const baseUrlResult = baseUrl(context)
       __DEBUG__ && console.log('baseUrl: using localeLoader function -', baseUrlResult)

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,9 +110,22 @@ export type NuxtI18nOptions<Context = unknown> = {
   debug?: boolean
   dynamicRouteParams?: boolean
   parallelPlugin?: boolean
+  /**
+   * The fallback base URL to use as a prefix for alternate URLs in hreflang tags.
+   * You can also use `site.url` instead of `i18n.baseUrl`.
+   *
+   * @remarks
+   * By default VueRouter's base URL will be used and only if that is not available, fallback URL will be used.
+   *
+   * Can also be a function (will be passed a Nuxt Context as a parameter) that returns a string.
+   *
+   * Useful to make base URL dynamic based on request headers.
+   *
+   * @defaultValue ''
+   */
+  baseUrl?: I18nRoutingOptions<Context>['baseUrl']
 } & Pick<
   I18nRoutingOptions<Context>,
-  | 'baseUrl'
   | 'strategy'
   | 'defaultDirection'
   | 'defaultLocale'


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt-modules/i18n/issues/2474

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds support for reading Nuxt config's `site.url`, provided by [Nuxt SEO's site-config module](https://nuxtseo.com/site-config), marking `i18n.baseUrl` as deprecated.

**Draft** because:
- [ ] `nuxt-site-config` does not (yet?) support options as functions, which has to be discussed

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
