### PR TITLE
fix: Do not pass locale props to NuxtLink

### DIFF
--- a/src/runtime/components/NuxtLinkLocale.ts
+++ b/src/runtime/components/NuxtLinkLocale.ts
@@ -46,9 +46,26 @@ export default defineComponent({
       return props.to === '' || hasProtocol(props.to, { acceptRelative: true })
     })
 
-    return () =>
-      isExternal.value
-        ? h(NuxtLinkLocale, props, slots.default)
-        : h(NuxtLinkLocale, { ...props, to: resolvedPath }, slots.default)
+    /**
+     * Get props to pass to NuxtLink
+     * @returns NuxtLink props
+     */
+    const getNuxtLinkProps = () => {
+      const _props = {
+        ...props
+      }
+
+      if (!isExternal.value) {
+        _props.to = resolvedPath
+      }
+
+      // The locale attribute cannot be set for NuxtLink
+      // @see https://github.com/nuxt-modules/i18n/issues/2498
+      delete _props.locale
+
+      return _props
+    }
+
+    return () => h(NuxtLinkLocale, getNuxtLinkProps(), slots.default)
   }
 })


### PR DESCRIPTION
### 🔗 Linked issue

#2498

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Inside `NuxtLinkLocale`, do not pass `locale` prop when rendering `NuxtLink`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
