### PR TITLE
fix: prevent strategy `no_prefix` redirect detection locale change attempt

### DIFF
--- a/specs/fixtures/basic/pages/category/[slug].vue
+++ b/specs/fixtures/basic/pages/category/[slug].vue
@@ -1,3 +1,4 @@
 <template>
   <p>This is cateory page on '{{ $route.params.slug }}'</p>
+  <NuxtLinkLocale id="return-home-link" to="/">Home</NuxtLinkLocale>
 </template>

--- a/specs/routing_strategies/no_prefix.spec.ts
+++ b/specs/routing_strategies/no_prefix.spec.ts
@@ -78,4 +78,24 @@ describe('strategy: no_prefix', async () => {
     // current locale
     expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('fr')
   })
+
+  test('(#2493) should navigate from url with and without trailing slash', async () => {
+    const page = await createPage()
+    await page.goto(url('/category/nested/'))
+    await page.waitForURL('**/category/nested/')
+
+    await page.locator('#return-home-link').click()
+
+    await page.waitForURL(/:[0-9]+\/$/)
+
+    expect(page.url()).toEqual(url('/'))
+
+    await page.goto(url('/category/nested'))
+    await page.waitForURL('**/category/nested')
+
+    await page.locator('#return-home-link').click()
+    await page.waitForURL(/:[0-9]+\/$/)
+
+    expect(page.url()).toEqual(url('/'))
+  })
 })

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -474,7 +474,7 @@ export default defineNuxtPlugin({
           route: { to, from },
           context: nuxtContext,
           targetLocale: locale,
-          routeLocaleGetter: getLocaleFromRoute,
+          routeLocaleGetter: nuxtI18nOptions.strategy === 'no_prefix' ? () => locale : getLocaleFromRoute,
           nuxtI18nOptions,
           calledWithRouting: true
         })


### PR DESCRIPTION


<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
#2493 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #2493 

It looks like `detectRedirect` tried to change locale based on route while using `no_prefix` strategy. This causes issues as we can't retrieve the locale from unprefixed paths.

This resolves the referenced issue but potentially a related/underlying issue remains. When resolving the `routePath` here: https://github.com/nuxt-modules/i18n/blob/main/src/runtime/utils.ts#L315-L323 on url with a trailing slash will cause a redirect as `routePath` will resolve to the same path without a trailing slash. In the case of the referenced issue this logic is never hit as the locale does not change. 
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
