### PR TITLE
fix: path ends with '/' equals the one without it

### DIFF
--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -320,7 +320,8 @@ export function detectRedirect<Context extends NuxtApp = NuxtApp>({
        * If it's the same as the previous route path, respect the current route without redirecting.
        * (If an empty string is set, the current route is respected. after this function return, it's pass navigate function)
        */
-      redirectPath = !(route.from && route.from.fullPath === routePath) ? routePath : ''
+      const fromFullPath = route.from?.fullPath?.endsWith('/') ? route.from.fullPath.slice(0, -1) : route.from?.fullPath
+      redirectPath = !(fromFullPath === routePath) ? routePath : ''
     }
   }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue

#2528

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In some case, routePath calculated like '/target/path',
even route.from.fullPath is assigned '/target/path/'.
they are same url in aspect of routing on Nuxt3.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
