### PR TITLE
ci: use node version 18.18+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [18.17]
+        node-version: [18]
         os: [ubuntu-latest]
     timeout-minutes: 10
 
@@ -47,7 +47,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [18.17]
+        node-version: [18]
         os: [ubuntu-latest]
     timeout-minutes: 10
 
@@ -83,7 +83,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [18.17]
+        node-version: [18]
         os: [ubuntu-latest]
     timeout-minutes: 25
 
@@ -148,7 +148,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [18.17]
+        node-version: [18]
         os: [ubuntu-latest]
     steps:
       - name: Checkout codes

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "ts-essentials": "^9.4.0",
     "typescript": "^5.2.2",
     "unbuild": "^2.0.0",
+    "undici": "^5.27.2",
     "vitest": "^0.34.6",
     "vue": "^3.3.4",
     "vue-router": "^4.2.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       unbuild:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.2.2)
+      undici:
+        specifier: ^5.27.2
+        version: 5.27.2
       vitest:
         specifier: ^0.34.6
         version: 0.34.6(jsdom@21.1.2)(playwright@1.38.1)
@@ -8083,7 +8086,7 @@ packages:
       destr: 1.2.2
       node-fetch-native: 0.1.8
       ufo: 0.8.6
-      undici: 5.26.4
+      undici: 5.27.2
     dev: true
 
   /on-finished@2.4.1:
@@ -8139,7 +8142,7 @@ packages:
       fast-glob: 3.3.1
       js-yaml: 4.1.0
       supports-color: 9.4.0
-      undici: 5.26.4
+      undici: 5.27.2
       yargs-parser: 21.1.1
     dev: true
 
@@ -10216,6 +10219,13 @@ packages:
 
   /undici@5.26.4:
     resolution: {integrity: sha512-OG+QOf0fTLtazL9P9X7yqWxQ+Z0395Wk6DSkyTxtaq3wQEjIroVe7Y4asCX/vcCxYpNGMnwz8F0qbRYUoaQVMw==}
+    engines: {node: '>=14.0'}
+    dependencies:
+      '@fastify/busboy': 2.0.0
+    dev: true
+
+  /undici@5.27.2:
+    resolution: {integrity: sha512-iS857PdOEy/y3wlM3yRp+6SNQQ6xU0mmZcwRSriqk+et/cwWAtwmIGf6WkoDN2EK/AMdCO/dfXzIwi+rFMrjjQ==}
     engines: {node: '>=14.0'}
     dependencies:
       '@fastify/busboy': 2.0.0

--- a/specs/different_domains.runtimeConfig.spec.ts
+++ b/specs/different_domains.runtimeConfig.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'vitest'
 import { fileURLToPath } from 'node:url'
-import { setup, $fetch } from './utils'
+import { setup, undiciRequest } from './utils'
 import { getDom } from './helper'
 
 await setup({
@@ -45,12 +45,12 @@ await setup({
 })
 
 test('pass `<NuxtLink> to props using domains from runtimeConfig', async () => {
-  const html = await $fetch('/', {
+  const res = await undiciRequest('/', {
     headers: {
       Host: 'fr.nuxt-app.localhost'
     }
   })
-  const dom = getDom(html)
+  const dom = getDom(await res.body.text())
   expect(dom.querySelector('#switch-locale-path-usages .switch-to-en a').getAttribute('href')).toEqual(
     `http://en.staging.nuxt-app.localhost`
   )

--- a/specs/different_domains.spec.ts
+++ b/specs/different_domains.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe } from 'vitest'
 import { fileURLToPath } from 'node:url'
-import { setup, $fetch } from './utils'
+import { setup, $fetch, undiciRequest } from './utils'
 import { getDom } from './helper'
 
 await setup({
@@ -36,12 +36,12 @@ describe('detection locale with host on server', () => {
     ['en', 'en.nuxt-app.localhost', 'Homepage'],
     ['fr', 'fr.nuxt-app.localhost', 'Accueil']
   ])('%s host', async (locale, host, header) => {
-    const html = await $fetch('/', {
+    const res = await undiciRequest('/', {
       headers: {
         Host: host
       }
     })
-    const dom = getDom(html)
+    const dom = getDom(await res.body.text())
 
     expect(dom.querySelector('#lang-switcher-current-locale code').textContent).toEqual(locale)
     expect(dom.querySelector('#home-header').textContent).toEqual(header)
@@ -61,12 +61,12 @@ test('detection locale with x-forwarded-host on server', async () => {
 })
 
 test('pass `<NuxtLink> to props', async () => {
-  const html = await $fetch('/', {
+  const res = await undiciRequest('/', {
     headers: {
       Host: 'fr.nuxt-app.localhost'
     }
   })
-  const dom = getDom(html)
+  const dom = getDom(await res.body.text())
   expect(dom.querySelector('#switch-locale-path-usages .switch-to-en a').getAttribute('href')).toEqual(
     `http://en.nuxt-app.localhost`
   )
@@ -76,12 +76,12 @@ test('pass `<NuxtLink> to props', async () => {
 })
 
 test('layer provides locales with domains', async () => {
-  const html = await $fetch('/', {
+  const res = await undiciRequest('/', {
     headers: {
       Host: 'fr.nuxt-app.localhost'
     }
   })
-  const dom = getDom(html)
+  const dom = getDom(await res.body.text())
 
   // `en` link uses project domain configuration, overrides layer
   expect(dom.querySelector('#switch-locale-path-usages .switch-to-en a').getAttribute('href')).toEqual(

--- a/specs/issues/2374.spec.ts
+++ b/specs/issues/2374.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe } from 'vitest'
 import { fileURLToPath } from 'node:url'
-import { setup, $fetch } from '../utils'
+import { setup, $fetch, undiciRequest } from '../utils'
 import { getDom } from '../helper'
 
 describe('#2374', async () => {
@@ -13,12 +13,12 @@ describe('#2374', async () => {
       ['en.nuxt-app.localhost', 'test issue 2374'],
       ['zh.nuxt-app.localhost', '测试问题2374']
     ])('%s host', async (host, header) => {
-      const html = await $fetch('/', {
+      const res = await undiciRequest('/', {
         headers: {
-          Host: host
+          host: host
         }
       })
-      const dom = getDom(html)
+      const dom = getDom(await res.body.text())
       expect(dom.querySelector('#content').textContent).toEqual(header)
     })
   })

--- a/specs/utils/server.ts
+++ b/specs/utils/server.ts
@@ -7,6 +7,7 @@ import { $fetch as _$fetch, fetch as _fetch } from 'ofetch'
 import * as _kit from '@nuxt/kit'
 import { resolve } from 'pathe'
 import { useTestContext } from './context'
+import { request } from 'undici'
 
 // @ts-expect-error type cast
 // eslint-disable-next-line
@@ -92,6 +93,10 @@ export function fetch(path: string, options?: any) {
 
 export function $fetch(path: string, options?: FetchOptions) {
   return _$fetch(url(path), options)
+}
+
+export function undiciRequest(path: string, options?: Parameters<typeof request>[1]) {
+  return request(url(path), options)
 }
 
 export function url(path: string) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
After a long search I finally figured out why tests failed using Node version `18.18.2` or higher. Our tests set the `Host` header to test server responses for different domains, but due to https://github.com/nodejs/undici/pull/2322 this broke as `fetch` is not allowed to set the `Host` header for security reasons. 

I have added `undici` as a dev dependency and used it in tests where this behaviour is needed.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
