### PR TITLE
fix: exclude unprefixed routes for strategy `prefix`

### DIFF
--- a/specs/routing_strategies/prefix.spec.ts
+++ b/specs/routing_strategies/prefix.spec.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'vitest'
 import { fileURLToPath } from 'node:url'
-import { setup, url } from '../utils'
+import { setup, url, fetch } from '../utils'
 import { getText, getData, renderPage, waitForURL } from '../helper'
 
 import type { Response } from 'playwright'
@@ -18,17 +18,14 @@ await setup({
 })
 
 describe('strategy: prefix', async () => {
-  test.todo('cannot access to no prefix url: /', async () => {
-    const home = url('/')
-    const { page } = await renderPage(home)
-    let res: Response | (Error & { status: () => number }) | null = null
-    try {
-      res = await page.goto(home)
-    } catch (error: unknown) {
-      res = error as Error & { status: () => number }
-    }
-    // 404
-    expect(res!.status()).toBe(404) // eslint-disable-line @typescript-eslint/no-non-null-assertion
+  test.each([
+    ['/', '/en'],
+    ['/about', '/en/about'],
+    ['/category/foo', '/en/category/foo']
+  ])('cannot access unprefixed url: %s', async (pathUrl, destination) => {
+    const res = await fetch(pathUrl, { redirect: 'manual' })
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe(destination)
   })
 
   test('can access to prefix locale: /en', async () => {

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -45,7 +45,7 @@ export function setupPages(
   let includeUprefixedFallback = nuxt.options.ssr === false
   nuxt.hook('nitro:init', () => {
     debug('enable includeUprefixedFallback')
-    includeUprefixedFallback = true
+    includeUprefixedFallback = options.strategy !== 'prefix'
   })
 
   const pagesDir = nuxt.options.dir && nuxt.options.dir.pages ? nuxt.options.dir.pages : 'pages'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
* #2524
* #2131
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
@kazupon 
What is the intended behavior for projects with `redirectOn: 'root'` when accessing an unprefixed (non existant in this case after this change) route like `/about`, should it return a 404? Right now this still redirects to the default language route, relevant issue: #2524.

Let me know if there are specific cases are missing tests for this change!


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
