### PR TITLE
fix: enable `verbatimModuleSyntax` and use explicit type imports

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -3,14 +3,16 @@ import { resolve } from 'pathe'
 import { extendWebpackConfig, extendViteConfig, addWebpackPlugin, addVitePlugin } from '@nuxt/kit'
 import VueI18nWebpackPlugin from '@intlify/unplugin-vue-i18n/webpack'
 import VueI18nVitePlugin from '@intlify/unplugin-vue-i18n/vite'
-import { TransformMacroPlugin, TransformMacroPluginOptions } from './transform/macros'
-import { ResourcePlugin, ResourcePluginOptions } from './transform/resource'
+import { TransformMacroPlugin } from './transform/macros'
+import { ResourcePlugin } from './transform/resource'
 import { assign } from '@intlify/shared'
 import { getLayerLangPaths } from './layers'
 
 import type { Nuxt } from '@nuxt/schema'
 import type { PluginOptions } from '@intlify/unplugin-vue-i18n'
 import type { NuxtI18nOptions } from './types'
+import type { TransformMacroPluginOptions } from './transform/macros'
+import type { ResourcePluginOptions } from './transform/resource'
 
 const debug = createDebug('@nuxtjs/i18n:bundler')
 

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -4,9 +4,10 @@ import createDebug from 'debug'
 import { EXECUTABLE_EXTENSIONS } from './constants'
 import { genImport, genDynamicImport } from 'knitwork'
 import { withQuery } from 'ufo'
-import { PrerenderTarget, getLocalePaths, toCode } from './utils'
+import { getLocalePaths, toCode } from './utils'
 
 import type { Nuxt } from '@nuxt/schema'
+import type { PrerenderTarget } from './utils'
 import type { NuxtI18nOptions, LocaleInfo, VueI18nConfigPathInfo, FileMeta } from './types'
 import type { LocaleObject } from 'vue-i18n-routing'
 

--- a/src/layers.ts
+++ b/src/layers.ts
@@ -1,18 +1,12 @@
 import createDebug from 'debug'
-import {
-  getLayerI18n,
-  getProjectPath,
-  mergeConfigLocales,
-  resolveVueI18nConfigInfo,
-  LocaleConfig,
-  formatMessage
-} from './utils'
+import { getLayerI18n, getProjectPath, mergeConfigLocales, resolveVueI18nConfigInfo, formatMessage } from './utils'
 
 import { useLogger } from '@nuxt/kit'
 import { isAbsolute, resolve } from 'pathe'
 import { isString } from '@intlify/shared'
 import { NUXT_I18N_MODULE_ID } from './constants'
 
+import type { LocaleConfig } from './utils'
 import type { Nuxt, NuxtConfigLayer } from '@nuxt/schema'
 import type { NuxtI18nOptions, VueI18nConfigPathInfo } from './types'
 

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -1,6 +1,6 @@
 import createDebug from 'debug'
 import { extendPages } from '@nuxt/kit'
-import { I18nRoute, localizeRoutes, DefaultLocalizeRoutesPrefixable } from 'vue-i18n-routing'
+import { localizeRoutes, DefaultLocalizeRoutesPrefixable } from 'vue-i18n-routing'
 import { isString } from '@intlify/shared'
 import { parse as parseSFC, compileScript } from '@vue/compiler-sfc'
 import { walk } from 'estree-walker'
@@ -11,7 +11,12 @@ import { resolve, parse as parsePath } from 'pathe'
 import { NUXT_I18N_COMPOSABLE_DEFINE_ROUTE } from './constants'
 
 import type { Nuxt, NuxtPage } from '@nuxt/schema'
-import type { RouteOptionsResolver, ComputedRouteOptions, LocalizeRoutesPrefixableOptions } from 'vue-i18n-routing'
+import type {
+  I18nRoute,
+  RouteOptionsResolver,
+  ComputedRouteOptions,
+  LocalizeRoutesPrefixableOptions
+} from 'vue-i18n-routing'
 import type { NuxtI18nOptions, CustomRoutePages } from './types'
 import type { Node, ObjectExpression, ArrayExpression } from '@babel/types'
 

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -10,7 +10,6 @@ import {
   localeRoute,
   switchLocalePath,
   localeHead,
-  LocaleObject,
   DefaultPrefixable,
   DefaultSwitchLocalePathIntercepter,
   getComposer,
@@ -35,6 +34,7 @@ import { joinURL, isEqual } from 'ufo'
 
 import type {
   Route,
+  LocaleObject,
   RouteLocationNormalized,
   RouteLocationNormalizedLoaded,
   BaseUrlResolveHandler,

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,7 +85,7 @@ export interface LocaleMessageCompilationOptions {
   escapeHtml?: boolean
 }
 
-export { I18nOptions }
+export type { I18nOptions }
 
 export type NuxtI18nOptions<Context = unknown> = {
   vueI18n?: string

--- a/test/gen.test.ts
+++ b/test/gen.test.ts
@@ -2,7 +2,7 @@ import { generateLoaderOptions } from '../src/gen'
 import { resolveLocales, resolveVueI18nConfigInfo } from '../src/utils'
 
 import type { LocaleInfo, NuxtI18nOptions, VueI18nConfigPathInfo } from '../src/types'
-import { Nuxt } from '@nuxt/schema'
+import type { Nuxt } from '@nuxt/schema'
 
 vi.mock('node:fs')
 

--- a/test/pages/custom_route.test.ts
+++ b/test/pages/custom_route.test.ts
@@ -5,7 +5,7 @@ import { localizeRoutes } from 'vue-i18n-routing'
 import { getRouteOptionsResolver, analyzeNuxtPages } from '../../src/pages'
 import { getNuxtOptions, stripFilePropertyFromPages } from './utils'
 
-import { NuxtPageAnalyzeContext, AnalyzedNuxtPageMeta } from '../../src/pages'
+import type { NuxtPageAnalyzeContext, AnalyzedNuxtPageMeta } from '../../src/pages'
 import type { NuxtI18nOptions } from '../../src/types'
 import type { NuxtPage } from './utils'
 

--- a/test/pages/ignore_route/disable.test.ts
+++ b/test/pages/ignore_route/disable.test.ts
@@ -6,7 +6,7 @@ import { localizeRoutes } from 'vue-i18n-routing'
 import { getRouteOptionsResolver, analyzeNuxtPages } from '../../../src/pages'
 import { getNuxtOptions, stripFilePropertyFromPages } from '../utils'
 
-import { NuxtPageAnalyzeContext, AnalyzedNuxtPageMeta } from '../../../src/pages'
+import type { NuxtPageAnalyzeContext, AnalyzedNuxtPageMeta } from '../../../src/pages'
 import type { NuxtI18nOptions } from '../../../src/types'
 import type { NuxtPage } from '../utils'
 

--- a/test/pages/ignore_route/pick.test.ts
+++ b/test/pages/ignore_route/pick.test.ts
@@ -6,7 +6,7 @@ import { localizeRoutes } from 'vue-i18n-routing'
 import { getRouteOptionsResolver, analyzeNuxtPages } from '../../../src/pages'
 import { getNuxtOptions, stripFilePropertyFromPages } from '../utils'
 
-import { NuxtPageAnalyzeContext, AnalyzedNuxtPageMeta } from '../../../src/pages'
+import type { NuxtPageAnalyzeContext, AnalyzedNuxtPageMeta } from '../../../src/pages'
 import type { NuxtI18nOptions } from '../../../src/types'
 import type { NuxtPage } from '../utils'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -112,7 +112,8 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */,
+    "verbatimModuleSyntax": true
   },
   "exclude": ["**/.nuxt/**", "**/*/dist/*", "docs/**", "playground/**", "specs/**.spec*", "src/runtime/templates/**"]
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
* https://github.com/nuxt/nuxt/pull/23447
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This is required since Nuxt 3.8, see https://github.com/nuxt/nuxt/pull/23447 and https://nuxt.com/blog/v3-8#type-import-changes.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
