### PR TITLE
fix: module type generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@babel/plugin-syntax-import-assertions": "^7.22.5",
     "@babel/types": "^7.23.0",
     "@intlify/vue-router-bridge": "^1.0.1",
-    "@nuxt/module-builder": "latest",
+    "@nuxt/module-builder": "^0.5.4",
     "@nuxt/schema": "^3.7.4",
     "@types/debug": "^4.1.9",
     "@typescript-eslint/eslint-plugin": "^6.7.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1(vue-router@4.2.5)(vue@3.3.4)
       '@nuxt/module-builder':
-        specifier: latest
-        version: 0.5.2(@nuxt/kit@3.7.4)(nuxi@3.9.0)(typescript@5.2.2)
+        specifier: ^0.5.4
+        version: 0.5.4(@nuxt/kit@3.7.4)(nuxi@3.9.1)(typescript@5.2.2)
       '@nuxt/schema':
         specifier: ^3.7.4
         version: 3.7.4(rollup@3.28.1)
@@ -2113,18 +2113,18 @@ packages:
       - rollup
       - supports-color
 
-  /@nuxt/module-builder@0.5.2(@nuxt/kit@3.7.4)(nuxi@3.9.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-MsnPTsa94VNrzV76RKCDS0C96uaKw9s3EbTtabI/BkAXOD4Ud1w6m0O20XUdI9tmRtE8Kbgyr4XUhD/YB3eeAw==}
+  /@nuxt/module-builder@0.5.4(@nuxt/kit@3.7.4)(nuxi@3.9.1)(typescript@5.2.2):
+    resolution: {integrity: sha512-lCPh8s8LSfYqHgIMMsctDhz+AX1z6TnATkUes/GXc/No4kApC0zmJkQWrbtDRjmsWjElwl1kE7l7OzYdYc3d4w==}
     hasBin: true
     peerDependencies:
-      '@nuxt/kit': ^3.7.4
-      nuxi: ^3.9.0
+      '@nuxt/kit': ^3.8.1
+      nuxi: ^3.9.1
     dependencies:
       '@nuxt/kit': 3.7.4(rollup@3.28.1)
       citty: 0.1.4
       consola: 3.2.3
       mlly: 1.4.2
-      nuxi: 3.9.0
+      nuxi: 3.9.1
       pathe: 1.1.1
       unbuild: 2.0.0(typescript@5.2.2)
     transitivePeerDependencies:
@@ -7871,8 +7871,8 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /nuxi@3.9.0:
-    resolution: {integrity: sha512-roCfCnQsp/oaHm6PL3HFvvGrwm1d2y1n7G9KzIx+i91eiO4P7fBuaVKibB2e8uqEJBgTwN52KxFha6MJnDykJQ==}
+  /nuxi@3.9.1:
+    resolution: {integrity: sha512-4R4tcC2uQ5QCnHxyKoX5nZm/YUesCcQM3bZBKYU/8ZWrWjK6aPG6Q5zOQG1aLPkAotyahNsqtSiU/CrRoenEgA==}
     engines: {node: ^14.18.0 || >=16.10.0}
     hasBin: true
     optionalDependencies:

--- a/src/module.ts
+++ b/src/module.ts
@@ -344,6 +344,8 @@ export interface ModuleHooks {
 }
 
 export interface RuntimeModuleHooks {
+  // NOTE: To make type inference work the function signature returns `HookResult`
+  // Should return `string | void`
   'i18n:beforeLocaleSwitch': <Context = unknown>(params: {
     oldLocale: string
     newLocale: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type { Strategies, I18nRoutingOptions, LocaleObject } from 'vue-i18n-routing'
-import type { Locale, I18nOptions } from 'vue-i18n'
+import type { Locale } from 'vue-i18n'
 import type { PluginOptions } from '@intlify/unplugin-vue-i18n'
 import type { ParsedPath } from 'path'
 
@@ -84,8 +84,6 @@ export interface LocaleMessageCompilationOptions {
   strictMessage?: boolean
   escapeHtml?: boolean
 }
-
-export type { I18nOptions }
 
 export type NuxtI18nOptions<Context = unknown> = {
   vueI18n?: string


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
* #2515
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The types generated on build in `types.d.ts` are incomplete as you can see [here](https://www.npmjs.com/package/@nuxtjs/i18n/v/8.0.0-rc.5?activeTab=code). This may be the cause for issues like #2515, or a separate issue entirely.

Unfortunately I wasn't able to accurately type the `i18n:beforeLocaleSwitch` runtime hook as the type inference broke whenever the return type was not `HookResult`. I added a comment describing this here: https://github.com/nuxt-modules/i18n/pull/2541/files#diff-030fc083b2cbf5cf008cfc0c49bb4f1b8d97ac07f93a291d068d81b4d1416f70R347-R354
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
