### PR TITLE
chore: fix playground not using `verbatimModuleSyntax`

### DIFF
--- a/playground/pages/[...catch].vue
+++ b/playground/pages/[...catch].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { LocaleObject } from '#i18n'
+import type { LocaleObject } from '#i18n'
 
 const route = useRoute()
 const { locale, locales } = useI18n()

--- a/playground/pages/category/[id].vue
+++ b/playground/pages/category/[id].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { LocaleObject } from '#i18n'
+import type { LocaleObject } from '#i18n'
 
 const route = useRoute()
 const { locale, locales } = useI18n()

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue'
 
 // import { useLocalePath, useSwitchLocalePath, useLocaleHead, useBrowserLocale } from '#i18n'
-import { LocaleObject } from '#i18n'
+import type { LocaleObject } from '#i18n'
 
 const route = useRoute()
 const {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The playground would throw an error when running as type imports were not using `verbatimModuleSyntax`. 
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
