### PR TITLE
feat: add `skipDefaultLocale` options

### DIFF
--- a/docs/content/3.options/10.misc.md
+++ b/docs/content/3.options/10.misc.md
@@ -55,3 +55,10 @@ Don't enable this option for use in production. Performance will be decreased.
 - default: `false`
 
 Set the plugin as `parallel`. See [nuxt plugin loading strategy](https://nuxt.com/docs/guide/directory-structure/plugins#loading-strategy).
+
+## `skipDefaultLocale`
+
+- type: `boolean`
+- default: `false`
+
+If `true`, the `DefaultLocale` will be skipped. By default, the `DefaultLocale` is added and loaded every time.

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -133,13 +133,13 @@ export default defineNuxtConfig({
         files: ['en.json', 'en-GB.js', 'en-KK.js'],
         name: 'English (UK)'
       },
-      // {
-      //   code: 'ja',
-      //   iso: 'ja-JP',
-      //   file: 'ja.ts',
-      //   domain: 'mydomain.com',
-      //   name: 'Japanses'
-      // },
+      {
+        code: 'ja',
+        iso: 'ja-JP',
+        file: 'ja.ts',
+        domain: 'mydomain.com',
+        name: 'Japanses'
+      },
       {
         code: 'fr',
         iso: 'fr-FR',

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -118,6 +118,7 @@ export default defineNuxtConfig({
     langDir: 'locales',
     lazy: true,
     baseUrl: 'http://localhost:3000',
+    // disableDefaultLocaleLoading: true,
     locales: [
       {
         code: 'en',
@@ -132,13 +133,13 @@ export default defineNuxtConfig({
         files: ['en.json', 'en-GB.js', 'en-KK.js'],
         name: 'English (UK)'
       },
-      {
-        code: 'ja',
-        iso: 'ja-JP',
-        file: 'ja.ts',
-        domain: 'mydomain.com',
-        name: 'Japanses'
-      },
+      // {
+      //   code: 'ja',
+      //   iso: 'ja-JP',
+      //   file: 'ja.ts',
+      //   domain: 'mydomain.com',
+      //   name: 'Japanses'
+      // },
       {
         code: 'fr',
         iso: 'fr-FR',

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -71,7 +71,8 @@ export default defineNuxtPlugin({
       routesNameSeparator,
       defaultLocaleRouteNameSuffix,
       strategy,
-      rootRedirect
+      rootRedirect,
+      skipDefaultLocale
     } = nuxtI18nOptions
     __DEBUG__ && console.log('isSSG', isSSG)
     __DEBUG__ && console.log('useCookie on setup', useCookie)
@@ -122,7 +123,8 @@ export default defineNuxtPlugin({
       ...nuxtI18nOptions,
       initialLocale,
       fallbackLocale: vueI18nOptions.fallbackLocale,
-      localeCodes
+      localeCodes,
+      skipDefaultLocale
     })
 
     /**

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -113,14 +113,18 @@ export async function loadInitialMessages<Context extends NuxtApp = NuxtApp>(
     messages[locale] = { ...base, ...message }
   }
 
+  const workedLocales: string[] = []
+  if (!options.skipDefaultLocale) {
+    workedLocales.push(defaultLocale)
+  }
+  workedLocales.push(initialLocale)
   // load fallback messages
   if (lazy && fallbackLocale) {
-    const fallbackLocales = makeFallbackLocaleCodes(fallbackLocale, [initialLocale])
+    const fallbackLocales = makeFallbackLocaleCodes(fallbackLocale, workedLocales)
     await Promise.all(fallbackLocales.map(locale => loadLocale(context, locale, setter)))
   }
-
   // load initial messages
-  const locales = lazy ? [...new Set<Locale>().add(initialLocale)] : localeCodes
+  const locales = lazy ? workedLocales : localeCodes
   await Promise.all(locales.map(locale => loadLocale(context, locale, setter)))
 
   return messages

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -115,12 +115,12 @@ export async function loadInitialMessages<Context extends NuxtApp = NuxtApp>(
 
   // load fallback messages
   if (lazy && fallbackLocale) {
-    const fallbackLocales = makeFallbackLocaleCodes(fallbackLocale, [defaultLocale, initialLocale])
+    const fallbackLocales = makeFallbackLocaleCodes(fallbackLocale, [initialLocale])
     await Promise.all(fallbackLocales.map(locale => loadLocale(context, locale, setter)))
   }
 
   // load initial messages
-  const locales = lazy ? [...new Set<Locale>().add(defaultLocale).add(initialLocale)] : localeCodes
+  const locales = lazy ? [...new Set<Locale>().add(initialLocale)] : localeCodes
   await Promise.all(locales.map(locale => loadLocale(context, locale, setter)))
 
   return messages

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,6 +112,7 @@ export type NuxtI18nOptions<Context = unknown> = {
   debug?: boolean
   dynamicRouteParams?: boolean
   parallelPlugin?: boolean
+  skipDefaultLocale?: boolean
 } & Pick<
   I18nRoutingOptions<Context>,
   | 'baseUrl'


### PR DESCRIPTION
### ❓ Type of change

- [X] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [X] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

~~removed the default locale from loadInitialMessages. Why is this needed? There's a FallbackLocale, if needed, one can add it themselves, but now it works weirdly, always loading the default locale, even if it's not needed.~~

I added the skipDefaultLocale option, which allows you to manually control the list of available locales.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.
