### PR TITLE
fix: Nuxt instance unavailable in `defineI18nConfig`

### DIFF
--- a/playground/vue-i18n.options.ts
+++ b/playground/vue-i18n.options.ts
@@ -1,26 +1,31 @@
 import fr from './locales/fr.json'
+import { useRuntimeConfig } from '#imports'
 
-export default defineI18nConfig(() => ({
-  legacy: false,
-  locale: 'en',
-  fallbackLocale: 'en',
-  messages: {
-    ja: {
-      bar: {
-        buz: 'こんにちは！{name}!',
-        fn: ({ named }: any) => `こんにちは！${named('name')}!`
+export default defineI18nConfig(() => {
+  // defineNuxtPlugin()
+  console.log(useRuntimeConfig())
+  return {
+    legacy: false,
+    locale: 'en',
+    fallbackLocale: 'en',
+    messages: {
+      ja: {
+        bar: {
+          buz: 'こんにちは！{name}!',
+          fn: ({ named }: any) => `こんにちは！${named('name')}!`
+        },
+        items: [{ name: 'りんご' }, { name: 'バナナ' }, { name: 'いちご' }]
       },
-      items: [{ name: 'りんご' }, { name: 'バナナ' }, { name: 'いちご' }]
+      fr
     },
-    fr
-  },
-  modifiers: {
-    // @ts-ignore
-    snakeCase: (str: string) => str.split(' ').join('-')
-  },
-  missingWarn: true,
-  fallbackWarn: true,
-  warnHtmlMessage: true,
-  silentFallbackWarn: false,
-  silentTranslationWarn: false
-}))
+    modifiers: {
+      // @ts-ignore
+      snakeCase: (str: string) => str.split(' ').join('-')
+    },
+    missingWarn: true,
+    fallbackWarn: true,
+    warnHtmlMessage: true,
+    silentFallbackWarn: false,
+    silentTranslationWarn: false
+  }
+})

--- a/specs/basic_usage.spec.ts
+++ b/specs/basic_usage.spec.ts
@@ -74,6 +74,12 @@ test('register module hook', async () => {
   expect(await getText(page, '#register-module')).toEqual('This is a merged module layer locale key in French')
 })
 
+test('vueI18n config file can access runtimeConfig', async () => {
+  const { page } = await renderPage('/')
+
+  expect(await getText(page, '#runtime-config')).toEqual('Hello from runtime config!')
+})
+
 test('layer provides locale `nl` and translation for key `hello`', async () => {
   const { page } = await renderPage('/layer-page')
 

--- a/specs/fixtures/basic_usage/config/i18n.config.ts
+++ b/specs/fixtures/basic_usage/config/i18n.config.ts
@@ -1,33 +1,38 @@
-export default defineI18nConfig(() => ({
-  legacy: false,
-  locale: 'en',
-  messages: {
-    fr: {
-      welcome: 'Bienvenue',
-      home: 'Accueil',
-      profile: 'Profil',
-      aboutSite: 'À propos de ce site',
-      snakeCaseText: "@.snakeCase:{'aboutSite'}",
-      pascalCaseText: "@.pascalCase:{'aboutSite'}",
-      hello: 'Bonjour le monde!',
-      modifier: "@.snakeCase:{'hello'}"
+export default defineI18nConfig(() => {
+  const config = useRuntimeConfig()
+
+  return {
+    legacy: false,
+    locale: 'en',
+    messages: {
+      fr: {
+        welcome: 'Bienvenue',
+        home: 'Accueil',
+        profile: 'Profil',
+        aboutSite: 'À propos de ce site',
+        snakeCaseText: "@.snakeCase:{'aboutSite'}",
+        pascalCaseText: "@.pascalCase:{'aboutSite'}",
+        hello: 'Bonjour le monde!',
+        modifier: "@.snakeCase:{'hello'}"
+      },
+      en: {
+        welcome: 'Welcome',
+        home: 'Homepage',
+        profile: 'Profile',
+        hello: 'Hello world!',
+        modifier: "@.snakeCase:{'hello'}",
+        fallbackMessage: 'This is the fallback message!',
+        runtimeKey: config.public.runtimeValue
+      },
+      nl: {
+        aboutSite: 'Over deze site',
+        snakeCaseText: "@.snakeCase:{'aboutSite'}",
+        pascalCaseText: "@.pascalCase:{'aboutSite'}"
+      }
     },
-    en: {
-      welcome: 'Welcome',
-      home: 'Homepage',
-      profile: 'Profile',
-      hello: 'Hello world!',
-      modifier: "@.snakeCase:{'hello'}",
-      fallbackMessage: 'This is the fallback message!'
-    },
-    nl: {
-      aboutSite: 'Over deze site',
-      snakeCaseText: "@.snakeCase:{'aboutSite'}",
-      pascalCaseText: "@.pascalCase:{'aboutSite'}"
+    modifiers: {
+      // @ts-ignore
+      snakeCase: (str: string) => str.split(' ').join('-')
     }
-  },
-  modifiers: {
-    // @ts-ignore
-    snakeCase: (str: string) => str.split(' ').join('-')
   }
-}))
+})

--- a/specs/fixtures/basic_usage/nuxt.config.ts
+++ b/specs/fixtures/basic_usage/nuxt.config.ts
@@ -1,6 +1,11 @@
 // https://nuxt.com/docs/guide/directory-structure/nuxt.config
 export default defineNuxtConfig({
   modules: ['./layer-module', '@nuxtjs/i18n'],
+  runtimeConfig: {
+    public: {
+      runtimeValue: 'Hello from runtime config!'
+    }
+  },
 
   i18n: {
     vueI18n: './config/i18n.config.ts'

--- a/specs/fixtures/basic_usage/pages/index.vue
+++ b/specs/fixtures/basic_usage/pages/index.vue
@@ -172,5 +172,8 @@ useHead({
     <section>
       <div id="fallback-key">{{ $t('fallbackMessage') }}</div>
     </section>
+    <section>
+      <div id="runtime-config">{{ $t('runtimeKey') }}</div>
+    </section>
   </div>
 </template>

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -21,7 +21,7 @@ const debug = createDebug('@nuxtjs/i18n:gen')
 
 const generateVueI18nConfiguration = (config: Required<VueI18nConfigPathInfo>): string => {
   return genDynamicImport(genImportSpecifier(config.meta, 'config'), {
-    comment: `webpackChunkName: ${config.meta.key}`
+    comment: `webpackChunkName: "${config.meta.key}"`
   })
 }
 

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -83,10 +83,9 @@ export function generateLoaderOptions(nuxt: Nuxt, { nuxtI18nOptions, vueI18nConf
   }
 
   /**
-   * Reverse order so project overwrites layers
+   * Prepare Vue I18n config imports
    */
   const vueI18nConfigImports = vueI18nConfigPaths
-    .reverse()
     .filter(config => config.absolute !== '')
     .map(config => generateVueI18nConfiguration(config))
 

--- a/src/options.d.ts
+++ b/src/options.d.ts
@@ -2,7 +2,7 @@
 import type { NuxtI18nOptions, NuxtI18nInternalOptions, RootRedirectOptions } from './types'
 import type { NuxtI18nOptionsDefault } from './constants'
 import type { DeepRequired } from 'ts-essentials'
-import type { NuxtApp } from '@nuxt/schema'
+import type { I18nOptions } from 'vue-i18n'
 
 /**
  * stub type definition for @nuxtjs/i18n internally
@@ -19,16 +19,12 @@ type LocaleLoader = {
 export const loadMessages: () => Promise<any> = () => Promise.resolve({})
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const localeMessages: Record<string, LocaleLoader[]> = {}
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const resolveNuxtI18nOptions: <Context = NuxtApp>(
-  context: Context
-) => Promise<DeepRequired<NuxtI18nOptions<Context>>> = () => Promise.resolve({})
-export type LoaderResult = Record<string, unknown> | (() => Record<string, unknown>)
-type LoadedConfig = Record<string, unknown>
-export type VLoaderType = () => Promise<{ default: LoadedConfig | (() => LoadedConfig) }>
-export const vueI18nConfigLoaders: VLoaderType[]
+
+export type VueI18nConfig = () => Promise<{ default: I18nOptions | (() => I18nOptions | Promise<I18nOptions>) }>
+export const vueI18nConfigs: VueI18nConfig[]
+
 export const localeCodes: string[] = []
-export const nuxtI18nOptions: DeepRequired<NuxtI18nOptions> = {}
+export const nuxtI18nOptions: DeepRequired<NuxtI18nOptions<Context>> = {}
 export const nuxtI18nOptionsDefault: NuxtI18nOptionsDefault = {}
 export const nuxtI18nInternalOptions: DeepRequired<NuxtI18nInternalOptions> = {}
 export const NUXT_I18N_MODULE_ID = ''

--- a/src/options.d.ts
+++ b/src/options.d.ts
@@ -2,6 +2,7 @@
 import type { NuxtI18nOptions, NuxtI18nInternalOptions, RootRedirectOptions } from './types'
 import type { NuxtI18nOptionsDefault } from './constants'
 import type { DeepRequired } from 'ts-essentials'
+import type { NuxtApp } from '@nuxt/schema'
 
 /**
  * stub type definition for @nuxtjs/i18n internally
@@ -19,9 +20,13 @@ export const loadMessages: () => Promise<any> = () => Promise.resolve({})
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const localeMessages: Record<string, LocaleLoader[]> = {}
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const resolveNuxtI18nOptions: <Context = unknown>(
+export const resolveNuxtI18nOptions: <Context = NuxtApp>(
   context: Context
 ) => Promise<DeepRequired<NuxtI18nOptions<Context>>> = () => Promise.resolve({})
+export type LoaderResult = Record<string, unknown> | (() => Record<string, unknown>)
+type LoadedConfig = Record<string, unknown>
+export type VLoaderType = () => Promise<{ default: LoadedConfig | (() => LoadedConfig) }>
+export const vueI18nConfigLoaders: VLoaderType[]
 export const localeCodes: string[] = []
 export const nuxtI18nOptions: DeepRequired<NuxtI18nOptions> = {}
 export const nuxtI18nOptionsDefault: NuxtI18nOptionsDefault = {}

--- a/src/runtime/internal.ts
+++ b/src/runtime/internal.ts
@@ -287,6 +287,7 @@ export function detectBrowserLanguage<Context extends NuxtApp = NuxtApp>(
   context: any,
   nuxtI18nOptions: DeepRequired<NuxtI18nOptions<Context>>,
   nuxtI18nInternalOptions: DeepRequired<NuxtI18nInternalOptions>,
+  vueI18nOptions: I18nOptions,
   detectLocaleContext: DetectLocaleContext,
   localeCodes: string[] = [],
   locale: Locale = ''
@@ -370,7 +371,7 @@ export function detectBrowserLanguage<Context extends NuxtApp = NuxtApp>(
       localeFrom
     )
 
-  const vueI18nLocale = locale || (nuxtI18nOptions.vueI18n as I18nOptions).locale
+  const vueI18nLocale = locale || vueI18nOptions.locale
   __DEBUG__ && console.log('detectBrowserLanguage: vueI18nLocale', vueI18nLocale)
 
   // handle cookie option to prevent multiple redirects

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -32,8 +32,7 @@ import {
   extendBaseUrl,
   extendPrefixable,
   extendSwitchLocalePathIntercepter,
-  _setLocale,
-  resolveVueI18nOptions
+  _setLocale
 } from '#build/i18n.utils.mjs'
 import {
   getBrowserLocale as _getBrowserLocale,
@@ -42,8 +41,9 @@ import {
   detectBrowserLanguage,
   DefaultDetectBrowserLanguageFromResult
 } from '#build/i18n.internal.mjs'
+import defu from 'defu'
 
-import type { Composer, Locale } from 'vue-i18n'
+import type { Composer, Locale, I18nOptions } from 'vue-i18n'
 import type { LocaleObject, ExtendProperyDescripters, VueI18nRoutingPluginOptions } from 'vue-i18n-routing'
 import type { NuxtApp } from '#app'
 
@@ -62,7 +62,13 @@ export default defineNuxtPlugin({
     const { vueApp: app } = nuxt
     const nuxtContext = nuxt as unknown as NuxtApp
 
-    const vueI18nOptions = await resolveVueI18nOptions(vueI18nConfigs)
+    let vueI18nOptions: I18nOptions = { messages: {} }
+    for (const configFile of vueI18nConfigs) {
+      const { default: resolver } = await configFile()
+      const resolved = typeof resolver === 'function' ? await resolver() : resolver
+
+      vueI18nOptions = defu(vueI18nOptions, resolved)
+    }
 
     const useCookie = nuxtI18nOptions.detectBrowserLanguage && nuxtI18nOptions.detectBrowserLanguage.useCookie
     const { __normalizedLocales: normalizedLocales } = nuxtI18nInternalOptions

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -17,6 +17,7 @@ import { defineNuxtPlugin, useRouter, useRoute, addRouteMiddleware, defineNuxtRo
 import {
   localeCodes,
   resolveNuxtI18nOptions,
+  vueI18nConfigLoaders,
   nuxtI18nInternalOptions,
   isSSG,
   parallelPlugin
@@ -44,6 +45,7 @@ import {
 import type { Composer, I18nOptions, Locale } from 'vue-i18n'
 import type { LocaleObject, ExtendProperyDescripters, VueI18nRoutingPluginOptions } from 'vue-i18n-routing'
 import type { NuxtApp } from '#app'
+import defu from 'defu'
 
 type GetRouteBaseName = typeof getRouteBaseName
 type LocalePath = typeof localePath
@@ -61,6 +63,18 @@ export default defineNuxtPlugin({
     const nuxtContext = nuxt as unknown as NuxtApp
 
     const nuxtI18nOptions = await resolveNuxtI18nOptions<NuxtApp>(nuxtContext)
+
+    // @ts-ignore
+    nuxtI18nOptions.vueI18n = { messages: {} }
+
+    for (const vLoader of vueI18nConfigLoaders) {
+      const { default: resolver } = await vLoader()
+      const resolved = typeof resolver === 'function' ? resolver() : resolver
+
+      // @ts-ignore
+      nuxtI18nOptions.vueI18n = defu(nuxtI18nOptions.vueI18n, resolved)
+    }
+
     const useCookie = nuxtI18nOptions.detectBrowserLanguage && nuxtI18nOptions.detectBrowserLanguage.useCookie
     const { __normalizedLocales: normalizedLocales } = nuxtI18nInternalOptions
     const {

--- a/src/runtime/templates/options.template.mjs
+++ b/src/runtime/templates/options.template.mjs
@@ -10,50 +10,14 @@ export const localeMessages = { <% options.localeMessages.forEach(function ([key
   ],<% }); %>
 }
 
+export const vueI18nConfigLoaders = [ 
+  <% options.vueI18nConfigs.forEach(function (importer) { %><%= importer %>,
+    <% }); %>
+]
+
 export const resolveNuxtI18nOptions = async (context) => {
   const nuxtI18nOptions = <%= JSON.stringify(options.nuxtI18nOptions, null, 2) %>
   
-  const vueI18nConfigLoader = async loader => {
-    const config = await loader().then(r => r.default || r)
-    if (typeof config === 'object') return config
-    if (typeof config === 'function') return await config()
-    return {}
-  }
-
-  const deepCopy = (src, des, predicate) => {
-    for (const key in src) {
-      if (typeof src[key] === 'object') {
-        if (!(typeof des[key] === 'object')) des[key] = {}
-        deepCopy(src[key], des[key], predicate)
-      } else {
-        if (predicate) {
-          if (predicate(src[key], des[key])) {
-            des[key] = src[key]
-          }
-        } else {
-          des[key] = src[key]
-        }
-      }
-    }
-  }
-  
-  const mergeVueI18nConfigs = async (loader) => {
-    const layerConfig = await vueI18nConfigLoader(loader)
-    const cfg = layerConfig || {}
-    
-    for (const [k, v] of Object.entries(cfg)) {
-      if(nuxtI18nOptions.vueI18n?.[k] === undefined || typeof nuxtI18nOptions.vueI18n?.[k] !== 'object') {
-        nuxtI18nOptions.vueI18n[k] = v
-      } else {
-        deepCopy(v, nuxtI18nOptions.vueI18n[k])
-      }
-    }
-  }
-
-  nuxtI18nOptions.vueI18n = { messages: {} }
-  <% options.vueI18nConfigs.forEach(function (importer) { %>
-  await mergeVueI18nConfigs(<%= importer %>) <% }); %>
-    
   return nuxtI18nOptions
 }
 

--- a/src/runtime/templates/options.template.mjs
+++ b/src/runtime/templates/options.template.mjs
@@ -2,7 +2,7 @@
 <% options.importStrings.forEach(function (importer) { %>
 <%= importer %><% }); %>
 
-export const localeCodes = <%= JSON.stringify(options.localeCodes, null, 2) %>
+export const localeCodes = <%= JSON.stringify(options.localeCodes, null, 2) %>;
 
 export const localeMessages = { <% options.localeMessages.forEach(function ([key, val]) { %>
   "<%= key %>": [<% val.forEach(function (entry) { %>
@@ -10,16 +10,11 @@ export const localeMessages = { <% options.localeMessages.forEach(function ([key
   ],<% }); %>
 }
 
-export const vueI18nConfigLoaders = [ 
-  <% options.vueI18nConfigs.forEach(function (importer) { %><%= importer %>,
-    <% }); %>
+export const vueI18nConfigs = [<% options.vueI18nConfigs.forEach(function (importer) { %>
+  <%= importer %>,<% }); %>
 ]
 
-export const resolveNuxtI18nOptions = async (context) => {
-  const nuxtI18nOptions = <%= JSON.stringify(options.nuxtI18nOptions, null, 2) %>
-  
-  return nuxtI18nOptions
-}
+export const nuxtI18nOptions = <%= JSON.stringify(options.nuxtI18nOptions, null, 2) %>
 
 export const nuxtI18nOptionsDefault = <%= JSON.stringify(options.nuxtI18nOptionsDefault, null, 2) %>
 

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -31,7 +31,6 @@ import {
   DefaultDetectBrowserLanguageFromResult
 } from '#build/i18n.internal.mjs'
 import { joinURL, isEqual } from 'ufo'
-import defu from 'defu'
 
 import type {
   Route,
@@ -44,12 +43,7 @@ import type {
 } from 'vue-i18n-routing'
 import type { NuxtApp } from '#app'
 import type { I18n, I18nOptions, Locale, FallbackLocale, LocaleMessages, DefineLocaleMessage } from 'vue-i18n'
-import type {
-  NuxtI18nOptions,
-  DetectBrowserLanguageOptions,
-  RootRedirectOptions,
-  VueI18nConfig
-} from '#build/i18n.options.mjs'
+import type { NuxtI18nOptions, DetectBrowserLanguageOptions, RootRedirectOptions } from '#build/i18n.options.mjs'
 import type { DetectLocaleContext } from '#build/i18n.internal.mjs'
 import type { DeepRequired } from 'ts-essentials'
 
@@ -535,19 +529,6 @@ export function extendBaseUrl<Context extends NuxtApp = NuxtApp>(
 
     return baseUrl
   }
-}
-
-export const resolveVueI18nOptions = async (configFiles: VueI18nConfig[]) => {
-  let resolvedOptions: I18nOptions = { messages: {} }
-
-  for (const configFile of configFiles) {
-    const { default: resolver } = await configFile()
-    const resolved = typeof resolver === 'function' ? await resolver() : resolver
-
-    resolvedOptions = defu(resolvedOptions, resolved)
-  }
-
-  return resolvedOptions
 }
 
 /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/test/__snapshots__/gen.test.ts.snap
+++ b/test/__snapshots__/gen.test.ts.snap
@@ -421,9 +421,9 @@ exports[`vueI18n option 1`] = `
     "vueI18n": "vue-i18n.config.ts",
   },
   "vueI18nConfigs": [
-    "() => import(\\"../foo/layer2/vue-i18n.options.js?hash=475488e5&config=1\\" /* webpackChunkName: vue_i18n_options_js_475488e5 */)",
-    "() => import(\\"../layer1/i18n.custom.ts?hash=0ca697e2&config=1\\" /* webpackChunkName: i18n_custom_ts_0ca697e2 */)",
     "() => import(\\"../to/i18n.config.ts?hash=fb1304e8&config=1\\" /* webpackChunkName: i18n_config_ts_fb1304e8 */)",
+    "() => import(\\"../layer1/i18n.custom.ts?hash=0ca697e2&config=1\\" /* webpackChunkName: i18n_custom_ts_0ca697e2 */)",
+    "() => import(\\"../foo/layer2/vue-i18n.options.js?hash=475488e5&config=1\\" /* webpackChunkName: vue_i18n_options_js_475488e5 */)",
   ],
 }
 `;

--- a/test/__snapshots__/gen.test.ts.snap
+++ b/test/__snapshots__/gen.test.ts.snap
@@ -45,7 +45,7 @@ exports[`basic 1`] = `
     "locales": [],
   },
   "vueI18nConfigs": [
-    "() => import(\\"../i18n.config.ts?hash=bffaebcb&config=1\\" /* webpackChunkName: i18n_config_ts_bffaebcb */)",
+    "() => import(\\"../i18n.config.ts?hash=bffaebcb&config=1\\" /* webpackChunkName: \\"i18n_config_ts_bffaebcb\\" */)",
   ],
 }
 `;
@@ -116,7 +116,7 @@ exports[`files with cache configuration 1`] = `
     "locales": [],
   },
   "vueI18nConfigs": [
-    "() => import(\\"../i18n.config.ts?hash=bffaebcb&config=1\\" /* webpackChunkName: i18n_config_ts_bffaebcb */)",
+    "() => import(\\"../i18n.config.ts?hash=bffaebcb&config=1\\" /* webpackChunkName: \\"i18n_config_ts_bffaebcb\\" */)",
   ],
 }
 `;
@@ -162,7 +162,7 @@ exports[`lazy 1`] = `
     "locales": [],
   },
   "vueI18nConfigs": [
-    "() => import(\\"../i18n.config.ts?hash=bffaebcb&config=1\\" /* webpackChunkName: i18n_config_ts_bffaebcb */)",
+    "() => import(\\"../i18n.config.ts?hash=bffaebcb&config=1\\" /* webpackChunkName: \\"i18n_config_ts_bffaebcb\\" */)",
   ],
 }
 `;
@@ -208,7 +208,7 @@ exports[`locale file in nested 1`] = `
     "locales": [],
   },
   "vueI18nConfigs": [
-    "() => import(\\"../i18n.config.ts?hash=bffaebcb&config=1\\" /* webpackChunkName: i18n_config_ts_bffaebcb */)",
+    "() => import(\\"../i18n.config.ts?hash=bffaebcb&config=1\\" /* webpackChunkName: \\"i18n_config_ts_bffaebcb\\" */)",
   ],
 }
 `;
@@ -279,7 +279,7 @@ exports[`multiple files 1`] = `
     "locales": [],
   },
   "vueI18nConfigs": [
-    "() => import(\\"../i18n.config.ts?hash=bffaebcb&config=1\\" /* webpackChunkName: i18n_config_ts_bffaebcb */)",
+    "() => import(\\"../i18n.config.ts?hash=bffaebcb&config=1\\" /* webpackChunkName: \\"i18n_config_ts_bffaebcb\\" */)",
   ],
 }
 `;
@@ -325,7 +325,7 @@ exports[`toCode: function (arrow) 1`] = `
     ],
   },
   "vueI18nConfigs": [
-    "() => import(\\"../i18n.config.ts?hash=bffaebcb&config=1\\" /* webpackChunkName: i18n_config_ts_bffaebcb */)",
+    "() => import(\\"../i18n.config.ts?hash=bffaebcb&config=1\\" /* webpackChunkName: \\"i18n_config_ts_bffaebcb\\" */)",
   ],
 }
 `;
@@ -371,7 +371,7 @@ exports[`toCode: function (named) 1`] = `
     ],
   },
   "vueI18nConfigs": [
-    "() => import(\\"../i18n.config.ts?hash=bffaebcb&config=1\\" /* webpackChunkName: i18n_config_ts_bffaebcb */)",
+    "() => import(\\"../i18n.config.ts?hash=bffaebcb&config=1\\" /* webpackChunkName: \\"i18n_config_ts_bffaebcb\\" */)",
   ],
 }
 `;
@@ -421,9 +421,9 @@ exports[`vueI18n option 1`] = `
     "vueI18n": "vue-i18n.config.ts",
   },
   "vueI18nConfigs": [
-    "() => import(\\"../to/i18n.config.ts?hash=fb1304e8&config=1\\" /* webpackChunkName: i18n_config_ts_fb1304e8 */)",
-    "() => import(\\"../layer1/i18n.custom.ts?hash=0ca697e2&config=1\\" /* webpackChunkName: i18n_custom_ts_0ca697e2 */)",
-    "() => import(\\"../foo/layer2/vue-i18n.options.js?hash=475488e5&config=1\\" /* webpackChunkName: vue_i18n_options_js_475488e5 */)",
+    "() => import(\\"../to/i18n.config.ts?hash=fb1304e8&config=1\\" /* webpackChunkName: \\"i18n_config_ts_fb1304e8\\" */)",
+    "() => import(\\"../layer1/i18n.custom.ts?hash=0ca697e2&config=1\\" /* webpackChunkName: \\"i18n_custom_ts_0ca697e2\\" */)",
+    "() => import(\\"../foo/layer2/vue-i18n.options.js?hash=475488e5&config=1\\" /* webpackChunkName: \\"vue_i18n_options_js_475488e5\\" */)",
   ],
 }
 `;


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
* #2548
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This should fix the issue of not being able to access the Nuxt instance in `defineI18nConfig`/Vue I18n config files. I added a test to confirm this, let me know if there are most cases to be tested.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
