### PR TITLE
fix: unpin and update `vue-i18n`

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "sucrase": "^3.34.0",
     "ufo": "^1.3.1",
     "unplugin": "^1.5.0",
-    "vue-i18n": "9.6.5",
+    "vue-i18n": "^9.7.1",
     "vue-i18n-routing": "^1.1.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         version: 9.7.0
       '@intlify/unplugin-vue-i18n':
         specifier: ^1.4.0
-        version: 1.5.0(rollup@3.28.1)(vue-i18n@9.6.5)
+        version: 1.5.0(rollup@3.28.1)(vue-i18n@9.7.1)
       '@nuxt/kit':
         specifier: ^3.7.4
         version: 3.7.4(rollup@3.28.1)
@@ -56,11 +56,11 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0
       vue-i18n:
-        specifier: 9.6.5
-        version: 9.6.5(vue@3.3.4)
+        specifier: ^9.7.1
+        version: 9.7.1(vue@3.3.4)
       vue-i18n-routing:
         specifier: ^1.1.4
-        version: 1.1.4(vue-i18n@9.6.5)(vue-router@4.2.5)(vue@3.3.4)
+        version: 1.1.4(vue-i18n@9.7.1)(vue-router@4.2.5)(vue@3.3.4)
     devDependencies:
       '@babel/parser':
         specifier: ^7.23.0
@@ -1468,7 +1468,7 @@ packages:
       vue: 3.3.4
     dev: true
 
-  /@intlify/bundle-utils@7.4.0(vue-i18n@9.6.5):
+  /@intlify/bundle-utils@7.4.0(vue-i18n@9.7.1):
     resolution: {integrity: sha512-AQfjBe2HUxzyN8ignIk3WhhSuVcSuirgzOzkd17nb337rCbI4Gv/t1R60UUyIqFoFdviLb/wLcDUzTD/xXjv9w==}
     engines: {node: '>= 14.16'}
     peerDependencies:
@@ -1489,16 +1489,16 @@ packages:
       magic-string: 0.30.4
       mlly: 1.4.2
       source-map-js: 1.0.2
-      vue-i18n: 9.6.5(vue@3.3.4)
+      vue-i18n: 9.7.1(vue@3.3.4)
       yaml-eslint-parser: 1.2.2
     dev: false
 
-  /@intlify/core-base@9.6.5:
-    resolution: {integrity: sha512-LzbGXiZkMWPIHnHI0g6q554S87Cmh2mmCmjytK/3pDQfjI84l+dgGoeQuKj02q7EbULRuUUgYVZVqAwEUawXGg==}
+  /@intlify/core-base@9.7.1:
+    resolution: {integrity: sha512-jPJTeECEhqQ7g//8g3Fb79j5SzSSRqlFCWD6pcX94uMLXU+L1m07gVZnnvzoJBnaMyJHiiwxOqZVfvu6rQfLvw==}
     engines: {node: '>= 16'}
     dependencies:
-      '@intlify/message-compiler': 9.6.5
-      '@intlify/shared': 9.6.5
+      '@intlify/message-compiler': 9.7.1
+      '@intlify/shared': 9.7.1
     dev: false
 
   /@intlify/message-compiler@9.6.5:
@@ -1506,6 +1506,14 @@ packages:
     engines: {node: '>= 16'}
     dependencies:
       '@intlify/shared': 9.6.5
+      source-map-js: 1.0.2
+    dev: false
+
+  /@intlify/message-compiler@9.7.1:
+    resolution: {integrity: sha512-HfIr2Hn/K7b0Zv4kGqkxAxwtipyxAwhI9a3krN5cuhH/G9gkaik7of1PdzjR3Mix43t2onBiKYQyaU7mo7e0aA==}
+    engines: {node: '>= 16'}
+    dependencies:
+      '@intlify/shared': 9.7.1
       source-map-js: 1.0.2
     dev: false
 
@@ -1519,7 +1527,12 @@ packages:
     engines: {node: '>= 16'}
     dev: false
 
-  /@intlify/unplugin-vue-i18n@1.5.0(rollup@3.28.1)(vue-i18n@9.6.5):
+  /@intlify/shared@9.7.1:
+    resolution: {integrity: sha512-CBKnHzlUYGrk5QII9q4nElAQKO5cX1rRx8VmSWXltyOZjbkGHXYQTHULn6KwRi+CypuBCfmPkyPBHMzosypIeg==}
+    engines: {node: '>= 16'}
+    dev: false
+
+  /@intlify/unplugin-vue-i18n@1.5.0(rollup@3.28.1)(vue-i18n@9.7.1):
     resolution: {integrity: sha512-jW0MCCdwxybxcwjEfCunAcKjVoxyO3i+cnLL6v+MNGRLUHqrpELF6zQAJUhgAK2afhY7mCliy8RxTFWKdXm26w==}
     engines: {node: '>= 14.16'}
     peerDependencies:
@@ -1534,7 +1547,7 @@ packages:
       vue-i18n-bridge:
         optional: true
     dependencies:
-      '@intlify/bundle-utils': 7.4.0(vue-i18n@9.6.5)
+      '@intlify/bundle-utils': 7.4.0(vue-i18n@9.7.1)
       '@intlify/shared': 9.7.0
       '@rollup/pluginutils': 5.0.4(rollup@3.28.1)
       '@vue/compiler-sfc': 3.3.4
@@ -1546,13 +1559,13 @@ packages:
       picocolors: 1.0.0
       source-map-js: 1.0.2
       unplugin: 1.5.0
-      vue-i18n: 9.6.5(vue@3.3.4)
+      vue-i18n: 9.7.1(vue@3.3.4)
     transitivePeerDependencies:
       - rollup
       - supports-color
     dev: false
 
-  /@intlify/vue-i18n-bridge@1.0.1(vue-i18n@9.6.5):
+  /@intlify/vue-i18n-bridge@1.0.1(vue-i18n@9.7.1):
     resolution: {integrity: sha512-MJ1uC39/P8sCsvSs8pdXClbBCKYp5g+DbvNyIPvsKdAH/yBXP4r0s4GIsrOgxrvAO6wABZIIZ/glHAZJZfj4nw==}
     engines: {node: '>= 12'}
     hasBin: true
@@ -1569,7 +1582,7 @@ packages:
       vue-i18n-bridge:
         optional: true
     dependencies:
-      vue-i18n: 9.6.5(vue@3.3.4)
+      vue-i18n: 9.7.1(vue@3.3.4)
     dev: false
 
   /@intlify/vue-router-bridge@1.0.1(vue-router@4.2.5)(vue@3.3.4):
@@ -11101,7 +11114,7 @@ packages:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
     dev: true
 
-  /vue-i18n-routing@1.1.4(vue-i18n@9.6.5)(vue-router@4.2.5)(vue@3.3.4):
+  /vue-i18n-routing@1.1.4(vue-i18n@9.7.1)(vue-router@4.2.5)(vue@3.3.4):
     resolution: {integrity: sha512-RG6t7g9zklNoCOswTq2zy15siilw9rATmJkx5LYm9dqNBP2MR7yzTiwXpGVpfDHKl12SDWSRD0zzy13HekNEQQ==}
     engines: {node: '>= 14.6'}
     peerDependencies:
@@ -11123,23 +11136,23 @@ packages:
         optional: true
     dependencies:
       '@intlify/shared': 9.7.0
-      '@intlify/vue-i18n-bridge': 1.0.1(vue-i18n@9.6.5)
+      '@intlify/vue-i18n-bridge': 1.0.1(vue-i18n@9.7.1)
       '@intlify/vue-router-bridge': 1.0.1(vue-router@4.2.5)(vue@3.3.4)
       ufo: 1.3.1
       vue: 3.3.4
       vue-demi: 0.14.5(vue@3.3.4)
-      vue-i18n: 9.6.5(vue@3.3.4)
+      vue-i18n: 9.7.1(vue@3.3.4)
       vue-router: 4.2.5(vue@3.3.4)
     dev: false
 
-  /vue-i18n@9.6.5(vue@3.3.4):
-    resolution: {integrity: sha512-dpUEjKHg7pEsaS7ZPPxp1CflaR7bGmsvZJEhnszHPKl9OTNyno5j/DvMtMSo41kpddq4felLA7GK2prjpnXVlw==}
+  /vue-i18n@9.7.1(vue@3.3.4):
+    resolution: {integrity: sha512-A6DzWqJQMdzBj+392+g3zIgGV0FnFC7o/V+txs5yIALANEZzY6ZV8hM2wvZR3nTbQI7dntAmzBHMeoEteJO0kQ==}
     engines: {node: '>= 16'}
     peerDependencies:
       vue: ^3.0.0
     dependencies:
-      '@intlify/core-base': 9.6.5
-      '@intlify/shared': 9.6.5
+      '@intlify/core-base': 9.7.1
+      '@intlify/shared': 9.7.1
       '@vue/devtools-api': 6.5.0
       vue: 3.3.4
     dev: false


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
* #2569 
* https://github.com/intlify/vue-i18n-next/issues/1637
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I think we should probably publish a new release candidate after merging this, it seems like users are experiencing issues with `vue-i18n` and `@intlify/shared` versions being pinned in `rc.5`.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
