### PR TITLE
fix: ensure `route.from.fullPath` is decoded

### DIFF
--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -335,8 +335,12 @@ export function detectRedirect<Context extends NuxtApp = NuxtApp>({
        * NOTE: for #1889, #2226
        * If it's the same as the previous route path, respect the current route without redirecting.
        * (If an empty string is set, the current route is respected. after this function return, it's pass navigate function)
+       *
+       * NOTE: for #2578
+       * Sometimes, the `route.from.fullPath` is encoded, so we need to decode it.
+       * (e.g. when the `route.from.fullPath` is `/check?email=test%40test.dev`, the `decodeURIComponent(route.from.fullPath)` is `/check?email=test@test.dev`)
        */
-      redirectPath = !(route.from && route.from.fullPath === routePath) ? routePath : ''
+      redirectPath = !(route.from && decodeURIComponent(route.from.fullPath) === routePath) ? routePath : ''
     }
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolve #2578

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Sometimes, the `route.from.fullPath` is encoded, so it needs to be decoded.

```ts
// When `route.from.fullPath` is `/check?email=test%40test.dev`
// and `routePath` is `/check?email=test@test.dev`

console.log(route.from.fullPath === routePath) // returns false
console.log(decodeURIComponent(route.from.fullPath) === routePath) // returns true
```

Or

```ts
// When `route.from.fullPath` is `/ja/%E3%83%86%E3%82%B9%E3%83%88`
// and `routePath` is `/ja/テスト`

console.log(route.from.fullPath === routePath) // returns false
console.log(decodeURIComponent(route.from.fullPath) === routePath) // returns true
```

I have attempted to ensure that `route.from.fullPath` is decoded to resolve this issue. Please let me know if there is anything I may have overlooked. Thank you.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
