### PR TITLE
fix: module locale option generation breaking SEO

### DIFF
--- a/specs/fixtures/issues/2590/app.vue
+++ b/specs/fixtures/issues/2590/app.vue
@@ -1,0 +1,43 @@
+<template>
+  <div>
+    {{ $t('welcome') }}
+  </div>
+</template>
+
+<script setup lang="ts">
+const { locale, locales, setLocale } = useI18n()
+
+const head = useLocaleHead({
+  addDirAttribute: true,
+  addSeoAttributes: true
+})
+
+useHead({
+  htmlAttrs: head.value.htmlAttrs
+})
+
+console.log(head.value.htmlAttrs)
+
+const availableLocales = computed(() => {
+  return (locales.value as LocaleObject[])
+    .filter(item => {
+      return item.code !== locale.value
+    })
+    .map(item => {
+      return {
+        label: item.name,
+        key: item.code
+      }
+    })
+})
+
+const currentLocale = computed(() => {
+  return (locales.value as LocaleObject[]).filter(item => {
+    return item.code === locale.value
+  })
+})
+
+function changeLocal(code: any) {
+  setLocale(code)
+}
+</script>

--- a/specs/fixtures/issues/2590/i18n.config.ts
+++ b/specs/fixtures/issues/2590/i18n.config.ts
@@ -1,0 +1,3 @@
+export default defineI18nConfig(() => ({
+  legacy: false
+}))

--- a/specs/fixtures/issues/2590/modules/i18n-module/index.ts
+++ b/specs/fixtures/issues/2590/modules/i18n-module/index.ts
@@ -1,0 +1,35 @@
+import { createResolver, defineNuxtModule, installModule } from '@nuxt/kit'
+
+export default defineNuxtModule({
+  async setup(options, nuxt) {
+    const { resolve } = createResolver(import.meta.url)
+
+    nuxt.hook('i18n:registerModule', registerModule =>
+      registerModule({
+        langDir: resolve('lang'),
+        locales: [
+          {
+            code: 'en',
+            iso: 'en-US',
+            file: 'en-US.ts',
+            name: 'English'
+          }
+        ]
+      })
+    )
+
+    await installModule('@nuxtjs/i18n', {
+      lazy: true,
+      defaultLocale: 'en',
+      experimental: {
+        jsTsFormatResource: true
+      },
+      detectBrowserLanguage: {
+        useCookie: true,
+        cookieKey: 'i18n_lang',
+        redirectOn: 'root'
+      },
+      vueI18n: './i18n.config.ts'
+    })
+  }
+})

--- a/specs/fixtures/issues/2590/modules/i18n-module/lang/en-US.ts
+++ b/specs/fixtures/issues/2590/modules/i18n-module/lang/en-US.ts
@@ -1,0 +1,5 @@
+export default defineI18nLocale(async () => {
+  return {
+    welcome: 'welcome translated'
+  }
+})

--- a/specs/fixtures/issues/2590/nuxt.config.ts
+++ b/specs/fixtures/issues/2590/nuxt.config.ts
@@ -1,0 +1,5 @@
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+  devtools: { enabled: false },
+  modules: ['./modules/i18n-module']
+})

--- a/specs/fixtures/issues/2590/package.json
+++ b/specs/fixtures/issues/2590/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "nuxt3-test-issues-2473",
+  "private": true,
+  "scripts": {
+    "build": "nuxt build",
+    "dev": "nuxt dev",
+    "generate": "nuxt generate",
+    "preview": "nuxt preview"
+  },
+  "devDependencies": {
+    "@nuxtjs/i18n": "latest",
+    "nuxt": "latest"
+  }
+}

--- a/specs/issues/2590.spec.ts
+++ b/specs/issues/2590.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect, describe } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { URL } from 'node:url'
+import { setup } from '../utils'
+import { renderPage } from '../helper'
+
+describe('#2590', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL(`../fixtures/issues/2590`, import.meta.url)),
+    browser: true
+  })
+
+  test('Locale ISO code is required to generate alternate link', async () => {
+    const { page } = await renderPage('/')
+
+    // html tag `lang` attribute
+    expect(await page.getAttribute('html', 'lang')).toMatch('en')
+
+    // html tag `dir` attribute
+    expect(await page.getAttribute('html', 'dir')).toMatch('ltr')
+  })
+})

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -25,11 +25,12 @@ const generateVueI18nConfiguration = (config: Required<VueI18nConfigPathInfo>): 
   })
 }
 
-function simplifyLocaleOptions(nuxt: Nuxt, locales: LocaleObject[]) {
-  const hasObjectLocales = nuxt.options._layers.some(
-    layer => layer?.config?.i18n?.locales?.some(x => typeof x !== 'string')
-  )
+function simplifyLocaleOptions(nuxt: Nuxt, options: NuxtI18nOptions) {
+  const hasObjectLocales =
+    nuxt.options._layers.some(layer => layer?.config?.i18n?.locales?.some(x => typeof x !== 'string')) ||
+    options?.i18nModules?.some(module => module?.locales?.some(x => typeof x !== 'string'))
 
+  const locales = (options.locales ?? []) as LocaleObject[]
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   return locales.map(({ meta, ...locale }) => {
     if (!hasObjectLocales) {
@@ -94,7 +95,7 @@ export function generateLoaderOptions(nuxt: Nuxt, { nuxtI18nOptions, vueI18nConf
 
   const generatedNuxtI18nOptions = {
     ...nuxtI18nOptions,
-    locales: simplifyLocaleOptions(nuxt, (nuxtI18nOptions?.locales ?? []) as unknown as LocaleObject[])
+    locales: simplifyLocaleOptions(nuxt, nuxtI18nOptions)
   }
   delete nuxtI18nOptions.vueI18n
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
* #2590
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

* Resolves #2590

Essentially the same as #2509 except it also includes locales added by modules using the `i18n:registerModule` hook. 

Still need to add tests.


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
