### PR TITLE
feat: `defineI18nRoute` name parameter

### DIFF
--- a/src/pages.ts
+++ b/src/pages.ts
@@ -1,12 +1,13 @@
 import createDebug from 'debug'
 import { extendPages } from '@nuxt/kit'
-import { localizeRoutes, DefaultLocalizeRoutesPrefixable } from 'vue-i18n-routing'
+import { DefaultLocalizeRoutesPrefixable } from 'vue-i18n-routing'
 import { isString } from '@intlify/shared'
 import { parse as parseSFC, compileScript } from '@vue/compiler-sfc'
 import { walk } from 'estree-walker'
 import MagicString from 'magic-string'
 import { formatMessage, getRoutePath, parseSegment, readFileSync } from './utils'
 import { mergeLayerPages } from './layers'
+import { localizeRoutes } from './routing'
 import { resolve, parse as parsePath } from 'pathe'
 import { NUXT_I18N_COMPOSABLE_DEFINE_ROUTE } from './constants'
 
@@ -238,6 +239,10 @@ function getRouteOptionsFromComponent(route: I18nRoute, localeCodes: string[]) {
     if (isString(customLocalePath)) {
       options.paths[locale] = resolveRoutePath(customLocalePath)
     }
+  }
+
+  if (componentOptions.name != null) {
+    options.name = componentOptions.name
   }
 
   return options

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -1,0 +1,246 @@
+import { STRATEGIES } from './constants'
+
+import type {
+  I18nRoute,
+  I18nRoutingOptions,
+  RouteOptionsResolver,
+  LocalizeRoutesPrefixableOptions
+} from 'vue-i18n-routing'
+import { assign, isString } from '@intlify/shared'
+import type { ComputedRouteOptions } from 'vue-i18n-routing'
+
+// NOTE:
+//  we avoid SSR issue with the temp variables
+//  (I think it seem to not be able to handle the MemberExpression case)
+// - https://github.com/vitejs/vite/pull/6171
+// - https://github.com/vitejs/vite/pull/3848
+/*
+export const VUE_I18N_ROUTING_DEFAULTS = {
+  defaultLocale: '',
+  strategy: 'prefix_except_default',
+  trailingSlash: false,
+  routesNameSeparator: '___',
+  defaultLocaleRouteNameSuffix: 'default'
+}
+*/
+
+/** @internal */
+export const DEFAULT_LOCALE = ''
+/** @internal */
+export const DEFAULT_STRATEGY = STRATEGIES.PREFIX_EXCEPT_DEFAULT
+/** @internal */
+export const DEFAULT_TRAILING_SLASH = false
+/** @internal */
+export const DEFAULT_ROUTES_NAME_SEPARATOR = '___'
+/** @internal */
+export const DEFAULT_LOCALE_ROUTE_NAME_SUFFIX = 'default'
+/** @internal */
+export const DEFAULT_DETECTION_DIRECTION = 'ltr'
+/** @internal */
+export const DEFAULT_BASE_URL = ''
+/** @internal */
+export const DEFAULT_DYNAMIC_PARAMS_KEY = ''
+
+// Language: typescript
+export function adjustRoutePathForTrailingSlash(
+  pagePath: string,
+  trailingSlash: boolean,
+  isChildWithRelativePath: boolean
+) {
+  return pagePath.replace(/\/+$/, '') + (trailingSlash ? '/' : '') || (isChildWithRelativePath ? '' : '/')
+}
+
+function prefixable(optons: LocalizeRoutesPrefixableOptions): boolean {
+  const { currentLocale, defaultLocale, strategy, isChild, path } = optons
+
+  const isDefaultLocale = currentLocale === defaultLocale
+  const isChildWithRelativePath = isChild && !path.startsWith('/')
+
+  // no need to add prefix if child's path is relative
+  return (
+    !isChildWithRelativePath &&
+    // skip default locale if strategy is 'prefix_except_default'
+    !(isDefaultLocale && strategy === 'prefix_except_default')
+  )
+}
+
+export const DefaultLocalizeRoutesPrefixable = prefixable
+
+/**
+ * Localize routes
+ *
+ * @param routes - Some routes
+ * @param options - An options
+ *
+ * @returns Localized routes
+ *
+ * @public
+ */
+export function localizeRoutes(
+  routes: I18nRoute[],
+  {
+    defaultLocale = DEFAULT_LOCALE,
+    strategy = DEFAULT_STRATEGY,
+    trailingSlash = DEFAULT_TRAILING_SLASH,
+    routesNameSeparator = DEFAULT_ROUTES_NAME_SEPARATOR,
+    defaultLocaleRouteNameSuffix = DEFAULT_LOCALE_ROUTE_NAME_SUFFIX,
+    includeUprefixedFallback = false,
+    optionsResolver = undefined,
+    localizeRoutesPrefixable = DefaultLocalizeRoutesPrefixable,
+    locales = []
+  }: Pick<
+    I18nRoutingOptions,
+    | 'defaultLocale'
+    | 'strategy'
+    | 'locales'
+    | 'routesNameSeparator'
+    | 'trailingSlash'
+    | 'defaultLocaleRouteNameSuffix'
+    | 'localizeRoutesPrefixable'
+  > & {
+    includeUprefixedFallback?: boolean
+    optionsResolver?: RouteOptionsResolver
+  }
+): I18nRoute[] {
+  if (strategy === 'no_prefix') {
+    return routes
+  }
+
+  // normalize localeCodes
+  const _localeCodes = locales.map(locale => (isString(locale) ? locale : locale.code))
+
+  function makeLocalizedRoutes(
+    route: I18nRoute,
+    allowedLocaleCodes: string[],
+    isChild = false,
+    isExtraPageTree = false
+  ): I18nRoute[] {
+    // skip route localization
+    if (route.redirect && (!route.component || !route.file)) {
+      return [route]
+    }
+
+    // resolve with route (page) options
+    let routeOptions: ComputedRouteOptions | null = null
+    if (optionsResolver != null) {
+      routeOptions = optionsResolver(route, allowedLocaleCodes)
+      if (routeOptions == null) {
+        return [route]
+      }
+    }
+
+    // component specific options
+    const componentOptions: ComputedRouteOptions = {
+      locales: _localeCodes,
+      paths: {}
+    }
+    if (routeOptions != null) {
+      assign(componentOptions, routeOptions)
+    }
+    assign(componentOptions, { locales: allowedLocaleCodes })
+
+    // double check locales to remove any locales not found in pageOptions.
+    // this is there to prevent children routes being localized even though they are disabled in the configuration.
+    if (
+      componentOptions.locales.length > 0 &&
+      routeOptions &&
+      routeOptions.locales != null &&
+      routeOptions.locales.length > 0
+    ) {
+      const filteredLocales = []
+      for (const locale of componentOptions.locales) {
+        if (routeOptions.locales.includes(locale)) {
+          filteredLocales.push(locale)
+        }
+      }
+      componentOptions.locales = filteredLocales
+    }
+
+    return componentOptions.locales.reduce((_routes, locale) => {
+      const { name } = route
+      let { path } = route
+      const localizedRoute = { ...route }
+
+      // make localized page name
+      if (componentOptions.name != null) {
+        localizedRoute.name = `${componentOptions.name}${routesNameSeparator}${locale}`
+      } else if (name) {
+        localizedRoute.name = `${name}${routesNameSeparator}${locale}`
+      }
+
+      // generate localized children routes
+      if (route.children) {
+        localizedRoute.children = route.children.reduce(
+          (children, child) => [...children, ...makeLocalizedRoutes(child, [locale], true, isExtraPageTree)],
+          [] as NonNullable<I18nRoute['children']>
+        )
+      }
+
+      // get custom path if any
+      if (componentOptions.paths && componentOptions.paths[locale]) {
+        path = componentOptions.paths[locale]
+      }
+
+      // For 'prefix_and_default' strategy and default locale:
+      // - if it's a parent page, add it with default locale suffix added (no suffix if page has children)
+      // - if it's a child page of that extra parent page, append default suffix to it
+      const isDefaultLocale = locale === defaultLocale
+      if (isDefaultLocale && strategy === 'prefix_and_default') {
+        if (!isChild) {
+          const defaultRoute = { ...localizedRoute, path }
+
+          if (name) {
+            defaultRoute.name = `${localizedRoute.name}${routesNameSeparator}${defaultLocaleRouteNameSuffix}`
+          }
+
+          if (route.children) {
+            // recreate child routes with default suffix added
+            defaultRoute.children = []
+            for (const childRoute of route.children) {
+              // isExtraRouteTree argument is true to indicate that this is extra route added for 'prefix_and_default' strategy
+              defaultRoute.children = defaultRoute.children.concat(
+                makeLocalizedRoutes(childRoute as I18nRoute, [locale], true, true)
+              )
+            }
+          }
+
+          _routes.push(defaultRoute)
+        } else if (isChild && isExtraPageTree && name) {
+          localizedRoute.name += `${routesNameSeparator}${defaultLocaleRouteNameSuffix}`
+        }
+      }
+
+      const isChildWithRelativePath = isChild && !path.startsWith('/')
+
+      // add route prefix
+      const shouldAddPrefix = localizeRoutesPrefixable({
+        isChild,
+        path,
+        currentLocale: locale,
+        defaultLocale,
+        strategy
+      })
+      if (shouldAddPrefix) {
+        path = `/${locale}${path}`
+      }
+
+      if (path) {
+        path = adjustRoutePathForTrailingSlash(path, trailingSlash, isChildWithRelativePath)
+      }
+
+      if (shouldAddPrefix && isDefaultLocale && strategy === 'prefix' && includeUprefixedFallback) {
+        _routes.push({ ...route })
+      }
+
+      localizedRoute.path = path
+      _routes.push(localizedRoute)
+
+      return _routes
+    }, [] as I18nRoute[])
+  }
+
+  return routes.reduce(
+    (localized, route) => [...localized, ...makeLocalizedRoutes(route, _localeCodes || [])],
+    [] as I18nRoute[]
+  )
+}

--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -226,6 +226,7 @@ const warnRuntimeUsage = (method: string) =>
  * The i18n custom route for page components
  */
 export interface I18nRoute {
+  name?: string
   /**
    * Customize page component routes per locale.
    *

--- a/src/vue-i18n-routing.d.ts
+++ b/src/vue-i18n-routing.d.ts
@@ -6,6 +6,10 @@ declare module 'vue-i18n-routing' {
     file?: string | LocaleFile
     files?: string[] | LocaleFile[]
   }
+
+  export interface ComputedRouteOptions {
+    name?: string
+  }
 }
 
 export {}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
* #2581
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This PR is still missing documentation and tests. This also moves/integrates and modifies route localization code from `vue-i18n-routing to make this possible.

This adds a `name` property to the object passed to `defineI18nRoute` to use instead of passing `name` to `definePageMeta` as this causes issues with page generation, see #2581. Perhaps I can add warnings when `name` is passed to `definePageMeta` as well.


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
