### PR TITLE
fix: `definePageMeta` name overriding localized route name

### DIFF
--- a/playground/pages/about/index.vue
+++ b/playground/pages/about/index.vue
@@ -32,6 +32,7 @@ export default defineComponent({
       }
     })
     definePageMeta({
+      name: 'named-about',
       title: 'pages.title.about'
     })
     return {}

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -74,7 +74,8 @@ definePageMeta({
     <p>{{ $t('bar.buz', { name: 'buz' }) }}</p>
     <h2>Pages</h2>
     <nav>
-      <NuxtLink :to="localePath('/')">Home</NuxtLink> | <NuxtLink :to="localePath({ name: 'about' })">About</NuxtLink> |
+      <NuxtLink :to="localePath('/')">Home</NuxtLink> |
+      <NuxtLink :to="localePath({ name: 'named-about' })">About</NuxtLink> |
       <NuxtLink :to="localePath({ name: 'blog' })">Blog</NuxtLink> |
       <NuxtLink :to="localePath({ name: 'server' })">Server</NuxtLink> |
       <NuxtLink :to="localePath({ name: 'category-id', params: { id: 'foo' } })">Category</NuxtLink> |

--- a/specs/basic_usage.spec.ts
+++ b/specs/basic_usage.spec.ts
@@ -319,3 +319,15 @@ test('server integration extended from `layers/layer-server`', async () => {
   const resQuery = await $fetch('/api/server', { query: { key: 'snakeCaseText', locale: 'fr' } })
   expect(resQuery?.snakeCaseText).toMatch('À-propos-de-ce-site')
 })
+
+test('(#2581) `definePageMeta` name does not override localized routes', async () => {
+  const { page } = await renderPage('/')
+
+  expect(await page.locator('#link-products-named').getAttribute('href')).toEqual('/products')
+
+  // click `nl` lang switch with `<NuxtLink>`
+  await page.locator('#switch-locale-path-usages .switch-to-nl a').click()
+  await waitForURL(page, '/nl')
+
+  expect(await page.locator('#link-products-named').getAttribute('href')).toEqual('/nl/producten')
+})

--- a/specs/fixtures/basic_usage/nuxt.config.ts
+++ b/specs/fixtures/basic_usage/nuxt.config.ts
@@ -18,7 +18,14 @@ export default defineNuxtConfig({
   i18n: {
     vueI18n: './config/i18n.config.ts',
     locales: ['en', 'fr'],
-    defaultLocale: 'en'
+    defaultLocale: 'en',
+    pages: {
+      // This is based on filename, not route name
+      products: {
+        en: '/products',
+        nl: '/producten'
+      }
+    }
     // debug: true,
   }
 })

--- a/specs/fixtures/basic_usage/pages/index.vue
+++ b/specs/fixtures/basic_usage/pages/index.vue
@@ -120,6 +120,11 @@ useHead({
             To the page with spaces!
           </NuxtLink>
         </li>
+        <li class="path-products-named">
+          <NuxtLink id="link-products-named" :to="localePath({ name: 'products-named' })">
+            {{ $t('products') }}
+          </NuxtLink>
+        </li>
       </ul>
     </section>
     <section id="nuxt-link-locale-usages">

--- a/specs/fixtures/basic_usage/pages/products.vue
+++ b/specs/fixtures/basic_usage/pages/products.vue
@@ -1,0 +1,19 @@
+<script lang="ts" setup>
+import { defineI18nRoute } from '#i18n'
+
+// @ts-ignore
+definePageMeta({
+  name: 'products-named'
+})
+
+// defineI18nRoute({
+//   paths: {
+//     nl: '/producten',
+//     en: '/products'
+//   }
+// })
+</script>
+
+<template>
+  <div></div>
+</template>

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -13,6 +13,7 @@ import type { PluginOptions } from '@intlify/unplugin-vue-i18n'
 import type { NuxtI18nOptions } from './types'
 import type { TransformMacroPluginOptions } from './transform/macros'
 import type { ResourcePluginOptions } from './transform/resource'
+import { RoutesPlugin, type RoutesPluginOptions } from './transform/routes'
 
 const debug = createDebug('@nuxtjs/i18n:bundler')
 
@@ -30,6 +31,10 @@ export async function extendBundler(nuxt: Nuxt, nuxtOptions: Required<NuxtI18nOp
   }
 
   const resourceOptions: ResourcePluginOptions = {
+    sourcemap: !!nuxt.options.sourcemap.server || !!nuxt.options.sourcemap.client
+  }
+
+  const routeOptions: RoutesPluginOptions = {
     sourcemap: !!nuxt.options.sourcemap.server || !!nuxt.options.sourcemap.client
   }
 
@@ -58,6 +63,7 @@ export async function extendBundler(nuxt: Nuxt, nuxtOptions: Required<NuxtI18nOp
 
     addWebpackPlugin(VueI18nWebpackPlugin(webpackPluginOptions))
     addWebpackPlugin(TransformMacroPlugin.webpack(macroOptions))
+    addWebpackPlugin(RoutesPlugin.webpack(routeOptions))
     addWebpackPlugin(ResourcePlugin.webpack(resourceOptions))
 
     extendWebpackConfig(config => {
@@ -105,6 +111,7 @@ export async function extendBundler(nuxt: Nuxt, nuxtOptions: Required<NuxtI18nOp
 
   addVitePlugin(VueI18nVitePlugin(vitePluginOptions))
   addVitePlugin(TransformMacroPlugin.vite(macroOptions))
+  addVitePlugin(RoutesPlugin.vite(routeOptions))
   addVitePlugin(ResourcePlugin.vite(resourceOptions))
 
   extendViteConfig(config => {

--- a/src/transform/routes.ts
+++ b/src/transform/routes.ts
@@ -25,8 +25,7 @@ export const RoutesPlugin = createUnplugin((options: RoutesPluginOptions) => {
         return false
       }
 
-      const { pathname } = parseURL(decodeURIComponent(pathToFileURL(id).href))
-      return /routes\.mjs$/.test(pathname)
+      return id.startsWith('virtual:nuxt:') && id.endsWith('routes.mjs')
     },
 
     transform(code, id) {
@@ -45,9 +44,12 @@ export const RoutesPlugin = createUnplugin((options: RoutesPluginOptions) => {
         }
       }
 
+      // Replace string
+      // name: (fileHashVariable?.name) ?? "(routeName)(___localeSuffix)"
       s.replaceAll(
-        new RegExp(`name:\\s(.+)\\s\\?\\?\\s"(.+)(___.+)"`, 'g'),
-        'name: ($1 ? $1 + "$3" : undefined) ?? "$2$3"'
+        /name:\s(?<varName>.+)\s\?\?\s"(?<routeName>.+)(?<localeSuffix>___.+)"/g,
+        (_, varName, routeName, localeSuffix) =>
+          `name: (${varName} ? ${varName} + "${localeSuffix}" : undefined) ?? "${routeName}${localeSuffix}"`
       )
 
       return result()

--- a/src/transform/routes.ts
+++ b/src/transform/routes.ts
@@ -1,0 +1,56 @@
+import createDebug from 'debug'
+import { pathToFileURL } from 'node:url'
+import { createUnplugin } from 'unplugin'
+import { parseURL } from 'ufo'
+import MagicString from 'magic-string'
+import { VIRTUAL_PREFIX_HEX } from './utils'
+
+export interface RoutesPluginOptions {
+  sourcemap?: boolean
+}
+
+const debug = createDebug('@nuxtjs/i18n:transform:routes')
+
+export const RoutesPlugin = createUnplugin((options: RoutesPluginOptions) => {
+  debug('options', options)
+
+  return {
+    name: 'nuxtjs:i18n-routes',
+    enforce: 'post',
+
+    transformInclude(id) {
+      debug('transformInclude', id)
+
+      if (!id || id.startsWith(VIRTUAL_PREFIX_HEX)) {
+        return false
+      }
+
+      const { pathname } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+      return /routes\.mjs$/.test(pathname)
+    },
+
+    transform(code, id) {
+      debug('transform', id)
+
+      const { pathname } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+
+      const s = new MagicString(code)
+
+      function result() {
+        if (s.hasChanged()) {
+          return {
+            code: s.toString(),
+            map: options.sourcemap && !/\.([c|m]?ts)$/.test(pathname) ? s.generateMap({ hires: true }) : null
+          }
+        }
+      }
+
+      s.replaceAll(
+        new RegExp(`name:\\s(.+)\\s\\?\\?\\s"(.+)(___.+)"`, 'g'),
+        'name: ($1 ? $1 + "$3" : undefined) ?? "$2$3"'
+      )
+
+      return result()
+    }
+  }
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
* #2581
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
While trying to figure out bundler plugins I figured there was an alternative way to tackle #2581. Maybe this is easier to break by Nuxt updates, but I feel this solution makes more sense than https://github.com/nuxt-modules/i18n/pull/2599. I still need to test this with disabled routes, and I may be missing other edge cases, please let me know.

What this PR does is transform the generated `routes.mjs` file, instead letting `name` defined in `definePageMeta` override the localized name (see [source code](https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/pages/utils.ts#L333)), we capture the locale route name suffix and combine it with the name if it exists, this makes named routes work as expected.

So in `routes.mjs` the generation would be changed like this example
```diff
-name: historyeTgp8UZZfFMeta?.name ?? "history___ja",
+name: (historyeTgp8UZZfFMeta?.name ? historyeTgp8UZZfFMeta?.name + "___ja" : undefined) ?? "history___ja",
```

What do you think @kazupon?
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
