### PR TITLE
fix: memory leak

### DIFF
--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -24,7 +24,7 @@ import {
 import {
   localeCodes,
   vueI18nConfigs,
-  nuxtI18nOptions as _nuxtI18nOptions,
+  nuxtI18nOptions,
   nuxtI18nInternalOptions,
   isSSG,
   localeMessages,
@@ -74,7 +74,6 @@ export default defineNuxtPlugin({
 
     const vueI18nOptions: I18nOptions = await loadVueI18nOptions(vueI18nConfigs, useNuxtApp())
 
-    const nuxtI18nOptions = { ..._nuxtI18nOptions }
     const useCookie = nuxtI18nOptions.detectBrowserLanguage && nuxtI18nOptions.detectBrowserLanguage.useCookie
     const { __normalizedLocales: normalizedLocales } = nuxtI18nInternalOptions
     const {

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -17,7 +17,7 @@ import { defineNuxtPlugin, useRouter, useRoute, addRouteMiddleware, defineNuxtRo
 import {
   localeCodes,
   vueI18nConfigs,
-  nuxtI18nOptions,
+  nuxtI18nOptions as _nuxtI18nOptions,
   nuxtI18nInternalOptions,
   isSSG,
   localeMessages,
@@ -67,6 +67,7 @@ export default defineNuxtPlugin({
 
     const vueI18nOptions: I18nOptions = await loadVueI18nOptions(vueI18nConfigs, nuxtContext)
 
+    const nuxtI18nOptions = { ..._nuxtI18nOptions }
     const useCookie = nuxtI18nOptions.detectBrowserLanguage && nuxtI18nOptions.detectBrowserLanguage.useCookie
     const { __normalizedLocales: normalizedLocales } = nuxtI18nInternalOptions
     const {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
* #2612
* #2034 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
It is unlikely that this fixes all present memory leaks in the module, but [this small change](https://github.com/nuxt-modules/i18n/pull/2616/commits/08958630588937cef18975d0f1a7a5bdc4233ffd) appears to have a measurable impact on the memory usage. 

I ran the reproductions with the latest release `rc.9`, and took memory snapshots with chrome. First without any requests, then running `siege` for 10 seconds with 10 concurrent users (`siege -t 10s -c 10 "http://localhost:3000/"`) after which I took another snapshot. After waiting for a short moment I took another snapshot in case any more memory was cleared 🤷‍♂️. Then I installed my local modified `@nuxtjs/i18n` and went through the same steps.

My testing isn't exactly thorough, but it was a reliable way to see the memory usage go up and stay up, it's possible memory will still increase after longer usage and uptime, it's something that takes time and patience.

Below a comparison of the snapshots before and after installing the modified package:
![memory-usage-comparison](https://github.com/nuxt-modules/i18n/assets/6649305/543c302c-d801-4935-a587-47c701ccc388)

I also tested https://github.com/nuxt-modules/i18n/issues/2034#issuecomment-1659386170 (or https://github.com/danielroe/i18n-memory-leak) after making this comparison image, memory usage went from ~121mb to ~33mb.

While profiling I kept seeing `nuxtI18Options` and `baseUrl`, based on thismy theory is that the nuxt context is not being disposed of correctly as it is being set on `nuxtI18nOptions` in the `i18n.ts` plugin. 

For example here:
https://github.com/nuxt-modules/i18n/blob/4bf4f5013a68a9fa7dcf0d7035d367cd40710eb1/src/runtime/plugins/i18n.ts#L86-L91

`nuxtI18nOptions.baseUrl` is being set to a function returned from `extendBaseUrl`, the returned function makes use of the passed nuxt context (`options.nuxt`), `nuxtI18nOptions` is not defined in the scope of the plugin so I can imagine it would be hard to know when to dispose/free the memory? Based on this assumption I instead create a new object using `nuxtI18nOptions`, which since it's scoped to the plugin should be easier to safely dispose/free.

I don't know enough about memory management or garbage collection in Javascript, but I have experience optimizing memory usage for mobile games in C#, to provide a background for my reasoning. If someone has good resources on this please share them so I can form more informed conclusions 😅

#### Update
Based on the testing I did, I changed the way the Nuxt context is used/retrieved. Instead of passing it to functions/closures and potentially causing leaks the `useNuxtApp` composable is used where possible. 

There is still a small and slow increase in memory usage for every few 1000s of requests, will look into that as well.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
