### PR TITLE
Fix: Maximum call stack size exceeded

### DIFF
--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -90,7 +90,8 @@ export default defineNuxtPlugin({
     __DEBUG__ && console.log('useCookie on setup', useCookie)
     __DEBUG__ && console.log('defaultLocale on setup', defaultLocale)
 
-    nuxtI18nOptions.baseUrl = extendBaseUrl(nuxtI18nOptions.baseUrl, {
+    let newBaseUrl = Object.assign({}, nuxtI18nOptions.baseUrl);
+    nuxtI18nOptions.baseUrl = extendBaseUrl(newBaseUrl, {
       differentDomains,
       localeCodeLoader: defaultLocale,
       normalizedLocales


### PR DESCRIPTION
### 🔗 Linked issue

more info here 
https://github.com/nuxt-modules/i18n/issues/2034#issuecomment-1855097787

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The problem lies in the extendBaseUrl method of the baseUrl function. The baseUrl function is referencing itself, and with each subsequent request, the nesting of calls increases. After around 6500 requests, everything crashes.

nuxtI18nOptions.baseUrl = extendBaseUrl(nuxtI18nOptions.baseUrl, {
The method is referencing itself, leading to an infinite loop.

### 📝 Checklist

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
