### PR TITLE
fix: do not use import from `nuxt/dist/app`

### DIFF
--- a/playground/layers/i18n-layer/nuxt.config.ts
+++ b/playground/layers/i18n-layer/nuxt.config.ts
@@ -1,5 +1,3 @@
-// import type { NuxtApp } from 'nuxt/dist/app/index'
-
 // https://nuxt.com/docs/guide/directory-structure/nuxt.config
 export default defineNuxtConfig({
   modules: ['@nuxtjs/i18n'],

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,7 +1,6 @@
 import Module1 from './module1'
 import LayerModule from './layer-module'
 import ModuleExperimental from './module-experimental'
-import type { NuxtApp } from 'nuxt/dist/app/index'
 
 // https://nuxt.com/docs/guide/directory-structure/nuxt.config
 export default defineNuxtConfig({

--- a/specs/fixtures/locale_codes/layers/i18n-layer/nuxt.config.ts
+++ b/specs/fixtures/locale_codes/layers/i18n-layer/nuxt.config.ts
@@ -1,5 +1,3 @@
-// import type { NuxtApp } from 'nuxt/dist/app/index'
-
 // https://nuxt.com/docs/guide/directory-structure/nuxt.config
 export default defineNuxtConfig({
   modules: ['@nuxtjs/i18n'],

--- a/src/runtime/messages.ts
+++ b/src/runtime/messages.ts
@@ -1,7 +1,7 @@
 import { deepCopy, isFunction, isArray, isObject, isString } from '@intlify/shared'
 
 import type { I18nOptions, Locale, FallbackLocale, LocaleMessages, DefineLocaleMessage } from 'vue-i18n'
-import type { NuxtApp } from 'nuxt/dist/app'
+import type { NuxtApp } from '#app'
 import type { DeepRequired } from 'ts-essentials'
 import type { VueI18nConfig, NuxtI18nOptions } from '../types'
 

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -7,7 +7,7 @@ import { loadVueI18nOptions, loadInitialMessages, makeFallbackLocaleCodes, loadL
 
 import type { NitroAppPlugin } from 'nitropack'
 import type { H3Event } from 'h3'
-import type { NuxtApp } from 'nuxt/dist/app'
+import type { NuxtApp } from 'nuxt/app'
 import type { Locale, FallbackLocale, LocaleMessages, DefineLocaleMessage } from 'vue-i18n'
 import type { CoreContext } from '@intlify/h3'
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

[Found via ecosystem-ci](https://github.com/nuxt/ecosystem-ci/actions/runs/7233707958/job/19710329753). These type imports will only work with old (legacy) module resolution. 

Instead I would recommend using `nuxt/app` (for type imports only) or `#app`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
