### PR TITLE
fix: `setI18nParams` breaks on current route change

### DIFF
--- a/specs/basic_usage.spec.ts
+++ b/specs/basic_usage.spec.ts
@@ -334,6 +334,15 @@ test('dynamic parameters', async () => {
   await gotoPath(page, '/nl/products/rode-mok')
   expect(await page.locator('#nuxt-locale-link-en').getAttribute('href')).toEqual('/products/red-mug')
 
+  // Translated params are not lost on query changes
+  await page.locator('#params-add-query').click()
+  await waitForURL(page, '/nl/products/rode-mok?test=123')
+  expect(await page.locator('#nuxt-locale-link-en').getAttribute('href')).toEqual('/products/red-mug?test=123')
+
+  await page.locator('#params-remove-query').click()
+  await waitForURL(page, '/nl/products/rode-mok')
+  expect(await page.locator('#nuxt-locale-link-en').getAttribute('href')).toEqual('/products/red-mug')
+
   // head tags - alt links are updated server side
   const product1Html = await $fetch('/products/big-chair')
   const product1Dom = getDom(product1Html)

--- a/specs/fixtures/basic_usage/pages/products.vue
+++ b/specs/fixtures/basic_usage/pages/products.vue
@@ -14,13 +14,23 @@ onMounted(async () => {
 <template>
   <div>
     <LangSwitcher />
-    <NuxtLink
-      class="product"
-      v-for="product in products"
-      :key="product.id"
-      :to="localePath({ name: 'products-slug', params: { slug: product?.slugs?.[locale] ?? 'none' } })"
-      >{{ product.name?.[locale] }}
-    </NuxtLink>
+    <ul>
+      <li>
+        <NuxtLink id="params-add-query" :to="localePath({ query: { test: '123' } })">Add query</NuxtLink>
+      </li>
+      <li>
+        <NuxtLink id="params-remove-query" :to="localePath({ query: undefined })">Remove query</NuxtLink>
+      </li>
+    </ul>
+    <ul>
+      <li v-for="product in products" :key="product.id">
+        <NuxtLink
+          class="product"
+          :to="localePath({ name: 'products-slug', params: { slug: product?.slugs?.[locale] ?? 'none' } })"
+          >{{ product.name?.[locale] }}
+        </NuxtLink>
+      </li>
+    </ul>
     <NuxtPage />
   </div>
 </template>

--- a/src/runtime/composables/index.ts
+++ b/src/runtime/composables/index.ts
@@ -1,5 +1,5 @@
 import { useRoute, useRouter, useRequestHeaders, useCookie, useNuxtApp } from '#imports'
-import { ref, computed } from 'vue'
+import { ref, computed, watch, onUnmounted } from 'vue'
 import { parseAcceptLanguage } from '../internal'
 import { nuxtI18nInternalOptions, nuxtI18nOptionsDefault, localeCodes as _localeCodes } from '#build/i18n.options.mjs'
 import { getActiveHead } from 'unhead'
@@ -46,19 +46,33 @@ import {
 export type SetI18nParamsFunction = (params: Record<string, unknown>) => void
 export function useSetI18nParams(seoAttributes?: SeoAttributesOptions): SetI18nParamsFunction {
   const route = useRoute()
+  // const router = useRouter()
   const head = getActiveHead()
 
   const i18n = useI18n()
   const locale = getLocale(i18n)
   const locales = getNormalizedLocales(getLocales(i18n))
+  const _i18nParams = ref({})
 
   const i18nParams = computed({
     get() {
       return route.meta.nuxtI18n ?? {}
     },
     set(val) {
+      _i18nParams.value = val
       route.meta.nuxtI18n = val
     }
+  })
+
+  const stop = watch(
+    () => route.fullPath,
+    () => {
+      route.meta.nuxtI18n = _i18nParams.value
+    }
+  )
+
+  onUnmounted(() => {
+    stop()
   })
 
   const currentLocale = getNormalizedLocales(locales).find(l => l.code === locale) || { code: locale }

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useI18n } from 'vue-i18n'
 import {
   getLocale,
   setLocale,
@@ -13,9 +12,6 @@ import {
   DefaultPrefixable,
   DefaultSwitchLocalePathIntercepter,
   getComposer,
-  useLocaleRoute,
-  useRouteBaseName,
-  useSwitchLocalePath,
   STRATEGIES
 } from 'vue-i18n-routing'
 import { joinURL, isEqual } from 'ufo'
@@ -53,6 +49,7 @@ import type { DeepRequired } from 'ts-essentials'
 import type { DetectLocaleContext } from './internal'
 import type { LocaleLoader as LocaleInternalLoader } from './messages'
 import type { HeadSafe } from '@unhead/vue'
+import { useLocaleRoute, useRouteBaseName, useSwitchLocalePath } from '#i18n'
 
 export function _setLocale(i18n: I18n, locale: Locale) {
   return callVueI18nInterfaces(i18n, 'setLocale', locale)
@@ -499,7 +496,7 @@ export type HeadParam = Required<Pick<HeadSafe, 'meta' | 'link'>>
 type IdParam = NonNullable<I18nHeadOptions['identifierAttribute']>
 
 export function addHreflangLinks(locales: LocaleObject[], head: HeadParam, idAttribute: IdParam) {
-  const { defaultLocale, strategy, baseUrl } = useI18n()
+  const { defaultLocale, strategy, baseUrl } = getComposer(useNuxtApp().$i18n)
   const switchLocalePath = useSwitchLocalePath()
 
   if (strategy === STRATEGIES.NO_PREFIX) {
@@ -556,7 +553,7 @@ export function addCanonicalLinksAndOgUrl(
   idAttribute: IdParam,
   seoAttributesOptions: SeoAttributesOptions = {}
 ) {
-  const { baseUrl } = useI18n()
+  const { baseUrl } = getComposer(useNuxtApp().$i18n)
   const route = useRoute()
   const localeRoute = useLocaleRoute()
   const getRouteBaseName = useRouteBaseName()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
* #2634
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #2634

Makes `useSetI18nParams` watch the current route to restore the translated parameters. Looking forward to integrating `vue-i18n-routing` in the future so we have more direct control over route resolve.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
