### PR TITLE
docs: Update 1.setup.md

### DIFF
--- a/docs/content/1.getting-started/1.setup.md
+++ b/docs/content/1.getting-started/1.setup.md
@@ -54,3 +54,13 @@ export default defineNuxtConfig({
   ]
 })
 ```
+
+To install the `@nuxtjs/i18n` module using the `installModule` function, you need to include your settings inside an object labeled `overrides`, which is a part of the second argument of the function. Here's how you can do it:
+In your `module.ts` file, use the `installModule` function and specify `@nuxtjs/i18n` as the first argument. For the second argument, create an object and within this object, use the key `overrides` and specify your options.
+```ts {}[module.ts]
+await installModule('@nuxtjs/i18n', {
+  overrides: {
+    /* module options */
+  }
+})
+```

--- a/docs/content/1.getting-started/1.setup.md
+++ b/docs/content/1.getting-started/1.setup.md
@@ -55,8 +55,7 @@ export default defineNuxtConfig({
 })
 ```
 
-To install the `@nuxtjs/i18n` module using the `installModule` function, you need to include your settings inside an object labeled `overrides`, which is a part of the second argument of the function. Here's how you can do it:
-In your `module.ts` file, use the `installModule` function and specify `@nuxtjs/i18n` as the first argument. For the second argument, create an object and within this object, use the key `overrides` and specify your options.
+To install the `@nuxtjs/i18n` module using the `installModule` function, you need to include your settings inside an object labeled `overrides`, which is a part of the second argument of the function. In your `module.ts` file, use the `installModule` function and specify `@nuxtjs/i18n` as the first argument. For the second argument, create an object and within this object, use the key `overrides` and specify your options.
 ```ts {}[module.ts]
 await installModule('@nuxtjs/i18n', {
   overrides: {


### PR DESCRIPTION
Added a paragraph about installing @nuxtjs/i18n using installModule function

### 🔗 Linked issue

### ❓ Type of change
- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

I have added a paragraph about installing @nuxtjs/i18n using installModule function. Currently there is no information in docs about passing config the correct way when using installModule. If there is no 'overrides' key in inlineOptions there will be no vueI18n config imported to i18n.options.mjs. I have modified this old stackblitz to show the issue, https://stackblitz.com/edit/nuxt-i18n-queistion-3v8ggj?file=.nuxt%2Fi18n.options.mjs
If you delete 'overrides' there will be no mergeVueI18NConfigs() with a path to the config file.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
