### PR TITLE
refactor: message loading and setting

### DIFF
--- a/src/gen.ts
+++ b/src/gen.ts
@@ -99,7 +99,7 @@ export function generateLoaderOptions(
     .filter(config => config.absolute !== '')
     .map(config => generateVueI18nConfiguration(config, isServer))
 
-  const localeMessages = localeInfo.map(locale => [locale.code, locale.meta?.map(meta => importMapper.get(meta.key))])
+  const localeLoaders = localeInfo.map(locale => [locale.code, locale.meta?.map(meta => importMapper.get(meta.key))])
 
   const generatedNuxtI18nOptions = {
     ...nuxtI18nOptions,
@@ -109,7 +109,7 @@ export function generateLoaderOptions(
 
   const generated = {
     importStrings,
-    localeMessages,
+    localeLoaders,
     nuxtI18nOptions: generatedNuxtI18nOptions,
     vueI18nConfigs: vueI18nConfigImports
   }

--- a/src/options.d.ts
+++ b/src/options.d.ts
@@ -14,10 +14,7 @@ type LocaleLoader = {
   cache: boolean
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const loadMessages: () => Promise<any> = () => Promise.resolve({})
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const localeMessages: Record<string, LocaleLoader[]> = {}
+export const localeLoaders: Record<string, LocaleLoader[]> = {}
 
 export const vueI18nConfigs: VueI18nConfig[]
 

--- a/src/runtime/messages.ts
+++ b/src/runtime/messages.ts
@@ -86,8 +86,6 @@ async function loadMessage(locale: Locale, { key, load }: LocaleLoader) {
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (e: any) {
-    // eslint-disable-next-line no-console
-    // console.error(formatMessage('Failed locale loading: ' + e.message))
     console.error('Failed locale loading: ' + e.message)
   }
   return message

--- a/src/runtime/messages.ts
+++ b/src/runtime/messages.ts
@@ -4,9 +4,12 @@ import type { I18nOptions, Locale, FallbackLocale, LocaleMessages, DefineLocaleM
 import type { NuxtApp } from '#app'
 import type { DeepRequired } from 'ts-essentials'
 import type { VueI18nConfig, NuxtI18nOptions } from '../types'
+import type { CoreContext } from '@intlify/h3'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type LocaleLoader = { key: string; load: () => Promise<any>; cache: boolean }
+
+const cacheMessages = new Map<string, LocaleMessages<DefineLocaleMessage>>()
 
 export async function loadVueI18nOptions(
   vueI18nConfigs: VueI18nConfig[],
@@ -43,45 +46,30 @@ export function makeFallbackLocaleCodes(fallback: FallbackLocale, locales: Local
 
 export async function loadInitialMessages<Context extends NuxtApp = NuxtApp>(
   messages: LocaleMessages<DefineLocaleMessage>,
-  localeLoaderMessages: Record<Locale, LocaleLoader[]>,
-  options: DeepRequired<NuxtI18nOptions<Context>> & {
+  localeLoaders: Record<Locale, LocaleLoader[]>,
+  options: Pick<DeepRequired<NuxtI18nOptions<Context>>, 'defaultLocale' | 'lazy'> & {
     initialLocale: Locale
     fallbackLocale: FallbackLocale
     localeCodes: string[]
-    cacheMessages?: Map<string, LocaleMessages<DefineLocaleMessage>>
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<Record<string, any>> {
-  const { defaultLocale, initialLocale, localeCodes, fallbackLocale, lazy, cacheMessages } = options
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const setter = (locale: Locale, message: Record<string, any>) => {
-    const base = messages[locale] || {}
-    deepCopy(message, base)
-    messages[locale] = base
-  }
+  const { defaultLocale, initialLocale, localeCodes, fallbackLocale, lazy } = options
 
   // load fallback messages
   if (lazy && fallbackLocale) {
     const fallbackLocales = makeFallbackLocaleCodes(fallbackLocale, [defaultLocale, initialLocale])
-    await Promise.all(
-      fallbackLocales.map(locale => loadLocale({ locale, setter, localeMessages: localeLoaderMessages }, cacheMessages))
-    )
+    await Promise.all(fallbackLocales.map(locale => loadAndSetLocaleMessages(locale, localeLoaders, messages)))
   }
 
   // load initial messages
   const locales = lazy ? [...new Set<Locale>().add(defaultLocale).add(initialLocale)] : localeCodes
-  await Promise.all(
-    locales.map((locale: Locale) => loadLocale({ locale, setter, localeMessages: localeLoaderMessages }, cacheMessages))
-  )
+  await Promise.all(locales.map((locale: Locale) => loadAndSetLocaleMessages(locale, localeLoaders, messages)))
 
   return messages
 }
 
-async function loadMessage(
-  locale: Locale,
-  { key, load }: LocaleLoader,
-  cacheMessages?: Map<string, LocaleMessages<DefineLocaleMessage>>
-) {
+async function loadMessage(locale: Locale, { key, load }: LocaleLoader) {
   let message: LocaleMessages<DefineLocaleMessage> | null = null
   try {
     __DEBUG__ && console.log('loadMessage: (locale) -', locale)
@@ -106,21 +94,13 @@ async function loadMessage(
 }
 
 export async function loadLocale(
-  {
-    locale,
-    localeMessages,
-    setter
-  }: {
-    locale: Locale
-    localeMessages: Record<Locale, LocaleLoader[]>
-    setter: (locale: Locale, message: LocaleMessages<DefineLocaleMessage>) => void
-  },
-  cacheMessages?: Map<string, LocaleMessages<DefineLocaleMessage>>
+  locale: Locale,
+  localeLoaders: Record<Locale, LocaleLoader[]>,
+  setter: (locale: Locale, message: LocaleMessages<DefineLocaleMessage>) => void
 ) {
-  const loaders = localeMessages[locale]
+  const loaders = localeLoaders[locale]
 
   if (loaders == null) {
-    // console.warn(formatMessage('Could not find messages for locale code: ' + locale))
     console.warn('Could not find messages for locale code: ' + locale)
     return
   }
@@ -135,7 +115,7 @@ export async function loadLocale(
     } else {
       __DEBUG__ && !loader.cache && console.log(loader.key + ' bypassing cache!')
       __DEBUG__ && console.log(loader.key + ' is loading ...')
-      message = await loadMessage(locale, loader, cacheMessages)
+      message = await loadMessage(locale, loader)
     }
 
     if (message != null) {
@@ -144,4 +124,22 @@ export async function loadLocale(
   }
 
   setter(locale, targetMessage)
+}
+
+type LocaleLoaderMessages = CoreContext['messages'] | LocaleMessages<DefineLocaleMessage>
+export async function loadAndSetLocaleMessages(
+  locale: Locale,
+  localeLoaders: Record<Locale, LocaleLoader[]>,
+  messages: LocaleLoaderMessages
+) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const setter = (locale: Locale, message: Record<string, any>) => {
+    // @ts-expect-error should be able to use `locale` as index
+    const base = messages[locale] || {}
+    deepCopy(message, base)
+    // @ts-expect-error should be able to use `locale` as index
+    messages[locale] = base
+  }
+
+  await loadLocale(locale, localeLoaders, setter)
 }

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -27,7 +27,7 @@ import {
   nuxtI18nOptions as _nuxtI18nOptions,
   nuxtI18nInternalOptions,
   isSSG,
-  localeMessages,
+  localeLoaders,
   parallelPlugin
 } from '#build/i18n.options.mjs'
 import { loadVueI18nOptions, loadInitialMessages } from '../messages'
@@ -129,7 +129,7 @@ export default defineNuxtPlugin({
     __DEBUG__ && console.log('first detect initial locale', initialLocale)
 
     // load initial vue-i18n locale messages
-    vueI18nOptions.messages = await loadInitialMessages(vueI18nOptions.messages, localeMessages, {
+    vueI18nOptions.messages = await loadInitialMessages(vueI18nOptions.messages, localeLoaders, {
       localeCodes,
       initialLocale,
       lazy: nuxtI18nOptions.lazy,

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -50,7 +50,7 @@ import {
   DefaultDetectBrowserLanguageFromResult
 } from '../internal'
 
-import type { Composer, Locale, I18nOptions, LocaleMessages, DefineLocaleMessage } from 'vue-i18n'
+import type { Composer, Locale, I18nOptions } from 'vue-i18n'
 import type { LocaleObject, ExtendProperyDescripters, VueI18nRoutingPluginOptions } from 'vue-i18n-routing'
 import type { NuxtApp } from '#app'
 
@@ -59,9 +59,6 @@ type LocalePath = typeof localePath
 type LocaleRoute = typeof localeRoute
 type LocaleHead = typeof localeHead
 type SwitchLocalePath = typeof switchLocalePath
-
-// cache for locale messages
-const cacheMessages = new Map<string, LocaleMessages<DefineLocaleMessage>>()
 
 export default defineNuxtPlugin({
   name: 'i18n:plugin',
@@ -133,11 +130,11 @@ export default defineNuxtPlugin({
 
     // load initial vue-i18n locale messages
     vueI18nOptions.messages = await loadInitialMessages(vueI18nOptions.messages, localeMessages, {
-      ...nuxtI18nOptions,
-      initialLocale,
-      fallbackLocale: vueI18nOptions.fallbackLocale,
       localeCodes,
-      cacheMessages
+      initialLocale,
+      lazy: nuxtI18nOptions.lazy,
+      defaultLocale: nuxtI18nOptions.defaultLocale,
+      fallbackLocale: vueI18nOptions.fallbackLocale
     })
 
     /**
@@ -214,11 +211,10 @@ export default defineNuxtPlugin({
           })
           composer.setLocale = async (locale: string) => {
             const localeSetup = isInitialLocaleSetup(locale)
-            const [modified] = await loadAndSetLocale(locale, localeMessages, i18n, {
+            const [modified] = await loadAndSetLocale(locale, i18n, {
               useCookie,
               differentDomains,
               initial: localeSetup,
-              cacheMessages,
               skipSettingLocaleOnNavigate,
               lazy
             })
@@ -472,11 +468,10 @@ export default defineNuxtPlugin({
         const localeSetup = isInitialLocaleSetup(locale)
         __DEBUG__ && console.log('localeSetup', localeSetup)
 
-        const [modified] = await loadAndSetLocale(locale, localeMessages, i18n, {
+        const [modified] = await loadAndSetLocale(locale, i18n, {
           useCookie,
           differentDomains,
           initial: localeSetup,
-          cacheMessages,
           skipSettingLocaleOnNavigate,
           lazy
         })

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -1,22 +1,18 @@
 import { defineI18nMiddleware } from '@intlify/h3'
-import { deepCopy } from '@intlify/shared'
 import { nuxtI18nOptions, localeCodes, vueI18nConfigs, localeMessages } from '#internal/i18n/options.mjs'
 // @ts-ignore
 import { localeDetector as _localeDetector } from '#internal/i18n/locale.detector.mjs'
-import { loadVueI18nOptions, loadInitialMessages, makeFallbackLocaleCodes, loadLocale } from '../messages'
+import { loadVueI18nOptions, loadInitialMessages, makeFallbackLocaleCodes, loadAndSetLocaleMessages } from '../messages'
 
 import type { NitroAppPlugin } from 'nitropack'
 import type { H3Event } from 'h3'
 import type { NuxtApp } from 'nuxt/app'
-import type { Locale, FallbackLocale, LocaleMessages, DefineLocaleMessage } from 'vue-i18n'
+import type { Locale, FallbackLocale, DefineLocaleMessage } from 'vue-i18n'
 import type { CoreContext } from '@intlify/h3'
 
 const nuxtMock: { runWithContext: NuxtApp['runWithContext'] } = { runWithContext: async fn => await fn() }
 
 export const nitroPlugin: NitroAppPlugin = async nitro => {
-  // cache for locale messages
-  const cacheMessages = new Map<string, LocaleMessages<DefineLocaleMessage>>()
-
   // `defineI18nMiddleware` options (internally, options passed to`createCoreContext` in intlify / core) are compatible with vue-i18n options
   const options = (await loadVueI18nOptions(vueI18nConfigs, nuxtMock)) as any // eslint-disable-line @typescript-eslint/no-explicit-any
   options.messages = options.messages || {}
@@ -27,11 +23,11 @@ export const nitroPlugin: NitroAppPlugin = async nitro => {
 
   // load initial locale messages for intlify/h3
   options.messages = await loadInitialMessages(options.messages, localeMessages, {
-    ...nuxtI18nOptions,
-    initialLocale,
-    fallbackLocale: options.fallbackLocale,
     localeCodes,
-    cacheMessages
+    initialLocale,
+    lazy: nuxtI18nOptions.lazy,
+    defaultLocale: nuxtI18nOptions.defaultLocale,
+    fallbackLocale: options.fallbackLocale
   })
 
   const localeDetector = async (
@@ -40,16 +36,13 @@ export const nitroPlugin: NitroAppPlugin = async nitro => {
   ): Promise<Locale> => {
     const locale = _localeDetector(event, { defaultLocale: initialLocale, fallbackLocale: options.fallbackLocale })
     if (lazy) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const setter = (locale: Locale, message: Record<string, any>) => {
-        i18nContext.messages[locale] = i18nContext.messages[locale] || {}
-        deepCopy(message, i18nContext.messages[locale])
-      }
       if (fallbackLocale) {
         const fallbackLocales = makeFallbackLocaleCodes(fallbackLocale, [locale])
-        await Promise.all(fallbackLocales.map(locale => loadLocale({ locale, setter, localeMessages }, cacheMessages)))
+        await Promise.all(
+          fallbackLocales.map(locale => loadAndSetLocaleMessages(locale, localeMessages, i18nContext.messages))
+        )
       }
-      await loadLocale({ locale, setter, localeMessages }, cacheMessages)
+      await loadAndSetLocaleMessages(locale, localeMessages, i18nContext.messages)
     }
     return locale
   }

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -1,5 +1,5 @@
 import { defineI18nMiddleware } from '@intlify/h3'
-import { nuxtI18nOptions, localeCodes, vueI18nConfigs, localeMessages } from '#internal/i18n/options.mjs'
+import { nuxtI18nOptions, localeCodes, vueI18nConfigs, localeLoaders } from '#internal/i18n/options.mjs'
 // @ts-ignore
 import { localeDetector as _localeDetector } from '#internal/i18n/locale.detector.mjs'
 import { loadVueI18nOptions, loadInitialMessages, makeFallbackLocaleCodes, loadAndSetLocaleMessages } from '../messages'
@@ -22,7 +22,7 @@ export const nitroPlugin: NitroAppPlugin = async nitro => {
   const initialLocale = defaultLocale || options.locale || 'en-US'
 
   // load initial locale messages for intlify/h3
-  options.messages = await loadInitialMessages(options.messages, localeMessages, {
+  options.messages = await loadInitialMessages(options.messages, localeLoaders, {
     localeCodes,
     initialLocale,
     lazy: nuxtI18nOptions.lazy,
@@ -39,10 +39,10 @@ export const nitroPlugin: NitroAppPlugin = async nitro => {
       if (fallbackLocale) {
         const fallbackLocales = makeFallbackLocaleCodes(fallbackLocale, [locale])
         await Promise.all(
-          fallbackLocales.map(locale => loadAndSetLocaleMessages(locale, localeMessages, i18nContext.messages))
+          fallbackLocales.map(locale => loadAndSetLocaleMessages(locale, localeLoaders, i18nContext.messages))
         )
       }
-      await loadAndSetLocaleMessages(locale, localeMessages, i18nContext.messages)
+      await loadAndSetLocaleMessages(locale, localeLoaders, i18nContext.messages)
     }
     return locale
   }

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -22,7 +22,7 @@ import {
   nuxtI18nOptionsDefault,
   NUXT_I18N_MODULE_ID,
   isSSG,
-  localeMessages
+  localeLoaders
 } from '#build/i18n.options.mjs'
 import {
   detectBrowserLanguage,
@@ -136,9 +136,9 @@ export async function loadAndSetLocale<Context extends NuxtApp = NuxtApp>(
     const setter = (locale: Locale, message: Record<string, any>) => mergeLocaleMessage(i18n, locale, message)
     if (i18nFallbackLocales) {
       const fallbackLocales = makeFallbackLocaleCodes(i18nFallbackLocales, [newLocale])
-      await Promise.all(fallbackLocales.map(locale => loadLocale(locale, localeMessages, setter)))
+      await Promise.all(fallbackLocales.map(locale => loadLocale(locale, localeLoaders, setter)))
     }
-    await loadLocale(newLocale, localeMessages, setter)
+    await loadLocale(newLocale, localeLoaders, setter)
   }
 
   if (skipSettingLocaleOnNavigate) {

--- a/src/template.ts
+++ b/src/template.ts
@@ -20,8 +20,8 @@ ${options.importStrings.length > 0 ? options.importStrings.join('\n') + '\n' : '
 
 export const localeCodes =  ${JSON.stringify(options.localeCodes, null, 2)}
 
-export const localeMessages = {
-${options.localeMessages
+export const localeLoaders = {
+${options.localeLoaders
   .map(([key, val]) => {
     return `  "${key}": [${val
       .map(

--- a/test/__snapshots__/gen.test.ts.snap
+++ b/test/__snapshots__/gen.test.ts.snap
@@ -7,7 +7,7 @@ exports[`basic 1`] = `
     "import locale__test_srcDir_ja_json from "../ja.json";",
     "import locale__test_srcDir_fr_json from "../fr.json";",
   ],
-  "localeMessages": [
+  "localeLoaders": [
     [
       "en",
       [
@@ -53,7 +53,7 @@ exports[`basic 1`] = `
 exports[`files with cache configuration 1`] = `
 {
   "importStrings": [],
-  "localeMessages": [
+  "localeLoaders": [
     [
       "en",
       [
@@ -124,7 +124,7 @@ exports[`files with cache configuration 1`] = `
 exports[`lazy 1`] = `
 {
   "importStrings": [],
-  "localeMessages": [
+  "localeLoaders": [
     [
       "en",
       [
@@ -170,7 +170,7 @@ exports[`lazy 1`] = `
 exports[`locale file in nested 1`] = `
 {
   "importStrings": [],
-  "localeMessages": [
+  "localeLoaders": [
     [
       "en",
       [
@@ -216,7 +216,7 @@ exports[`locale file in nested 1`] = `
 exports[`multiple files 1`] = `
 {
   "importStrings": [],
-  "localeMessages": [
+  "localeLoaders": [
     [
       "en",
       [
@@ -287,7 +287,7 @@ exports[`multiple files 1`] = `
 exports[`toCode: function (arrow) 1`] = `
 {
   "importStrings": [],
-  "localeMessages": [],
+  "localeLoaders": [],
   "nuxtI18nOptions": {
     "defaultLocale": "en",
     "lazy": false,
@@ -333,7 +333,7 @@ exports[`toCode: function (arrow) 1`] = `
 exports[`toCode: function (named) 1`] = `
 {
   "importStrings": [],
-  "localeMessages": [],
+  "localeLoaders": [],
   "nuxtI18nOptions": {
     "defaultLocale": "en",
     "lazy": false,
@@ -383,7 +383,7 @@ exports[`vueI18n option 1`] = `
     "import locale__test_srcDir_ja_json from "../ja.json";",
     "import locale__test_srcDir_fr_json from "../fr.json";",
   ],
-  "localeMessages": [
+  "localeLoaders": [
     [
       "en",
       [

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     setupFiles: ['./specs/utils/setup-env.ts'],
     exclude: [...configDefaults.exclude],
     poolOptions: {
-      vmThreads: {
+      threads: {
         maxThreads: process.env.CI ? undefined : 4,
         minThreads: process.env.CI ? undefined : 4
       }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist
Moves `cacheMessages` and `setter` inside `messages.ts` where possible.

Unfortunately it's not possible to import the generated `localeMessages` (renamed to `localeLoaders`) in `messages.ts` due to Vue/Nitro virtual imports, if that were possible we wouldn't have to pass it to all message functions 😥.


<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
