### PR TITLE
feat: Support multiple languages on one or more domains while having different domains

### DIFF
--- a/docs/content/docs/2.guide/9.different-domains.md
+++ b/docs/content/docs/2.guide/9.different-domains.md
@@ -113,3 +113,60 @@ NUXT_PUBLIC_I18N_LOCALES_FR_DOMAIN=fr.example.test
 NUXT_PUBLIC_I18N_LOCALES_UK_DOMAIN=uk.staging.example.test
 NUXT_PUBLIC_I18N_LOCALES_FR_DOMAIN=fr.staging.example.test
 ```
+
+## Using different domains for only some of the languages
+
+If one or more of the domains need to host multiple languages, the default language of each domain needs to have `domainDefault: true` so there is a per domain fallback locale.
+The option `differentDomains` still need to be set to `true` though.
+
+```js {}[nuxt.config.js]
+export default defineNuxtConfig({
+  // ...
+  i18n: {
+    locales: [
+      {
+        code: 'en',
+        domain: 'mydomain.com',
+        domainDefault: true
+      },
+      {
+        code: 'pl',
+        domain: 'mydomain.com'
+      },
+      {
+        code: 'ua',
+        domain: 'mydomain.com'
+      },
+      {
+        code: 'es',
+        domain: 'es.mydomain.com',
+        domainDefault: true
+      },
+      {
+        code: 'fr',
+        domain: 'fr.mydomain.com',
+        domainDefault: true
+      }
+    ],
+    strategy: 'prefix',
+    differentDomains: true
+    // Or enable the option in production only
+    // differentDomains: (process.env.NODE_ENV === 'production')
+  },
+  // ...
+})
+```
+
+Given above configuration with the `prefix` strategy, following requests will be:
+- https://mydomain.com -> https://mydomain.com/en (en language)
+- https://mydomain.com/pl -> https://mydomain.com/pl (pl language)
+- https://mydomain.com/ua -> https://mydomain.com/ua (ua language)
+- https://es.mydomain.com -> https://es.mydomain.com/es (es language)
+- https://fr.mydomain.com -> https://fr.mydomain.com/fr (fr language)
+
+The same requests when using the `prefix_except_default` strategy, will be:
+- https://mydomain.com -> https://mydomain.com (en language)
+- https://mydomain.com/pl -> https://mydomain.com/pl (pl language)
+- https://mydomain.com/ua -> https://mydomain.com/ua (ua language)
+- https://es.mydomain.com -> https://es.mydomain.com (es language)
+- https://fr.mydomain.com -> https://fr.mydomain.com (fr language)

--- a/docs/content/docs/3.options/2.routing.md
+++ b/docs/content/docs/3.options/2.routing.md
@@ -44,6 +44,7 @@ When using an object form, the properties can be:
 - `files` - The name of the file in which multiple locale messages are defined. Will be resolved relative to `langDir` path when loading locale messages from file.
 - `dir` - The dir property specifies the direction of the elements and content, value could be `'rtl'`, `'ltr'` or `'auto'`.
 - `domain` (required when using [`differentDomains`](/docs/options/domain#differentdomains)) - the domain name you'd like to use for that locale (including the port if used). This property can also be set using [`runtimeConfig`](/docs/options/runtime-config).
+- `domainDefault` (required when using [`differentDomains`](/docs/options/domain#differentdomains) while one or more of the domains having multiple locales) - set `domainDefault` to `true` for each locale that should act as a default locale for the particular domain.
 - `...` - any custom property set on the object will be exposed at runtime. This can be used, for example, to define the language name for the purpose of using it in a language selector on the page.
 
 You can access all the properties of the current locale through the `localeProperties` property. When using an array of codes, it will only include the `code` property.

--- a/specs/different_domains.spec.ts
+++ b/specs/different_domains.spec.ts
@@ -41,6 +41,7 @@ await setup({
         }
       ],
       differentDomains: true,
+      strategy: 'no_prefix',
       detectBrowserLanguage: {
         useCookie: true
       }

--- a/specs/different_domains_multi_locales_prefix.spec.ts
+++ b/specs/different_domains_multi_locales_prefix.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect, describe } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, $fetch, undiciRequest } from './utils'
+import { getDom } from './helper'
+
+await setup({
+  rootDir: fileURLToPath(new URL(`./fixtures/different_domains`, import.meta.url)),
+  // overrides
+  nuxtConfig: {
+    i18n: {
+      locales: [
+        {
+          code: 'en',
+          iso: 'en',
+          name: 'English',
+          domain: 'nuxt-app.localhost',
+          domainDefault: true
+        },
+        {
+          code: 'no',
+          iso: 'no-NO',
+          name: 'Norwegian',
+          domain: 'nuxt-app.localhost'
+        },
+        {
+          code: 'fr',
+          iso: 'fr-FR',
+          name: 'Français',
+          domain: 'fr.nuxt-app.localhost'
+        }
+      ],
+      differentDomains: true,
+      strategy: 'prefix',
+      detectBrowserLanguage: {
+        useCookie: true
+      }
+    }
+  }
+})
+
+describe('detection locale with host on server', () => {
+  test.each([
+    ['en', 'nuxt-app.localhost', 'Homepage'],
+    ['fr', 'fr.nuxt-app.localhost', 'Accueil']
+  ])('%s host', async (locale, host, header) => {
+    const res = await undiciRequest('/' + locale, {
+      headers: {
+        Host: host
+      }
+    })
+    const dom = getDom(await res.body.text())
+
+    expect(dom.querySelector('#lang-switcher-current-locale code').textContent).toEqual(locale)
+    expect(dom.querySelector('#home-header').textContent).toEqual(header)
+  })
+})
+
+test('detection locale with x-forwarded-host on server', async () => {
+  const html = await $fetch('/fr', {
+    headers: {
+      'X-Forwarded-Host': 'fr.nuxt-app.localhost'
+    }
+  })
+  const dom = getDom(html)
+
+  expect(dom.querySelector('#lang-switcher-current-locale code').textContent).toEqual('fr')
+  expect(dom.querySelector('#home-header').textContent).toEqual('Accueil')
+})
+
+test('pass `<NuxtLink> to props', async () => {
+  const res = await undiciRequest('/fr', {
+    headers: {
+      Host: 'fr.nuxt-app.localhost'
+    }
+  })
+  const dom = getDom(await res.body.text())
+  expect(dom.querySelector('#switch-locale-path-usages .switch-to-en a').getAttribute('href')).toEqual(
+    `http://nuxt-app.localhost/en`
+  )
+  expect(dom.querySelector('#switch-locale-path-usages .switch-to-no a').getAttribute('href')).toEqual(
+    `http://nuxt-app.localhost/no`
+  )
+  expect(dom.querySelector('#switch-locale-path-usages .switch-to-fr a').getAttribute('href')).toEqual(
+    `http://fr.nuxt-app.localhost/fr`
+  )
+})

--- a/specs/different_domains_multi_locales_prefix_except_default.spec.ts
+++ b/specs/different_domains_multi_locales_prefix_except_default.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect, describe } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, $fetch, undiciRequest } from './utils'
+import { getDom } from './helper'
+
+await setup({
+  rootDir: fileURLToPath(new URL(`./fixtures/different_domains`, import.meta.url)),
+  // overrides
+  nuxtConfig: {
+    i18n: {
+      locales: [
+        {
+          code: 'en',
+          iso: 'en',
+          name: 'English',
+          domain: 'nuxt-app.localhost',
+          domainDefault: true
+        },
+        {
+          code: 'no',
+          iso: 'no-NO',
+          name: 'Norwegian',
+          domain: 'nuxt-app.localhost'
+        },
+        {
+          code: 'fr',
+          iso: 'fr-FR',
+          name: 'Français',
+          domain: 'fr.nuxt-app.localhost',
+          domainDefault: true
+        },
+        {
+          code: 'ja',
+          iso: 'jp-JA',
+          name: 'Japan',
+          domain: 'ja.nuxt-app.localhost',
+          domainDefault: true
+        }
+      ],
+      differentDomains: true,
+      strategy: 'prefix_except_default',
+      detectBrowserLanguage: {
+        useCookie: true
+      }
+    }
+  }
+})
+
+describe('detection locale with host on server', () => {
+  test.each([
+    ['/', 'en', 'nuxt-app.localhost', 'Homepage'],
+    ['/no', 'no', 'nuxt-app.localhost', 'Hjemmeside'],
+    ['/', 'fr', 'fr.nuxt-app.localhost', 'Accueil']
+  ])('%s host', async (path, locale, host, header) => {
+    const res = await undiciRequest(path, {
+      headers: {
+        Host: host
+      }
+    })
+    const dom = getDom(await res.body.text())
+
+    expect(dom.querySelector('#lang-switcher-current-locale code').textContent).toEqual(locale)
+    expect(dom.querySelector('#home-header').textContent).toEqual(header)
+  })
+})
+
+test('detection locale with x-forwarded-host on server', async () => {
+  const html = await $fetch('/', {
+    headers: {
+      'X-Forwarded-Host': 'fr.nuxt-app.localhost'
+    }
+  })
+  const dom = getDom(html)
+
+  expect(dom.querySelector('#lang-switcher-current-locale code').textContent).toEqual('fr')
+  expect(dom.querySelector('#home-header').textContent).toEqual('Accueil')
+})
+
+test('pass `<NuxtLink> to props', async () => {
+  const res = await undiciRequest('/', {
+    headers: {
+      Host: 'fr.nuxt-app.localhost'
+    }
+  })
+  const dom = getDom(await res.body.text())
+  expect(dom.querySelector('#switch-locale-path-usages .switch-to-en a').getAttribute('href')).toEqual(
+    `http://nuxt-app.localhost`
+  )
+  expect(dom.querySelector('#switch-locale-path-usages .switch-to-no a').getAttribute('href')).toEqual(
+    `http://nuxt-app.localhost/no`
+  )
+  expect(dom.querySelector('#switch-locale-path-usages .switch-to-fr a').getAttribute('href')).toEqual(
+    `http://fr.nuxt-app.localhost`
+  )
+})

--- a/specs/fixtures/different_domains/i18n.config.ts
+++ b/specs/fixtures/different_domains/i18n.config.ts
@@ -27,6 +27,19 @@ export default {
           article: 'This is blog article page'
         }
       }
+    },
+    no: {
+      welcome: 'Velkommen',
+      home: 'Hjemmeside',
+      profile: 'Profil',
+      about: 'Om oss',
+      posts: 'Artikkeler',
+      dynamic: 'Dynamic',
+      pages: {
+        blog: {
+          article: 'Dette er bloggartikkelsiden'
+        }
+      }
     }
   },
   fallbackLocale: 'en'

--- a/specs/fixtures/different_domains/nuxt.config.ts
+++ b/specs/fixtures/different_domains/nuxt.config.ts
@@ -15,6 +15,12 @@ export default defineNuxtConfig({
         domain: 'en.nuxt-app.localhost'
       },
       {
+        code: 'no',
+        iso: 'no-NO',
+        name: 'Norwegian',
+        domain: 'no.nuxt-app.localhost'
+      },
+      {
         code: 'fr',
         iso: 'fr-FR',
         name: 'Français',

--- a/src/module.ts
+++ b/src/module.ts
@@ -114,13 +114,6 @@ export default defineNuxtModule<NuxtI18nOptions>({
       )
     }
 
-    if (options.strategy === 'no_prefix' && options.differentDomains) {
-      logger.warn(
-        '`differentDomains` option and `no_prefix` strategy are not compatible. ' +
-          'Change strategy or disable `differentDomains` option.'
-      )
-    }
-
     if (options.dynamicRouteParams) {
       logger.warn(
         'The `dynamicRouteParams` options is deprecated and will be removed in `v9`, use the `useSetI18nParams` composable instead.'

--- a/src/runtime/internal.ts
+++ b/src/runtime/internal.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { isArray, isString } from '@intlify/shared'
+import { isArray, isString, isObject } from '@intlify/shared'
 import { hasProtocol } from 'ufo'
 import isHTTPS from 'is-https'
 import {
@@ -338,10 +338,22 @@ export function getHost() {
   return host
 }
 
-export function getLocaleDomain(locales: LocaleObject[]): string {
+export function getLocaleDomain(
+  locales: LocaleObject[],
+  strategy: string,
+  route: string | Route | RouteLocationNormalized | RouteLocationNormalizedLoaded
+): string {
   let host = getHost() || ''
   if (host) {
-    const matchingLocale = locales.find(locale => {
+    __DEBUG__ &&
+      console.log(
+        `MultiDomainsMultiLocales: locating domain for host: `,
+        host,
+        strategy,
+        isObject(route) ? route.path : route
+      )
+    let matchingLocale: LocaleObject | undefined
+    const matchingLocales = locales.filter(locale => {
       if (locale && locale.domain) {
         let domain = locale.domain
         if (hasProtocol(locale.domain)) {
@@ -351,6 +363,53 @@ export function getLocaleDomain(locales: LocaleObject[]): string {
       }
       return false
     })
+
+    if (matchingLocales.length === 1) {
+      matchingLocale = matchingLocales[0]
+      __DEBUG__ &&
+        console.log(`MultiDomainsMultiLocales: found only one matching domain: `, host, matchingLocales[0].code)
+    } else if (matchingLocales.length > 1) {
+      if (strategy === 'no_prefix') {
+        console.warn(
+          formatMessage(
+            'Multiple matching domains found! This is not supported for no_prefix strategy in combination with differentDomains!'
+          )
+        )
+        // Just return the first matching domain locale
+        matchingLocale = matchingLocales[0]
+      } else {
+        // get prefix from route
+        if (route) {
+          const routePath = isObject(route) ? route.path : isString(route) ? route : ''
+
+          __DEBUG__ &&
+            console.log(`MultiDomainsMultiLocales: Check in matched domain for locale match in path: `, routePath, host)
+
+          if (routePath && routePath !== '') {
+            const matches = routePath.match(getLocalesRegex(matchingLocales.map(l => l.code)))
+            if (matches && matches.length > 1) {
+              matchingLocale = matchingLocales.find(l => l.code === matches[1])
+              __DEBUG__ &&
+                console.log(
+                  `MultiDomainsMultiLocales: Found matching locale from path. MatchingLocale is now`,
+                  matchingLocale?.code
+                )
+            }
+          }
+        }
+
+        if (!matchingLocale) {
+          // Fall back to default language on this domain - if set
+          matchingLocale = matchingLocales.find(l => l.domainDefault)
+          __DEBUG__ &&
+            console.log(
+              `MultiDomainsMultiLocales: matching locale not found - trying to get default for this domain. MatchingLocale is now`,
+              matchingLocale?.code
+            )
+        }
+      }
+    }
+
     if (matchingLocale) {
       return matchingLocale.code
     } else {

--- a/src/runtime/internal.ts
+++ b/src/runtime/internal.ts
@@ -341,7 +341,7 @@ export function getHost() {
 export function getLocaleDomain(
   locales: LocaleObject[],
   strategy: string,
-  route: string | Route | RouteLocationNormalized | RouteLocationNormalizedLoaded
+  route: string | RouteLocationNormalized | RouteLocationNormalizedLoaded
 ): string {
   let host = getHost() || ''
   if (host) {

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -414,6 +414,8 @@ export function injectNuxtHelpers(nuxt: NuxtApp, i18n: I18n | VueI18n | Composer
 // override prefix for route path, support domain
 export function extendPrefixable(runtimeConfig = useRuntimeConfig()) {
   return (opts: PrefixableOptions): boolean => {
+    __DEBUG__ && console.log('extendPrefixable', DefaultPrefixable(opts))
+
     return DefaultPrefixable(opts) && !runtimeConfig.public.i18n.differentDomains
   }
 }

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -216,7 +216,7 @@ export function detectLocale(
 
   if (!finalLocale) {
     if (differentDomains) {
-      finalLocale = getLocaleDomain(normalizedLocales)
+      finalLocale = getLocaleDomain(normalizedLocales, strategy, route)
     } else if (strategy !== 'no_prefix') {
       finalLocale = routeLocaleGetter(route)
     } else {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#2418

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This change will support different domains while having more than one language on one or more of the domains.
In order to support the various strategies one must set a `domainDefault: true` on the default/fallback locale on each domain.

Resolves #2418


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
