### PR TITLE
fix: common composable option passing

### DIFF
--- a/specs/fixtures/issues/2726/app.vue
+++ b/specs/fixtures/issues/2726/app.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { useLocaleHead, useLocalePath, useLocaleRoute, useRouteBaseName, useSwitchLocalePath } from '#i18n'
+import { computed, useHead } from '#imports'
+
+const localePath = useLocalePath()
+const localeRoute = useLocaleRoute()
+const switchLocalePath = useSwitchLocalePath()
+const routeBaseName = useRouteBaseName()
+const localeHead = useLocaleHead({ addDirAttribute: true, addSeoAttributes: true, identifierAttribute: 'id' })
+
+const metaTestEntries = computed(() => [
+  { id: 'locale-path', content: localePath('/nested/test-route') },
+  { id: 'locale-route', content: localeRoute('/nested/test-route')?.fullPath ?? '' },
+  { id: 'switch-locale-path', content: switchLocalePath('fr') },
+  { id: 'route-base-name', content: routeBaseName(localeRoute('/nested/test-route', 'fr')) ?? '' }
+])
+
+useHead({
+  htmlAttrs: {
+    ...localeHead.value.htmlAttrs
+  },
+  link: () => [...(localeHead.value.link ?? [])],
+  meta: () => [...(localeHead.value.meta ?? []), ...metaTestEntries.value]
+})
+</script>
+
+<template>
+  <div>
+    <NuxtPage />
+  </div>
+</template>

--- a/specs/fixtures/issues/2726/nuxt.config.ts
+++ b/specs/fixtures/issues/2726/nuxt.config.ts
@@ -1,0 +1,19 @@
+// https://nuxt.com/docs/guide/directory-structure/nuxt.config
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/i18n'],
+  debug: false,
+  i18n: {
+    defaultLocale: 'en',
+    strategy: 'prefix_and_default',
+    locales: [
+      {
+        code: 'en',
+        iso: 'en-US'
+      },
+      {
+        code: 'fr',
+        iso: 'fr-FR'
+      }
+    ]
+  }
+})

--- a/specs/fixtures/issues/2726/package.json
+++ b/specs/fixtures/issues/2726/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "nuxt3-test-basic-usage-layers",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "nuxi dev",
+    "build": "nuxt build",
+    "start": "node .output/server/index.mjs"
+  },
+  "devDependencies": {
+    "@nuxtjs/i18n": "latest",
+    "nuxt": "latest"
+  }
+}

--- a/specs/fixtures/issues/2726/pages/index.vue
+++ b/specs/fixtures/issues/2726/pages/index.vue
@@ -1,0 +1,3 @@
+<template>
+  <h1>Home</h1>
+</template>

--- a/specs/fixtures/issues/2726/pages/nested/test-route.vue
+++ b/specs/fixtures/issues/2726/pages/nested/test-route.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Test route</div>
+</template>

--- a/specs/issues/2726.spec.ts
+++ b/specs/issues/2726.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect, describe } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, $fetch } from '../utils'
+import { getDom } from '../helper'
+
+describe('#2726 - Composable requires access to the Nuxt instance', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL(`../fixtures/issues/2726`, import.meta.url))
+  })
+
+  test('Composables correctly initialize common options, no internal server error', async () => {
+    const html = await $fetch('/')
+    const dom = getDom(html)
+
+    expect(dom.querySelector('head #locale-path').content).toEqual('/nested/test-route')
+    expect(dom.querySelector('head #locale-route').content).toEqual('/nested/test-route')
+    expect(dom.querySelector('head #switch-locale-path').content).toEqual('/fr')
+    expect(dom.querySelector('head #route-base-name').content).toEqual('nested-test-route')
+  })
+})

--- a/src/runtime/composables/index.ts
+++ b/src/runtime/composables/index.ts
@@ -108,17 +108,16 @@ export function useSetI18nParams(
 }
 
 /**
- * The function that resolve route.
+ * The `localeHead` function returns localized head properties for locale-related aspects.
  *
  * @remarks
- * The parameter sygnatures of this function is same as {@link localeRoute}.
+ * The parameter signature of this function is the same as {@link localeHead}.
  *
- * @param route - A route location. The path or name of the route or an object for more complex routes.
- * @param locale - A locale optinal, if not specified, uses the current locale.
+ * @param options - An options object, see {@link I18nHeadOptions}
  *
  * @returns the route object for a given route, the route object is resolved by vue-router rather than just a full route path.
  *
- * @see {@link useLocaleRoute}
+ * @see {@link localeHead}
  *
  * @public
  */
@@ -127,7 +126,7 @@ export type LocaleHeadFunction = (options: I18nHeadOptions) => ReturnType<typeof
 /**
  * The `useLocaleHead` composable returns localized head properties for locale-related aspects.
  *
- * @param options - An options, see about details {@link I18nHeadOptions}
+ * @param options - An options object, see {@link I18nHeadOptions}
  *
  * @returns The localized {@link I18nHeadMetaInfo | head properties} with Vue `ref`.
  *
@@ -209,7 +208,7 @@ export function useRouteBaseName(): RouteBaseNameFunction {
  * The function that resolve locale path.
  *
  * @remarks
- * The parameter sygnatures of this function is same as {@link localePath}.
+ * The parameter signature of this function is same as {@link localePath}.
  *
  * @param route - A route location. The path or name of the route or an object for more complex routes.
  * @param locale - A locale optional, if not specified, uses the current locale.
@@ -240,7 +239,7 @@ export function useLocalePath(common = initComposableOptions()): LocalePathFunct
  * The function that resolve route.
  *
  * @remarks
- * The parameter sygnatures of this function is same as {@link localeRoute}.
+ * The parameter signature of this function is same as {@link localeRoute}.
  *
  * @param route - A route location. The path or name of the route or an object for more complex routes.
  * @param locale - A locale optinal, if not specified, uses the current locale.
@@ -274,7 +273,7 @@ export function useLocaleRoute(common = initComposableOptions()): LocaleRouteFun
  * The function that resolve locale location.
  *
  * @remarks
- * The parameter sygnatures of this function is same as {@link localeLocation}.
+ * The parameter signature of this function is same as {@link localeLocation}.
  *
  * @param route - A route location. The path or name of the route or an object for more complex routes.
  * @param locale - A locale optional, if not specified, uses the current locale.
@@ -305,7 +304,7 @@ export function useLocaleLocation(common = initComposableOptions()): LocaleLocat
  * The functin that swtich locale path.
  *
  * @remarks
- * The parameter sygnatures of this function is same as {@link switchLocalePath}.
+ * The parameter signature of this function is same as {@link switchLocalePath}.
  *
  * @param locale - A locale optional, if not specified, uses the current locale.
  *

--- a/src/runtime/composables/index.ts
+++ b/src/runtime/composables/index.ts
@@ -161,10 +161,11 @@ export function useLocaleHead({
   }
 
   function updateMeta() {
-    metaObject.value = localeHead(
-      { addDirAttribute, addSeoAttributes, identifierAttribute },
-      common
-    ) as I18nHeadMetaInfo
+    metaObject.value = localeHead(common, {
+      addDirAttribute,
+      addSeoAttributes,
+      identifierAttribute
+    }) as I18nHeadMetaInfo
   }
 
   if (process.client) {

--- a/src/runtime/internal.ts
+++ b/src/runtime/internal.ts
@@ -19,11 +19,10 @@ import {
   nuxtI18nOptions,
   normalizedLocales
 } from '#build/i18n.options.mjs'
+import { findBrowserLocale, getLocalesRegex, getI18nTarget } from './routing/utils'
 
-import type { NuxtApp } from '#app'
 import type { Locale } from 'vue-i18n'
 import type { DetectBrowserLanguageOptions, LocaleObject } from '#build/i18n.options.mjs'
-import { findBrowserLocale, getLocalesRegex, getI18nTarget } from './routing/utils'
 import type { RouteLocationNormalized, RouteLocationNormalizedLoaded } from 'vue-router'
 
 export function formatMessage(message: string) {
@@ -45,26 +44,6 @@ export function getVueI18nPropertyValue<Return = any>(i18n: any, name: string): 
 
 export function defineGetter<K extends string | number | symbol, V>(obj: Record<K, V>, key: K, val: V) {
   Object.defineProperty(obj, key, { get: () => val })
-}
-
-export function proxyNuxt<T extends (...args: any) => any>(nuxt: NuxtApp, target: T) {
-  return function () {
-    return Reflect.apply(
-      target,
-      {
-        i18n: (nuxt as any).$i18n,
-        getRouteBaseName: nuxt.$getRouteBaseName,
-        localePath: nuxt.$localePath,
-        localeRoute: nuxt.$localeRoute,
-        switchLocalePath: nuxt.$switchLocalePath,
-        localeHead: nuxt.$localeHead,
-        route: (nuxt as any).$router.currentRoute.value,
-        router: (nuxt as any).$router
-      },
-      // eslint-disable-next-line prefer-rest-params
-      arguments
-    ) as (this: NuxtApp, ...args: Parameters<T>) => ReturnType<T>
-  }
 }
 
 /**

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -34,6 +34,7 @@ import type { Composer, Locale, I18nOptions } from 'vue-i18n'
 import type { NuxtApp } from '#app'
 import type { ExtendPropertyDescriptors, VueI18nRoutingPluginOptions } from '../routing/extends'
 import type { getRouteBaseName, localePath, localeRoute, switchLocalePath, localeHead } from '../routing/compatibles'
+import type { LocaleHeadFunction, LocalePathFunction, LocaleRouteFunction, SwitchLocalePathFunction } from '#i18n'
 
 export default defineNuxtPlugin({
   name: 'i18n:plugin',
@@ -414,12 +415,6 @@ export default defineNuxtPlugin({
   }
 })
 
-type GetRouteBaseName = typeof getRouteBaseName
-type LocalePath = typeof localePath
-type LocaleRoute = typeof localeRoute
-type LocaleHead = typeof localeHead
-type SwitchLocalePath = typeof switchLocalePath
-
 declare module '#app' {
   interface NuxtApp {
     /**
@@ -432,7 +427,7 @@ declare module '#app' {
      *
      * @returns The route base name. if cannot get, `undefined` is returned.
      */
-    $getRouteBaseName: (...args: Parameters<GetRouteBaseName>) => ReturnType<GetRouteBaseName>
+    $getRouteBaseName: (...args: Parameters<typeof getRouteBaseName>) => ReturnType<typeof getRouteBaseName>
     /**
      * Returns localized path for passed in route.
      *
@@ -444,7 +439,7 @@ declare module '#app' {
      *
      * @returns A path of the current route.
      */
-    $localePath: (...args: Parameters<LocalePath>) => ReturnType<LocalePath>
+    $localePath: (...args: Parameters<LocalePathFunction>) => ReturnType<typeof localePath>
     /**
      * Returns localized route for passed in `route` parameters.
      *
@@ -456,7 +451,7 @@ declare module '#app' {
      *
      * @returns A route. if cannot resolve, `undefined` is returned.
      */
-    $localeRoute: (...args: Parameters<LocaleRoute>) => ReturnType<LocaleRoute>
+    $localeRoute: (...args: Parameters<LocaleRouteFunction>) => ReturnType<typeof localeRoute>
     /**
      * Returns localized head properties for locale-related aspects.
      *
@@ -464,7 +459,7 @@ declare module '#app' {
      *
      * @returns The localized head properties.
      */
-    $localeHead: (...args: Parameters<LocaleHead>) => ReturnType<LocaleHead>
+    $localeHead: (...args: Parameters<LocaleHeadFunction>) => ReturnType<typeof localeHead>
     /**
      * Returns path of the current route for specified locale
      *
@@ -472,6 +467,6 @@ declare module '#app' {
      *
      * @returns A path of the current route
      */
-    $switchLocalePath: (...args: Parameters<SwitchLocalePath>) => ReturnType<SwitchLocalePath>
+    $switchLocalePath: (...args: Parameters<SwitchLocalePathFunction>) => ReturnType<typeof switchLocalePath>
   }
 }

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -34,7 +34,12 @@ import type { Composer, Locale, I18nOptions } from 'vue-i18n'
 import type { NuxtApp } from '#app'
 import type { ExtendPropertyDescriptors, VueI18nRoutingPluginOptions } from '../routing/extends'
 import type { getRouteBaseName, localePath, localeRoute, switchLocalePath, localeHead } from '../routing/compatibles'
-import type { LocaleHeadFunction, LocalePathFunction, LocaleRouteFunction, SwitchLocalePathFunction } from '#i18n'
+import type {
+  LocaleHeadFunction,
+  LocalePathFunction,
+  LocaleRouteFunction,
+  SwitchLocalePathFunction
+} from '../composables'
 
 export default defineNuxtPlugin({
   name: 'i18n:plugin',

--- a/src/runtime/routing/compatibles/head.ts
+++ b/src/runtime/routing/compatibles/head.ts
@@ -58,12 +58,12 @@ export function localeHead(
     }
 
     metaObject.link.push(
-      ...getHreflangLinks(unref(locales) as LocaleObject[], idAttribute, common),
-      ...getCanonicalLink(idAttribute, seoAttributes, common)
+      ...getHreflangLinks(common, unref(locales) as LocaleObject[], idAttribute),
+      ...getCanonicalLink(common, idAttribute, seoAttributes)
     )
 
     metaObject.meta.push(
-      ...getOgUrl(idAttribute, seoAttributes, common),
+      ...getOgUrl(common, idAttribute, seoAttributes),
       ...getCurrentOgLocale(currentLocale, currentIso, idAttribute),
       ...getAlternateOgLocales(unref(locales) as LocaleObject[], currentIso, idAttribute)
     )
@@ -78,9 +78,9 @@ function getBaseUrl() {
 }
 
 export function getHreflangLinks(
+  common: CommonComposableOptions,
   locales: LocaleObject[],
-  idAttribute: NonNullable<I18nHeadOptions['identifierAttribute']>,
-  common: CommonComposableOptions
+  idAttribute: NonNullable<I18nHeadOptions['identifierAttribute']>
 ) {
   const baseUrl = getBaseUrl()
   const { defaultLocale, strategy } = nuxtI18nOptions
@@ -106,7 +106,7 @@ export function getHreflangLinks(
   }
 
   for (const [iso, mapLocale] of localeMap.entries()) {
-    const localePath = switchLocalePath(mapLocale.code, undefined, common)
+    const localePath = switchLocalePath(common, mapLocale.code)
     if (localePath) {
       links.push({
         [idAttribute]: `i18n-alt-${iso}`,
@@ -118,7 +118,7 @@ export function getHreflangLinks(
   }
 
   if (defaultLocale) {
-    const localePath = switchLocalePath(defaultLocale, undefined, common)
+    const localePath = switchLocalePath(common, defaultLocale)
     if (localePath) {
       links.push({
         [idAttribute]: 'i18n-xd',
@@ -133,12 +133,12 @@ export function getHreflangLinks(
 }
 
 export function getCanonicalUrl(
+  common: CommonComposableOptions,
   baseUrl: string,
-  seoAttributes: I18nHeadOptions['addSeoAttributes'],
-  common: CommonComposableOptions
+  seoAttributes: I18nHeadOptions['addSeoAttributes']
 ) {
   const route = common.router.currentRoute.value
-  const currentRoute = localeRoute({ ...route, name: getRouteBaseName(route) }, undefined, common)
+  const currentRoute = localeRoute(common, { ...route, name: getRouteBaseName(route) })
 
   if (!currentRoute) return ''
   let href = toAbsoluteUrl(currentRoute.path, baseUrl)
@@ -167,24 +167,24 @@ export function getCanonicalUrl(
 }
 
 export function getCanonicalLink(
+  common: CommonComposableOptions,
   idAttribute: NonNullable<I18nHeadOptions['identifierAttribute']>,
-  seoAttributes: I18nHeadOptions['addSeoAttributes'],
-  common: CommonComposableOptions
+  seoAttributes: I18nHeadOptions['addSeoAttributes']
 ) {
   const baseUrl = getBaseUrl()
-  const href = getCanonicalUrl(baseUrl, seoAttributes, common)
+  const href = getCanonicalUrl(common, baseUrl, seoAttributes)
   if (!href) return []
 
   return [{ [idAttribute]: 'i18n-can', rel: 'canonical', href }]
 }
 
 export function getOgUrl(
+  common: CommonComposableOptions,
   idAttribute: NonNullable<I18nHeadOptions['identifierAttribute']>,
-  seoAttributes: I18nHeadOptions['addSeoAttributes'],
-  common: CommonComposableOptions
+  seoAttributes: I18nHeadOptions['addSeoAttributes']
 ) {
   const baseUrl = getBaseUrl()
-  const href = getCanonicalUrl(baseUrl, seoAttributes, common)
+  const href = getCanonicalUrl(common, baseUrl, seoAttributes)
   if (!href) return []
 
   return [{ [idAttribute]: 'i18n-og-url', property: 'og:url', content: href }]

--- a/src/runtime/routing/compatibles/head.ts
+++ b/src/runtime/routing/compatibles/head.ts
@@ -18,12 +18,12 @@ import type { CommonComposableOptions } from '../../utils'
  * @public
  */
 export function localeHead(
+  common: CommonComposableOptions,
   {
     addDirAttribute = false,
     addSeoAttributes: seoAttributes = true,
     identifierAttribute: idAttribute = 'hid'
-  }: I18nHeadOptions,
-  common: CommonComposableOptions
+  }: I18nHeadOptions
 ): I18nHeadMetaInfo {
   const { defaultDirection } = nuxtI18nOptions
   const i18n = getComposer(common.i18n)

--- a/src/runtime/routing/compatibles/routing.ts
+++ b/src/runtime/routing/compatibles/routing.ts
@@ -71,11 +71,11 @@ export function getRouteBaseName(givenRoute?: RouteLocation): string | undefined
  * @public
  */
 export function localePath(
+  common: CommonComposableOptions,
   route: RouteLocationRaw,
-  locale: Locale | undefined, // TODO: locale should be more type inference (completion)
-  common: CommonComposableOptions
+  locale?: Locale // TODO: locale should be more type inference (completion)
 ): string {
-  const localizedRoute = resolveRoute(route, locale, common)
+  const localizedRoute = resolveRoute(common, route, locale)
   return localizedRoute == null ? '' : localizedRoute.redirectedFrom?.fullPath || localizedRoute.fullPath
 }
 
@@ -93,11 +93,11 @@ export function localePath(
  * @public
  */
 export function localeRoute(
+  common: CommonComposableOptions,
   route: RouteLocationRaw,
-  locale: Locale | undefined, // TODO: locale should be more type inference (completion)
-  common: CommonComposableOptions
+  locale?: Locale // TODO: locale should be more type inference (completion)
 ): ReturnType<Router['resolve']> | undefined {
-  const resolved = resolveRoute(route, locale, common)
+  const resolved = resolveRoute(common, route, locale)
   return resolved ?? undefined
 }
 
@@ -115,15 +115,15 @@ export function localeRoute(
  * @public
  */
 export function localeLocation(
+  common: CommonComposableOptions,
   route: RouteLocationRaw,
-  locale: Locale | undefined, // TODO: locale should be more type inference (completion)
-  common: CommonComposableOptions
+  locale?: Locale // TODO: locale should be more type inference (completion)
 ): Location | (RouteLocation & { href: string }) | undefined {
-  const resolved = resolveRoute(route, locale, common)
+  const resolved = resolveRoute(common, route, locale)
   return resolved ?? undefined
 }
 
-export function resolveRoute(route: RouteLocationRaw, locale: Locale | undefined, common: CommonComposableOptions) {
+export function resolveRoute(common: CommonComposableOptions, route: RouteLocationRaw, locale: Locale | undefined) {
   const { router, i18n } = common
   const _locale = locale || getLocale(i18n)
   const { routesNameSeparator, defaultLocale, defaultLocaleRouteNameSuffix, strategy, trailingSlash } = nuxtI18nOptions
@@ -150,7 +150,7 @@ export function resolveRoute(route: RouteLocationRaw, locale: Locale | undefined
     'path' in val && !!val.path && !('name' in val)
 
   if (isRouteLocationPathRaw(localizedRoute)) {
-    const resolvedRoute = resolve(localizedRoute, strategy, _locale, common)
+    const resolvedRoute = resolve(common, localizedRoute, strategy, _locale)
 
     // @ts-ignore
     const resolvedRouteName = getRouteBaseName(resolvedRoute)
@@ -228,9 +228,9 @@ function getLocalizableMetaFromDynamicParams(
  * @public
  */
 export function switchLocalePath(
+  common: CommonComposableOptions,
   locale: Locale,
-  _route: RouteLocationNormalized | RouteLocationNormalizedLoaded | undefined,
-  common: CommonComposableOptions
+  _route?: RouteLocationNormalized | RouteLocationNormalizedLoaded
 ): string {
   const route = _route ?? common.router.currentRoute.value
   const name = getRouteBaseName(route)
@@ -244,7 +244,7 @@ export function switchLocalePath(
   const resolvedParams = getLocalizableMetaFromDynamicParams(route)[locale]
 
   const baseRoute = { ...routeCopy, name, params: { ...routeCopy.params, ...resolvedParams } }
-  const path = localePath(baseRoute, locale, common)
+  const path = localePath(common, baseRoute, locale)
 
   // custom locale path with interceptor
   return switchLocalePathIntercepter(path, locale)

--- a/src/runtime/routing/compatibles/routing.ts
+++ b/src/runtime/routing/compatibles/routing.ts
@@ -123,11 +123,8 @@ export function localeLocation(
   return resolved ?? undefined
 }
 
-export function resolveRoute(
-  route: RouteLocationRaw,
-  locale: Locale | undefined,
-  { i18n, router }: CommonComposableOptions
-) {
+export function resolveRoute(route: RouteLocationRaw, locale: Locale | undefined, common: CommonComposableOptions) {
+  const { router, i18n } = common
   const _locale = locale || getLocale(i18n)
   const { routesNameSeparator, defaultLocale, defaultLocaleRouteNameSuffix, strategy, trailingSlash } = nuxtI18nOptions
   const prefixable = extendPrefixable()
@@ -153,7 +150,7 @@ export function resolveRoute(
     'path' in val && !!val.path && !('name' in val)
 
   if (isRouteLocationPathRaw(localizedRoute)) {
-    const resolvedRoute = resolve(localizedRoute, strategy, _locale)
+    const resolvedRoute = resolve(localizedRoute, strategy, _locale, common)
 
     // @ts-ignore
     const resolvedRouteName = getRouteBaseName(resolvedRoute)

--- a/src/runtime/routing/compatibles/utils.ts
+++ b/src/runtime/routing/compatibles/utils.ts
@@ -1,9 +1,9 @@
-import { useRouter } from '#imports'
 import { assign } from '@intlify/shared'
 
 import type { Locale } from 'vue-i18n'
 import type { RouteLocationNormalizedLoaded, RouteLocationPathRaw } from 'vue-router'
 import type { Strategies } from '#build/i18n.options.mjs'
+import type { CommonComposableOptions } from '../../utils'
 
 function split(str: string, index: number) {
   const result = [str.slice(0, index), str.slice(index)]
@@ -37,8 +37,12 @@ export function routeToObject(route: RouteLocationNormalizedLoaded) {
  * When using the `prefix` strategy, the path specified by `localePath` is specified as a path not prefixed with a locale.
  * This will cause vue-router to issue a warning, so we can work-around by using `router.options.routes`.
  */
-export function resolve(route: RouteLocationPathRaw, strategy: Strategies, locale: Locale) {
-  const router = useRouter()
+export function resolve(
+  route: RouteLocationPathRaw,
+  strategy: Strategies,
+  locale: Locale,
+  { router }: CommonComposableOptions
+) {
   if (strategy !== 'prefix') {
     return router.resolve(route)
   }

--- a/src/runtime/routing/compatibles/utils.ts
+++ b/src/runtime/routing/compatibles/utils.ts
@@ -38,10 +38,10 @@ export function routeToObject(route: RouteLocationNormalizedLoaded) {
  * This will cause vue-router to issue a warning, so we can work-around by using `router.options.routes`.
  */
 export function resolve(
+  { router }: CommonComposableOptions,
   route: RouteLocationPathRaw,
   strategy: Strategies,
-  locale: Locale,
-  { router }: CommonComposableOptions
+  locale: Locale
 ) {
   if (strategy !== 'prefix') {
     return router.resolve(route)

--- a/src/runtime/routing/extends/i18n.ts
+++ b/src/runtime/routing/extends/i18n.ts
@@ -2,9 +2,16 @@ import { isObject, isFunction, assign } from '@intlify/shared'
 import { computed, effectScope, ref, watch } from '#imports'
 import { DEFAULT_BASE_URL } from '#build/i18n.options.mjs'
 import { resolveBaseUrl, isVueI18n, getComposer, inBrowser } from '../utils'
-import { getRouteBaseName, resolveRoute } from '../compatibles'
-import { useLocalePath, useLocaleRoute, useLocaleLocation, useSwitchLocalePath, useLocaleHead } from '#i18n'
-import { initComposableOptions } from '../../utils'
+import {
+  getRouteBaseName,
+  localeLocation,
+  localePath,
+  localeRoute,
+  resolveRoute,
+  switchLocalePath
+} from '../compatibles'
+import { useLocaleHead, wrapComposable } from '../../composables'
+import { initCommonComposableOptions } from '../../utils'
 
 import type { NuxtApp } from 'nuxt/app'
 import type {
@@ -132,16 +139,16 @@ export function extendI18n<Context = unknown, TI18n extends I18n = I18n>(
     }
 
     if (pluginOptions.inject) {
-      const common = initComposableOptions(i18n)
+      const common = initCommonComposableOptions(i18n)
       // extend vue component instance
       vue.mixin({
         methods: {
           resolveRoute,
           getRouteBaseName,
-          localePath: useLocalePath(common),
-          localeRoute: useLocaleRoute(common),
-          localeLocation: useLocaleLocation(common),
-          switchLocalePath: useSwitchLocalePath(common),
+          localePath: wrapComposable(localePath, common),
+          localeRoute: wrapComposable(localeRoute, common),
+          localeLocation: wrapComposable(localeLocation, common),
+          switchLocalePath: wrapComposable(switchLocalePath, common),
           localeHead: useLocaleHead
         }
       })

--- a/src/runtime/routing/extends/i18n.ts
+++ b/src/runtime/routing/extends/i18n.ts
@@ -2,15 +2,9 @@ import { isObject, isFunction, assign } from '@intlify/shared'
 import { computed, effectScope, ref, watch } from '#imports'
 import { DEFAULT_BASE_URL } from '#build/i18n.options.mjs'
 import { resolveBaseUrl, isVueI18n, getComposer, inBrowser } from '../utils'
-import {
-  localePath,
-  localeRoute,
-  localeLocation,
-  switchLocalePath,
-  getRouteBaseName,
-  resolveRoute,
-  localeHead
-} from '../compatibles'
+import { getRouteBaseName, resolveRoute } from '../compatibles'
+import { useLocalePath, useLocaleRoute, useLocaleLocation, useSwitchLocalePath, useLocaleHead } from '#i18n'
+import { initComposableOptions } from '../../utils'
 
 import type { NuxtApp } from 'nuxt/app'
 import type {
@@ -138,16 +132,17 @@ export function extendI18n<Context = unknown, TI18n extends I18n = I18n>(
     }
 
     if (pluginOptions.inject) {
+      const common = initComposableOptions(i18n)
       // extend vue component instance
       vue.mixin({
         methods: {
           resolveRoute,
-          localePath,
-          localeRoute,
-          localeLocation,
-          switchLocalePath,
           getRouteBaseName,
-          localeHead
+          localePath: useLocalePath(common),
+          localeRoute: useLocaleRoute(common),
+          localeLocation: useLocaleLocation(common),
+          switchLocalePath: useSwitchLocalePath(common),
+          localeHead: useLocaleHead
         }
       })
     }

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -80,7 +80,7 @@ export async function finalizePendingLocaleChange(i18n: I18n) {
 
 /**
  * Common options used internally by composable functions, these
- * are initialized when calling a composable wrapper function.
+ * are initialized when calling a wrapped composable function.
  *
  * @internal
  */
@@ -89,7 +89,7 @@ export type CommonComposableOptions = {
   i18n: I18n
   runtimeConfig: RuntimeConfig
 }
-export function initComposableOptions(i18n?: I18n): CommonComposableOptions {
+export function initCommonComposableOptions(i18n?: I18n): CommonComposableOptions {
   return {
     i18n: i18n ?? useNuxtApp().$i18n,
     router: useRouter(),
@@ -256,7 +256,7 @@ export function detectRedirect({
   calledWithRouting?: boolean
 }): string {
   const nuxtApp = useNuxtApp()
-  const common = initComposableOptions()
+  const common = initCommonComposableOptions()
   const { strategy, differentDomains } = nuxtI18nOptions
   __DEBUG__ && console.log('detectRedirect: targetLocale -> ', targetLocale)
   __DEBUG__ && console.log('detectRedirect: route -> ', route)
@@ -301,7 +301,7 @@ export function detectRedirect({
      *  so, we don't call that function, and instead, we call `useSwitchLocalePath`,
      *  let it be processed by the route of the router middleware.
      */
-    const routePath = switchLocalePath(targetLocale, route.to, common)
+    const routePath = switchLocalePath(common, targetLocale, route.to)
     __DEBUG__ && console.log('detectRedirect: calculate domain or ssg routePath -> ', routePath)
     if (isString(routePath) && routePath && !isEqual(routePath, toFullPath) && !routePath.startsWith('//')) {
       redirectPath = routePath

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -78,6 +78,12 @@ export async function finalizePendingLocaleChange(i18n: I18n) {
   return callVueI18nInterfaces(i18n, 'finalizePendingLocaleChange')
 }
 
+/**
+ * Common options used internally by composable functions, these
+ * are initialized when calling a composable wrapper function.
+ *
+ * @internal
+ */
 export type CommonComposableOptions = {
   router: Router
   i18n: I18n


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
* #2736
* #2710
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
* Resolves #2736
* Resolves #2710

My changes to the composables made during the `vue-i18n-routing` integration PR broke composable usage in certain scenarios. ~~I still need to add regression tests to prevent this from happening again.~~

The pattern used in `vue-i18n-routing` uses `Reflect.apply` to set these common options to `this`, I opted to pass the common options as arguments instead. ~~Maybe this should be changed to prevent users from passing these options themselves?~~ I changed my implementation, it now uses a function to wrap composables and provide the common options, this way the creation and passing of the options is not exposed to users.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
