### PR TITLE
fix: custom child route localization

### DIFF
--- a/test/pages/__snapshots__/custom_route.test.ts.snap
+++ b/test/pages/__snapshots__/custom_route.test.ts.snap
@@ -56,7 +56,7 @@ exports[`#1649 1`] = `
         "children": [],
         "file": "/path/to/1649/pages/account/addresses.vue",
         "name": "account-addresses___fr",
-        "path": "/fr/compte/adresses",
+        "path": "adresses",
       },
       {
         "children": [],
@@ -68,7 +68,7 @@ exports[`#1649 1`] = `
         "children": [],
         "file": "/path/to/1649/pages/account/profile.vue",
         "name": "account-profile___fr",
-        "path": "/fr/compte/profil",
+        "path": "profil",
       },
     ],
     "file": "/path/to/1649/pages/account.vue",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
* #2351
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #2351 

Based on debugging this, I think we may be able to improve this functionality in the future. Currently we expect users to supply a full localized path the a child route using `defineI18nRoute` or `pages` in config (e.g. `/parent/child`), it would be better if users only have to provide localization for the child path segment (e.g. `/child` or `child`).  This way the parent route could be renamed or the child route could be moved without having to update the custom route localization in multiple files.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
