### PR TITLE
feat: allow passing external links to `localePath`

### DIFF
--- a/specs/fixtures/routing/pages/index.vue
+++ b/specs/fixtures/routing/pages/index.vue
@@ -45,6 +45,11 @@ const localeRoute = useLocaleRoute()
 
       <!-- no define name -->
       <span class="undefined-name">{{ localePath('vue-i18n') }}</span>
+
+      <!-- external -->
+      <span class="external-link">{{ localePath('https://github.com') }}</span>
+      <span class="external-mail">{{ localePath('mailto:example@mail.com') }}</span>
+      <span class="external-phone">{{ localePath('tel:+31612345678') }}</span>
     </section>
     <ClientOnly>
       <section id="locale-route">

--- a/specs/routing/routing-tests.ts
+++ b/specs/routing/routing-tests.ts
@@ -64,6 +64,11 @@ export async function localePathTests(strategy: Strategies) {
   // undefined name
   expect(await getText(page, '#locale-path .undefined-name')).toEqual('')
 
+  // external
+  expect(await getText(page, '#locale-path .external-link')).toEqual('https://github.com')
+  expect(await getText(page, '#locale-path .external-mail')).toEqual('mailto:example@mail.com')
+  expect(await getText(page, '#locale-path .external-phone')).toEqual('tel:+31612345678')
+
   // for vue-router deprecation
   // https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22
   expect(consoleLogs.find(log => log.text.includes('Discarded invalid param(s)'))).toBeFalsy()

--- a/src/runtime/routing/compatibles/routing.ts
+++ b/src/runtime/routing/compatibles/routing.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { isString, assign } from '@intlify/shared'
-import { parsePath, parseQuery, withTrailingSlash, withoutTrailingSlash } from 'ufo'
+import { hasProtocol, parsePath, parseQuery, withTrailingSlash, withoutTrailingSlash } from 'ufo'
 import { nuxtI18nOptions, DEFAULT_DYNAMIC_PARAMS_KEY } from '#build/i18n.options.mjs'
 import { unref } from '#imports'
 
@@ -75,6 +75,11 @@ export function localePath(
   route: RouteLocationRaw,
   locale?: Locale // TODO: locale should be more type inference (completion)
 ): string {
+  // return external url as is
+  if (typeof route === 'string' && hasProtocol(route, { acceptRelative: true })) {
+    return route
+  }
+
   const localizedRoute = resolveRoute(common, route, locale)
   return localizedRoute == null ? '' : localizedRoute.redirectedFrom?.fullPath || localizedRoute.fullPath
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
* #1830 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #1830 

In cases where links are localized inside components or loops, it can be convenient to always use `localePath`. Instead of returning `null` or `''` when passing an external link (string), it will return the link as is.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
