### PR TITLE
fix: NuxtLinkLocale support custom route paths

### DIFF
--- a/docs/content/4.API/2.components.md
+++ b/docs/content/4.API/2.components.md
@@ -24,6 +24,23 @@ const localePath = useLocalePath()
 </template>
 ```
 
+For custom route paths use name prop:
+```vue
+<template>
+  <NuxtLinkLocale name="services-advanced">{{ $t('advanced') }}</NuxtLinkLocale>
+</template>
+
+<!-- equivalent to -->
+
+<script setup>
+const localePath = useLocalePath()
+</script>
+
+<template>
+  <NuxtLink :to="localePath({ name: 'services-advanced'})">{{ $t('advanced') }}</NuxtLink>
+</template>
+```
+
 #### Forcing locale resolution
 ```vue
 <template>

--- a/src/runtime/components/NuxtLinkLocale.ts
+++ b/src/runtime/components/NuxtLinkLocale.ts
@@ -16,6 +16,11 @@ export default defineComponent<NuxtLinkProps & { locale?: string }>({
       type: String as PropType<string>,
       default: undefined,
       required: false
+    },
+    name: {
+      type: String as PropType<string>,
+      default: undefined,
+      required: false
     }
   },
   setup(props, { slots }) {
@@ -29,6 +34,10 @@ export default defineComponent<NuxtLinkProps & { locale?: string }>({
     }
 
     const resolvedPath = computed(() => {
+      if (props.name) {
+        return localePath({name: props.name}, props.locale);
+      }
+      
       const destination = props.to ?? props.href
       return destination != null ? localePath(destination, props.locale) : destination
     })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
https://github.com/nuxt-modules/i18n/issues/2767

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Added prop "name" to <NuxtLinkLocale> to support custom route paths

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.
