### PR TITLE
docs: clarify custom route path usage with `localePath` and `<NuxtLinkLocale>`

### DIFF
--- a/docs/content/2.guide/4.custom-paths.md
+++ b/docs/content/2.guide/4.custom-paths.md
@@ -38,7 +38,20 @@ Note that each key within the `pages` object should **correspond to the relative
 Customized route paths **must start with a `/`** and **not include the locale prefix**.
 
 
-In addition, the `localePath` specified for custom paths resolution must be a named route.
+You can now use the `localePath` function or the `<NuxtLinkLocale>` component but be sure to use named routes! For example route `/services/advanced` should be `services–advanced`:
+
+```vue
+<script setup>
+const { t } = useI18n()
+</script>
+
+<template>
+  <NuxtLinkLocale to="about">{{ $t('about') }}</NuxtLinkLocale>
+  <NuxtLinkLocale to="services–advanced">{{ $t('advanced') }}</NuxtLinkLocale>
+</template>
+```
+
+Or:
 
 ```vue
 <script setup>
@@ -47,7 +60,8 @@ const localePath = useLocalePath()
 </script>
 
 <template>
-  <NuxtLink :to="localePath({ name: 'about' })">{{ t('about') }}</NuxtLink>
+  <NuxtLink :to="localePath('about')" })">{{ t('about') }}</NuxtLink>
+  <NuxtLink :to="localePath('services-advanced')" })">{{ t('advanced') }}</NuxtLink>
 </template>
 ```
 

--- a/docs/content/2.guide/4.custom-paths.md
+++ b/docs/content/2.guide/4.custom-paths.md
@@ -38,7 +38,7 @@ Note that each key within the `pages` object should **correspond to the relative
 Customized route paths **must start with a `/`** and **not include the locale prefix**.
 
 
-You can now use the `localePath` function or the `<NuxtLinkLocale>` component but be sure to use named routes! For example route `/services/advanced` should be `services–advanced`:
+You can now use the `localePath` function or the `<NuxtLinkLocale>` component but be sure to use named routes. For example route `/services/advanced` should be `services–advanced`:
 
 ```vue
 <script setup>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
https://github.com/nuxt-modules/i18n/issues/2767

### ❓ Type of change
- [X] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
It wasnt documented that <NuxtLinkLocale> can use named routes.

### 📝 Checklist
- [X] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.
