### PR TITLE
fix: `statusCode` in `rootRedirect` not working with strategy 'prefix'

### DIFF
--- a/specs/fixtures/issues/2758/app.vue
+++ b/specs/fixtures/issues/2758/app.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts"></script>
+
+<template>
+  <div>
+    <NuxtPage />
+  </div>
+</template>

--- a/specs/fixtures/issues/2758/nuxt.config.ts
+++ b/specs/fixtures/issues/2758/nuxt.config.ts
@@ -1,0 +1,23 @@
+// https://nuxt.com/docs/guide/directory-structure/nuxt.config
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/i18n'],
+  debug: false,
+  i18n: {
+    defaultLocale: 'en',
+    strategy: 'prefix',
+    rootRedirect: {
+      statusCode: 418,
+      path: 'test-route'
+    },
+    locales: [
+      {
+        code: 'en',
+        iso: 'en-US'
+      },
+      {
+        code: 'fr',
+        iso: 'fr-FR'
+      }
+    ]
+  }
+})

--- a/specs/fixtures/issues/2758/package.json
+++ b/specs/fixtures/issues/2758/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "nuxt3-test-basic-usage-layers",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "nuxi dev",
+    "build": "nuxt build",
+    "start": "node .output/server/index.mjs"
+  },
+  "devDependencies": {
+    "@nuxtjs/i18n": "latest",
+    "nuxt": "latest"
+  }
+}

--- a/specs/fixtures/issues/2758/pages/index.vue
+++ b/specs/fixtures/issues/2758/pages/index.vue
@@ -1,0 +1,3 @@
+<template>
+  <h1>Home</h1>
+</template>

--- a/specs/fixtures/issues/2758/pages/test-route.vue
+++ b/specs/fixtures/issues/2758/pages/test-route.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Test route</div>
+</template>

--- a/specs/issues/2758.spec.ts
+++ b/specs/issues/2758.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect, describe } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, fetch, url } from '../utils'
+
+describe('#2758', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL(`../fixtures/issues/2758`, import.meta.url))
+  })
+
+  test('`statusCode` in `rootRedirect` should work with strategy "prefix"', async () => {
+    const res = await fetch(url('/'))
+    expect(res.status).toEqual(418)
+    expect(res.headers.get('location')).toEqual('/en/test-route')
+  })
+})

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -178,6 +178,7 @@ export default defineNuxtPlugin({
               async () =>
                 await navigate(
                   {
+                    nuxtApp: nuxtContext,
                     i18n,
                     redirectPath,
                     locale,
@@ -424,7 +425,9 @@ export default defineNuxtPlugin({
 
         routeChangeCount++
 
-        return await nuxtContext.runWithContext(async () => navigate({ i18n, redirectPath, locale, route: to }))
+        return await nuxtContext.runWithContext(async () =>
+          navigate({ nuxtApp: nuxtContext, i18n, redirectPath, locale, route: to })
+        )
       }),
       { global: true }
     )

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -329,7 +329,6 @@ type NavigateArgs = {
 }
 
 function _navigate(redirectPath: string, status: number) {
-  console.log(redirectPath, status)
   return navigateTo(redirectPath, { redirectCode: status })
 }
 

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -321,6 +321,7 @@ function isRootRedirectOptions(rootRedirect: unknown): rootRedirect is RootRedir
 const useRedirectState = () => useState<string>(NUXT_I18N_MODULE_ID + ':redirect', () => '')
 
 type NavigateArgs = {
+  nuxtApp: NuxtApp
   i18n: I18n
   redirectPath: string
   locale: string
@@ -328,6 +329,7 @@ type NavigateArgs = {
 }
 
 function _navigate(redirectPath: string, status: number) {
+  console.log(redirectPath, status)
   return navigateTo(redirectPath, { redirectCode: status })
 }
 
@@ -339,7 +341,7 @@ export async function navigate(
   const differentDomains = nuxtI18nOptions.differentDomains ?? nuxtI18nOptionsDefault.differentDomains
   const skipSettingLocaleOnNavigate =
     nuxtI18nOptions.skipSettingLocaleOnNavigate ?? nuxtI18nOptionsDefault.skipSettingLocaleOnNavigate
-  const { i18n, locale, route } = args
+  const { nuxtApp, i18n, locale, route } = args
   let { redirectPath } = args
 
   __DEBUG__ &&
@@ -360,6 +362,7 @@ export async function navigate(
       redirectPath = '/' + rootRedirect.path
       status = rootRedirect.statusCode
     }
+    redirectPath = nuxtApp.$localePath(redirectPath, locale)
     __DEBUG__ && console.log('navigate: rootRedirect mode redirectPath -> ', redirectPath, ' status -> ', status)
     return _navigate(redirectPath, status)
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
* #2758 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #2758 

I think the `rootRedirect.statusCode` was ignored because the request was redirected twice, once from `/` to the configured `rootRedirect.path` (e.g. `about`) with the statusCode, then again because `/about` doesn't exist for strategy `prefix` so it will be redirected to `/en/about` while ignoring `rootRedirect` configuration, as it's no longer redirecting on root.

This PR changes `rootRedirect` to try and translate the redirect path, so that a single redirection happens with the configured status code.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
