### PR TITLE
docs: set production url to resolve og image correctly

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -1,9 +1,10 @@
 export default defineNuxtConfig({
   extends: ['@nuxt/ui-pro'],
   modules: ['@nuxt/content', '@nuxt/ui', '@nuxtjs/fontaine', '@nuxtjs/google-fonts', 'nuxt-og-image'],
-  routeRules: {
-    '/api/search.json': { prerender: true }
-  },
+  routeRules: { '/api/search.json': { prerender: true } },
+
+  // SEO
+  site: { url: 'https://i18n.nuxtjs.org' },
 
   // Nuxt UI & UI Pro
   ui: { icons: ['heroicons', 'simple-icons'] },


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

OG images were generated correctly but wrongly prefixed with the default `localehost:3000`. Setting the production URL as instructed in [ogImage docs](https://nuxtseo.com/og-image/getting-started/installation) solves the issue.

Before
![Before](https://github.com/nuxt-modules/i18n/assets/86230182/a5c59480-d56b-428f-8acc-c6263577530c) 

After
![After](https://github.com/nuxt-modules/i18n/assets/86230182/738263da-fa2c-4c0e-8625-7e6b9d0ad658)

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
