### PR TITLE
refactor: pass generated options through `runtimeConfig`

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -54,7 +54,7 @@ export const DEFAULT_OPTIONS = {
   strategy: STRATEGY_PREFIX_EXCEPT_DEFAULT,
   lazy: false,
   langDir: null,
-  rootRedirect: null,
+  rootRedirect: undefined,
   detectBrowserLanguage: {
     alwaysRedirect: false,
     cookieCrossOrigin: false,
@@ -87,5 +87,3 @@ export const JS_EXTENSIONS = ['.js', '.cjs', '.mjs']
 export const EXECUTABLE_EXTENSIONS = [...JS_EXTENSIONS, ...TS_EXTENSIONS]
 
 export const NULL_HASH = '00000000' as const
-
-export type NuxtI18nOptionsDefault = typeof DEFAULT_OPTIONS

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -32,7 +32,7 @@ const generateVueI18nConfiguration = (config: Required<VueI18nConfigPathInfo>, i
   )
 }
 
-function simplifyLocaleOptions(nuxt: Nuxt, options: NuxtI18nOptions) {
+export function simplifyLocaleOptions(nuxt: Nuxt, options: NuxtI18nOptions) {
   const isLocaleObjectsArray = (locales?: string[] | LocaleObject[]) => locales?.some(x => typeof x !== 'string')
 
   const hasLocaleObjects =

--- a/src/module.ts
+++ b/src/module.ts
@@ -17,7 +17,7 @@ import { setupAlias } from './alias'
 import { setupPages } from './pages'
 import { setupNitro } from './nitro'
 import { extendBundler } from './bundler'
-import { generateI18nPageTypes, generateI18nTypes, generateLoaderOptions } from './gen'
+import { generateI18nPageTypes, generateI18nTypes, generateLoaderOptions, simplifyLocaleOptions } from './gen'
 import {
   NUXT_I18N_MODULE_ID,
   DEFAULT_OPTIONS,
@@ -140,8 +140,20 @@ export default defineNuxtModule<NuxtI18nOptions>({
      */
 
     // for public
+    // @ts-expect-error generated type
     nuxt.options.runtimeConfig.public.i18n = defu(nuxt.options.runtimeConfig.public.i18n, {
       baseUrl: options.baseUrl,
+      defaultLocale: options.defaultLocale,
+      defaultDirection: options.defaultDirection,
+      strategy: options.strategy,
+      lazy: options.lazy,
+      rootRedirect: options.rootRedirect,
+      routesNameSeparator: options.routesNameSeparator,
+      defaultLocaleRouteNameSuffix: options.defaultLocaleRouteNameSuffix,
+      skipSettingLocaleOnNavigate: options.skipSettingLocaleOnNavigate,
+      differentDomains: options.differentDomains,
+      trailingSlash: options.trailingSlash,
+      configLocales: options.locales,
       locales: options.locales.reduce(
         (obj, locale) => {
           if (typeof locale === 'string') {
@@ -222,6 +234,9 @@ export default defineNuxtModule<NuxtI18nOptions>({
         parallelPlugin: options.parallelPlugin
       })
     }
+
+    // @ts-expect-error type error
+    nuxt.options.runtimeConfig.public.i18n.configLocales = simplifyLocaleOptions(nuxt, defu({}, options))
 
     addTemplate({
       filename: NUXT_I18N_TEMPLATE_OPTIONS_KEY,
@@ -337,7 +352,20 @@ export default defineNuxtModule<NuxtI18nOptions>({
 export interface ModuleOptions extends NuxtI18nOptions {}
 
 export interface ModulePublicRuntimeConfig {
-  i18n: Required<Pick<NuxtI18nOptions<unknown>, 'baseUrl' | 'detectBrowserLanguage'>>
+  i18n: Pick<NuxtI18nOptions<unknown>, 'baseUrl' | 'rootRedirect'> &
+    Pick<
+      Required<NuxtI18nOptions<unknown>>,
+      | 'differentDomains'
+      | 'skipSettingLocaleOnNavigate'
+      | 'defaultLocale'
+      | 'lazy'
+      | 'defaultDirection'
+      | 'detectBrowserLanguage'
+      | 'strategy'
+      | 'routesNameSeparator'
+      | 'defaultLocaleRouteNameSuffix'
+      | 'trailingSlash'
+    > & { configLocales: NonNullable<Required<NuxtI18nOptions<unknown>>['locales']> }
 }
 
 export interface ModuleHooks {

--- a/src/options.d.ts
+++ b/src/options.d.ts
@@ -1,6 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { NuxtI18nOptions, VueI18nConfig } from './types'
-import type { NuxtI18nOptionsDefault } from './constants'
 import type { DeepRequired } from 'ts-essentials'
 
 export type * from './types'
@@ -30,5 +29,4 @@ export const NUXT_I18N_MODULE_ID = ''
 export const DEFAULT_DYNAMIC_PARAMS_KEY: string
 export const DEFAULT_COOKIE_KEY: string
 
-export { NuxtI18nOptionsDefault }
 export { NuxtI18nOptions, DetectBrowserLanguageOptions, RootRedirectOptions } from './types'

--- a/src/runtime/composables/index.ts
+++ b/src/runtime/composables/index.ts
@@ -202,7 +202,7 @@ export type RouteBaseNameFunction = (givenRoute?: RouteLocationNormalizedLoaded)
  * @public
  */
 export function useRouteBaseName(): RouteBaseNameFunction {
-  return getRouteBaseName
+  return wrapComposable(getRouteBaseName)
 }
 
 /**

--- a/src/runtime/internal.ts
+++ b/src/runtime/internal.ts
@@ -11,14 +11,7 @@ import {
   useNuxtApp,
   unref
 } from '#imports'
-import {
-  NUXT_I18N_MODULE_ID,
-  DEFAULT_COOKIE_KEY,
-  isSSG,
-  localeCodes,
-  nuxtI18nOptions,
-  normalizedLocales
-} from '#build/i18n.options.mjs'
+import { NUXT_I18N_MODULE_ID, DEFAULT_COOKIE_KEY, isSSG, localeCodes, normalizedLocales } from '#build/i18n.options.mjs'
 import { findBrowserLocale, getLocalesRegex, getI18nTarget } from './routing/utils'
 import { initCommonComposableOptions, type CommonComposableOptions } from './utils'
 
@@ -26,6 +19,7 @@ import type { Locale } from 'vue-i18n'
 import type { DetectBrowserLanguageOptions, LocaleObject } from '#build/i18n.options.mjs'
 import type { RouteLocationNormalized, RouteLocationNormalizedLoaded } from 'vue-router'
 import type { CookieRef } from 'nuxt/app'
+import type { ModulePublicRuntimeConfig } from '../module'
 
 export function formatMessage(message: string) {
   return NUXT_I18N_MODULE_ID + ' ' + message
@@ -128,9 +122,14 @@ export function getLocaleCookie(
   }
 
   const localeCode: string | undefined = cookieRef.value ?? undefined
-  __DEBUG__ && console.log(`getLocaleCookie cookie (${process.client ? 'client' : 'server'}) -`, localeCode)
+  if (localeCode == null) {
+    __DEBUG__ && console.log(`getLocaleCookie (${process.client ? 'client' : 'server'}) - none`)
+    return
+  }
 
-  if (localeCode && localeCodes.includes(localeCode)) {
+  if (localeCodes.includes(localeCode)) {
+    __DEBUG__ &&
+      console.log(`getLocaleCookie (${process.client ? 'client' : 'server'}) - locale from cookie: `, localeCode)
     return localeCode
   }
 }
@@ -183,7 +182,7 @@ export function detectBrowserLanguage(
   detectLocaleContext: DetectLocaleContext,
   locale: Locale = ''
 ): DetectBrowserLanguageFromResult {
-  const { strategy } = nuxtI18nOptions
+  const { strategy } = useRuntimeConfig().public.i18n
   const { ssg, callType, firstAccess, localeCookie } = detectLocaleContext
   __DEBUG__ && console.log('detectBrowserLanguage: (ssg, callType, firstAccess) - ', ssg, callType, firstAccess)
 
@@ -376,8 +375,9 @@ export function getDomainFromLocale(localeCode: Locale): string | undefined {
 
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-export const runtimeDetectBrowserLanguage = () => {
-  const opts = useRuntimeConfig().public.i18n
+export const runtimeDetectBrowserLanguage = (
+  opts: ModulePublicRuntimeConfig['i18n'] = useRuntimeConfig().public.i18n
+) => {
   if (opts?.detectBrowserLanguage === false) return false
 
   return opts?.detectBrowserLanguage

--- a/src/runtime/routing/compatibles/head.ts
+++ b/src/runtime/routing/compatibles/head.ts
@@ -1,5 +1,4 @@
-import { unref, useNuxtApp } from '#imports'
-import { nuxtI18nOptions } from '#build/i18n.options.mjs'
+import { unref, useNuxtApp, useRuntimeConfig } from '#imports'
 
 import { getComposer, getLocale, getLocales, getNormalizedLocales } from '../utils'
 import { getRouteBaseName, localeRoute, switchLocalePath } from './routing'
@@ -25,7 +24,7 @@ export function localeHead(
     identifierAttribute: idAttribute = 'hid'
   }: I18nHeadOptions
 ): I18nHeadMetaInfo {
-  const { defaultDirection } = nuxtI18nOptions
+  const { defaultDirection } = useRuntimeConfig().public.i18n
   const i18n = getComposer(common.i18n)
 
   const metaObject: Required<I18nHeadMetaInfo> = {
@@ -83,7 +82,7 @@ export function getHreflangLinks(
   idAttribute: NonNullable<I18nHeadOptions['identifierAttribute']>
 ) {
   const baseUrl = getBaseUrl()
-  const { defaultLocale, strategy } = nuxtI18nOptions
+  const { defaultLocale, strategy } = useRuntimeConfig().public.i18n
   const links: MetaAttrs[] = []
 
   if (strategy === 'no_prefix') return links
@@ -138,7 +137,7 @@ export function getCanonicalUrl(
   seoAttributes: I18nHeadOptions['addSeoAttributes']
 ) {
   const route = common.router.currentRoute.value
-  const currentRoute = localeRoute(common, { ...route, name: getRouteBaseName(route) })
+  const currentRoute = localeRoute(common, { ...route, name: getRouteBaseName(common, route) })
 
   if (!currentRoute) return ''
   let href = toAbsoluteUrl(currentRoute.path, baseUrl)

--- a/src/runtime/routing/compatibles/routing.ts
+++ b/src/runtime/routing/compatibles/routing.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { isString, assign } from '@intlify/shared'
 import { hasProtocol, parsePath, parseQuery, withTrailingSlash, withoutTrailingSlash } from 'ufo'
-import { nuxtI18nOptions, DEFAULT_DYNAMIC_PARAMS_KEY } from '#build/i18n.options.mjs'
+import { DEFAULT_DYNAMIC_PARAMS_KEY } from '#build/i18n.options.mjs'
 import { unref } from '#imports'
 
 import { resolve, routeToObject } from './utils'
@@ -47,8 +47,8 @@ export const DefaultPrefixable = prefixable
  * 
  * @public
  */
-export function getRouteBaseName(givenRoute?: RouteLocation): string | undefined {
-  const { routesNameSeparator } = nuxtI18nOptions
+export function getRouteBaseName(common: CommonComposableOptions, givenRoute?: RouteLocation): string | undefined {
+  const { routesNameSeparator } = common.runtimeConfig.public.i18n
   const route = unref(givenRoute)
   if (route == null || !route.name) {
     return
@@ -131,8 +131,9 @@ export function localeLocation(
 export function resolveRoute(common: CommonComposableOptions, route: RouteLocationRaw, locale: Locale | undefined) {
   const { router, i18n } = common
   const _locale = locale || getLocale(i18n)
-  const { routesNameSeparator, defaultLocale, defaultLocaleRouteNameSuffix, strategy, trailingSlash } = nuxtI18nOptions
-  const prefixable = extendPrefixable()
+  const { routesNameSeparator, defaultLocale, defaultLocaleRouteNameSuffix, strategy, trailingSlash } =
+    common.runtimeConfig.public.i18n
+  const prefixable = extendPrefixable(common.runtimeConfig)
   // if route parameter is a string, check if it's a path or name of route.
   let _route: RouteLocationPathRaw | RouteLocationNamedRaw
   if (isString(route)) {
@@ -158,7 +159,7 @@ export function resolveRoute(common: CommonComposableOptions, route: RouteLocati
     const resolvedRoute = resolve(common, localizedRoute, strategy, _locale)
 
     // @ts-ignore
-    const resolvedRouteName = getRouteBaseName(resolvedRoute)
+    const resolvedRouteName = getRouteBaseName(common, resolvedRoute)
     if (isString(resolvedRouteName)) {
       localizedRoute = {
         name: getLocaleRouteName(resolvedRouteName, _locale, {
@@ -187,7 +188,7 @@ export function resolveRoute(common: CommonComposableOptions, route: RouteLocati
     }
   } else {
     if (!localizedRoute.name && !('path' in localizedRoute)) {
-      localizedRoute.name = getRouteBaseName(router.currentRoute.value)
+      localizedRoute.name = getRouteBaseName(common, router.currentRoute.value)
     }
 
     localizedRoute.name = getLocaleRouteName(localizedRoute.name, _locale, {
@@ -238,13 +239,13 @@ export function switchLocalePath(
   _route?: RouteLocationNormalized | RouteLocationNormalizedLoaded
 ): string {
   const route = _route ?? common.router.currentRoute.value
-  const name = getRouteBaseName(route)
+  const name = getRouteBaseName(common, route)
 
   if (!name) {
     return ''
   }
 
-  const switchLocalePathIntercepter = extendSwitchLocalePathIntercepter()
+  const switchLocalePathIntercepter = extendSwitchLocalePathIntercepter(common.runtimeConfig)
   const routeCopy = routeToObject(route)
   const resolvedParams = getLocalizableMetaFromDynamicParams(route)[locale]
 

--- a/src/runtime/routing/extends/router.ts
+++ b/src/runtime/routing/extends/router.ts
@@ -1,11 +1,12 @@
 import { isString, isObject } from '@intlify/shared'
 import { getLocalesRegex } from '../utils'
-import { localeCodes, nuxtI18nOptions } from '#build/i18n.options.mjs'
+import { localeCodes } from '#build/i18n.options.mjs'
 
 import type { RouteLocationNormalized, RouteLocationNormalizedLoaded } from 'vue-router'
+import { useRuntimeConfig } from 'nuxt/app'
 
 export function createLocaleFromRouteGetter() {
-  const { routesNameSeparator, defaultLocaleRouteNameSuffix } = nuxtI18nOptions
+  const { routesNameSeparator, defaultLocaleRouteNameSuffix } = useRuntimeConfig().public.i18n
   const localesPattern = `(${localeCodes.join('|')})`
   const defaultSuffixPattern = `(?:${routesNameSeparator}${defaultLocaleRouteNameSuffix})?`
   const regexpName = new RegExp(`${routesNameSeparator}${localesPattern}${defaultSuffixPattern}$`, 'i')

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -1,32 +1,33 @@
+import { useRuntimeConfig } from '#imports'
 import { defineI18nMiddleware } from '@intlify/h3'
-import { nuxtI18nOptions, localeCodes, vueI18nConfigs, localeLoaders } from '#internal/i18n/options.mjs'
+import { localeCodes, vueI18nConfigs, localeLoaders } from '#internal/i18n/options.mjs'
+import { defineNitroPlugin } from 'nitropack/dist/runtime/plugin'
 // @ts-ignore
 import { localeDetector as _localeDetector } from '#internal/i18n/locale.detector.mjs'
 import { loadVueI18nOptions, loadInitialMessages, makeFallbackLocaleCodes, loadAndSetLocaleMessages } from '../messages'
 
-import type { NitroAppPlugin } from 'nitropack'
 import type { H3Event } from 'h3'
-import type { NuxtApp } from 'nuxt/app'
 import type { Locale, FallbackLocale, DefineLocaleMessage } from 'vue-i18n'
 import type { CoreContext } from '@intlify/h3'
+import type { NuxtApp } from 'nuxt/app'
 
 const nuxtMock: { runWithContext: NuxtApp['runWithContext'] } = { runWithContext: async fn => await fn() }
 
-export const nitroPlugin: NitroAppPlugin = async nitro => {
+export default defineNitroPlugin(async nitro => {
   // `defineI18nMiddleware` options (internally, options passed to`createCoreContext` in intlify / core) are compatible with vue-i18n options
   const options = (await loadVueI18nOptions(vueI18nConfigs, nuxtMock)) as any // eslint-disable-line @typescript-eslint/no-explicit-any
   options.messages = options.messages || {}
   const fallbackLocale = (options.fallbackLocale = options.fallbackLocale ?? false) as FallbackLocale
 
-  const { defaultLocale, lazy } = nuxtI18nOptions
-  const initialLocale = defaultLocale || options.locale || 'en-US'
+  const runtimeI18n = useRuntimeConfig().public.i18n
+  const initialLocale = runtimeI18n.defaultLocale || options.locale || 'en-US'
 
   // load initial locale messages for intlify/h3
   options.messages = await loadInitialMessages(options.messages, localeLoaders, {
     localeCodes,
     initialLocale,
-    lazy: nuxtI18nOptions.lazy,
-    defaultLocale: nuxtI18nOptions.defaultLocale,
+    lazy: runtimeI18n.lazy,
+    defaultLocale: runtimeI18n.defaultLocale,
     fallbackLocale: options.fallbackLocale
   })
 
@@ -35,7 +36,7 @@ export const nitroPlugin: NitroAppPlugin = async nitro => {
     i18nContext: CoreContext<string, DefineLocaleMessage>
   ): Promise<Locale> => {
     const locale = _localeDetector(event, { defaultLocale: initialLocale, fallbackLocale: options.fallbackLocale })
-    if (lazy) {
+    if (runtimeI18n.lazy) {
       if (fallbackLocale) {
         const fallbackLocales = makeFallbackLocaleCodes(fallbackLocale, [locale])
         await Promise.all(
@@ -54,6 +55,4 @@ export const nitroPlugin: NitroAppPlugin = async nitro => {
 
   nitro.hooks.hook('request', onRequest)
   nitro.hooks.hook('afterResponse', onAfterResponse)
-}
-
-export default nitroPlugin
+})

--- a/src/types.ts
+++ b/src/types.ts
@@ -127,7 +127,7 @@ export type NuxtI18nOptions<
    * Do not use in projects
    */
   i18nModules?: { langDir?: string | null; locales?: NuxtI18nOptions<Context>['locales'] }[]
-  rootRedirect?: string | null | RootRedirectOptions
+  rootRedirect?: string | RootRedirectOptions
   skipSettingLocaleOnNavigate?: boolean
   types?: 'composition' | 'legacy'
   debug?: boolean


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Replaces #2734 

I would still like to improve the type in `ModulePublicRuntimeConfig` so users know which values cannot be configured using `runtimeConfig`, for example those used during route generation, should I mark these `@internal` using JSDocs?

By using `runtimeConfig` to pass the generated options we can reduce the complexity of our generated options templates (`#build/i18n.options.mjs` and `#internal/i18n/options.mjs`) and will make it easier for us to add `runtimeConfig` support for options used exclusively during runtime ([`detectBrowserLanguage`](https://github.com/nuxt-modules/i18n/pull/2824) for example).

I had to add `configLocales` to the runtime config as `locales` was already used for runtime domain support, we should probably merge these configurations for v9.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
