### PR TITLE
chore: mark generated `runtimeConfig` properties as internal

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -352,22 +352,78 @@ export default defineNuxtModule<NuxtI18nOptions>({
 export interface ModuleOptions extends NuxtI18nOptions {}
 
 export interface ModulePublicRuntimeConfig {
-  i18n: Pick<NuxtI18nOptions<unknown>, 'baseUrl' | 'rootRedirect'> &
-    Pick<
-      Required<NuxtI18nOptions<unknown>>,
-      | 'differentDomains'
-      | 'skipSettingLocaleOnNavigate'
-      | 'defaultLocale'
-      | 'lazy'
-      | 'defaultDirection'
-      | 'detectBrowserLanguage'
-      | 'strategy'
-      | 'routesNameSeparator'
-      | 'defaultLocaleRouteNameSuffix'
-      | 'trailingSlash'
-    > & { configLocales: NonNullable<Required<NuxtI18nOptions<unknown>>['locales']> }
-}
+  i18n: {
+    baseUrl: NuxtI18nOptions['baseUrl']
+    rootRedirect: NuxtI18nOptions['rootRedirect']
 
+    /**
+     * Overwritten at build time, used to pass generated options to runtime
+     *
+     * @internal
+     */
+    configLocales: NonNullable<Required<NuxtI18nOptions<unknown>>['locales']>
+    /**
+     * Overwritten at build time, used to pass generated options to runtime
+     *
+     * @internal
+     */
+    differentDomains: Required<NuxtI18nOptions>['differentDomains']
+    /**
+     * Overwritten at build time, used to pass generated options to runtime
+     *
+     * @internal
+     */
+    skipSettingLocaleOnNavigate: Required<NuxtI18nOptions>['skipSettingLocaleOnNavigate']
+    /**
+     * Overwritten at build time, used to pass generated options to runtime
+     *
+     * @internal
+     */
+    defaultLocale: Required<NuxtI18nOptions>['defaultLocale']
+    /**
+     * Overwritten at build time, used to pass generated options to runtime
+     *
+     * @internal
+     */
+    lazy: Required<NuxtI18nOptions>['lazy']
+    /**
+     * Overwritten at build time, used to pass generated options to runtime
+     *
+     * @internal
+     */
+    defaultDirection: Required<NuxtI18nOptions>['defaultDirection']
+    /**
+     * Overwritten at build time, used to pass generated options to runtime
+     *
+     * @internal
+     */
+    detectBrowserLanguage: Required<NuxtI18nOptions>['detectBrowserLanguage']
+    /**
+     * Overwritten at build time, used to pass generated options to runtime
+     *
+     * @internal
+     */
+    strategy: Required<NuxtI18nOptions>['strategy']
+    /**
+     * Overwritten at build time, used to pass generated options to runtime
+     *
+     * @internal
+     */
+    routesNameSeparator: Required<NuxtI18nOptions>['routesNameSeparator']
+    /**
+     * Overwritten at build time, used to pass generated options to runtime
+     *
+     * @internal
+     */
+    defaultLocaleRouteNameSuffix: Required<NuxtI18nOptions>['defaultLocaleRouteNameSuffix']
+    /**
+     * Overwritten at build time, used to pass generated options to runtime
+     *
+     * @internal
+     */
+    trailingSlash: Required<NuxtI18nOptions>['trailingSlash']
+  }
+}
 export interface ModuleHooks {
   'i18n:registerModule': (
     registerModule: (config: Pick<NuxtI18nOptions<unknown>, 'langDir' | 'locales'>) => void


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxtjs.com/docs/community/contribution
-->

### 🔗 Linked issue
* #2828 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I forgot to mark the `runtimeConfig` properties as `@internal` in #2828, is the description clear enough?
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
