### PR TITLE
chore: disable `devLogs` in playground

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -4,6 +4,11 @@ import ModuleExperimental from './module-experimental'
 
 // https://nuxt.com/docs/guide/directory-structure/nuxt.config
 export default defineNuxtConfig({
+  // devLogs broken, should be resolved by https://github.com/nuxt/nuxt/commit/b3ced3d694c89344c8e77b804a2dc76434d27668
+  // remove after updating to Nuxt >3.11.0
+  features: {
+    devLogs: false
+  },
   experimental: {
     typedPages: true
   },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Having this enable breaks the playground, possibly resolved by https://github.com/nuxt/nuxt/commit/b3ced3d694c89344c8e77b804a2dc76434d27668 but not yet released.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
