### PR TITLE
[WIP] feat: detect browser language from `localStorage`

### DIFF
--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -202,7 +202,7 @@ export default defineNuxtPlugin({
           }
           composer.differentDomains = runtimeI18n.differentDomains
           composer.defaultLocale = runtimeI18n.defaultLocale
-          composer.getBrowserLocale = () => _getBrowserLocale()
+          composer.getBrowserLocale = () => _getBrowserLocale(_detectBrowserLanguage)
           composer.getLocaleCookie = () =>
             _getLocaleCookie(localeCookie, _detectBrowserLanguage, runtimeI18n.defaultLocale)
           composer.setLocaleCookie = (locale: string) => _setLocaleCookie(localeCookie, locale, _detectBrowserLanguage)

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,13 @@ export interface DetectBrowserLanguageOptions {
   fallbackLocale?: Locale | null
   redirectOn?: RedirectOnOptions
   useCookie?: boolean
+  /**
+   * When set to a string this is used as key to detect language stored in `localStorage`.
+   * This is useful when cookies are not an option but still want to store the locale from `Accept-Language` on server-side and cannot rely on `navigator.languages`
+   *
+   * @default undefined
+   */
+  useLocalStorage?: string
 }
 
 export type LocaleType = 'static' | 'dynamic' | 'unknown'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This is still a work in progress!

Adds `detectBrowserLanguage.useLocalStorage` which can be set to `string | undefined`, when set to a string this will be used to attempt to retrieve stored language in `localStorage` on the client-side.

This could potentially be useful for projects that want to store language settings but are not able (or don't want to) to use cookies, as is the case for https://github.com/elk-zone/elk.

I think we may want to consider a similar pattern as the `localeDetector` we currently use for the server side translations feature.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
