### PR TITLE
fix: sync cookie when setting locale

### DIFF
--- a/docs/content/docs/2.guide/5.browser-language-detection.md
+++ b/docs/content/docs/2.guide/5.browser-language-detection.md
@@ -23,7 +23,7 @@ For better SEO, it's recommended to set `redirectOn` to `root` (which is the def
 
 Browser language is detected either from `navigator` when running on client-side, or from the `accept-language` HTTP header. Configured `locales` (or locales `iso` and/or `code` when locales are specified in object form) are matched against locales reported by the browser (for example `en-US,en;q=0.9,no;q=0.8`). If there is no exact match for the full locale, the language code (letters before `-`) are matched against configured locales.
 
-To prevent redirecting users every time they visit the app, **Nuxt i18n module** sets a cookie after the first redirection. You can change the cookie's name by setting `detectBrowserLanguage.cookieKey` option to whatever you'd like, the default is _i18n_redirected_.
+To prevent redirecting users every time they visit the app, **Nuxt i18n module** sets a cookie using the detected locale. You can change the cookie's name by setting `detectBrowserLanguage.cookieKey` option to whatever you'd like, the default is _i18n_redirected_.
 
 ```ts [nuxt.config.ts]
 i18n: {

--- a/docs/content/docs/5.v7/3.options-reference.md
+++ b/docs/content/docs/5.v7/3.options-reference.md
@@ -160,7 +160,7 @@ Supported properties:
   - `all` - detect browser locale on all paths.
   - `root` (recommended for improved SEO) - only detect the browser locale on the root path (`/`) of the site. Only effective when using strategy other than `'no_prefix'`.
   - `no prefix` - a more permissive variant of `root` that will detect the browser locale on the root path (`/`) and also on paths that have no locale prefix (like `/foo`). Only effective when using strategy other than `'no_prefix'`.
-- `useCookie` (default: `true`) - If enabled, a cookie is set once the user has been redirected to browser's preferred locale, to prevent subsequent redirections. Set to `false` to redirect every time.
+- `useCookie` (default: `true`) - If enabled, a cookie is set (if unset) using the browser's preferred locale, to prevent subsequent redirections. Set to `false` to redirect every time.
 - `cookieAge` (default: `365`) - Sets the max age of the cookie in days.
 - `cookieKey` (default: `'i18n_redirected'`) - Cookie name.
 - `cookieDomain` (default: `null`) - Set to override the default domain of the cookie. Defaults to the **host** of the site.

--- a/specs/browser_language_detection/no_prefix.spec.ts
+++ b/specs/browser_language_detection/no_prefix.spec.ts
@@ -38,6 +38,10 @@ test('detection with cookie', async () => {
   })
   const { page } = await renderPage('/', { locale: 'en' })
   const ctx = await page.context()
+  expect(await ctx.cookies()).toMatchObject([
+    { name: 'my_custom_cookie_name', value: 'en', secure: true, sameSite: 'None' }
+  ])
+
   // click `fr` lang switch link
   await page.locator('#set-locale-link-fr').click()
   expect(await ctx.cookies()).toMatchObject([

--- a/specs/browser_language_detection/prefix_and_default.spec.ts
+++ b/specs/browser_language_detection/prefix_and_default.spec.ts
@@ -110,6 +110,7 @@ test('alwaysRedirect: no prefix', async () => {
 
   // detect locale from navigator language
   expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('en')
+  expect(await ctx.cookies()).toMatchObject([{ name: 'i18n_redirected', value: 'en' }])
 
   // click `fr` lang switch with nutlink
   await page.locator('#set-locale-link-fr').click()

--- a/specs/issues/2262.spec.ts
+++ b/specs/issues/2262.spec.ts
@@ -16,6 +16,7 @@ describe('#2262', async () => {
     const ctx = await page.context()
 
     expect(await getText(page, '#msg')).toEqual('Welcome')
+    expect(await ctx.cookies()).toMatchObject([{ name: 'i18n_redirected', value: 'en' }])
 
     // change to `fr`
     await page.locator('#fr').click()

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -166,7 +166,7 @@ export default defineNuxtPlugin({
           )
           composer.setLocale = async (locale: string) => {
             const localeSetup = isInitialLocaleSetup(locale)
-            const [modified] = await loadAndSetLocale(locale, i18n, runtimeI18n, localeSetup)
+            const modified = await loadAndSetLocale(locale, i18n, runtimeI18n, localeSetup)
 
             if (modified && localeSetup) {
               notInitialSetup = false
@@ -450,7 +450,7 @@ export default defineNuxtPlugin({
         const localeSetup = isInitialLocaleSetup(locale)
         __DEBUG__ && console.log('localeSetup', localeSetup)
 
-        const [modified] = await loadAndSetLocale(locale, i18n, runtimeI18n, localeSetup)
+        const modified = await loadAndSetLocale(locale, i18n, runtimeI18n, localeSetup)
 
         if (modified && localeSetup) {
           notInitialSetup = false


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* #2829 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #2829 

Please note that this actually changes the cookie behavior slightly, this is why I set this RP to draft status.

These changes ensure that the cookie is always set and up to date (if configured of course), even when no redirection takes place necessarily. I feel like this would only ensure the correct locale is used even if the user has not been redirected (e.g. entering the website on a page in which redirection would occur anyways), are there any downsides to this change?

If we want to keep this change we may need to adjust the documentation a bit, I haven't looked into this yet.


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
