### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/specs/fixtures/issues/2220/app.vue
+++ b/specs/fixtures/issues/2220/app.vue
@@ -12,7 +12,7 @@
 
 <script setup lang="ts">
 const data = ref([])
-const env = process.dev ? 'DEV' : 'PROD'
+const env = import.meta.dev ? 'DEV' : 'PROD'
 const correct = computed(() => ['Test', 'Тест'].includes(data.value[0]))
 
 data.value = await $fetch('/api/foo')

--- a/specs/seo/baseUrl.spec.ts
+++ b/specs/seo/baseUrl.spec.ts
@@ -10,7 +10,7 @@ await setup({
     i18n: {
       defaultLocale: 'en',
       baseUrl: () => {
-        if (process.server) {
+        if (import.meta.server) {
           // @ts-ignore
           const headers = useRequestHeaders(['x-override-base-url'])
           const xOverrideBaseUrl = headers['x-override-base-url']

--- a/src/runtime/composables/index.ts
+++ b/src/runtime/composables/index.ts
@@ -160,7 +160,7 @@ export function useLocaleHead({
     }) as I18nHeadMetaInfo
   }
 
-  if (process.client) {
+  if (import.meta.client) {
     const stop = watch(
       () => common.router.currentRoute.value,
       () => {
@@ -349,7 +349,7 @@ export function useBrowserLocale(): string | null {
   return (
     findBrowserLocale(
       normalizedLocales,
-      process.client ? (navigator.languages as string[]) : parseAcceptLanguage(headers['accept-language'] || '')
+      import.meta.client ? (navigator.languages as string[]) : parseAcceptLanguage(headers['accept-language'] || '')
     ) || null
   )
 }
@@ -375,9 +375,9 @@ export function useCookieLocale(): Ref<string> {
     const cookieKey = detect.cookieKey!
 
     let code: string | null = null
-    if (process.client) {
+    if (import.meta.client) {
       code = useNuxtCookie<string>(cookieKey).value
-    } else if (process.server) {
+    } else if (import.meta.server) {
       const cookie = useRequestHeaders(['cookie'])
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       code = (cookie as any)[cookieKey]
@@ -428,7 +428,7 @@ export interface I18nRoute {
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function defineI18nRoute(route: I18nRoute | false): void {
-  if (process.dev) {
+  if (import.meta.dev) {
     warnRuntimeUsage('defineI18nRoute')
   }
 }

--- a/src/runtime/internal.ts
+++ b/src/runtime/internal.ts
@@ -69,13 +69,13 @@ export function parseAcceptLanguage(input: string): string[] {
 export function getBrowserLocale(): string | undefined {
   let ret: string | undefined
 
-  if (process.client) {
+  if (import.meta.client) {
     if (navigator.languages) {
       // get browser language either from navigator if running on client side, or from the headers
       ret = findBrowserLocale(normalizedLocales, navigator.languages as string[])
       __DEBUG__ && console.log('getBrowserLocale (navigator.languages, ret) -', navigator.languages, ret)
     }
-  } else if (process.server) {
+  } else if (import.meta.server) {
     const header = useRequestHeaders(['accept-language'])
     __DEBUG__ && console.log('getBrowserLocale accept-language', header)
     const accept = header['accept-language']
@@ -123,7 +123,7 @@ export function getLocaleCookie(
   }
 
   const localeCode: string | undefined = cookieRef.value ?? undefined
-  const env = process.client ? 'client' : 'server'
+  const env = import.meta.client ? 'client' : 'server'
   if (localeCode == null) {
     __DEBUG__ && console.log(`getLocaleCookie (${env}) - none`)
     return
@@ -201,7 +201,7 @@ export function detectBrowserLanguage(
   __DEBUG__ && console.log('detectBrowserLanguage: (ssg, callType, firstAccess) - ', ssg, callType, firstAccess)
 
   // browser detection is ignored if it's a nuxt generate.
-  if (isSSG && strategy === 'no_prefix' && (process.server || ssg === 'ssg_ignore')) {
+  if (isSSG && strategy === 'no_prefix' && (import.meta.server || ssg === 'ssg_ignore')) {
     return { locale: '', stat: true, reason: 'detect_ignore_on_ssg' }
   }
 
@@ -321,9 +321,9 @@ export function detectBrowserLanguage(
 
 export function getHost() {
   let host: string | undefined
-  if (process.client) {
+  if (import.meta.client) {
     host = window.location.host
-  } else if (process.server) {
+  } else if (import.meta.server) {
     const header = useRequestHeaders(['x-forwarded-host', 'host'])
 
     let detectedHost: string | undefined
@@ -432,7 +432,7 @@ export function getDomainFromLocale(localeCode: Locale): string | undefined {
       return domain
     }
     let protocol
-    if (process.server) {
+    if (import.meta.server) {
       const {
         node: { req }
       } = useRequestEvent(nuxtApp)!

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -118,7 +118,7 @@ export default defineNuxtPlugin({
      * NOTE:
      *  avoid hydration mismatch for SSG mode
      */
-    if (isSSGModeInitialSetup() && runtimeI18n.strategy === 'no_prefix' && process.client) {
+    if (isSSGModeInitialSetup() && runtimeI18n.strategy === 'no_prefix' && import.meta.client) {
       nuxt.hook('app:mounted', async () => {
         __DEBUG__ && console.log('hook app:mounted')
         const {

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -283,7 +283,7 @@ export function detectRedirect({
 
   let redirectPath = ''
   const { fullPath: toFullPath } = route.to
-  const isStaticGenerate = isSSG && process.server
+  const isStaticGenerate = isSSG && import.meta.server
 
   /**
    * decide whether we should redirect to a different route.
@@ -311,7 +311,7 @@ export function detectRedirect({
     }
   }
 
-  if ((differentDomains || (isSSG && process.client)) && routeLocaleGetter(route.to) !== targetLocale) {
+  if ((differentDomains || (isSSG && import.meta.client)) && routeLocaleGetter(route.to) !== targetLocale) {
     /**
      * `$router.currentRoute` does not yet reflect the `to` value,
      *  when the Router middleware handler is executed.
@@ -380,7 +380,7 @@ export async function navigate(
     return _navigate(redirectPath, status)
   }
 
-  if (process.client && skipSettingLocaleOnNavigate) {
+  if (import.meta.client && skipSettingLocaleOnNavigate) {
     i18n.__pendingLocale = locale
     i18n.__pendingLocalePromise = new Promise(resolve => {
       i18n.__resolvePendingLocalePromise = resolve
@@ -398,10 +398,10 @@ export async function navigate(
     const state = useRedirectState()
     __DEBUG__ && console.log('redirect state ->', state.value, 'redirectPath -> ', redirectPath)
     if (state.value && state.value !== redirectPath) {
-      if (process.client) {
+      if (import.meta.client) {
         state.value = '' // reset redirect path
         window.location.assign(redirectPath)
-      } else if (process.server) {
+      } else if (import.meta.server) {
         __DEBUG__ && console.log('differentDomains servermode ', redirectPath)
         state.value = redirectPath // set redirect path
       }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
