### PR TITLE
fix: `defineI18nRoute` macro transformed inside `<template>`

### DIFF
--- a/specs/fixtures/basic/pages/index.vue
+++ b/specs/fixtures/basic/pages/index.vue
@@ -66,8 +66,8 @@ useHead(() => ({
       go to product foo
     </NuxtLink>
     <NuxtLink id="link-history" :to="localePath({ name: 'history' })">go to history</NuxtLink>
-    <NuxtLink id="link-define-i18n-route-false" exact :to="localePath('/define-i18n-route-false')">
-      go to defineI18nRoute(false)
+    <NuxtLink id="link-define-i18n-route-false" exact :to="localePath('/define-i18n-route-false')"
+      >go to defineI18nRoute(false)
     </NuxtLink>
     <section>
       <span id="issue-2020-existing">{{ localePath('/test-route?foo=bar') }}</span>

--- a/specs/routing_strategies/prefix.spec.ts
+++ b/specs/routing_strategies/prefix.spec.ts
@@ -153,6 +153,13 @@ describe('strategy: prefix', async () => {
     await restore()
   })
 
+  test('should not transform `defineI18nRoute()` inside template', async () => {
+    const { page } = await renderPage('/', { locale: 'en' })
+    await waitForURL(page, '/en')
+
+    expect(await getText(page, '#link-define-i18n-route-false')).toEqual('go to defineI18nRoute(false)')
+  })
+
   test("(#2132) should redirect on root url with `redirectOn: 'no prefix'`", async () => {
     const restore = await startServerWithRuntimeConfig({
       public: {

--- a/src/transform/utils.ts
+++ b/src/transform/utils.ts
@@ -1,3 +1,6 @@
+import { pathToFileURL } from 'node:url'
+import { parseQuery, parseURL } from 'ufo'
+
 import type { UnpluginContextMeta } from 'unplugin'
 
 export const VIRTUAL_PREFIX = '\0' as const
@@ -14,4 +17,38 @@ export function getVirtualId(id: string, framework: UnpluginContextMeta['framewo
 
 export function asVirtualId(id: string, framework: UnpluginContextMeta['framework'] = 'vite') {
   return framework === 'vite' ? VIRTUAL_PREFIX + id : id
+}
+
+// from https://github.com/nuxt/nuxt/blob/a80d1a0d6349bf1003666fc79a513c0d7370c931/packages/nuxt/src/core/utils/plugins.ts#L4-L35
+export function isVue(id: string, opts: { type?: Array<'template' | 'script' | 'style'> } = {}) {
+  // Bare `.vue` file (in Vite)
+  const { search } = parseURL(decodeURIComponent(pathToFileURL(id).href))
+  if (id.endsWith('.vue') && !search) {
+    return true
+  }
+
+  if (!search) {
+    return false
+  }
+
+  const query = parseQuery(search)
+
+  // Component async/lazy wrapper
+  if (query.nuxt_component) {
+    return false
+  }
+
+  // Macro
+  if (query.macro && (search === '?macro=true' || !opts.type || opts.type.includes('script'))) {
+    return true
+  }
+
+  // Non-Vue or Styles
+  const type = 'setup' in query ? 'script' : (query.type as 'script' | 'template' | 'style')
+  if (!('vue' in query) || (opts.type && !opts.type.includes(type))) {
+    return false
+  }
+
+  // Query `?vue&type=template` (in Webpack or external template)
+  return true
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This is very specific, I don't think anyone ran into this bug 😅 

While refactoring/merging tests I noticed that the text `defineI18nRoute(false)` inside of `<template>` in `specs/fixtures/basic/pages/index.vue` was being transformed and replaced to `false && /*#__PURE__*/ defineI18nRoute(false)`. This should only happen inside the script contents.

Maybe this PR changes the transform plugin more than it should, if anything is off let me know!
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
