### PR TITLE
fix: ignore root when prerendering using `strategy: 'prefix'`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -198,6 +198,25 @@ export default defineNuxtModule<NuxtI18nOptions>({
     }
 
     /**
+     * ignore `/` during prerender when using prefixed routing
+     */
+
+    if (options.strategy === 'prefix' && nuxt.options._generate) {
+      const localizedEntryPages = normalizedLocales.map(x => ['/', x.code].join(''))
+      nuxt.hook('nitro:config', config => {
+        config.prerender ??= {}
+
+        // ignore `/` which is added by nitro by default
+        config.prerender.ignore ??= []
+        config.prerender.ignore.push(/^\/$/)
+
+        // add localized routes as entry pages for prerendering
+        config.prerender.routes ??= []
+        config.prerender.routes.push(...localizedEntryPages)
+      })
+    }
+
+    /**
      * setup module alias
      */
 

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -57,6 +57,13 @@ export function setupPages(options: Required<NuxtI18nOptions>, nuxt: Nuxt) {
       includeUnprefixedFallback,
       optionsResolver: getRouteOptionsResolver(ctx, options)
     })
+
+    // keep root when using prefixed routing without prerendering
+    const indexPage = pages.find(x => x.path === '/')
+    if (!nuxt.options._generate && options.strategy === 'prefix' && indexPage != null) {
+      localizedPages.unshift(indexPage)
+    }
+
     pages.splice(0, pages.length)
     pages.unshift(...(localizedPages as NuxtPage[]))
     debug('... made pages', pages)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* #2855
* Related #2790
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #2855 

Not sure how to test this exactly 🤔 

These changes removes/ignores the `/` entry route added by nitro during prerendering and adds localized entry pages to use instead. This also excludes the `/` route from the generated build, which I think is/was the original behavior when running generate with strategy prefix (currently without these changes this throws an error). 

When not prerendering we re-add the index page (not localized) so that requests on root can be redirected. 
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
