### PR TITLE
fix: locale head reactivity on locale change for `strategy: 'no_prefix'`

### DIFF
--- a/specs/fixtures/layers/layer-locale-arabic/locales/ar.json
+++ b/specs/fixtures/layers/layer-locale-arabic/locales/ar.json
@@ -1,0 +1,4 @@
+{
+  "hello": "Hello world! (Arabic)",
+  "home": "Homepage (Arabic)"
+}

--- a/specs/fixtures/layers/layer-locale-arabic/nuxt.config.ts
+++ b/specs/fixtures/layers/layer-locale-arabic/nuxt.config.ts
@@ -1,0 +1,15 @@
+// https://nuxt.com/docs/guide/directory-structure/nuxt.config
+export default defineNuxtConfig({
+  i18n: {
+    langDir: 'locales',
+    locales: [
+      {
+        code: 'ar',
+        iso: 'ar',
+        file: 'ar.json',
+        name: 'Arabic',
+        dir: 'rtl'
+      }
+    ]
+  }
+})

--- a/specs/routing_strategies/no_prefix.spec.ts
+++ b/specs/routing_strategies/no_prefix.spec.ts
@@ -164,6 +164,7 @@ describe('strategy: no_prefix', async () => {
 
     // click `ar` lang switch link
     await page.locator('#set-locale-link-ar').click()
+    await page.waitForFunction(() => document.querySelector('title')?.textContent === 'Homepage (Arabic)')
 
     // title tag
     expect(await getText(page, 'title')).toMatch('Homepage (Arabic)')

--- a/src/runtime/composables/index.ts
+++ b/src/runtime/composables/index.ts
@@ -161,8 +161,9 @@ export function useLocaleHead({
   }
 
   if (import.meta.client) {
+    const i18n = getComposer(common.i18n)
     const stop = watch(
-      () => common.router.currentRoute.value,
+      [() => common.router.currentRoute.value, i18n.locale],
       () => {
         cleanMeta()
         updateMeta()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* #2871 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #2871 

Even though SEO tags don't make much sense for the unprefixed routing strategy, the locale head composable also handles the `lang` and `dir` attributes which do need to be updated.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
