### PR TITLE
docs: change for generating page title in default.vue

### DIFF
--- a/docs/content/docs/2.guide/6.seo.md
+++ b/docs/content/docs/2.guide/6.seo.md
@@ -82,7 +82,8 @@ const head = useLocaleHead({
   identifierAttribute: 'id',
   addSeoAttributes: true
 })
-const title = computed(() => t('layouts.title', { title: t(route.meta.title ?? 'TBD') }))
+const title = computed(() => t(route.meta.title ?? 'TBD', t('layouts.title'))
+);
 </script>
 
 <template>


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Change in the Nuxt SEO docs.
With the method described it was not possible to set the page title from definePageMeta as the default title.


