### PR TITLE
fix: locale prefixes are not added to route aliases

### DIFF
--- a/specs/experimental/scan_page_meta.spec.ts
+++ b/specs/experimental/scan_page_meta.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, url } from '../utils'
+import { getText, renderPage } from '../helper'
+
+await setup({
+  rootDir: fileURLToPath(new URL(`../fixtures/basic_usage`, import.meta.url)),
+  browser: true,
+  // overrides
+  nuxtConfig: {
+    experimental: {
+      scanPageMeta: true
+    }
+  }
+})
+
+describe('Using Nuxt experimental feature `scanPageMeta`', async () => {
+  test('can access localized alias', async () => {
+    const { page } = await renderPage('/')
+
+    // Aliases path renders home
+    await page.goto(url('/aliased-home-path'))
+    expect(await getText(page, 'title')).toEqual('Page - Homepage')
+
+    await page.goto(url('/fr/aliased-home-path'))
+    expect(await getText(page, 'title')).toEqual('Page - Accueil')
+  })
+})

--- a/specs/fixtures/basic_usage/pages/index.vue
+++ b/specs/fixtures/basic_usage/pages/index.vue
@@ -58,7 +58,8 @@ route.meta.pageTransition = {
 }
 // @ts-ignore
 definePageMeta({
-  title: 'home'
+  title: 'home',
+  alias: ['/aliased-home-path']
 })
 
 const i18nHead = useLocaleHead({

--- a/src/module.ts
+++ b/src/module.ts
@@ -126,6 +126,12 @@ export default defineNuxtModule<NuxtI18nOptions>({
       )
     }
 
+    if (nuxt.options.experimental.scanPageMeta === false) {
+      logger.warn(
+        "Route localization features (e.g. custom name, prefixed aliases) require Nuxt's `experimental.scanPageMeta` to be enabled.\nThis feature will be enabled in future Nuxt versions (https://github.com/nuxt/nuxt/pull/27134), check out the docs for more details: https://nuxt.com/docs/guide/going-further/experimental-features#scanpagemeta"
+      )
+    }
+
     /**
      * nuxt layers handling ...
      */

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -1,4 +1,4 @@
-import { getNormalizedLocales } from './utils'
+import { getNormalizedLocales, toArray } from './utils'
 import { isObject } from '@intlify/shared'
 
 import type { Locale } from 'vue-i18n'
@@ -150,6 +150,35 @@ export function localizeRoutes(routes: NuxtPage[], options: LocalizeRoutesParams
         if (isDefaultLocale && options.strategy === 'prefix' && options.includeUnprefixedFallback) {
           localizedRoutes.push({ ...route, locale, parent })
         }
+      }
+
+      // TODO: alias custom paths?
+      // add prefixes to aliases where applicable
+      if (localized.alias) {
+        const aliases = toArray(localized.alias)
+        const localizedAliases: string | string[] | undefined = []
+
+        for (const alias of aliases) {
+          const aliasPrefixable = prefixLocalizedRoute(
+            { defaultLocale: isDefaultLocale ? locale : options.defaultLocale, ...localized, path: alias },
+            options,
+            extra
+          )
+
+          let localizedAlias = alias
+          if (aliasPrefixable) {
+            localizedAlias = join('/', locale, localizedAlias)
+          }
+
+          localizedAlias &&= adjustRoutePathForTrailingSlash(
+            { ...localized, path: localizedAlias },
+            options.trailingSlash
+          )
+
+          localizedAliases.push(localizedAlias)
+        }
+
+        localized.alias = localizedAliases
       }
 
       localized.path &&= adjustRoutePathForTrailingSlash(localized, options.trailingSlash)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -621,3 +621,7 @@ export const applyOptionOverrides = (options: NuxtI18nOptions, nuxt: Nuxt) => {
     Object.assign(options, defu(overrides, mergedOptions))
   }
 }
+
+export function toArray<T>(value: T | T[]): T[] {
+  return Array.isArray(value) ? value : [value]
+}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* #2957 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #2957 

This adds locale prefixes to route aliases but requires the experimental `scanPageMeta` feature to be enabled to work, not entirely sure where in the docs would be appropriate to document this.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
