### PR TITLE
refactor: restructure extend vue-i18n

### DIFF
--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -223,14 +223,9 @@ export default defineNuxtPlugin({
         composer.setLocaleCookie = (locale: string) => _setLocaleCookie(localeCookie, locale, _detectBrowserLanguage)
 
         composer.onBeforeLanguageSwitch = (oldLocale, newLocale, initialSetup, context) =>
-          nuxtContext.callHook('i18n:beforeLocaleSwitch', {
-            oldLocale,
-            newLocale,
-            initialSetup,
-            context
-          }) as Promise<void>
+          nuxt.callHook('i18n:beforeLocaleSwitch', { oldLocale, newLocale, initialSetup, context }) as Promise<void>
         composer.onLanguageSwitched = (oldLocale, newLocale) =>
-          nuxtContext.callHook('i18n:localeSwitched', { oldLocale, newLocale }) as Promise<void>
+          nuxt.callHook('i18n:localeSwitched', { oldLocale, newLocale }) as Promise<void>
 
         composer.finalizePendingLocaleChange = async () => {
           if (!i18n.__pendingLocale) {

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -7,7 +7,6 @@ import {
   isSSG,
   localeLoaders,
   parallelPlugin,
-  type LocaleObject,
   normalizedLocales
 } from '#build/i18n.options.mjs'
 import { loadVueI18nOptions, loadInitialMessages, loadLocale } from '../messages'
@@ -33,6 +32,7 @@ import {
 import { getLocale, inBrowser, resolveBaseUrl, setLocale } from '../routing/utils'
 import { extendI18n, createLocaleFromRouteGetter } from '../routing/extends'
 
+import type { LocaleObject } from '#build/i18n.options.mjs'
 import type { Locale, I18nOptions, Composer, ExportedGlobalComposer, VueI18n } from 'vue-i18n'
 import type { NuxtApp } from '#app'
 import type { getRouteBaseName, localePath, localeRoute, switchLocalePath, localeHead } from '../routing/compatibles'

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -107,8 +107,8 @@ export default defineNuxtPlugin({
     // create i18n instance
     const i18n = createI18n({ ...vueI18nOptions, locale: initialLocale })
 
-    const notInitialSetup = ref(true)
-    const isInitialLocaleSetup = (locale: Locale) => initialLocale !== locale && notInitialSetup.value
+    let notInitialSetup = true
+    const isInitialLocaleSetup = (locale: Locale) => initialLocale !== locale && notInitialSetup
 
     let ssgModeInitialSetup = true
     const isSSGModeInitialSetup = () => isSSG && ssgModeInitialSetup
@@ -155,7 +155,6 @@ export default defineNuxtPlugin({
     extendI18n(i18n, {
       extendComposer: (composer: Composer) => {
         const route = useRoute()
-        const getLocaleFromRoute = createLocaleFromRouteGetter()
         const _locales = ref<string[] | LocaleObject[]>(runtimeI18n.configLocales)
         const _localeCodes = ref<string[]>(localeCodes)
         const _baseUrl = ref<string>('')
@@ -185,7 +184,7 @@ export default defineNuxtPlugin({
           const modified = await loadAndSetLocale(locale, i18n, runtimeI18n, localeSetup)
 
           if (modified && localeSetup) {
-            notInitialSetup.value = false
+            notInitialSetup = false
           }
 
           const redirectPath = await nuxtContext.runWithContext(() =>
@@ -345,7 +344,7 @@ export default defineNuxtPlugin({
         const modified = await loadAndSetLocale(locale, i18n, runtimeI18n, localeSetup)
 
         if (modified && localeSetup) {
-          notInitialSetup.value = false
+          notInitialSetup = false
         }
 
         const redirectPath = await nuxtContext.runWithContext(() =>

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -33,7 +33,7 @@ import { getLocale, inBrowser, resolveBaseUrl, setLocale } from '../routing/util
 import { extendI18n, createLocaleFromRouteGetter } from '../routing/extends'
 
 import type { LocaleObject } from '#build/i18n.options.mjs'
-import type { Locale, I18nOptions, Composer, ExportedGlobalComposer, VueI18n } from 'vue-i18n'
+import type { Locale, I18nOptions } from 'vue-i18n'
 import type { NuxtApp } from '#app'
 import type { getRouteBaseName, localePath, localeRoute, switchLocalePath, localeHead } from '../routing/compatibles'
 import type {
@@ -153,7 +153,7 @@ export default defineNuxtPlugin({
 
     // extend i18n instance
     extendI18n(i18n, {
-      extendComposer: (composer: Composer) => {
+      extendComposer(composer) {
         const route = useRoute()
         const _locales = ref<string[] | LocaleObject[]>(runtimeI18n.configLocales)
         const _localeCodes = ref<string[]>(localeCodes)
@@ -246,7 +246,7 @@ export default defineNuxtPlugin({
           }
         }
       },
-      extendComposerInstance: (instance: VueI18n | ExportedGlobalComposer, c: Composer) => {
+      extendComposerInstance(instance, c) {
         type ExtendPropertyDescriptors = { [key: string]: Pick<PropertyDescriptor, 'get'> }
 
         const properties: ExtendPropertyDescriptors = {

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -223,11 +223,14 @@ export default defineNuxtPlugin({
         composer.setLocaleCookie = (locale: string) => _setLocaleCookie(localeCookie, locale, _detectBrowserLanguage)
 
         composer.onBeforeLanguageSwitch = (oldLocale, newLocale, initialSetup, context) =>
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-          nuxtContext.callHook('i18n:beforeLocaleSwitch', { oldLocale, newLocale, initialSetup, context })
+          nuxtContext.callHook('i18n:beforeLocaleSwitch', {
+            oldLocale,
+            newLocale,
+            initialSetup,
+            context
+          }) as Promise<void>
         composer.onLanguageSwitched = (oldLocale, newLocale) =>
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-          nuxtContext.callHook('i18n:localeSwitched', { oldLocale, newLocale })
+          nuxtContext.callHook('i18n:localeSwitched', { oldLocale, newLocale }) as Promise<void>
 
         composer.finalizePendingLocaleChange = async () => {
           if (!i18n.__pendingLocale) {
@@ -235,7 +238,7 @@ export default defineNuxtPlugin({
           }
           setLocale(i18n, i18n.__pendingLocale)
           if (i18n.__resolvePendingLocalePromise) {
-            // eslint-disable-next-line @typescript-eslint/await-thenable
+            // eslint-disable-next-line @typescript-eslint/await-thenable -- FIXME: `__resolvePendingLocalePromise` should be `Promise<void>`
             await i18n.__resolvePendingLocalePromise()
           }
           i18n.__pendingLocale = undefined

--- a/src/runtime/routing/extends/i18n.ts
+++ b/src/runtime/routing/extends/i18n.ts
@@ -1,6 +1,5 @@
-import { isObject, isFunction, assign } from '@intlify/shared'
-import { computed, effectScope, ref, watch } from '#imports'
-import { resolveBaseUrl, isVueI18n, getComposer, inBrowser } from '../utils'
+import { computed, effectScope, ref, useRoute, watch, type Ref } from '#imports'
+import { resolveBaseUrl, isVueI18n, getComposer, inBrowser, setLocale } from '../utils'
 import {
   getRouteBaseName,
   localeHead,
@@ -10,25 +9,42 @@ import {
   resolveRoute,
   switchLocalePath
 } from '../compatibles'
-import { wrapComposable } from '../../internal'
-import { initCommonComposableOptions } from '../../utils'
+import {
+  wrapComposable,
+  getBrowserLocale as _getBrowserLocale,
+  getLocaleCookie as _getLocaleCookie,
+  setLocaleCookie as _setLocaleCookie,
+  getI18nCookie,
+  runtimeDetectBrowserLanguage
+} from '../../internal'
+import {
+  detectRedirect,
+  initCommonComposableOptions,
+  loadAndSetLocale,
+  mergeLocaleMessage,
+  navigate
+} from '../../utils'
+import { localeLoaders, normalizedLocales } from '#build/i18n.options.mjs'
 
 import type { NuxtApp } from 'nuxt/app'
 import type {
   Composer,
   ComposerExtender,
-  Disposer,
   ExportedGlobalComposer,
   I18n,
+  Locale,
   VueI18n,
   VueI18nExtender
 } from 'vue-i18n'
-import type { LocaleObject, NuxtI18nOptions } from '#build/i18n.options.mjs'
+import type { LocaleObject } from '#build/i18n.options.mjs'
+import type { ModulePublicRuntimeConfig } from '../../../module'
+import { loadLocale } from '../../messages'
+import { createLocaleFromRouteGetter } from './router'
 
 /**
- * An options of Vue I18n Routing Plugin
+ * Options of Vue I18n Routing Plugin
  */
-export interface VueI18nRoutingPluginOptions {
+interface VueI18nRoutingPluginOptions {
   /**
    * Whether to inject some option APIs style methods into Vue instance
    *
@@ -45,73 +61,56 @@ export interface VueI18nRoutingPluginOptions {
   __vueI18nExtend?: VueI18nExtender
 }
 
-export interface ExtendPropertyDescriptors {
+interface ExtendPropertyDescriptors {
   [key: string]: Pick<PropertyDescriptor, 'get'>
 }
-export type ExtendComposerHook = (compser: Composer) => void
-export type ExtendVueI18nHook = (composer: Composer) => ExtendPropertyDescriptors
-export type ExtendExportedGlobalHook = (global: Composer) => ExtendPropertyDescriptors
+type ExtendComposerHook = (composer: Composer) => ExtendPropertyDescriptors
 
-export interface ExtendHooks {
-  onExtendComposer?: ExtendComposerHook
-  onExtendExportedGlobal?: ExtendExportedGlobalHook
-  onExtendVueI18n?: ExtendVueI18nHook
+type VueI18nExtendOptions = {
+  isInitialLocaleSetup: (locale: string) => boolean
+  notInitialSetup: Ref<boolean>
+  localeCodes: string[]
+  localeCookie: ReturnType<typeof getI18nCookie>
+  nuxtContext: NuxtApp
+  _detectBrowserLanguage: ReturnType<typeof runtimeDetectBrowserLanguage>
+  runtimeI18n: ModulePublicRuntimeConfig['i18n']
 }
-
-export type VueI18nExtendOptions<Context = unknown> = Pick<NuxtI18nOptions<Context>, 'baseUrl'> & {
-  locales?: string[] | LocaleObject[]
-  localeCodes?: string[]
-  context?: Context
-  hooks?: ExtendHooks
-}
-
-export function extendI18n<Context = unknown, TI18n extends I18n = I18n>(
-  i18n: TI18n,
-  {
-    locales = [],
-    localeCodes = [],
-    baseUrl = '',
-    hooks = {},
-    context = {} as Context
-  }: VueI18nExtendOptions<Context> = {}
-) {
+export function extendI18n(i18n: I18n, extendOptions: VueI18nExtendOptions) {
   const scope = effectScope()
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const orgInstall = i18n.install
   // @ts-ignore
   i18n.install = (vue: NuxtApp['vueApp'], ...options: unknown[]) => {
-    const pluginOptions = isPluginOptions(options[0]) ? assign({}, options[0]) : { inject: true }
-    if (pluginOptions.inject == null) {
-      pluginOptions.inject = true
-    }
-    const orgComposerExtend = pluginOptions.__composerExtend
-    pluginOptions.__composerExtend = (localComposer: Composer) => {
-      const globalComposer = getComposer(i18n)
+    const pluginOptions: VueI18nRoutingPluginOptions = Object.assign({ inject: true }, options[0])
+    pluginOptions.inject ??= true
 
-      localComposer.locales = computed(() => globalComposer.locales.value)
-      localComposer.localeCodes = computed(() => globalComposer.localeCodes.value)
-      localComposer.baseUrl = computed(() => globalComposer.baseUrl.value)
+    pluginOptions.__composerExtend = (c: Composer) => {
+      const g = getComposer(i18n)
 
-      let orgComposerDispose: Disposer | undefined
-      if (isFunction(orgComposerExtend)) {
-        orgComposerDispose = Reflect.apply(orgComposerExtend, pluginOptions, [localComposer])
-      }
-      return () => {
-        orgComposerDispose && orgComposerDispose()
-      }
+      c.locales = computed(() => g.locales.value)
+      c.localeCodes = computed(() => g.localeCodes.value)
+      c.baseUrl = computed(() => g.baseUrl.value)
+
+      c.strategy = g.strategy
+      c.localeProperties = computed(() => g.localeProperties.value)
+      c.setLocale = g.setLocale
+      c.differentDomains = g.differentDomains
+      c.getBrowserLocale = g.getBrowserLocale
+      c.getLocaleCookie = g.getLocaleCookie
+      c.setLocaleCookie = g.setLocaleCookie
+      c.onBeforeLanguageSwitch = g.onBeforeLanguageSwitch
+      c.onLanguageSwitched = g.onLanguageSwitched
+      c.finalizePendingLocaleChange = g.finalizePendingLocaleChange
+      c.waitForPendingLocaleChange = g.waitForPendingLocaleChange
+
+      return () => {}
     }
+
     if (i18n.mode === 'legacy') {
-      const orgVueI18nExtend = pluginOptions.__vueI18nExtend
       pluginOptions.__vueI18nExtend = (vueI18n: VueI18n) => {
-        extendVueI18n(vueI18n, hooks.onExtendVueI18n)
-        let orgVueI18nDispose: Disposer | undefined
-        if (isFunction(orgVueI18nExtend)) {
-          orgVueI18nDispose = Reflect.apply(orgVueI18nExtend, pluginOptions, [vueI18n])
-        }
-        return () => {
-          orgVueI18nDispose && orgVueI18nDispose()
-        }
+        extendVueI18n(vueI18n)
+        return () => {}
       }
     }
 
@@ -122,9 +121,9 @@ export function extendI18n<Context = unknown, TI18n extends I18n = I18n>(
 
     // extend global
     scope.run(() => {
-      extendComposer(globalComposer, { locales, localeCodes, baseUrl, hooks, context })
+      extendComposer(globalComposer, extendOptions, i18n)
       if (i18n.mode === 'legacy' && isVueI18n(i18n.global)) {
-        extendVueI18n(i18n.global, hooks.onExtendVueI18n)
+        extendVueI18n(i18n.global)
       }
     })
 
@@ -137,7 +136,7 @@ export function extendI18n<Context = unknown, TI18n extends I18n = I18n>(
       // for legacy mode
       : null
     if (exported) {
-      extendExportedGlobal(exported, globalComposer, hooks.onExtendExportedGlobal)
+      extendExportedGlobal(exported, globalComposer)
     }
 
     if (pluginOptions.inject) {
@@ -170,11 +169,23 @@ export function extendI18n<Context = unknown, TI18n extends I18n = I18n>(
   return scope
 }
 
-function extendComposer<Context = unknown>(composer: Composer, options: VueI18nExtendOptions<Context>) {
-  const { locales, localeCodes, baseUrl, context } = options
-
-  const _locales = ref<string[] | LocaleObject[]>(locales!)
-  const _localeCodes = ref<string[]>(localeCodes!)
+function extendComposer(
+  composer: Composer,
+  {
+    localeCodes,
+    isInitialLocaleSetup,
+    notInitialSetup,
+    localeCookie,
+    nuxtContext,
+    _detectBrowserLanguage,
+    runtimeI18n
+  }: VueI18nExtendOptions,
+  i18n: I18n
+) {
+  const route = useRoute()
+  const getLocaleFromRoute = createLocaleFromRouteGetter()
+  const _locales = ref<string[] | LocaleObject[]>(runtimeI18n.configLocales)
+  const _localeCodes = ref<string[]>(localeCodes)
   const _baseUrl = ref<string>('')
 
   // @ts-ignore
@@ -186,40 +197,97 @@ function extendComposer<Context = unknown>(composer: Composer, options: VueI18nE
     watch(
       composer.locale,
       () => {
-        _baseUrl.value = resolveBaseUrl(baseUrl!, context!)
+        _baseUrl.value = resolveBaseUrl(runtimeI18n.baseUrl!, nuxtContext!)
       },
       { immediate: true }
     )
   } else {
-    _baseUrl.value = resolveBaseUrl(baseUrl!, context!)
+    _baseUrl.value = resolveBaseUrl(runtimeI18n.baseUrl!, nuxtContext!)
   }
 
-  if (options.hooks && options.hooks.onExtendComposer) {
-    options.hooks.onExtendComposer(composer)
+  composer.strategy = runtimeI18n.strategy
+  composer.localeProperties = computed(
+    () => normalizedLocales.find(l => l.code === composer.locale.value) || { code: composer.locale.value }
+  )
+  composer.setLocale = async (locale: string) => {
+    const localeSetup = isInitialLocaleSetup(locale)
+    const modified = await loadAndSetLocale(locale, i18n, runtimeI18n, localeSetup)
+
+    if (modified && localeSetup) {
+      notInitialSetup.value = false
+    }
+
+    const redirectPath = await nuxtContext.runWithContext(() =>
+      detectRedirect({
+        route: { to: route },
+        targetLocale: locale,
+        routeLocaleGetter: getLocaleFromRoute
+      })
+    )
+    __DEBUG__ && console.log('redirectPath on setLocale', redirectPath)
+
+    await nuxtContext.runWithContext(
+      async () =>
+        await navigate(
+          {
+            nuxtApp: nuxtContext,
+            i18n,
+            redirectPath,
+            locale,
+            route
+          },
+          { enableNavigate: true }
+        )
+    )
+  }
+  composer.loadLocaleMessages = async (locale: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const setter = (locale: Locale, message: Record<string, any>) => mergeLocaleMessage(i18n, locale, message)
+    await loadLocale(locale, localeLoaders, setter)
+  }
+  composer.differentDomains = runtimeI18n.differentDomains
+  composer.defaultLocale = runtimeI18n.defaultLocale
+  composer.getBrowserLocale = () => _getBrowserLocale()
+  composer.getLocaleCookie = () => _getLocaleCookie(localeCookie, _detectBrowserLanguage, runtimeI18n.defaultLocale)
+  composer.setLocaleCookie = (locale: string) => _setLocaleCookie(localeCookie, locale, _detectBrowserLanguage)
+
+  composer.onBeforeLanguageSwitch = (oldLocale, newLocale, initialSetup, context) =>
+    nuxtContext.callHook('i18n:beforeLocaleSwitch', { oldLocale, newLocale, initialSetup, context })
+  composer.onLanguageSwitched = (oldLocale, newLocale) =>
+    nuxtContext.callHook('i18n:localeSwitched', { oldLocale, newLocale })
+
+  composer.finalizePendingLocaleChange = async () => {
+    if (!i18n.__pendingLocale) {
+      return
+    }
+    setLocale(i18n, i18n.__pendingLocale)
+    if (i18n.__resolvePendingLocalePromise) {
+      await i18n.__resolvePendingLocalePromise()
+    }
+    i18n.__pendingLocale = undefined
+  }
+  composer.waitForPendingLocaleChange = async () => {
+    if (i18n.__pendingLocale && i18n.__pendingLocalePromise) {
+      await i18n.__pendingLocalePromise
+    }
   }
 }
 
 function extendPropertyDescriptors(
   composer: Composer,
   exported: any, // eslint-disable-line @typescript-eslint/no-explicit-any
-  hook?: ExtendVueI18nHook | ExtendExportedGlobalHook
+  hook?: ExtendComposerHook
 ): void {
   const properties: ExtendPropertyDescriptors[] = [
     {
       locales: {
-        get() {
-          return composer.locales.value
-        }
+        get: () => composer.locales.value
       },
       localeCodes: {
-        get() {
-          return composer.localeCodes.value
-        }
+        get: () => composer.localeCodes.value
       },
       baseUrl: {
-        get() {
-          return composer.baseUrl.value
-        }
+        get: () => composer.baseUrl.value
       }
     }
   ]
@@ -231,16 +299,103 @@ function extendPropertyDescriptors(
   }
 }
 
-function extendExportedGlobal(exported: ExportedGlobalComposer, g: Composer, hook?: ExtendExportedGlobalHook) {
+function extendExportedGlobal(exported: ExportedGlobalComposer, g: Composer) {
+  function hook(g: Composer): ExtendPropertyDescriptors {
+    return {
+      strategy: {
+        get: () => g.strategy
+      },
+      localeProperties: {
+        get: () => g.localeProperties.value
+      },
+      setLocale: {
+        get: () => async (locale: string) => Reflect.apply(g.setLocale, g, [locale])
+      },
+      differentDomains: {
+        get: () => g.differentDomains
+      },
+      defaultLocale: {
+        get: () => g.defaultLocale
+      },
+      getBrowserLocale: {
+        get: () => () => Reflect.apply(g.getBrowserLocale, g, [])
+      },
+      getLocaleCookie: {
+        get: () => () => Reflect.apply(g.getLocaleCookie, g, [])
+      },
+      setLocaleCookie: {
+        get: () => (locale: string) => Reflect.apply(g.setLocaleCookie, g, [locale])
+      },
+      onBeforeLanguageSwitch: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        get: () => (oldLocale: string, newLocale: string, initialSetup: boolean, context: NuxtApp) =>
+          Reflect.apply(g.onBeforeLanguageSwitch, g, [oldLocale, newLocale, initialSetup, context])
+      },
+      onLanguageSwitched: {
+        get: () => (oldLocale: string, newLocale: string) =>
+          Reflect.apply(g.onLanguageSwitched, g, [oldLocale, newLocale])
+      },
+      finalizePendingLocaleChange: {
+        get: () => () => Reflect.apply(g.finalizePendingLocaleChange, g, [])
+      },
+      waitForPendingLocaleChange: {
+        get: () => () => Reflect.apply(g.waitForPendingLocaleChange, g, [])
+      }
+    }
+  }
   extendPropertyDescriptors(g, exported, hook)
 }
 
-function extendVueI18n(vueI18n: VueI18n, hook?: ExtendVueI18nHook): void {
+function extendVueI18n(vueI18n: VueI18n): void {
   const c = getComposer(vueI18n)
-  extendPropertyDescriptors(c, vueI18n, hook)
-}
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function isPluginOptions(options: any): options is VueI18nRoutingPluginOptions {
-  return isObject(options) && ('inject' in options || '__composerExtend' in options || '__vueI18nExtend' in options)
+  function hook(composer: Composer): ExtendPropertyDescriptors {
+    return {
+      strategy: {
+        get: () => composer.strategy
+      },
+      localeProperties: {
+        get: () => composer.localeProperties.value
+      },
+      setLocale: {
+        get: () => async (locale: string) => Reflect.apply(composer.setLocale, composer, [locale])
+      },
+      loadLocaleMessages: {
+        get: () => async (locale: string) => Reflect.apply(composer.loadLocaleMessages, composer, [locale])
+      },
+      differentDomains: {
+        get: () => composer.differentDomains
+      },
+      defaultLocale: {
+        get: () => composer.defaultLocale
+      },
+      getBrowserLocale: {
+        get: () => () => Reflect.apply(composer.getBrowserLocale, composer, [])
+      },
+      getLocaleCookie: {
+        get: () => () => Reflect.apply(composer.getLocaleCookie, composer, [])
+      },
+      setLocaleCookie: {
+        get: () => (locale: string) => Reflect.apply(composer.setLocaleCookie, composer, [locale])
+      },
+      onBeforeLanguageSwitch: {
+        get:
+          () =>
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (oldLocale: string, newLocale: string, initialSetup: boolean, context: NuxtApp) =>
+            Reflect.apply(composer.onBeforeLanguageSwitch, composer, [oldLocale, newLocale, initialSetup, context])
+      },
+      onLanguageSwitched: {
+        get: () => (oldLocale: string, newLocale: string) =>
+          Reflect.apply(composer.onLanguageSwitched, composer, [oldLocale, newLocale])
+      },
+      finalizePendingLocaleChange: {
+        get: () => () => Reflect.apply(composer.finalizePendingLocaleChange, composer, [])
+      },
+      waitForPendingLocaleChange: {
+        get: () => () => Reflect.apply(composer.waitForPendingLocaleChange, composer, [])
+      }
+    }
+  }
+  extendPropertyDescriptors(c, vueI18n, hook)
 }

--- a/src/runtime/routing/extends/i18n.ts
+++ b/src/runtime/routing/extends/i18n.ts
@@ -9,12 +9,7 @@ import {
   resolveRoute,
   switchLocalePath
 } from '../compatibles'
-import {
-  wrapComposable,
-  getBrowserLocale as _getBrowserLocale,
-  getLocaleCookie as _getLocaleCookie,
-  setLocaleCookie as _setLocaleCookie
-} from '../../internal'
+import { wrapComposable } from '../../internal'
 import { initCommonComposableOptions } from '../../utils'
 
 import type { NuxtApp } from 'nuxt/app'
@@ -45,7 +40,7 @@ type VueI18nExtendOptions = {
   extendComposerInstance: (instance: VueI18n | ExportedGlobalComposer, composer: Composer) => void
 }
 
-export function extendI18n(i18n: I18n, extendOptions: VueI18nExtendOptions) {
+export function extendI18n(i18n: I18n, { extendComposer, extendComposerInstance }: VueI18nExtendOptions) {
   const scope = effectScope()
 
   const installI18n = i18n.install.bind(i18n)
@@ -77,7 +72,7 @@ export function extendI18n(i18n: I18n, extendOptions: VueI18nExtendOptions) {
 
     if (i18n.mode === 'legacy') {
       pluginOptions.__vueI18nExtend = (vueI18n: VueI18n) => {
-        extendOptions.extendComposerInstance(vueI18n, getComposer(vueI18n))
+        extendComposerInstance(vueI18n, getComposer(vueI18n))
         return () => {}
       }
     }
@@ -90,15 +85,15 @@ export function extendI18n(i18n: I18n, extendOptions: VueI18nExtendOptions) {
 
     // extend global
     scope.run(() => {
-      extendOptions.extendComposer(globalComposer)
+      extendComposer(globalComposer)
       if (i18n.mode === 'legacy' && isVueI18n(i18n.global)) {
-        extendOptions.extendComposerInstance(i18n.global, getComposer(i18n.global))
+        extendComposerInstance(i18n.global, getComposer(i18n.global))
       }
     })
 
     // extend vue component instance for Vue 3
-    if (i18n.mode === 'composition') {
-      extendOptions.extendComposerInstance(app.config.globalProperties.$i18n, globalComposer)
+    if (i18n.mode === 'composition' && app.config.globalProperties.$i18n != null) {
+      extendComposerInstance(app.config.globalProperties.$i18n, globalComposer)
     }
 
     // extend vue component instance

--- a/src/runtime/routing/extends/i18n.ts
+++ b/src/runtime/routing/extends/i18n.ts
@@ -1,5 +1,5 @@
-import { computed, effectScope, ref, useRoute, watch, type Ref } from '#imports'
-import { resolveBaseUrl, isVueI18n, getComposer, inBrowser, setLocale } from '../utils'
+import { computed, effectScope } from '#imports'
+import { isVueI18n, getComposer } from '../utils'
 import {
   getRouteBaseName,
   localeHead,
@@ -13,33 +13,12 @@ import {
   wrapComposable,
   getBrowserLocale as _getBrowserLocale,
   getLocaleCookie as _getLocaleCookie,
-  setLocaleCookie as _setLocaleCookie,
-  getI18nCookie,
-  runtimeDetectBrowserLanguage
+  setLocaleCookie as _setLocaleCookie
 } from '../../internal'
-import {
-  detectRedirect,
-  initCommonComposableOptions,
-  loadAndSetLocale,
-  mergeLocaleMessage,
-  navigate
-} from '../../utils'
-import { localeLoaders, normalizedLocales } from '#build/i18n.options.mjs'
+import { initCommonComposableOptions } from '../../utils'
 
 import type { NuxtApp } from 'nuxt/app'
-import type {
-  Composer,
-  ComposerExtender,
-  ExportedGlobalComposer,
-  I18n,
-  Locale,
-  VueI18n,
-  VueI18nExtender
-} from 'vue-i18n'
-import type { LocaleObject } from '#build/i18n.options.mjs'
-import type { ModulePublicRuntimeConfig } from '../../../module'
-import { loadLocale } from '../../messages'
-import { createLocaleFromRouteGetter } from './router'
+import type { Composer, ComposerExtender, ExportedGlobalComposer, I18n, VueI18n, VueI18nExtender } from 'vue-i18n'
 
 /**
  * Internal options for the Vue I18n plugin.
@@ -62,14 +41,10 @@ interface VueI18nInternalPluginOptions {
 }
 
 type VueI18nExtendOptions = {
-  isInitialLocaleSetup: (locale: string) => boolean
-  notInitialSetup: Ref<boolean>
-  localeCodes: string[]
-  localeCookie: ReturnType<typeof getI18nCookie>
-  nuxtContext: NuxtApp
-  _detectBrowserLanguage: ReturnType<typeof runtimeDetectBrowserLanguage>
-  runtimeI18n: ModulePublicRuntimeConfig['i18n']
+  extendComposer: (composer: Composer) => void
+  extendComposerInstance: (instance: VueI18n | ExportedGlobalComposer, composer: Composer) => void
 }
+
 export function extendI18n(i18n: I18n, extendOptions: VueI18nExtendOptions) {
   const scope = effectScope()
 
@@ -102,7 +77,7 @@ export function extendI18n(i18n: I18n, extendOptions: VueI18nExtendOptions) {
 
     if (i18n.mode === 'legacy') {
       pluginOptions.__vueI18nExtend = (vueI18n: VueI18n) => {
-        extendComposerInstance(vueI18n, getComposer(vueI18n))
+        extendOptions.extendComposerInstance(vueI18n, getComposer(vueI18n))
         return () => {}
       }
     }
@@ -115,15 +90,15 @@ export function extendI18n(i18n: I18n, extendOptions: VueI18nExtendOptions) {
 
     // extend global
     scope.run(() => {
-      extendComposer(globalComposer, extendOptions, i18n)
+      extendOptions.extendComposer(globalComposer)
       if (i18n.mode === 'legacy' && isVueI18n(i18n.global)) {
-        extendComposerInstance(i18n.global, getComposer(i18n.global))
+        extendOptions.extendComposerInstance(i18n.global, getComposer(i18n.global))
       }
     })
 
     // extend vue component instance for Vue 3
     if (i18n.mode === 'composition') {
-      extendComposerInstance(app.config.globalProperties.$i18n, globalComposer)
+      extendOptions.extendComposerInstance(app.config.globalProperties.$i18n, globalComposer)
     }
 
     // extend vue component instance
@@ -153,180 +128,4 @@ export function extendI18n(i18n: I18n, extendOptions: VueI18nExtendOptions) {
   }
 
   return scope
-}
-
-function extendComposer(
-  composer: Composer,
-  {
-    localeCodes,
-    isInitialLocaleSetup,
-    notInitialSetup,
-    localeCookie,
-    nuxtContext,
-    _detectBrowserLanguage,
-    runtimeI18n
-  }: VueI18nExtendOptions,
-  i18n: I18n
-) {
-  const route = useRoute()
-  const getLocaleFromRoute = createLocaleFromRouteGetter()
-  const _locales = ref<string[] | LocaleObject[]>(runtimeI18n.configLocales)
-  const _localeCodes = ref<string[]>(localeCodes)
-  const _baseUrl = ref<string>('')
-
-  // @ts-ignore
-  composer.locales = computed(() => _locales.value)
-  composer.localeCodes = computed(() => _localeCodes.value)
-  composer.baseUrl = computed(() => _baseUrl.value)
-
-  if (inBrowser) {
-    watch(
-      composer.locale,
-      () => {
-        _baseUrl.value = resolveBaseUrl(runtimeI18n.baseUrl!, nuxtContext)
-      },
-      { immediate: true }
-    )
-  } else {
-    _baseUrl.value = resolveBaseUrl(runtimeI18n.baseUrl!, nuxtContext)
-  }
-
-  composer.strategy = runtimeI18n.strategy
-  composer.localeProperties = computed(
-    () => normalizedLocales.find(l => l.code === composer.locale.value) || { code: composer.locale.value }
-  )
-  composer.setLocale = async (locale: string) => {
-    const localeSetup = isInitialLocaleSetup(locale)
-    const modified = await loadAndSetLocale(locale, i18n, runtimeI18n, localeSetup)
-
-    if (modified && localeSetup) {
-      notInitialSetup.value = false
-    }
-
-    const redirectPath = await nuxtContext.runWithContext(() =>
-      detectRedirect({
-        route: { to: route },
-        targetLocale: locale,
-        routeLocaleGetter: getLocaleFromRoute
-      })
-    )
-    __DEBUG__ && console.log('redirectPath on setLocale', redirectPath)
-
-    await nuxtContext.runWithContext(
-      async () =>
-        await navigate(
-          {
-            nuxtApp: nuxtContext,
-            i18n,
-            redirectPath,
-            locale,
-            route
-          },
-          { enableNavigate: true }
-        )
-    )
-  }
-  composer.loadLocaleMessages = async (locale: string) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const setter = (locale: Locale, message: Record<string, any>) => mergeLocaleMessage(i18n, locale, message)
-    await loadLocale(locale, localeLoaders, setter)
-  }
-  composer.differentDomains = runtimeI18n.differentDomains
-  composer.defaultLocale = runtimeI18n.defaultLocale
-  composer.getBrowserLocale = () => _getBrowserLocale()
-  composer.getLocaleCookie = () => _getLocaleCookie(localeCookie, _detectBrowserLanguage, runtimeI18n.defaultLocale)
-  composer.setLocaleCookie = (locale: string) => _setLocaleCookie(localeCookie, locale, _detectBrowserLanguage)
-
-  composer.onBeforeLanguageSwitch = (oldLocale, newLocale, initialSetup, context) =>
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    nuxtContext.callHook('i18n:beforeLocaleSwitch', { oldLocale, newLocale, initialSetup, context })
-  composer.onLanguageSwitched = (oldLocale, newLocale) =>
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    nuxtContext.callHook('i18n:localeSwitched', { oldLocale, newLocale })
-
-  composer.finalizePendingLocaleChange = async () => {
-    if (!i18n.__pendingLocale) {
-      return
-    }
-    setLocale(i18n, i18n.__pendingLocale)
-    if (i18n.__resolvePendingLocalePromise) {
-      // eslint-disable-next-line @typescript-eslint/await-thenable
-      await i18n.__resolvePendingLocalePromise()
-    }
-    i18n.__pendingLocale = undefined
-  }
-  composer.waitForPendingLocaleChange = async () => {
-    if (i18n.__pendingLocale && i18n.__pendingLocalePromise) {
-      await i18n.__pendingLocalePromise
-    }
-  }
-}
-
-interface ExtendPropertyDescriptors {
-  [key: string]: Pick<PropertyDescriptor, 'get'>
-}
-
-/**
- * Extends the VueI18n or Composer instance properties with those from the provided composer instance.
- *
- * @param instance - The VueI18n or Composer instance to extend.
- * @param c - The composer instance containing the additional properties and methods.
- */
-function extendComposerInstance(instance: VueI18n | ExportedGlobalComposer, c: Composer) {
-  const properties: ExtendPropertyDescriptors = {
-    locales: {
-      get: () => c.locales.value
-    },
-    localeCodes: {
-      get: () => c.localeCodes.value
-    },
-    baseUrl: {
-      get: () => c.baseUrl.value
-    },
-    strategy: {
-      get: () => c.strategy
-    },
-    localeProperties: {
-      get: () => c.localeProperties.value
-    },
-    setLocale: {
-      get: () => async (locale: string) => Reflect.apply(c.setLocale, c, [locale])
-    },
-    loadLocaleMessages: {
-      get: () => async (locale: string) => Reflect.apply(c.loadLocaleMessages, c, [locale])
-    },
-    differentDomains: {
-      get: () => c.differentDomains
-    },
-    defaultLocale: {
-      get: () => c.defaultLocale
-    },
-    getBrowserLocale: {
-      get: () => () => Reflect.apply(c.getBrowserLocale, c, [])
-    },
-    getLocaleCookie: {
-      get: () => () => Reflect.apply(c.getLocaleCookie, c, [])
-    },
-    setLocaleCookie: {
-      get: () => (locale: string) => Reflect.apply(c.setLocaleCookie, c, [locale])
-    },
-    onBeforeLanguageSwitch: {
-      get: () => (oldLocale: string, newLocale: string, initialSetup: boolean, context: NuxtApp) =>
-        Reflect.apply(c.onBeforeLanguageSwitch, c, [oldLocale, newLocale, initialSetup, context])
-    },
-    onLanguageSwitched: {
-      get: () => (oldLocale: string, newLocale: string) =>
-        Reflect.apply(c.onLanguageSwitched, c, [oldLocale, newLocale])
-    },
-    finalizePendingLocaleChange: {
-      get: () => () => Reflect.apply(c.finalizePendingLocaleChange, c, [])
-    },
-    waitForPendingLocaleChange: {
-      get: () => () => Reflect.apply(c.waitForPendingLocaleChange, c, [])
-    }
-  }
-
-  for (const [key, descriptor] of Object.entries(properties)) {
-    Object.defineProperty(instance, key, descriptor)
-  }
 }

--- a/src/runtime/routing/extends/i18n.ts
+++ b/src/runtime/routing/extends/i18n.ts
@@ -1,4 +1,4 @@
-import { computed, effectScope } from '#imports'
+import { effectScope } from '#imports'
 import { isVueI18n, getComposer } from '../utils'
 import {
   getRouteBaseName,
@@ -37,7 +37,7 @@ interface VueI18nInternalPluginOptions {
 
 type VueI18nExtendOptions = {
   extendComposer: (composer: Composer) => void
-  extendComposerInstance: (instance: VueI18n | ExportedGlobalComposer, composer: Composer) => void
+  extendComposerInstance: (instance: Composer | VueI18n | ExportedGlobalComposer, composer: Composer) => void
 }
 
 /**
@@ -55,25 +55,7 @@ export function extendI18n(i18n: I18n, { extendComposer, extendComposerInstance 
     pluginOptions.inject ??= true
 
     pluginOptions.__composerExtend = (c: Composer) => {
-      const g = getComposer(i18n)
-
-      c.strategy = g.strategy
-      c.differentDomains = g.differentDomains
-
-      c.baseUrl = computed(() => g.baseUrl.value)
-      c.locales = computed(() => g.locales.value)
-      c.localeCodes = computed(() => g.localeCodes.value)
-      c.localeProperties = computed(() => g.localeProperties.value)
-
-      c.setLocale = g.setLocale
-      c.getBrowserLocale = g.getBrowserLocale
-      c.getLocaleCookie = g.getLocaleCookie
-      c.setLocaleCookie = g.setLocaleCookie
-      c.onBeforeLanguageSwitch = g.onBeforeLanguageSwitch
-      c.onLanguageSwitched = g.onLanguageSwitched
-      c.waitForPendingLocaleChange = g.waitForPendingLocaleChange
-      c.finalizePendingLocaleChange = g.finalizePendingLocaleChange
-
+      extendComposerInstance(c, getComposer(i18n))
       return () => {}
     }
 

--- a/src/runtime/routing/extends/i18n.ts
+++ b/src/runtime/routing/extends/i18n.ts
@@ -197,12 +197,12 @@ function extendComposer(
     watch(
       composer.locale,
       () => {
-        _baseUrl.value = resolveBaseUrl(runtimeI18n.baseUrl!, nuxtContext!)
+        _baseUrl.value = resolveBaseUrl(runtimeI18n.baseUrl!, nuxtContext)
       },
       { immediate: true }
     )
   } else {
-    _baseUrl.value = resolveBaseUrl(runtimeI18n.baseUrl!, nuxtContext!)
+    _baseUrl.value = resolveBaseUrl(runtimeI18n.baseUrl!, nuxtContext)
   }
 
   composer.strategy = runtimeI18n.strategy
@@ -252,8 +252,10 @@ function extendComposer(
   composer.setLocaleCookie = (locale: string) => _setLocaleCookie(localeCookie, locale, _detectBrowserLanguage)
 
   composer.onBeforeLanguageSwitch = (oldLocale, newLocale, initialSetup, context) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     nuxtContext.callHook('i18n:beforeLocaleSwitch', { oldLocale, newLocale, initialSetup, context })
   composer.onLanguageSwitched = (oldLocale, newLocale) =>
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     nuxtContext.callHook('i18n:localeSwitched', { oldLocale, newLocale })
 
   composer.finalizePendingLocaleChange = async () => {
@@ -262,6 +264,7 @@ function extendComposer(
     }
     setLocale(i18n, i18n.__pendingLocale)
     if (i18n.__resolvePendingLocalePromise) {
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await i18n.__resolvePendingLocalePromise()
     }
     i18n.__pendingLocale = undefined
@@ -327,7 +330,6 @@ function extendExportedGlobal(exported: ExportedGlobalComposer, g: Composer) {
         get: () => (locale: string) => Reflect.apply(g.setLocaleCookie, g, [locale])
       },
       onBeforeLanguageSwitch: {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         get: () => (oldLocale: string, newLocale: string, initialSetup: boolean, context: NuxtApp) =>
           Reflect.apply(g.onBeforeLanguageSwitch, g, [oldLocale, newLocale, initialSetup, context])
       },
@@ -379,11 +381,8 @@ function extendVueI18n(vueI18n: VueI18n): void {
         get: () => (locale: string) => Reflect.apply(composer.setLocaleCookie, composer, [locale])
       },
       onBeforeLanguageSwitch: {
-        get:
-          () =>
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (oldLocale: string, newLocale: string, initialSetup: boolean, context: NuxtApp) =>
-            Reflect.apply(composer.onBeforeLanguageSwitch, composer, [oldLocale, newLocale, initialSetup, context])
+        get: () => (oldLocale: string, newLocale: string, initialSetup: boolean, context: NuxtApp) =>
+          Reflect.apply(composer.onBeforeLanguageSwitch, composer, [oldLocale, newLocale, initialSetup, context])
       },
       onLanguageSwitched: {
         get: () => (oldLocale: string, newLocale: string) =>

--- a/src/runtime/routing/extends/i18n.ts
+++ b/src/runtime/routing/extends/i18n.ts
@@ -84,7 +84,7 @@ export function extendI18n(i18n: I18n, { extendComposer, extendComposerInstance 
       }
     }
 
-    // install vue-i18n
+    // install Vue I18n
     Reflect.apply(installI18n, i18n, [app, pluginOptions])
 
     const globalComposer = getComposer(i18n)
@@ -97,12 +97,12 @@ export function extendI18n(i18n: I18n, { extendComposer, extendComposerInstance 
       }
     })
 
-    // extend vue component instance for Vue 3
+    // extend Vue component instance for Vue 3
     if (i18n.mode === 'composition' && app.config.globalProperties.$i18n != null) {
       extendComposerInstance(app.config.globalProperties.$i18n, globalComposer)
     }
 
-    // extend vue component instance
+    // extend Vue component instance
     if (pluginOptions.inject) {
       const common = initCommonComposableOptions(i18n)
       app.mixin({


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
We still have some split logic between this module and what was originally in `vue-i18n-routing`, because of this we were extending `vue-i18n` in two places. 

After some reorganizing I noticed that `onExtendExportGlobal` and `onExtendVueI18n` were actually doing the same thing but with different variable names 🤔 possibly `__composerExtend` did the same as well, after merging and generalizing these extends it appears to still be working.

I feel like my changes should have broken something.. 😂 Either the refactored code was interchangeable or it contains untested logic 🤔

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
