### PR TITLE
refactor: separate switchLocalePath SSR feature into plugin

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -217,6 +217,7 @@ export default defineNuxtModule<NuxtI18nOptions>({
 
     // for core plugin
     addPlugin(resolve(runtimeDir, 'plugins/i18n'))
+    addPlugin(resolve(runtimeDir, 'plugins/switch-locale-path-ssr'))
 
     // for composables
     nuxt.options.alias['#i18n'] = resolve(distDir, 'runtime/composables/index.mjs')

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -7,11 +7,9 @@ import {
   isSSG,
   localeLoaders,
   parallelPlugin,
-  normalizedLocales,
-  SWITCH_LOCALE_PATH_LINK_IDENTIFIER
+  normalizedLocales
 } from '#build/i18n.options.mjs'
 import { loadVueI18nOptions, loadInitialMessages, loadLocale } from '../messages'
-import { useSwitchLocalePath } from '../composables'
 import {
   loadAndSetLocale,
   detectLocale,
@@ -400,29 +398,6 @@ export default defineNuxtPlugin({
 
     // inject for nuxt helpers
     injectNuxtHelpers(nuxtContext, i18n)
-
-    // Replace `SwitchLocalePathLink` href in rendered html for SSR support
-    if (runtimeI18n.experimental.switchLocalePathLinkSSR === true) {
-      const switchLocalePath = useSwitchLocalePath()
-
-      const switchLocalePathLinkWrapperExpr = new RegExp(
-        [
-          `<!--${SWITCH_LOCALE_PATH_LINK_IDENTIFIER}-\\[(\\w+)\\]-->`,
-          `.+?`,
-          `<!--/${SWITCH_LOCALE_PATH_LINK_IDENTIFIER}-->`
-        ].join(''),
-        'g'
-      )
-
-      nuxt.hook('app:rendered', ctx => {
-        if (ctx.renderResult?.html == null) return
-
-        ctx.renderResult.html = ctx.renderResult.html.replaceAll(
-          switchLocalePathLinkWrapperExpr,
-          (match: string, p1: string) => match.replace(/href="([^"]+)"/, `href="${switchLocalePath(p1 ?? '')}"`)
-        )
-      })
-    }
 
     let routeChangeCount = 0
 

--- a/src/runtime/plugins/switch-locale-path-ssr.ts
+++ b/src/runtime/plugins/switch-locale-path-ssr.ts
@@ -1,0 +1,32 @@
+import { defineNuxtPlugin } from '#imports'
+import { useSwitchLocalePath } from '#i18n'
+import { SWITCH_LOCALE_PATH_LINK_IDENTIFIER } from '#build/i18n.options.mjs'
+
+// Replace `SwitchLocalePathLink` href in rendered html for SSR support
+export default defineNuxtPlugin({
+  name: 'i18n:plugin:switch-locale-path-ssr',
+  dependsOn: ['i18n:plugin'],
+  setup(nuxt) {
+    if (nuxt.$config.public.i18n.experimental.switchLocalePathLinkSSR !== true) return
+
+    const switchLocalePath = useSwitchLocalePath()
+
+    const switchLocalePathLinkWrapperExpr = new RegExp(
+      [
+        `<!--${SWITCH_LOCALE_PATH_LINK_IDENTIFIER}-\\[(\\w+)\\]-->`,
+        `.+?`,
+        `<!--/${SWITCH_LOCALE_PATH_LINK_IDENTIFIER}-->`
+      ].join(''),
+      'g'
+    )
+
+    nuxt.hook('app:rendered', ctx => {
+      if (ctx.renderResult?.html == null) return
+
+      ctx.renderResult.html = ctx.renderResult.html.replaceAll(
+        switchLocalePathLinkWrapperExpr,
+        (match: string, p1: string) => match.replace(/href="([^"]+)"/, `href="${switchLocalePath(p1 ?? '')}"`)
+      )
+    })
+  }
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I feel like there is a lot going on in the i18n plugin, after looking at Nuxt's source code I noticed some features are separated into plugins, so I tried to do the same here 😅 

I also tried another way of reorganizing the plugin logic here https://github.com/nuxt-modules/i18n/pull/3017, but that's a bit more involved.

If refactors like these actually make things harder to read, do let me know, I'm too familiar with the codebase now to notice if that is the case 😂
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
