### PR TITLE
feat: generate `Locale` type based on configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "sucrase": "^3.35.0",
     "ufo": "^1.3.1",
     "unplugin": "^1.10.1",
-    "vue-i18n": "^10.0.0-beta.1",
+    "vue-i18n": "^10.0.0-beta.4",
     "vue-router": "^4.4.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         version: 10.0.0-beta.1
       '@intlify/unplugin-vue-i18n':
         specifier: ^5.0.0-beta.3
-        version: 5.0.0-beta.3(@vue/compiler-dom@3.4.31)(eslint@9.5.0)(rollup@3.29.4)(typescript@5.5.2)(vue-i18n@10.0.0-beta.1(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2))
+        version: 5.0.0-beta.3(@vue/compiler-dom@3.4.31)(eslint@9.5.0)(rollup@3.29.4)(typescript@5.5.2)(vue-i18n@10.0.0-beta.4(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2))
       '@intlify/utils':
         specifier: ^0.12.0
         version: 0.12.0
@@ -74,8 +74,8 @@ importers:
         specifier: ^1.10.1
         version: 1.10.1
       vue-i18n:
-        specifier: ^10.0.0-beta.1
-        version: 10.0.0-beta.1(vue@3.4.31(typescript@5.5.2))
+        specifier: ^10.0.0-beta.4
+        version: 10.0.0-beta.4(vue@3.4.31(typescript@5.5.2))
       vue-router:
         specifier: ^4.4.0
         version: 4.4.0(vue@3.4.31(typescript@5.5.2))
@@ -1186,8 +1186,8 @@ packages:
       vue-i18n:
         optional: true
 
-  '@intlify/core-base@10.0.0-beta.1':
-    resolution: {integrity: sha512-eSjIKjIbDVGy/0yXAvL6O5LOVJ8E7jkbPUyQyM1vPVmu+5o05NNOTbZlsdOm9dDgXfXnFga4aUNWSkge7efe4Q==}
+  '@intlify/core-base@10.0.0-beta.4':
+    resolution: {integrity: sha512-dP0quM/R9iM+sxo3WfEHLqzQPh4R5nX8qAE8tgBHW83dGHo9787S0QHHEVAD62OtkEhRndNuMqzpkEzyuMIW2Q==}
     engines: {node: '>= 16'}
 
   '@intlify/core-base@9.13.1':
@@ -1202,12 +1202,8 @@ packages:
     resolution: {integrity: sha512-cgfrtD3qu3BPJ47gfZ35J2LJpI64Riic0K8NGgid5ilyPXRQTNY7mXlT/B+HZYQg1hmBxKa5G5HJXyAZ4R2H5A==}
     engines: {node: '>= 18'}
 
-  '@intlify/message-compiler@10.0.0-beta.1':
-    resolution: {integrity: sha512-rBmXBZzDgq3yPkL/3/r9uK0nrsJOYHSpaW0mtGBxxjt9pY9vaPL0UAKbVAjFPRnfEY41ixgpkpTjai6IKZ+hvg==}
-    engines: {node: '>= 16'}
-
-  '@intlify/message-compiler@10.0.0-beta.2':
-    resolution: {integrity: sha512-2yl340oNiCDjdpPIfo49a7o56ZTc+35iN7mxdQvXOLxJ6Pdh9p0GkB0duV44hfHaAxsD1cGQ4naLDRokKUdyvQ==}
+  '@intlify/message-compiler@10.0.0-beta.4':
+    resolution: {integrity: sha512-jMuRHSgUYJ6gPoDVo5AbGb89l6Ha4VLiBfr4W90ore/EKKAAH4j9a9a5fR5r086WHGc8kOiPRKRVnH6X+HcT2w==}
     engines: {node: '>= 16'}
 
   '@intlify/message-compiler@9.13.1':
@@ -1218,8 +1214,8 @@ packages:
     resolution: {integrity: sha512-61MnYhgqS/TyAto9CXOltHlhK2WflLBcKpIkRhZCUL2IkiVvh7qKevsqZ3RYZylyC3q19ajLW6mB+iJtnbAOpg==}
     engines: {node: '>= 16'}
 
-  '@intlify/shared@10.0.0-beta.2':
-    resolution: {integrity: sha512-u3ey3jn7VZl8SfuBH1nZC1xvdu59/PYkjR6UjXMWiDoowmr/PuPzmIRmOD8jZvRfCbKnKWYRK33HN4uTWLr/Yw==}
+  '@intlify/shared@10.0.0-beta.4':
+    resolution: {integrity: sha512-DBNuWRMmVRXDGb/4eJnMMT52yXg+LTM3No5xybvN4CCnrelnt76AagwmgsyRQybopThrqUk0cK/2zAmeIaukyA==}
     engines: {node: '>= 16'}
 
   '@intlify/shared@9.13.1':
@@ -6490,8 +6486,8 @@ packages:
   vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
 
-  vue-i18n@10.0.0-beta.1:
-    resolution: {integrity: sha512-bw2i2pQlYuwv9X7pAtLkC5UznmxzfQzzkC+FFxHs6owoAd/nlrvP1tGQv8+j1waZnOx7rFcXV17dco+a+VLEQA==}
+  vue-i18n@10.0.0-beta.4:
+    resolution: {integrity: sha512-WdgPczq1nE3LmNBHAv8emqRIzPp9Qt+F91Iz5djW4W5K1QhWyxhFryYSnrQ1X+em8XWDdY8sombWK9ipy1FI7g==}
     engines: {node: '>= 16'}
     peerDependencies:
       vue: ^3.0.0
@@ -7393,10 +7389,10 @@ snapshots:
       '@iconify/types': 2.0.0
       vue: 3.4.31(typescript@5.5.2)
 
-  '@intlify/bundle-utils@9.0.0-beta.0(vue-i18n@10.0.0-beta.1(vue@3.4.31(typescript@5.5.2)))':
+  '@intlify/bundle-utils@9.0.0-beta.0(vue-i18n@10.0.0-beta.4(vue@3.4.31(typescript@5.5.2)))':
     dependencies:
-      '@intlify/message-compiler': 10.0.0-beta.2
-      '@intlify/shared': 10.0.0-beta.2
+      '@intlify/message-compiler': 10.0.0-beta.4
+      '@intlify/shared': 10.0.0-beta.4
       acorn: 8.12.0
       escodegen: 2.1.0
       estree-walker: 2.0.2
@@ -7405,12 +7401,12 @@ snapshots:
       source-map-js: 1.2.0
       yaml-eslint-parser: 1.2.3
     optionalDependencies:
-      vue-i18n: 10.0.0-beta.1(vue@3.4.31(typescript@5.5.2))
+      vue-i18n: 10.0.0-beta.4(vue@3.4.31(typescript@5.5.2))
 
-  '@intlify/core-base@10.0.0-beta.1':
+  '@intlify/core-base@10.0.0-beta.4':
     dependencies:
-      '@intlify/message-compiler': 10.0.0-beta.1
-      '@intlify/shared': 10.0.0-beta.1
+      '@intlify/message-compiler': 10.0.0-beta.4
+      '@intlify/shared': 10.0.0-beta.4
 
   '@intlify/core-base@9.13.1':
     dependencies:
@@ -7427,14 +7423,9 @@ snapshots:
       '@intlify/core': 9.13.1
       '@intlify/utils': 0.12.0
 
-  '@intlify/message-compiler@10.0.0-beta.1':
+  '@intlify/message-compiler@10.0.0-beta.4':
     dependencies:
-      '@intlify/shared': 10.0.0-beta.1
-      source-map-js: 1.2.0
-
-  '@intlify/message-compiler@10.0.0-beta.2':
-    dependencies:
-      '@intlify/shared': 10.0.0-beta.2
+      '@intlify/shared': 10.0.0-beta.4
       source-map-js: 1.2.0
 
   '@intlify/message-compiler@9.13.1':
@@ -7444,16 +7435,16 @@ snapshots:
 
   '@intlify/shared@10.0.0-beta.1': {}
 
-  '@intlify/shared@10.0.0-beta.2': {}
+  '@intlify/shared@10.0.0-beta.4': {}
 
   '@intlify/shared@9.13.1': {}
 
-  '@intlify/unplugin-vue-i18n@5.0.0-beta.3(@vue/compiler-dom@3.4.31)(eslint@9.5.0)(rollup@3.29.4)(typescript@5.5.2)(vue-i18n@10.0.0-beta.1(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2))':
+  '@intlify/unplugin-vue-i18n@5.0.0-beta.3(@vue/compiler-dom@3.4.31)(eslint@9.5.0)(rollup@3.29.4)(typescript@5.5.2)(vue-i18n@10.0.0-beta.4(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2))':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.5.0)
-      '@intlify/bundle-utils': 9.0.0-beta.0(vue-i18n@10.0.0-beta.1(vue@3.4.31(typescript@5.5.2)))
-      '@intlify/shared': 10.0.0-beta.2
-      '@intlify/vue-i18n-extensions': 6.2.0(@intlify/shared@10.0.0-beta.2)(@vue/compiler-dom@3.4.31)(vue-i18n@10.0.0-beta.1(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2))
+      '@intlify/bundle-utils': 9.0.0-beta.0(vue-i18n@10.0.0-beta.4(vue@3.4.31(typescript@5.5.2)))
+      '@intlify/shared': 10.0.0-beta.4
+      '@intlify/vue-i18n-extensions': 6.2.0(@intlify/shared@10.0.0-beta.4)(@vue/compiler-dom@3.4.31)(vue-i18n@10.0.0-beta.4(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2))
       '@rollup/pluginutils': 5.1.0(rollup@3.29.4)
       '@typescript-eslint/scope-manager': 7.14.1
       '@typescript-eslint/typescript-estree': 7.14.1(typescript@5.5.2)
@@ -7468,7 +7459,7 @@ snapshots:
       unplugin: 1.11.0
       vue: 3.4.31(typescript@5.5.2)
     optionalDependencies:
-      vue-i18n: 10.0.0-beta.1(vue@3.4.31(typescript@5.5.2))
+      vue-i18n: 10.0.0-beta.4(vue@3.4.31(typescript@5.5.2))
     transitivePeerDependencies:
       - '@vue/compiler-dom'
       - eslint
@@ -7478,14 +7469,14 @@ snapshots:
 
   '@intlify/utils@0.12.0': {}
 
-  '@intlify/vue-i18n-extensions@6.2.0(@intlify/shared@10.0.0-beta.2)(@vue/compiler-dom@3.4.31)(vue-i18n@10.0.0-beta.1(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2))':
+  '@intlify/vue-i18n-extensions@6.2.0(@intlify/shared@10.0.0-beta.4)(@vue/compiler-dom@3.4.31)(vue-i18n@10.0.0-beta.4(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2))':
     dependencies:
       '@babel/parser': 7.24.7
     optionalDependencies:
-      '@intlify/shared': 10.0.0-beta.2
+      '@intlify/shared': 10.0.0-beta.4
       '@vue/compiler-dom': 3.4.31
       vue: 3.4.31(typescript@5.5.2)
-      vue-i18n: 10.0.0-beta.1(vue@3.4.31(typescript@5.5.2))
+      vue-i18n: 10.0.0-beta.4(vue@3.4.31(typescript@5.5.2))
 
   '@ioredis/commands@1.2.0': {}
 
@@ -14959,10 +14950,10 @@ snapshots:
 
   vue-devtools-stub@0.1.0: {}
 
-  vue-i18n@10.0.0-beta.1(vue@3.4.31(typescript@5.5.2)):
+  vue-i18n@10.0.0-beta.4(vue@3.4.31(typescript@5.5.2)):
     dependencies:
-      '@intlify/core-base': 10.0.0-beta.1
-      '@intlify/shared': 10.0.0-beta.1
+      '@intlify/core-base': 10.0.0-beta.4
+      '@intlify/shared': 10.0.0-beta.4
       '@vue/devtools-api': 6.6.3
       vue: 3.4.31(typescript@5.5.2)
 

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -9,6 +9,7 @@ import { getLayerI18n, getLocalePaths, getNormalizedLocales, toCode } from './ut
 import type { Nuxt } from '@nuxt/schema'
 import type { PrerenderTarget } from './utils'
 import type { NuxtI18nOptions, LocaleInfo, VueI18nConfigPathInfo, FileMeta, LocaleObject } from './types'
+import type { Locale } from 'vue-i18n'
 
 export type LoaderOptions = {
   vueI18nConfigPaths: Required<VueI18nConfigPathInfo>[]
@@ -31,7 +32,7 @@ const generateVueI18nConfiguration = (config: Required<VueI18nConfigPathInfo>, i
 }
 
 export function simplifyLocaleOptions(nuxt: Nuxt, options: NuxtI18nOptions) {
-  const isLocaleObjectsArray = (locales?: string[] | LocaleObject[]) => locales?.some(x => typeof x !== 'string')
+  const isLocaleObjectsArray = (locales?: Locale[] | LocaleObject[]) => locales?.some(x => typeof x !== 'string')
 
   const hasLocaleObjects =
     nuxt.options._layers.some(layer => isLocaleObjectsArray(getLayerI18n(layer)?.locales)) ||
@@ -64,7 +65,7 @@ export function generateLoaderOptions(
   const importMapper = new Map<string, { key: string; load: string; cache: string }>()
   const importStrings: string[] = []
 
-  function generateLocaleImports(locale: string, meta: NonNullable<LocaleInfo['meta']>[number], isServer = false) {
+  function generateLocaleImports(locale: Locale, meta: NonNullable<LocaleInfo['meta']>[number], isServer = false) {
     if (importMapper.has(meta.key)) return
     const importSpecifier = genImportSpecifier({ ...meta, isServer }, 'locale', { locale })
     const importer = { code: locale, key: meta.loadPath, load: '', cache: meta.file.cache ?? true }

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -197,10 +197,11 @@ declare module 'vue-i18n' {
   interface ComposerCustom extends ComposerCustomProperties<${resolvedLocaleType}> {}
   interface ExportedGlobalComposer extends NuxtI18nRoutingCustomProperties<${resolvedLocaleType}> {}
   interface VueI18n extends NuxtI18nRoutingCustomProperties<${resolvedLocaleType}> {}
+}
 
-  // generated based on configure locales
-  type Locale = ${localeCodeStrings.map(x => JSON.stringify(x)).join(' | ')}
-  interface ComposerGeneratedTypeConfig { 
+declare module '@intlify/core' {
+  // generated based on configured locales
+  interface IntlifyGeneratedTypeConfig { 
     locale: ${localeCodeStrings.map(x => JSON.stringify(x)).join(' | ')}
   }
 }

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -200,6 +200,9 @@ declare module 'vue-i18n' {
 
   // generated based on configure locales
   type Locale = ${localeCodeStrings.map(x => JSON.stringify(x)).join(' | ')}
+  interface ComposerGeneratedTypeConfig { 
+    locale: ${localeCodeStrings.map(x => JSON.stringify(x)).join(' | ')}
+  }
 }
 
 

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -201,7 +201,7 @@ declare module 'vue-i18n' {
 
 declare module '@intlify/core' {
   // generated based on configured locales
-  interface IntlifyGeneratedTypeConfig { 
+  interface GeneratedTypeConfig { 
     locale: ${localeCodeStrings.map(x => JSON.stringify(x)).join(' | ')}
   }
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -41,7 +41,8 @@ import { applyLayerOptions, checkLayerOptions, resolveLayerVueI18nConfigInfo } f
 import { generateTemplateNuxtI18nOptions } from './template'
 
 import type { HookResult } from '@nuxt/schema'
-import type { NuxtI18nOptions } from './types'
+import type { LocaleObject, NuxtI18nOptions } from './types'
+import type { Locale } from 'vue-i18n'
 
 export * from './types'
 
@@ -362,8 +363,11 @@ export default defineNuxtModule<NuxtI18nOptions>({
   }
 })
 
+// Prevent type errors while configuring locale codes, as generated types will conflict with changes
+type UserNuxtI18nOptions = Omit<NuxtI18nOptions, 'locales'> & { locales?: string[] | LocaleObject<string>[] }
+
 // Used by nuxt/module-builder for `types.d.ts` generation
-export interface ModuleOptions extends NuxtI18nOptions {}
+export interface ModuleOptions extends UserNuxtI18nOptions {}
 
 export interface ModulePublicRuntimeConfig {
   i18n: {
@@ -454,13 +458,13 @@ export interface ModuleRuntimeHooks {
   // NOTE: To make type inference work the function signature returns `HookResult`
   // Should return `string | void`
   'i18n:beforeLocaleSwitch': <Context = unknown>(params: {
-    oldLocale: string
-    newLocale: string
+    oldLocale: Locale
+    newLocale: Locale
     initialSetup: boolean
     context: Context
   }) => HookResult
 
-  'i18n:localeSwitched': (params: { oldLocale: string; newLocale: string }) => HookResult
+  'i18n:localeSwitched': (params: { oldLocale: Locale; newLocale: Locale }) => HookResult
 }
 
 // Used by module for type inference in source code
@@ -470,10 +474,10 @@ declare module '#app' {
 
 declare module '@nuxt/schema' {
   interface NuxtConfig {
-    ['i18n']?: Partial<ModuleOptions>
+    ['i18n']?: Partial<UserNuxtI18nOptions>
   }
   interface NuxtOptions {
-    ['i18n']?: ModuleOptions
+    ['i18n']?: UserNuxtI18nOptions
   }
   interface NuxtHooks extends ModuleHooks {}
   interface PublicRuntimeConfig extends ModulePublicRuntimeConfig {}

--- a/src/runtime/compatibility.ts
+++ b/src/runtime/compatibility.ts
@@ -70,11 +70,11 @@ export function getLocale(i18n: I18n): Locale {
   return getI18nProperty(i18n, 'locale')
 }
 
-export function getLocales(i18n: I18n): string[] | LocaleObject[] {
+export function getLocales(i18n: I18n): Locale[] | LocaleObject[] {
   return getI18nProperty(i18n, 'locales')
 }
 
-export function getLocaleCodes(i18n: I18n): string[] {
+export function getLocaleCodes(i18n: I18n): Locale[] {
   return getI18nProperty(i18n, 'localeCodes')
 }
 
@@ -93,15 +93,15 @@ export function mergeLocaleMessage(i18n: I18n, locale: Locale, messages: Record<
 
 export async function onBeforeLanguageSwitch(
   i18n: I18n,
-  oldLocale: string,
-  newLocale: string,
+  oldLocale: Locale,
+  newLocale: Locale,
   initial: boolean,
   context: NuxtApp
 ) {
   return getI18nTarget(i18n).onBeforeLanguageSwitch(oldLocale, newLocale, initial, context)
 }
 
-export function onLanguageSwitched(i18n: I18n, oldLocale: string, newLocale: string) {
+export function onLanguageSwitched(i18n: I18n, oldLocale: Locale, newLocale: Locale) {
   return getI18nTarget(i18n).onLanguageSwitched(oldLocale, newLocale)
 }
 

--- a/src/runtime/components/NuxtLinkLocale.ts
+++ b/src/runtime/components/NuxtLinkLocale.ts
@@ -1,4 +1,4 @@
-import { useLocalePath } from '#i18n'
+import { useLocalePath, type Locale } from '#i18n'
 import { defineComponent, computed, h } from 'vue'
 import { defineNuxtLink } from '#imports'
 import { hasProtocol } from 'ufo'
@@ -8,13 +8,13 @@ import type { NuxtLinkProps } from 'nuxt/app'
 
 const NuxtLinkLocale = defineNuxtLink({ componentName: 'NuxtLinkLocale' })
 
-export default defineComponent<NuxtLinkProps & { locale?: string }>({
+export default defineComponent<NuxtLinkProps & { locale?: Locale }>({
   name: 'NuxtLinkLocale',
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
   props: {
     ...NuxtLinkLocale.props,
     locale: {
-      type: String as PropType<string>,
+      type: String as PropType<Locale>,
       default: undefined,
       required: false
     }

--- a/src/runtime/components/SwitchLocalePathLink.ts
+++ b/src/runtime/components/SwitchLocalePathLink.ts
@@ -1,5 +1,5 @@
 import { SWITCH_LOCALE_PATH_LINK_IDENTIFIER } from '#build/i18n.options.mjs'
-import { useSwitchLocalePath } from '#i18n'
+import { useSwitchLocalePath, type Locale } from '#i18n'
 import { defineNuxtLink } from '#imports'
 import { Comment, defineComponent, h } from 'vue'
 
@@ -11,7 +11,7 @@ export default defineComponent({
   name: 'SwitchLocalePathLink',
   props: {
     locale: {
-      type: String as PropType<string>,
+      type: String as PropType<Locale>,
       required: true
     }
   },

--- a/src/runtime/composables/index.ts
+++ b/src/runtime/composables/index.ts
@@ -38,7 +38,7 @@ export * from './shared'
  *
  * @public
  */
-export type SetI18nParamsFunction = (params: Record<string, unknown>) => void
+export type SetI18nParamsFunction = (params: Partial<Record<Locale, unknown>>) => void
 export function useSetI18nParams(seoAttributes?: SeoAttributesOptions): SetI18nParamsFunction {
   const common = initCommonComposableOptions()
   const head = getActiveHead()
@@ -102,7 +102,7 @@ export function useSetI18nParams(seoAttributes?: SeoAttributesOptions): SetI18nP
     head?.push(metaObject)
   }
 
-  return function (params: Record<string, unknown>) {
+  return function (params: Partial<Record<Locale, unknown>>) {
     i18nParams.value = { ...params }
     setMeta()
   }
@@ -416,11 +416,11 @@ export interface I18nRoute {
    *
    * @description You can specify static and dynamic paths for vue-router.
    */
-  paths?: Record<Locale, string>
+  paths?: Partial<Record<Locale, string>>
   /**
    * Some locales to which the page component should be localized.
    */
-  locales?: string[]
+  locales?: Locale[]
 }
 
 /**

--- a/src/runtime/messages.ts
+++ b/src/runtime/messages.ts
@@ -33,7 +33,7 @@ export async function loadVueI18nOptions(
 }
 
 export function makeFallbackLocaleCodes(fallback: FallbackLocale, locales: Locale[]): Locale[] {
-  let fallbackLocales: string[] = []
+  let fallbackLocales: Locale[] = []
   if (isArray(fallback)) {
     fallbackLocales = fallback
   } else if (isObject(fallback)) {

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -214,7 +214,12 @@ export default defineNuxtPlugin({
         composer.setLocaleCookie = (locale: string) => setLocaleCookie(localeCookie, locale, _detectBrowserLanguage)
 
         composer.onBeforeLanguageSwitch = (oldLocale, newLocale, initialSetup, context) =>
-          nuxt.callHook('i18n:beforeLocaleSwitch', { oldLocale, newLocale, initialSetup, context }) as Promise<void>
+          nuxt.callHook('i18n:beforeLocaleSwitch', {
+            oldLocale,
+            newLocale,
+            initialSetup,
+            context
+          }) as Promise<Locale | void>
         composer.onLanguageSwitched = (oldLocale, newLocale) =>
           nuxt.callHook('i18n:localeSwitched', { oldLocale, newLocale }) as Promise<void>
 

--- a/src/runtime/routing/utils.ts
+++ b/src/runtime/routing/utils.ts
@@ -5,7 +5,7 @@ import type { Locale } from 'vue-i18n'
 
 export const inBrowser = typeof window !== 'undefined'
 
-export function getNormalizedLocales(locales: string[] | LocaleObject[]): LocaleObject[] {
+export function getNormalizedLocales(locales: Locale[] | LocaleObject[]): LocaleObject[] {
   locales = locales || []
   const normalized: LocaleObject[] = []
   for (const locale of locales) {

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -17,11 +17,11 @@ import type { Locale } from 'vue-i18n'
  * @returns The new locale to switch, or `undefined` to keep the new locale.
  */
 type BeforeLanguageSwitchHandler = (
-  oldLocale: string,
-  newLocale: string,
+  oldLocale: Locale,
+  newLocale: Locale,
   initialSetup: boolean,
   context: NuxtApp
-) => Promise<string | void>
+) => Promise<Locale | void>
 
 /**
  * Called after the app's locale is switched.
@@ -29,10 +29,10 @@ type BeforeLanguageSwitchHandler = (
  * @param oldLocale - The app's locale before the switch
  * @param newLocale - The app's locale after the switch.
  */
-type LanguageSwitchedHandler = (oldLocale: string, newLocale: string) => Promise<void>
+type LanguageSwitchedHandler = (oldLocale: Locale, newLocale: Locale) => Promise<void>
 
 export interface ComposerCustomProperties<
-  ConfiguredLocaleType extends string[] | LocaleObject[] = string[] | LocaleObject[]
+  ConfiguredLocaleType extends Locale[] | LocaleObject[] = Locale[] | LocaleObject[]
 > {
   /**
    * List of locales
@@ -44,7 +44,7 @@ export interface ComposerCustomProperties<
   /**
    * List of locale codes
    */
-  localeCodes: ComputedRef<string[]>
+  localeCodes: ComputedRef<Locale[]>
   /**
    * Base URL that is used in generating canonical links
    */
@@ -79,13 +79,13 @@ export interface ComposerCustomProperties<
    *
    * @param locale - A {@link Locale}
    */
-  setLocale: (locale: string) => Promise<void>
+  setLocale: (locale: Locale) => Promise<void>
   /**
    * Loads locale messages of the specified locale code.
    *
    * @param locale - A {@link Locale}
    */
-  loadLocaleMessages: (locale: string) => Promise<void>
+  loadLocaleMessages: (locale: Locale) => Promise<void>
   /**
    * Returns browser locale code filtered against the ones defined in options.
    *
@@ -106,7 +106,7 @@ export interface ComposerCustomProperties<
    *
    * @param locale - A {@link Locale}
    */
-  setLocaleCookie: (locale: string) => void
+  setLocaleCookie: (locale: Locale) => void
   /**
    * Called before the app's locale is switched.
    *
@@ -139,7 +139,7 @@ export interface ComposerCustomProperties<
 }
 
 export interface NuxtI18nRoutingCustomProperties<
-  ConfiguredLocaleType extends string[] | LocaleObject[] = string[] | LocaleObject[]
+  ConfiguredLocaleType extends Locale[] | LocaleObject[] = Locale[] | LocaleObject[]
 > {
   /**
    * List of locales
@@ -151,7 +151,7 @@ export interface NuxtI18nRoutingCustomProperties<
   /**
    * List of locale codes
    */
-  readonly localeCodes: string[]
+  readonly localeCodes: Locale[]
   /**
    * Base URL that is used in generating canonical links
    */
@@ -186,7 +186,7 @@ export interface NuxtI18nRoutingCustomProperties<
    *
    * @param locale - A {@link Locale}
    */
-  setLocale: (locale: string) => Promise<void>
+  setLocale: (locale: Locale) => Promise<void>
   /**
    * Returns browser locale code filtered against the ones defined in options.
    *
@@ -207,7 +207,7 @@ export interface NuxtI18nRoutingCustomProperties<
    *
    * @param locale - A {@link Locale}
    */
-  setLocaleCookie: (locale: string) => void
+  setLocaleCookie: (locale: Locale) => void
   /**
    * Called before the app's locale is switched.
    *

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -74,7 +74,7 @@ export function initCommonComposableOptions(i18n?: I18n): CommonComposableOption
 }
 
 export async function loadAndSetLocale(
-  newLocale: string,
+  newLocale: Locale,
   i18n: I18n,
   runtimeI18n: ModulePublicRuntimeConfig['i18n'],
   initial: boolean = false

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,7 +153,7 @@ export type NuxtI18nOptions<
    *
    * @defaultValue '' (empty string)
    */
-  defaultLocale?: string
+  defaultLocale?: Locale
   /**
    * List of locales supported by your app
    *
@@ -241,8 +241,8 @@ export type Directions = 'ltr' | 'rtl' | 'auto'
  * @public
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface LocaleObject extends Record<string, any> {
-  code: Locale
+export interface LocaleObject<T = Locale> extends Record<string, any> {
+  code: T
   name?: string
   dir?: Directions
   domain?: string
@@ -267,8 +267,8 @@ export type BaseUrlResolveHandler<Context = any> = (context: Context) => string
  * @public
  */
 export interface ComputedRouteOptions {
-  locales: readonly string[]
-  paths: Record<string, string>
+  locales: readonly Locale[]
+  paths: Record<Locale, string>
 }
 
 /**
@@ -276,7 +276,7 @@ export interface ComputedRouteOptions {
  *
  * @public
  */
-export type RouteOptionsResolver = (route: NuxtPage, localeCodes: string[]) => ComputedRouteOptions | undefined
+export type RouteOptionsResolver = (route: NuxtPage, localeCodes: Locale[]) => ComputedRouteOptions | undefined
 
 /**
  * Localize route path prefix judgment options used in {@link LocalizeRoutesPrefixable}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* #2857 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This changes type generation to narrow the `Locale` type to the configured `locales`, this way functions that accept a `locale` parameter (such as our composables) will have proper autocompletion for all configured locales.

@kazupon 
There's still an issue/quirk with the type, I'm don't know how to narrow the `locale` property on the `Composer` type in the same way, so currently the following would cause a type error:

```typescript
const { locale } = useI18n()
const switchLocalePath = useSwitchLocalePath()

switchLocalePath(locale.value) // Argument of type 'string' is not assignable to parameter of type 'Locale'.
```

Maybe you know how to resolve this? I don't think this should be merged while this issue is present 😅

Also working on this https://github.com/BobbieGoede/i18n/pull/49.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
