### PR TITLE
fix: generated module augmentation should use `@intlify/core-base`

### DIFF
--- a/src/gen.ts
+++ b/src/gen.ts
@@ -199,7 +199,7 @@ declare module 'vue-i18n' {
   interface VueI18n extends NuxtI18nRoutingCustomProperties<${resolvedLocaleType}> {}
 }
 
-declare module '@intlify/core' {
+declare module '@intlify/core-base' {
   // generated based on configured locales
   interface GeneratedTypeConfig { 
     locale: ${localeCodeStrings.map(x => JSON.stringify(x)).join(' | ')}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
After some more testing it seems necessary to augment `@intlify/core-base`, as the types will not be inferred when using `@intlify/core`. I suppose this makes as this is where the other packages import from? 🤔 I will open a PR to correct the JSDoc/comment in `vue-i18n` as well (https://github.com/intlify/vue-i18n/pull/1898).

This behavior differs from the types in the playground within this repository, in which case augmenting `@intlify/core` works as well, I'm not entirely sure why that is.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
