### PR TITLE
fix: encode `switchLocalePath` during SSR replacement

### DIFF
--- a/specs/experimental/switch_locale_path_link_ssr.spec.ts
+++ b/specs/experimental/switch_locale_path_link_ssr.spec.ts
@@ -55,4 +55,14 @@ describe('experimental.switchLocalePathLinkSSR', async () => {
     expect(product2dom.querySelector('#i18n-alt-en').href).toEqual('/products/red-mug')
     expect(product2dom.querySelector('#switch-locale-path-link-en').href).toEqual('/products/red-mug')
   })
+
+  test('encode localized path to prevent XSS', async () => {
+    const url = `/experimental//"><script>console.log('xss')</script><`
+
+    const html = await $fetch(url)
+    const dom = getDom(html)
+
+    // the localized should be the same as encoded
+    expect(dom.querySelector('#slp-xss a').href).toEqual(encodeURI('/nl' + url))
+  })
 })

--- a/specs/fixtures/basic_usage/pages/experimental/[...slug].vue
+++ b/specs/fixtures/basic_usage/pages/experimental/[...slug].vue
@@ -1,0 +1,8 @@
+<script setup lang="ts"></script>
+
+<template>
+  <h1>No XSS</h1>
+  <section id="slp-xss">
+    <SwitchLocalePathLink locale="nl">Switch to NL</SwitchLocalePathLink>
+  </section>
+</template>

--- a/src/runtime/components/SwitchLocalePathLink.ts
+++ b/src/runtime/components/SwitchLocalePathLink.ts
@@ -21,7 +21,7 @@ export default defineComponent({
 
     return () => [
       h(Comment, `${SWITCH_LOCALE_PATH_LINK_IDENTIFIER}-[${props.locale}]`),
-      h(NuxtLink, { ...attrs, to: switchLocalePath(props.locale) }, slots.default),
+      h(NuxtLink, { ...attrs, to: encodeURI(switchLocalePath(props.locale)) }, slots.default),
       h(Comment, `/${SWITCH_LOCALE_PATH_LINK_IDENTIFIER}`)
     ]
   }

--- a/src/runtime/plugins/switch-locale-path-ssr.ts
+++ b/src/runtime/plugins/switch-locale-path-ssr.ts
@@ -25,7 +25,8 @@ export default defineNuxtPlugin({
 
       ctx.renderResult.html = ctx.renderResult.html.replaceAll(
         switchLocalePathLinkWrapperExpr,
-        (match: string, p1: string) => match.replace(/href="([^"]+)"/, `href="${switchLocalePath(p1 ?? '')}"`)
+        (match: string, p1: string) =>
+          match.replace(/href="([^"]+)"/, `href="${encodeURI(switchLocalePath(p1 ?? ''))}"`)
       )
     })
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* https://github.com/nuxt-modules/i18n/issues/3042
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This should resolve #3042, but if I'm overlooking something please let me know.

@kazupon 
I created a [`v8` branch](https://github.com/nuxt-modules/i18n/tree/v8) which diverts from `main` at 7930a2773311bef05bd98a3a98540ce17b6a7d6b, I have also cherry picked some changes from the main branch where possible.

If this PR gets merged it will need to be added to the `v8` branch as well, will the normal release flow work from that branch? 🤔

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
