### PR TITLE
fix: `strategy: 'no_prefix'` when using `differentDomains`

### DIFF
--- a/docs/content/docs/2.guide/1.index.md
+++ b/docs/content/docs/2.guide/1.index.md
@@ -58,7 +58,7 @@ There are 4 supported strategies that affect how app's routes are generated:
 With this strategy, your routes won't have a locale prefix added. The locale will be detected & changed without changing the URL. This implies that you have to rely on browser & cookie detection, and implement locale switches by calling the i18n API.
 
 ::callout{icon="i-heroicons-light-bulb"}
-This strategy doesn't support [Custom paths](/docs/guide/custom-paths) and [Ignore routes](/docs/guide/ignoring-localized-routes) features.
+This strategy doesn't support [Custom paths](/docs/guide/custom-paths) and [Ignore routes](/docs/guide/ignoring-localized-routes) features unless you're also using [`differentDomains`](/docs/guide/different-domains).
 ::
 
 ### `prefix_except_default`

--- a/docs/content/docs/2.guide/3.custom-paths.md
+++ b/docs/content/docs/2.guide/3.custom-paths.md
@@ -8,7 +8,7 @@ In some cases, you might want to translate URLs in addition to having them prefi
 Which method is used is configured by setting the [`customRoutes` options](/docs/options/routing#customroutes) this is set to `'page'` by default. Using both methods at the same time is not possible.
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
-Custom paths are not supported when using the `no-prefix` [strategy](/docs/guide).
+Custom paths are not supported when using the `no_prefix` [strategy](/docs/guide) unless combined with [`differentDomains`](/docs/guide/different-domains).
 ::
 
 ### Module configuration

--- a/docs/content/docs/2.guide/4.ignoring-localized-routes.md
+++ b/docs/content/docs/2.guide/4.ignoring-localized-routes.md
@@ -4,7 +4,7 @@ description: Customize localized route exclusions per page component.
 ---
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
-This feature is not supported with the `no-prefix` [strategy](/docs/guide).
+This feature is not supported when using the `no_prefix` [strategy](/docs/guide) unless you're also using [`differentDomains`](/docs/guide/different-domains).
 ::
 
 If you'd like some pages to be available in some languages only, you can configure the list of supported languages to override the global settings. The options can be specified within either the page components themselves or globally, within the module configuration.

--- a/docs/content/docs/3.options/5.domain.md
+++ b/docs/content/docs/3.options/5.domain.md
@@ -8,4 +8,4 @@ description: Browser locale management options.
 - type: `boolean`
 - default: `false`
 
-Set this to `true` when using different domains for each locale. If enabled, no prefix is added to your routes and you MUST configure locales as an array of objects, each containing a `domain` key. Refer to the [Different domains](/docs/guide/different-domains) for more information.
+Set this to `true` when using different domains for each locale, with this enabled you MUST configure locales as an array of objects, each containing a `domain` key. Refer to the [Different domains](/docs/guide/different-domains) for more information.

--- a/docs/content/docs/5.v9/2.guide/1.index.md
+++ b/docs/content/docs/5.v9/2.guide/1.index.md
@@ -58,7 +58,7 @@ There are 4 supported strategies that affect how app's routes are generated:
 With this strategy, your routes won't have a locale prefix added. The locale will be detected & changed without changing the URL. This implies that you have to rely on browser & cookie detection, and implement locale switches by calling the i18n API.
 
 ::callout{icon="i-heroicons-light-bulb"}
-This strategy doesn't support [Custom paths](/docs/guide/custom-paths) and [Ignore routes](/docs/guide/ignoring-localized-routes) features.
+This strategy doesn't support [Custom paths](/docs/guide/custom-paths) and [Ignore routes](/docs/guide/ignoring-localized-routes) features unless you're also using [`differentDomains`](/docs/guide/different-domains).
 ::
 
 ### `prefix_except_default`

--- a/docs/content/docs/5.v9/2.guide/3.custom-paths.md
+++ b/docs/content/docs/5.v9/2.guide/3.custom-paths.md
@@ -8,7 +8,7 @@ In some cases, you might want to translate URLs in addition to having them prefi
 Which method is used is configured by setting the [`customRoutes` options](/docs/options/routing#customroutes) this is set to `'page'` by default. Using both methods at the same time is not possible.
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
-Custom paths are not supported when using the `no-prefix` [strategy](/docs/guide).
+Custom paths are not supported when using the `no_prefix` [strategy](/docs/guide) unless combined with [`differentDomains`](/docs/guide/different-domains).
 ::
 
 ### Module configuration

--- a/docs/content/docs/5.v9/2.guide/4.ignoring-localized-routes.md
+++ b/docs/content/docs/5.v9/2.guide/4.ignoring-localized-routes.md
@@ -4,7 +4,7 @@ description: Customize localized route exclusions per page component.
 ---
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
-This feature is not supported with the `no-prefix` [strategy](/docs/guide).
+This feature is not supported when using the `no_prefix` [strategy](/docs/guide) unless you're also using [`differentDomains`](/docs/guide/different-domains).
 ::
 
 If you'd like some pages to be available in some languages only, you can configure the list of supported languages to override the global settings. The options can be specified within either the page components themselves or globally, within the module configuration.

--- a/docs/content/docs/5.v9/3.options/5.domain.md
+++ b/docs/content/docs/5.v9/3.options/5.domain.md
@@ -8,4 +8,4 @@ description: Browser locale management options.
 - type: `boolean`
 - default: `false`
 
-Set this to `true` when using different domains for each locale. If enabled, no prefix is added to your routes and you MUST configure locales as an array of objects, each containing a `domain` key. Refer to the [Different domains](/docs/guide/different-domains) for more information.
+Set this to `true` when using different domains for each locale, with this enabled you MUST configure locales as an array of objects, each containing a `domain` key. Refer to the [Different domains](/docs/guide/different-domains) for more information.

--- a/docs/content/docs/6.v7/7.custom-paths.md
+++ b/docs/content/docs/6.v7/7.custom-paths.md
@@ -6,7 +6,7 @@ description: nuxt/i18n v7 custom route paths.
 In some cases, you might want to translate URLs in addition to having them prefixed with the locale code. There are 2 ways of configuring custom paths for your pages: [in-component options](#in-component-options) or via the [module's configuration](#modules-configuration).
 
 ::callout{icon="i-heroicons-light-bulb"}
-Custom paths are not supported when using the `no-prefix` [strategy](./strategies).
+Custom paths are not supported when using the `no_prefix` [strategy](./strategies).
 ::
 
 ### In-component options

--- a/docs/content/docs/6.v7/8.ignoring-localized-routes.md
+++ b/docs/content/docs/6.v7/8.ignoring-localized-routes.md
@@ -3,7 +3,7 @@ title: Ignoring Localized Routes
 ---
 
 ::callout{icon="i-heroicons-light-bulb"}
-This feature is not supported with the `no-prefix` [strategy](./strategies).
+This feature is not supported with the `no_prefix` [strategy](./strategies).
 ::
 
 If you'd like some pages to be available in some languages only, you can configure the list of supported languages to override the global settings. The options can be specified within either the page components themselves or globally, within then module options.

--- a/specs/different_domains/different_domains.spec.ts
+++ b/specs/different_domains/different_domains.spec.ts
@@ -45,6 +45,15 @@ await setup({
       strategy: 'no_prefix',
       detectBrowserLanguage: {
         useCookie: true
+      },
+      customRoutes: 'config',
+      pages: {
+        'localized-route': {
+          en: '/localized-in-english',
+          fr: '/localized-in-french',
+          ja: '/localized-in-japanese',
+          nl: '/localized-in-dutch'
+        }
       }
     }
   }
@@ -151,4 +160,28 @@ test('(#2374) detect with x-forwarded-host on server', async () => {
   const dom = getDom(html)
 
   expect(dom.querySelector('#welcome-text').textContent).toEqual('Bienvenue')
+})
+
+test("supports custom routes with `strategy: 'no_prefix'`", async () => {
+  const res = await undiciRequest('/localized-in-french', {
+    headers: {
+      host: 'fr.nuxt-app.localhost'
+    }
+  })
+  const resBody = await res.body.text()
+  const dom = getDom(resBody)
+
+  // `en` link uses project domain configuration, overrides layer
+  expect(dom.querySelector('#switch-locale-path-usages .switch-to-en a').getAttribute('href')).toEqual(
+    `http://en.nuxt-app.localhost/localized-in-english`
+  )
+
+  // `nl` link uses layer domain configuration
+  expect(dom.querySelector('#switch-locale-path-usages .switch-to-nl a').getAttribute('href')).toEqual(
+    `http://layer-nl.example.com/localized-in-dutch`
+  )
+  // `ja` link uses layer domain configuration
+  expect(dom.querySelector('#switch-locale-path-usages .switch-to-ja a').getAttribute('href')).toEqual(
+    `http://layer-ja.example.com/localized-in-japanese`
+  )
 })

--- a/specs/fixtures/different_domains/pages/localized-route.vue
+++ b/specs/fixtures/different_domains/pages/localized-route.vue
@@ -1,0 +1,11 @@
+<script setup>
+import BasicUsage from '../components/BasicUsage.vue'
+import LangSwitcher from '../components/LangSwitcher.vue'
+</script>
+
+<template>
+  <div>
+    <BasicUsage />
+    <LangSwitcher />
+  </div>
+</template>

--- a/src/module.ts
+++ b/src/module.ts
@@ -37,7 +37,6 @@ import {
   filterLocales
 } from './utils'
 import { distDir, runtimeDir } from './dirs'
-import { shouldLocalizeRoutes } from './routing'
 import { applyLayerOptions, checkLayerOptions, resolveLayerVueI18nConfigInfo } from './layers'
 import { generateTemplateNuxtI18nOptions } from './template'
 
@@ -180,7 +179,7 @@ export default defineNuxtModule<NuxtI18nOptions>({
      * setup nuxt/pages
      */
 
-    if (localeCodes.length && shouldLocalizeRoutes(options)) {
+    if (localeCodes.length) {
       setupPages(options, nuxt)
     }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -37,6 +37,7 @@ import {
   filterLocales
 } from './utils'
 import { distDir, runtimeDir } from './dirs'
+import { shouldLocalizeRoutes } from './routing'
 import { applyLayerOptions, checkLayerOptions, resolveLayerVueI18nConfigInfo } from './layers'
 import { generateTemplateNuxtI18nOptions } from './template'
 
@@ -179,7 +180,7 @@ export default defineNuxtModule<NuxtI18nOptions>({
      * setup nuxt/pages
      */
 
-    if (options.strategy !== 'no_prefix' && localeCodes.length) {
+    if (localeCodes.length && shouldLocalizeRoutes(options)) {
       setupPages(options, nuxt)
     }
 

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -70,8 +70,12 @@ export function setupPages(options: Required<NuxtI18nOptions>, nuxt: Nuxt) {
       localizedPages.unshift(indexPage)
     }
 
-    pages.splice(0, pages.length)
-    pages.unshift(...localizedPages)
+    // do not mutate pages if localization is skipped
+    if (pages !== localizedPages) {
+      pages.splice(0, pages.length)
+      pages.unshift(...localizedPages)
+    }
+
     debug('... made pages', pages)
   })
 }

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -108,6 +108,8 @@ type LocalizeRouteParams = {
  * @public
  */
 export function localizeRoutes(routes: NuxtPage[], options: LocalizeRoutesParams): NuxtPage[] {
+  if (!shouldLocalizeRoutes(options)) return routes
+
   let defaultLocales = [options.defaultLocale ?? '']
   if (options.differentDomains) {
     const domainDefaults = options.locales

--- a/src/runtime/routing/compatibles/routing.ts
+++ b/src/runtime/routing/compatibles/routing.ts
@@ -132,8 +132,7 @@ export function localeLocation(
 export function resolveRoute(common: CommonComposableOptions, route: RouteLocationRaw, locale: Locale | undefined) {
   const { router, i18n } = common
   const _locale = locale || getLocale(i18n)
-  const { routesNameSeparator, defaultLocale, defaultLocaleRouteNameSuffix, strategy, trailingSlash } =
-    common.runtimeConfig.public.i18n
+  const { defaultLocale, strategy, trailingSlash } = common.runtimeConfig.public.i18n
   const prefixable = extendPrefixable(common.runtimeConfig)
   // if route parameter is a string, check if it's a path or name of route.
   let _route: RouteLocationPathRaw | RouteLocationNamedRaw
@@ -163,12 +162,7 @@ export function resolveRoute(common: CommonComposableOptions, route: RouteLocati
     const resolvedRouteName = getRouteBaseName(common, resolvedRoute)
     if (isString(resolvedRouteName)) {
       localizedRoute = {
-        name: getLocaleRouteName(resolvedRouteName, _locale, {
-          defaultLocale,
-          strategy,
-          routesNameSeparator,
-          defaultLocaleRouteNameSuffix
-        }),
+        name: getLocaleRouteName(resolvedRouteName, _locale, common.runtimeConfig.public.i18n),
         // @ts-ignore
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- FIXME
         params: resolvedRoute.params,
@@ -194,12 +188,7 @@ export function resolveRoute(common: CommonComposableOptions, route: RouteLocati
       localizedRoute.name = getRouteBaseName(common, router.currentRoute.value)
     }
 
-    localizedRoute.name = getLocaleRouteName(localizedRoute.name, _locale, {
-      defaultLocale,
-      strategy,
-      routesNameSeparator,
-      defaultLocaleRouteNameSuffix
-    })
+    localizedRoute.name = getLocaleRouteName(localizedRoute.name, _locale, common.runtimeConfig.public.i18n)
   }
 
   try {

--- a/src/runtime/routing/utils.ts
+++ b/src/runtime/routing/utils.ts
@@ -39,10 +39,18 @@ export function getLocaleRouteName(
     defaultLocale,
     strategy,
     routesNameSeparator,
-    defaultLocaleRouteNameSuffix
-  }: { defaultLocale: string; strategy: Strategies; routesNameSeparator: string; defaultLocaleRouteNameSuffix: string }
+    defaultLocaleRouteNameSuffix,
+    differentDomains
+  }: {
+    defaultLocale: string
+    strategy: Strategies
+    routesNameSeparator: string
+    defaultLocaleRouteNameSuffix: string
+    differentDomains: boolean
+  }
 ) {
-  let name = getRouteName(routeName) + (strategy === 'no_prefix' ? '' : routesNameSeparator + locale)
+  const localizedRoutes = strategy !== 'no_prefix' || differentDomains
+  let name = getRouteName(routeName) + (localizedRoutes ? routesNameSeparator + locale : '')
   if (locale === defaultLocale && strategy === 'prefix_and_default') {
     name += routesNameSeparator + defaultLocaleRouteNameSuffix
   }

--- a/test/routing-utils.test.ts
+++ b/test/routing-utils.test.ts
@@ -53,7 +53,8 @@ describe('getLocaleRouteName', () => {
           defaultLocale: 'en',
           strategy: 'prefix_and_default',
           routesNameSeparator: '___',
-          defaultLocaleRouteNameSuffix: 'default'
+          defaultLocaleRouteNameSuffix: 'default',
+          differentDomains: false
         }),
         'route1___en___default'
       )
@@ -67,7 +68,8 @@ describe('getLocaleRouteName', () => {
           defaultLocale: 'en',
           strategy: 'prefix_except_default',
           routesNameSeparator: '___',
-          defaultLocaleRouteNameSuffix: 'default'
+          defaultLocaleRouteNameSuffix: 'default',
+          differentDomains: false
         }),
         'route1___en'
       )
@@ -81,7 +83,8 @@ describe('getLocaleRouteName', () => {
           defaultLocale: 'en',
           strategy: 'no_prefix',
           routesNameSeparator: '___',
-          defaultLocaleRouteNameSuffix: 'default'
+          defaultLocaleRouteNameSuffix: 'default',
+          differentDomains: false
         }),
         'route1'
       )
@@ -96,7 +99,8 @@ describe('getLocaleRouteName', () => {
             defaultLocale: 'en',
             strategy: 'prefix_and_default',
             routesNameSeparator: '___',
-            defaultLocaleRouteNameSuffix: 'default'
+            defaultLocaleRouteNameSuffix: 'default',
+            differentDomains: false
           }),
           '(null)___en___default'
         )


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* #3058
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This should resolve #3058

I went through the docs and changed the notice on the `no_prefix` where applicable. Someday I'll try and restructure the docs to better describe the route localization rules as the special cases/notices are a bit scattered through the pages now 🤔

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
