### PR TITLE
test: fix test failures due to `$route` not being stringified

### DIFF
--- a/specs/basic_usage.spec.ts
+++ b/specs/basic_usage.spec.ts
@@ -95,11 +95,11 @@ describe('basic usage', async () => {
     expect(await getText(page, '#locale-path')).toEqual('/nl/nuxt-context-extension')
 
     const localeRoute = JSON.parse(await getText(page, '#locale-route')) as RouteLocation
-    // remove absolute file path which differs where test is run
+    // remove properties that vary based on test environment and vue-router version
+    // we only need to know if the correct route (object) is returned
     localeRoute.matched = localeRoute.matched.map(x => {
       for (const component in x.components) {
-        // @ts-ignore
-        delete x.components[component].__file
+        x.components[component] = {}
       }
       // @ts-ignore
       delete x.mods
@@ -115,9 +115,7 @@ describe('basic usage', async () => {
           {
             "children": [],
             "components": {
-              "default": {
-                "__name": "nuxt-context-extension",
-              },
+              "default": {},
             },
             "enterCallbacks": {},
             "instances": {},

--- a/specs/basic_usage.spec.ts
+++ b/specs/basic_usage.spec.ts
@@ -101,6 +101,8 @@ describe('basic usage', async () => {
         // @ts-ignore
         delete x.components[component].__file
       }
+      // @ts-ignore
+      delete x.mods
       return x
     })
     expect(localeRoute).toMatchInlineSnapshot(
@@ -113,22 +115,20 @@ describe('basic usage', async () => {
           {
             "children": [],
             "components": {
-              "default": {},
+              "default": {
+                "__name": "nuxt-context-extension",
+              },
             },
             "enterCallbacks": {},
             "instances": {},
-            "leaveGuards": {
-              "Set(0)": [],
-            },
+            "leaveGuards": {},
             "meta": {},
             "name": "nuxt-context-extension___en",
             "path": "/nuxt-context-extension",
             "props": {
               "default": false,
             },
-            "updateGuards": {
-              "Set(0)": [],
-            },
+            "updateGuards": {},
           },
         ],
         "meta": {},

--- a/specs/fixtures/basic_usage/pages/nuxt-context-extension.vue
+++ b/specs/fixtures/basic_usage/pages/nuxt-context-extension.vue
@@ -1,9 +1,11 @@
+<script setup></script>
+
 <template>
   <div>
     <p id="get-route-base-name">{{ $nuxt.$getRouteBaseName($route) }}</p>
     <p id="switch-locale-path">{{ $nuxt.$switchLocalePath('ja') }}</p>
     <p id="locale-path">{{ $nuxt.$localePath('nuxt-context-extension', 'nl') }}</p>
-    <p id="locale-route">{{ $nuxt.$localeRoute($route) }}</p>
+    <p id="locale-route">{{ JSON.stringify($nuxt.$localeRoute()) }}</p>
     <p id="locale-head">{{ $nuxt.$localeHead({}) }}</p>
   </div>
 </template>

--- a/specs/fixtures/routing/pages/index.vue
+++ b/specs/fixtures/routing/pages/index.vue
@@ -53,32 +53,32 @@ const localeRoute = useLocaleRoute()
     </section>
     <ClientOnly>
       <section id="locale-route">
-        <span class="index">{{ localeRoute('/') }}</span>
-        <span class="index-name-ja">{{ localeRoute('index', 'ja') }}</span>
-        <span class="about-name">{{ localeRoute('about') }}</span>
-        <span class="about-ja">{{ localeRoute('/about', 'ja') }}</span>
-        <span class="about-name-ja">{{ localeRoute('about', 'ja') }}</span>
-        <span class="about-object-ja">{{ localeRoute({ name: 'about' }, 'ja') }}</span>
-        <span class="path-match-ja">{{ localeRoute('/:pathMatch(.*)*', 'ja') }}</span>
-        <span class="path-match-name">{{ localeRoute('pathMatch') }}</span>
-        <span class="path-match-name-ja">{{ localeRoute('pathMatch', 'ja') }}</span>
-        <span class="undefined-path-ja">{{ localeRoute('/vue-i18n', 'ja') }}</span>
-        <span class="undefined-name-ja">{{ localeRoute('vue-i18n', 'ja') }}</span>
+        <span class="index">{{ JSON.stringify(localeRoute('/')) }}</span>
+        <span class="index-name-ja">{{ JSON.stringify(localeRoute('index', 'ja')) }}</span>
+        <span class="about-name">{{ JSON.stringify(localeRoute('about')) }}</span>
+        <span class="about-ja">{{ JSON.stringify(localeRoute('/about', 'ja')) }}</span>
+        <span class="about-name-ja">{{ JSON.stringify(localeRoute('about', 'ja')) }}</span>
+        <span class="about-object-ja">{{ JSON.stringify(localeRoute({ name: 'about' }, 'ja')) }}</span>
+        <span class="path-match-ja">{{ JSON.stringify(localeRoute('/:pathMatch(.*)*', 'ja')) }}</span>
+        <span class="path-match-name">{{ JSON.stringify(localeRoute('pathMatch')) }}</span>
+        <span class="path-match-name-ja">{{ JSON.stringify(localeRoute('pathMatch', 'ja')) }}</span>
+        <span class="undefined-path-ja">{{ JSON.stringify(localeRoute('/vue-i18n', 'ja')) }}</span>
+        <span class="undefined-name-ja">{{ JSON.stringify(localeRoute('vue-i18n', 'ja')) }}</span>
       </section>
     </ClientOnly>
     <ClientOnly>
       <section id="locale-location">
-        <span class="index">{{ localeLocation('/') }}</span>
-        <span class="index-name-ja">{{ localeLocation('index', 'ja') }}</span>
-        <span class="about-name">{{ localeLocation('about') }}</span>
-        <span class="about-ja">{{ localeLocation('/about', 'ja') }}</span>
-        <span class="about-name-ja">{{ localeLocation('about', 'ja') }}</span>
-        <span class="about-object-ja">{{ localeLocation({ name: 'about' }, 'ja') }}</span>
-        <span class="path-match-ja">{{ localeLocation('/:pathMatch(.*)*', 'ja') }}</span>
-        <span class="path-match-name">{{ localeLocation('pathMatch') }}</span>
-        <span class="path-match-name-ja">{{ localeLocation('pathMatch', 'ja') }}</span>
-        <span class="undefined-path-ja">{{ localeRoute('/vue-i18n', 'ja') }}</span>
-        <span class="undefined-name-ja">{{ localeRoute('vue-i18n', 'ja') }}</span>
+        <span class="index">{{ JSON.stringify(localeLocation('/')) }}</span>
+        <span class="index-name-ja">{{ JSON.stringify(localeLocation('index', 'ja')) }}</span>
+        <span class="about-name">{{ JSON.stringify(localeLocation('about')) }}</span>
+        <span class="about-ja">{{ JSON.stringify(localeLocation('/about', 'ja')) }}</span>
+        <span class="about-name-ja">{{ JSON.stringify(localeLocation('about', 'ja')) }}</span>
+        <span class="about-object-ja">{{ JSON.stringify(localeLocation({ name: 'about' }, 'ja')) }}</span>
+        <span class="path-match-ja">{{ JSON.stringify(localeLocation('/:pathMatch(.*)*', 'ja')) }}</span>
+        <span class="path-match-name">{{ JSON.stringify(localeLocation('pathMatch')) }}</span>
+        <span class="path-match-name-ja">{{ JSON.stringify(localeLocation('pathMatch', 'ja')) }}</span>
+        <span class="undefined-path-ja">{{ JSON.stringify(localeRoute('/vue-i18n', 'ja')) }}</span>
+        <span class="undefined-name-ja">{{ JSON.stringify(localeRoute('vue-i18n', 'ja')) }}</span>
       </section>
     </ClientOnly>
   </div>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This targets the failing tests in Nuxt's ecosystem-ci, changes in Nuxt prevent the stringifying of `$route` and prevents hydration from updating/rendering the stringified route. (https://github.com/nuxt/nuxt/pull/28841)

We should consider changing these tests to check the `localeRoute` results keys instead of comparing the entire object, or figure out how to test its results in unit tests.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
