### PR TITLE
fix: webpack bundler

### DIFF
--- a/internals.d.ts
+++ b/internals.d.ts
@@ -60,7 +60,7 @@ declare module '#internal/i18n/locale.detector.mjs' {
   export const localeDetector: LocaleDetector
 }
 
-declare module 'virtual:nuxt-i18n-logger' {
+declare module '~nuxt-i18n/logger' {
   import type { ConsolaInstance } from 'consola'
 
   export function createLogger(label: string): ConsolaInstance

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -7,6 +7,7 @@ import { TransformMacroPlugin } from './transform/macros'
 import { ResourcePlugin } from './transform/resource'
 import { TransformI18nFunctionPlugin } from './transform/i18n-function-injection'
 import { getLayerLangPaths } from './layers'
+// import { I18nVirtualLoggerPlugin } from './virtual-logger'
 
 import type { Nuxt } from '@nuxt/schema'
 import type { PluginOptions } from '@intlify/unplugin-vue-i18n'
@@ -42,12 +43,13 @@ export async function extendBundler({ options: nuxtOptions }: I18nNuxtContext, n
       compositionOnly: nuxtOptions.bundle.compositionOnly,
       onlyLocales: nuxtOptions.bundle.onlyLocales,
       dropMessageCompiler: nuxtOptions.bundle.dropMessageCompiler,
-      optimizeTranslationDirective: true,
+      optimizeTranslationDirective: false,
       strictMessage: nuxtOptions.compilation.strictMessage,
       escapeHtml: nuxtOptions.compilation.escapeHtml,
       include: localeIncludePaths
     }
 
+    // addWebpackPlugin(I18nVirtualLoggerPlugin.webpack({ debug: nuxt.options.debug }))
     addWebpackPlugin(VueI18nWebpackPlugin(webpackPluginOptions))
     addWebpackPlugin(TransformMacroPlugin.webpack(sourceMapOptions))
     addWebpackPlugin(ResourcePlugin.webpack(sourceMapOptions))
@@ -83,6 +85,7 @@ export async function extendBundler({ options: nuxtOptions }: I18nNuxtContext, n
     include: localeIncludePaths
   }
 
+  // addVitePlugin(I18nVirtualLoggerPlugin.vite({ debug: nuxt.options.debug }))
   addVitePlugin(VueI18nVitePlugin(vitePluginOptions))
   addVitePlugin(TransformMacroPlugin.vite(sourceMapOptions))
   addVitePlugin(ResourcePlugin.vite(sourceMapOptions))

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -20,7 +20,7 @@ import {
 import type { Nuxt } from '@nuxt/schema'
 import type { LocaleInfo } from './types'
 import { resolveI18nDir } from './layers'
-import { i18nVirtualLoggerPlugin } from './virtual-logger'
+import { I18nVirtualLoggerPlugin } from './virtual-logger'
 import type { I18nNuxtContext } from './context'
 
 const debug = createDebug('@nuxtjs/i18n:nitro')
@@ -57,7 +57,7 @@ export async function setupNitro(
         : [nitroConfig.rollupConfig.plugins]
 
       // @ts-ignore NOTE: A type error occurs due to a mismatch between Vite plugins and those of Rollup
-      nitroConfig.rollupConfig.plugins.push(i18nVirtualLoggerPlugin(nuxtOptions.debug))
+      nitroConfig.rollupConfig.plugins.push(I18nVirtualLoggerPlugin.rollup({ debug: nuxtOptions.debug }))
 
       const yamlPaths = getResourcePaths(additionalParams.localeInfo, /\.ya?ml$/)
       if (yamlPaths.length > 0) {

--- a/src/prepare/runtime.ts
+++ b/src/prepare/runtime.ts
@@ -1,8 +1,8 @@
 import type { Nuxt } from '@nuxt/schema'
 import type { I18nNuxtContext } from '../context'
-import { i18nVirtualLoggerPlugin, RESOLVED_VIRTUAL_NUXT_I18N_LOGGER, VIRTUAL_NUXT_I18N_LOGGER } from '../virtual-logger'
+import { I18nVirtualLoggerPlugin, RESOLVED_VIRTUAL_NUXT_I18N_LOGGER, VIRTUAL_NUXT_I18N_LOGGER } from '../virtual-logger'
 import { defu } from 'defu'
-import { addPlugin, addTemplate, addTypeTemplate } from '@nuxt/kit'
+import { addPlugin, addTemplate, addTypeTemplate, addVitePlugin, addWebpackPlugin } from '@nuxt/kit'
 import { generateTemplateNuxtI18nOptions } from '../template'
 import { generateI18nTypes, generateLoaderOptions, simplifyLocaleOptions } from '../gen'
 import { NUXT_I18N_TEMPLATE_OPTIONS_KEY } from '../constants'
@@ -53,12 +53,21 @@ export function prepareRuntime(ctx: I18nNuxtContext, nuxt: Nuxt) {
   nuxt.options.imports.transform.include ??= []
   nuxt.options.imports.transform.include.push(new RegExp(`${RESOLVED_VIRTUAL_NUXT_I18N_LOGGER}$`))
 
-  nuxt.hook('vite:extendConfig', cfg => {
+  addVitePlugin(I18nVirtualLoggerPlugin.vite({ debug: options.debug }))
+  addWebpackPlugin(I18nVirtualLoggerPlugin.webpack({ debug: options.debug }))
+
+  /*nuxt.hook('vite:extendConfig', cfg => {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     cfg.plugins ||= []
     // @ts-ignore NOTE: A type error occurs due to a mismatch between Vite plugins and those of Rollup
-    cfg.plugins.push(i18nVirtualLoggerPlugin(options.debug))
+    cfg.plugins.push(I18nVirtualLoggerPlugin.vite({ debug: options.debug }))
   })
+  nuxt.hook('webpack:config', cfg => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    cfg.plugins ||= []
+    // @ts-ignore NOTE: A type error occurs due to a mismatch between Vite plugins and those of Rollup
+    cfg.plugins.push(I18nVirtualLoggerPlugin.webpack({ debug: options.debug }))
+  })*/
 
   /**
    * `$i18n` type narrowing based on 'legacy' or 'composition'

--- a/src/runtime/internal.ts
+++ b/src/runtime/internal.ts
@@ -14,7 +14,7 @@ import {
 import { NUXT_I18N_MODULE_ID, DEFAULT_COOKIE_KEY, isSSG, localeCodes, normalizedLocales } from '#build/i18n.options.mjs'
 import { findBrowserLocale, getLocalesRegex, getRouteName } from './routing/utils'
 import { initCommonComposableOptions, type CommonComposableOptions } from './utils'
-import { createLogger } from 'virtual:nuxt-i18n-logger'
+import { createLogger } from '~nuxt-i18n/logger'
 
 import type { Locale } from 'vue-i18n'
 import type { DetectBrowserLanguageOptions, LocaleObject } from './shared-types'

--- a/src/runtime/messages.ts
+++ b/src/runtime/messages.ts
@@ -1,5 +1,5 @@
 import { deepCopy, isFunction, isArray, isObject, isString } from '@intlify/shared'
-import { createLogger } from 'virtual:nuxt-i18n-logger'
+import { createLogger } from '~nuxt-i18n/logger'
 
 import type { I18nOptions, Locale, FallbackLocale, LocaleMessages, DefineLocaleMessage } from 'vue-i18n'
 import type { NuxtApp } from '#app'

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -24,7 +24,7 @@ import {
 import { inBrowser, resolveBaseUrl } from '../routing/utils'
 import { extendI18n, createLocaleFromRouteGetter } from '../routing/extends'
 import { setLocale, getLocale, mergeLocaleMessage, setLocaleProperty } from '../compatibility'
-import { createLogger } from 'virtual:nuxt-i18n-logger'
+import { createLogger } from '~nuxt-i18n/logger'
 
 import type { NuxtI18nPluginInjections } from '../injections'
 import type { Locale, I18nOptions } from 'vue-i18n'

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -34,7 +34,7 @@ import {
   setLocaleProperty,
   setLocaleCookie
 } from './compatibility'
-import { createLogger } from 'virtual:nuxt-i18n-logger'
+import { createLogger } from '~nuxt-i18n/logger'
 import { createLocaleFromRouteGetter } from './routing/extends/router'
 
 import type { I18n, Locale } from 'vue-i18n'

--- a/src/virtual-logger.ts
+++ b/src/virtual-logger.ts
@@ -1,31 +1,34 @@
-import type { Plugin } from 'vite'
+import { createUnplugin } from 'unplugin'
 
-export const VIRTUAL_NUXT_I18N_LOGGER = 'virtual:nuxt-i18n-logger'
+export const VIRTUAL_NUXT_I18N_LOGGER = '~nuxt-i18n/logger'
 export const RESOLVED_VIRTUAL_NUXT_I18N_LOGGER = `\0${VIRTUAL_NUXT_I18N_LOGGER}`
 
-export function i18nVirtualLoggerPlugin(debug: boolean | 'verbose') {
-  return <Plugin>{
+export const I18nVirtualLoggerPlugin = createUnplugin<{ debug: boolean | 'verbose' }>(options => {
+  return {
     name: 'nuxtjs:i18n-logger',
     enforce: 'pre',
     resolveId(id) {
-      if (id === VIRTUAL_NUXT_I18N_LOGGER) return RESOLVED_VIRTUAL_NUXT_I18N_LOGGER
+      return id === VIRTUAL_NUXT_I18N_LOGGER ? RESOLVED_VIRTUAL_NUXT_I18N_LOGGER : undefined
+    },
+    loadInclude(id) {
+      return id === RESOLVED_VIRTUAL_NUXT_I18N_LOGGER
     },
     load(id) {
-      if (id !== RESOLVED_VIRTUAL_NUXT_I18N_LOGGER) return
+      if (id !== RESOLVED_VIRTUAL_NUXT_I18N_LOGGER) return undefined
 
       // return stub if debug logging is disabled
-      if (!debug) {
+      if (!options.debug) {
         return `export function createLogger() {}`
       }
 
       return `
 import { createConsola } from 'consola'
 
-const debugLogger = createConsola({ level: ${debug === 'verbose' ? 999 : 4} }).withTag('i18n')
+const debugLogger = createConsola({ level: ${options.debug === 'verbose' ? 999 : 4} }).withTag('i18n')
 
 export function createLogger(label) {
   return debugLogger.withTag(label)
 }`
     }
   }
-}
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
This PR disables `optimizeTranslationDirective` when using webpack and refactors the virtual logger to use unplugin:

![imagen](https://github.com/user-attachments/assets/e6dfed5c-892f-43b3-b0d9-7ad185ae8fca)
_error enabling `optimizeTranslationDirective`_

Looks like we need something more to run it with webpack: https://github.com/userquin/nuxt-i18n-pwa-virtual/pull/1

Virtual modules in webpack cannot have `:`:

![imagen](https://github.com/user-attachments/assets/cbb52149-d478-4793-bfec-540c4df172bd)
_error using virtual:nuxt-i18n-logger_

![imagen](https://github.com/user-attachments/assets/71e9a1fb-1d33-4c6a-a28c-a494682ff2d3)
_error using ~nuxt-i18n/logger_

/cc @danielroe there is no way, some hint :pray: about virtuals in webpack?

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
