### PR TITLE
refactor: remove runtime routing index files

### DIFF
--- a/src/runtime/composables/index.ts
+++ b/src/runtime/composables/index.ts
@@ -10,13 +10,15 @@ import {
   getCurrentOgLocale,
   getHreflangLinks,
   getOgUrl,
+  localeHead
+} from '../routing/compatibles/head'
+import {
   getRouteBaseName,
-  localeHead,
   localeLocation,
   localePath,
   localeRoute,
   switchLocalePath
-} from '../routing/compatibles'
+} from '../routing/compatibles/routing'
 import { findBrowserLocale } from '../routing/utils'
 import { getLocale, getLocales, getComposer } from '../compatibility'
 

--- a/src/runtime/injections.ts
+++ b/src/runtime/injections.ts
@@ -5,13 +5,8 @@ import type {
   RouteBaseNameFunction,
   SwitchLocalePathFunction
 } from '#i18n'
-import type {
-  getRouteBaseName,
-  localeHead,
-  localePath,
-  localeRoute,
-  switchLocalePath
-} from './routing/compatibles/index'
+import type { localeHead } from './routing/compatibles/head'
+import type { getRouteBaseName, localePath, localeRoute, switchLocalePath } from './routing/compatibles/routing'
 
 export type NuxtI18nPluginInjections = {
   /**

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -22,7 +22,8 @@ import {
   setupMultiDomainLocales
 } from '../internal'
 import { inBrowser, resolveBaseUrl } from '../routing/utils'
-import { extendI18n, createLocaleFromRouteGetter } from '../routing/extends'
+import { extendI18n } from '../routing/extends/i18n'
+import { createLocaleFromRouteGetter } from '../routing/extends/router'
 import { setLocale, getLocale, mergeLocaleMessage, setLocaleProperty } from '../compatibility'
 import { createLogger } from 'virtual:nuxt-i18n-logger'
 

--- a/src/runtime/routing/compatibles/index.ts
+++ b/src/runtime/routing/compatibles/index.ts
@@ -1,2 +1,0 @@
-export * from './routing'
-export * from './head'

--- a/src/runtime/routing/extends/i18n.ts
+++ b/src/runtime/routing/extends/i18n.ts
@@ -1,14 +1,14 @@
 import { effectScope } from '#imports'
 import { isVueI18n, getComposer } from '../../compatibility'
+import { localeHead } from '../compatibles/head'
 import {
   getRouteBaseName,
-  localeHead,
   localeLocation,
   localePath,
   localeRoute,
   resolveRoute,
   switchLocalePath
-} from '../compatibles'
+} from '../compatibles/routing'
 import { wrapComposable } from '../../internal'
 import { initCommonComposableOptions } from '../../utils'
 

--- a/src/runtime/routing/extends/index.ts
+++ b/src/runtime/routing/extends/index.ts
@@ -1,2 +1,0 @@
-export * from './i18n'
-export * from './router'

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -14,15 +14,15 @@ import {
   DetectFailure
 } from './internal'
 import { loadLocale, makeFallbackLocaleCodes } from './messages'
+import { localeHead } from './routing/compatibles/head'
 import {
-  localeHead,
   localePath,
   localeRoute,
   getRouteBaseName,
   switchLocalePath,
   DefaultPrefixable,
   DefaultSwitchLocalePathIntercepter
-} from './routing/compatibles'
+} from './routing/compatibles/routing'
 import {
   getI18nProperty,
   getI18nTarget,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This is just a small refactor to remove some re-exporting, the `runtime/routing` structure is still a remnant of `vue-i18n-routing` which is where it originated.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
