### PR TITLE
fix: use `next` tag for v9 edge release

### DIFF
--- a/scripts/release-edge.sh
+++ b/scripts/release-edge.sh
@@ -21,4 +21,4 @@ fi
 
 # Release package
 echo "⚡ Publishing edge version"
-npx npm@8.17.0 publish --access public --tolerate-republish
+npx npm@8.17.0 publish --tag next --access public --tolerate-republish


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I hope this tags the edge releases for `v9` as `next` so users can install edge releases of `v9` with `pnpm i -D @nuxtjs/i18n@npm:@nuxtjs/i18n-edge@next` 🤔 but trying to be careful with changes to release flow.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
