### PR TITLE
fix: warn when using SEO features without `baseUrl`

### DIFF
--- a/src/runtime/composables/index.ts
+++ b/src/runtime/composables/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 import { useRequestHeaders, useCookie as useNuxtCookie } from '#imports'
-import { ref, computed, watch, onUnmounted } from 'vue'
+import { ref, computed, watch, onUnmounted, unref } from 'vue'
 import { parseAcceptLanguage, wrapComposable, runtimeDetectBrowserLanguage } from '../internal'
 import { DEFAULT_DYNAMIC_PARAMS_KEY, localeCodes, normalizedLocales } from '#build/i18n.options.mjs'
 import { getActiveHead } from 'unhead'
@@ -79,6 +79,10 @@ export function useSetI18nParams(seo?: SeoAttributesOptions): SetI18nParamsFunct
 
   const currentLocale = getNormalizedLocales(locales).find(l => l.code === locale) || { code: locale }
   const currentLocaleLanguage = currentLocale.language
+
+  if (!unref(i18n.baseUrl)) {
+    console.warn('I18n `baseUrl` is required to generate valid SEO tag links.')
+  }
 
   const setMeta = () => {
     const metaObject: HeadParam = {

--- a/src/runtime/routing/compatibles/head.ts
+++ b/src/runtime/routing/compatibles/head.ts
@@ -33,8 +33,13 @@ export function localeHead(
     meta: []
   }
 
+  const i18nBaseUrl = unref(i18n.baseUrl)
+  if (!i18nBaseUrl) {
+    console.warn('I18n `baseUrl` is required to generate valid SEO tag links.')
+  }
+
   // skip if no locales or baseUrl is set
-  if (unref(i18n.locales) == null || unref(i18n.baseUrl) == null) {
+  if (unref(i18n.locales) == null || i18nBaseUrl == null) {
     return metaObject
   }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* #2941
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #2941 

Adds a warning when using SEO features without setting `baseUrl`, may change this to throw an error instead before creating release candidate.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
