### PR TITLE
fix!: remove deprecated locale `iso` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ npx nuxi@latest module add i18n
   ],
   i18n: {
     locales: [
-      { code: 'en', iso: 'en-US' },
-      { code: 'fr', iso: 'fr-FR' }
+      { code: 'en', language: 'en-US' },
+      { code: 'fr', language: 'fr-FR' }
     ]
     defaultLocale: 'en',
   }

--- a/docs/content/docs/2.guide/5.browser-language-detection.md
+++ b/docs/content/docs/2.guide/5.browser-language-detection.md
@@ -21,7 +21,7 @@ export default defineNuxtConfig({
 For better SEO, it's recommended to set `redirectOn` to `root` (which is the default value). When set, the language detection is only attempted when the user visits the root path (`/`) of the site. This allows crawlers to access the requested page rather than being redirected away based on detected locale. It also allows linking to pages in specific locales.
 ::
 
-Browser language is detected either from `navigator` when running on client-side, or from the `accept-language` HTTP header. Configured `locales` (or locales `iso` and/or `code` when locales are specified in object form) are matched against locales reported by the browser (for example `en-US,en;q=0.9,no;q=0.8`). If there is no exact match for the full locale, the language code (letters before `-`) are matched against configured locales.
+Browser language is detected either from `navigator` when running on client-side, or from the `accept-language` HTTP header. Configured `locales` (or locales `language` and/or `code` when locales are specified in object form) are matched against locales reported by the browser (for example `en-US,en;q=0.9,no;q=0.8`). If there is no exact match for the full locale, the language code (letters before `-`) are matched against configured locales.
 
 To prevent redirecting users every time they visit the app, **Nuxt i18n module** sets a cookie using the detected locale. You can change the cookie's name by setting `detectBrowserLanguage.cookieKey` option to whatever you'd like, the default is _i18n_redirected_.
 

--- a/docs/content/docs/2.guide/6.seo.md
+++ b/docs/content/docs/2.guide/6.seo.md
@@ -16,7 +16,7 @@ Here are the specific optimizations and features that it enables:
 
 ## Requirements
 
-To leverage the SEO benefits, you must configure the `locales` option as an array of objects, where each object has an `iso` option set to the locale language tags:
+To leverage the SEO benefits, you must configure the `locales` option as an array of objects, where each object has an `language` option set to the locale language tags:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
@@ -24,15 +24,15 @@ export default defineNuxtConfig({
     locales: [
       {
         code: 'en',
-        iso: 'en-US'
+        language: 'en-US'
       },
       {
         code: 'es',
-        iso: 'es-ES'
+        language: 'es-ES'
       },
       {
         code: 'fr',
-        iso: 'fr-FR'
+        language: 'fr-FR'
       }
     ]
   }
@@ -165,11 +165,11 @@ useHead({
 
 - `lang` attribute for the `<html>` tag
 
-  Sets the correct `lang` attribute, equivalent to the current locale's `iso` value, in the `<html>` tag.
+  Sets the correct `lang` attribute, equivalent to the current locale's `language` value, in the `<html>` tag.
 
 - `hreflang` alternate link
 
-  Generates `<link rel="alternate" hreflang="x">` tags for every configured locale. The locales' `iso` value are used as `hreflang` values.
+  Generates `<link rel="alternate" hreflang="x">` tags for every configured locale. The locales' `language` value are used as `hreflang` values.
 
   A "catchall" locale hreflang link is provided for each locale group (e.g. `en-*`). By default, it is the first locale provided, but another locale can be selected by setting `isCatchallLocale` to `true` on that specific locale object in your **Nuxt i18n module** configuration. [More on hreflang](https://support.google.com/webmasters/answer/189077)
 
@@ -181,11 +181,11 @@ useHead({
       locales: [
         {
           code: 'en',
-          iso: 'en-US' // Will be used as "catchall" locale by default
+          language: 'en-US' // Will be used as "catchall" locale by default
         },
         {
           code: 'gb',
-          iso: 'en-GB'
+          language: 'en-GB'
         }
       ]
     }
@@ -200,11 +200,11 @@ useHead({
       locales: [
         {
           code: 'en',
-          iso: 'en-US'
+          language: 'en-US'
         },
         {
           code: 'gb',
-          iso: 'en-GB',
+          language: 'en-GB',
           isCatchallLocale: true // This one will be used as catchall locale
         }
       ]
@@ -212,7 +212,7 @@ useHead({
   })
   ```
 
-  In case you already have an `en` locale `iso` set, it'll be used as the "catchall" without doing anything
+  In case you already have an `en` locale `language` set, it'll be used as the "catchall" without doing anything
 
   ```ts [nuxt.config.ts]
   export default defineNuxtConfig({
@@ -220,11 +220,11 @@ useHead({
       locales: [
         {
           code: 'gb',
-          iso: 'en-GB'
+          language: 'en-GB'
         },
         {
           code: 'en',
-          iso: 'en' // will be used as "catchall" locale
+          language: 'en' // will be used as "catchall" locale
         }
       ]
     }

--- a/docs/content/docs/3.options/2.routing.md
+++ b/docs/content/docs/3.options/2.routing.md
@@ -27,16 +27,16 @@ List of locales supported by your app. Can either be an array of codes (`['en', 
 
 ```json
 [
-  { "code": "en", "iso": "en-US", "file": "en.js", "dir": "ltr" },
-  { "code": "ar", "iso": "ar-EG", "file": "ar.js", "dir": "rtl" },
-  { "code": "fr", "iso": "fr-FR", "file": "fr.js" }
+  { "code": "en", "language": "en-US", "file": "en.js", "dir": "ltr" },
+  { "code": "ar", "language": "ar-EG", "file": "ar.js", "dir": "rtl" },
+  { "code": "fr", "language": "fr-FR", "file": "fr.js" }
 ]
 ```
 
 When using an object form, the properties can be:
 
 - `code` (**required**) - unique identifier of the locale
-- `iso` (required when using SEO features) - A language-range used for SEO features and for matching browser locales when using [`detectBrowserLanguage`](/docs/options/browser#detectbrowserlanguage) functionality. Should use the [language tag syntax](https://www.w3.org/International/articles/language-tags/) as defined by the IETF's [BCP47](https://www.rfc-editor.org/info/bcp47), for example:
+- `language` (required when using SEO features) - A language-range used for SEO features and for matching browser locales when using [`detectBrowserLanguage`](/docs/options/browser#detectbrowserlanguage) functionality. Should use the [language tag syntax](https://www.w3.org/International/articles/language-tags/) as defined by the IETF's [BCP47](https://www.rfc-editor.org/info/bcp47), for example:
   - `'en'` (`language` subtag for English)
   - `'fr-CA'` (`language+region` subtags for French as used in Canada)
   - `'zh-Hans'` (`language+script` subtags for Chinese written with Simplified script)

--- a/playground/layer-module/index.ts
+++ b/playground/layer-module/index.ts
@@ -9,19 +9,19 @@ export default defineNuxtModule({
         locales: [
           {
             code: 'en',
-            iso: 'en-US',
+            language: 'en-US',
             file: 'en.json',
             name: 'English'
           },
           {
             code: 'fr',
-            iso: 'fr-FR',
+            language: 'fr-FR',
             file: 'fr.json',
             name: 'Francais'
           },
           {
             code: 'nl',
-            iso: 'nl-NL',
+            language: 'nl-NL',
             file: 'nl.json',
             name: 'Nederlands'
           }

--- a/playground/layer-module/nuxt.config.ts
+++ b/playground/layer-module/nuxt.config.ts
@@ -10,21 +10,21 @@ export default defineNuxtConfig({
     locales: [
       {
         code: 'en',
-        iso: 'en-US',
+        language: 'en-US',
         file: 'en.json',
         // domain: 'localhost',
         name: 'English'
       },
       {
         code: 'fr',
-        iso: 'fr-FR',
+        language: 'fr-FR',
         file: 'fr.json',
         // domain: 'localhost',
         name: 'Francais'
       },
       {
         code: 'nl',
-        iso: 'nl-NL',
+        language: 'nl-NL',
         file: 'nl.json',
         // domain: 'localhost',
         name: 'Nederlands'

--- a/playground/layers/i18n-layer/nuxt.config.ts
+++ b/playground/layers/i18n-layer/nuxt.config.ts
@@ -17,41 +17,41 @@ export default defineNuxtConfig({
     locales: [
       {
         code: 'en',
-        iso: 'en-US',
+        language: 'en-US',
         file: 'en.json',
         // domain: 'localhost',
         name: 'English'
       },
       {
         code: 'fr',
-        iso: 'fr-FR',
+        language: 'fr-FR',
         file: 'fr.json',
         domain: 'layer-fr.example.com',
         name: 'Francais'
       },
       {
         code: 'nl',
-        iso: 'nl-NL',
+        language: 'nl-NL',
         file: 'nl.json',
         // domain: 'localhost',
         name: 'Nederlands'
       }
       //   {
       //     code: 'en-GB',
-      //     iso: 'en-GB',
+      //     language: 'en-GB',
       //     files: ['en.json', 'en-GB.json'],
       //     name: 'English (UK)'
       //   },
       //   {
       //     code: 'ja',
-      //     iso: 'ja-JP',
+      //     language: 'ja-JP',
       //     file: 'ja.json',
       //     domain: 'mydomain.com',
       //     name: 'Japanses'
       //   },
       //   {
       //     code: 'fr',
-      //     iso: 'fr-FR',
+      //     language: 'fr-FR',
       //     file: 'fr.json',
       //     domain: 'mydomain.fr',
       //     name: 'Français'

--- a/playground/module-experimental/index.ts
+++ b/playground/module-experimental/index.ts
@@ -21,12 +21,12 @@ export default defineNuxtModule<ModuleOptions>({
         locales: [
           {
             code: 'de',
-            iso: 'de-DE',
+            language: 'de-DE',
             file: 'de.ts'
           },
           {
             code: 'en',
-            iso: 'en-US',
+            language: 'en-US',
             file: 'en.ts'
           }
         ]

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -40,27 +40,27 @@ export default defineNuxtConfig({
         locales: [
           {
             code: 'en',
-            iso: 'en-US',
+            language: 'en-US',
             file: 'en.json',
             // domain: 'localhost',
             name: 'English'
           },
           {
             code: 'en-GB',
-            iso: 'en-GB',
+            language: 'en-GB',
             files: ['en.json', 'en-GB.js', 'en-KK.js'],
             name: 'English (UK)'
           },
           {
             code: 'ja',
-            iso: 'ja-JP',
+            language: 'ja-JP',
             file: 'ja.ts',
             domain: 'mydomain.com',
             name: 'Japanses'
           },
           {
             code: 'fr',
-            iso: 'fr-FR',
+            language: 'fr-FR',
             file: 'fr.json',
             domain: 'mydomain.fr',
             name: 'Français'
@@ -138,27 +138,27 @@ export default defineNuxtConfig({
     locales: [
       {
         code: 'en',
-        iso: 'en-US',
+        language: 'en-US',
         file: 'en.json',
         // domain: 'localhost',
         name: 'English'
       },
       {
         code: 'en-GB',
-        iso: 'en-GB',
+        language: 'en-GB',
         files: ['en.json', 'en-GB.js', 'en-KK.js', 'en-US.yaml', 'en-CA.json5'],
         name: 'English (UK)'
       },
       {
         code: 'ja',
-        iso: 'ja-JP',
+        language: 'ja-JP',
         file: 'ja.ts',
         domain: 'mydomain.com',
         name: 'Japanses'
       },
       {
         code: 'fr',
-        iso: 'fr-FR',
+        language: 'fr-FR',
         file: 'fr.json',
         domain: 'project-fr.example.com',
         name: 'Français'

--- a/specs/different_domains/different_domains.spec.ts
+++ b/specs/different_domains/different_domains.spec.ts
@@ -24,19 +24,19 @@ await setup({
       locales: [
         {
           code: 'en',
-          iso: 'en',
+          language: 'en',
           name: 'English',
           domain: 'en.nuxt-app.localhost'
         },
         {
           code: 'fr',
-          iso: 'fr-FR',
+          language: 'fr-FR',
           name: 'Français',
           domain: 'fr.nuxt-app.localhost'
         },
         {
           code: 'kr',
-          iso: 'ko-KR',
+          language: 'ko-KR',
           name: '한국어',
           domain: 'kr.nuxt-app.localhost'
         }

--- a/specs/different_domains/different_domains_multi_locales_prefix.spec.ts
+++ b/specs/different_domains/different_domains_multi_locales_prefix.spec.ts
@@ -12,20 +12,20 @@ await setup({
       locales: [
         {
           code: 'en',
-          iso: 'en',
+          language: 'en',
           name: 'English',
           domain: 'nuxt-app.localhost',
           domainDefault: true
         },
         {
           code: 'no',
-          iso: 'no-NO',
+          language: 'no-NO',
           name: 'Norwegian',
           domain: 'nuxt-app.localhost'
         },
         {
           code: 'fr',
-          iso: 'fr-FR',
+          language: 'fr-FR',
           name: 'Français',
           domain: 'fr.nuxt-app.localhost'
         }

--- a/specs/different_domains/different_domains_multi_locales_prefix_except_default.spec.ts
+++ b/specs/different_domains/different_domains_multi_locales_prefix_except_default.spec.ts
@@ -12,27 +12,27 @@ await setup({
       locales: [
         {
           code: 'en',
-          iso: 'en',
+          language: 'en',
           name: 'English',
           domain: 'nuxt-app.localhost',
           domainDefault: true
         },
         {
           code: 'no',
-          iso: 'no-NO',
+          language: 'no-NO',
           name: 'Norwegian',
           domain: 'nuxt-app.localhost'
         },
         {
           code: 'fr',
-          iso: 'fr-FR',
+          language: 'fr-FR',
           name: 'Français',
           domain: 'fr.nuxt-app.localhost',
           domainDefault: true
         },
         {
           code: 'ja',
-          iso: 'jp-JA',
+          language: 'jp-JA',
           name: 'Japan',
           domain: 'ja.nuxt-app.localhost',
           domainDefault: true

--- a/specs/fixtures/basic/nuxt.config.ts
+++ b/specs/fixtures/basic/nuxt.config.ts
@@ -12,12 +12,12 @@ export default defineNuxtConfig({
     locales: [
       {
         code: 'en',
-        iso: 'en',
+        language: 'en',
         name: 'English'
       },
       {
         code: 'fr',
-        iso: 'fr-FR',
+        language: 'fr-FR',
         name: 'Français'
       }
     ],

--- a/specs/fixtures/basic_usage/installer-module/index.ts
+++ b/specs/fixtures/basic_usage/installer-module/index.ts
@@ -10,7 +10,7 @@ export default defineNuxtModule({
       locales: [
         {
           code: 'en',
-          iso: 'en',
+          language: 'en',
           files: [resolve('./locales/en.json')],
           name: 'English'
         }

--- a/specs/fixtures/basic_usage/layer-module/index.ts
+++ b/specs/fixtures/basic_usage/layer-module/index.ts
@@ -9,19 +9,19 @@ export default defineNuxtModule({
         locales: [
           {
             code: 'en',
-            iso: 'en-US',
+            language: 'en-US',
             files: ['en-base.json', 'en.json'],
             name: 'English'
           },
           {
             code: 'fr',
-            iso: 'fr-FR',
+            language: 'fr-FR',
             file: 'fr.json',
             name: 'Francais'
           },
           {
             code: 'nl',
-            iso: 'nl-NL',
+            language: 'nl-NL',
             file: 'nl.ts',
             name: 'Nederlands'
           }

--- a/specs/fixtures/basic_usage_compat_4/installer-module/index.ts
+++ b/specs/fixtures/basic_usage_compat_4/installer-module/index.ts
@@ -10,7 +10,7 @@ export default defineNuxtModule({
       locales: [
         {
           code: 'en',
-          iso: 'en',
+          language: 'en',
           files: [resolve('./locales/en.json')],
           name: 'English'
         }

--- a/specs/fixtures/basic_usage_compat_4/layer-module/index.ts
+++ b/specs/fixtures/basic_usage_compat_4/layer-module/index.ts
@@ -9,19 +9,19 @@ export default defineNuxtModule({
         locales: [
           {
             code: 'en',
-            iso: 'en-US',
+            language: 'en-US',
             files: ['en-base.json', 'en.json'],
             name: 'English'
           },
           {
             code: 'fr',
-            iso: 'fr-FR',
+            language: 'fr-FR',
             file: 'fr.json',
             name: 'Francais'
           },
           {
             code: 'nl',
-            iso: 'nl-NL',
+            language: 'nl-NL',
             file: 'nl.ts',
             name: 'Nederlands'
           }

--- a/specs/fixtures/basic_usage_compat_4/nuxt.config.ts
+++ b/specs/fixtures/basic_usage_compat_4/nuxt.config.ts
@@ -29,13 +29,13 @@ export default defineNuxtConfig({
     locales: [
       {
         code: 'en',
-        iso: 'en-US',
+        language: 'en-US',
         file: 'en.json5',
         name: 'English'
       },
       {
         code: 'ja',
-        iso: 'ja-JP',
+        language: 'ja-JP',
         file: 'ja.yaml',
         name: 'Japanese'
       }

--- a/specs/fixtures/different_domains/nuxt.config.ts
+++ b/specs/fixtures/different_domains/nuxt.config.ts
@@ -10,19 +10,19 @@ export default defineNuxtConfig({
     locales: [
       {
         code: 'en',
-        iso: 'en',
+        language: 'en',
         name: 'English',
         domain: 'en.nuxt-app.localhost'
       },
       {
         code: 'no',
-        iso: 'no-NO',
+        language: 'no-NO',
         name: 'Norwegian',
         domain: 'no.nuxt-app.localhost'
       },
       {
         code: 'fr',
-        iso: 'fr-FR',
+        language: 'fr-FR',
         name: 'Français',
         domain: 'fr.nuxt-app.localhost'
       }

--- a/specs/fixtures/external_module/i18n-module/index.ts
+++ b/specs/fixtures/external_module/i18n-module/index.ts
@@ -9,13 +9,13 @@ export default defineNuxtModule({
         locales: [
           {
             code: 'fr',
-            iso: 'fr-FR',
+            language: 'fr-FR',
             file: 'locale-file-module-fr.json',
             name: 'Francais'
           },
           {
             code: 'nl',
-            iso: 'nl-NL',
+            language: 'nl-NL',
             file: 'locale-file-module-nl.ts',
             name: 'Nederlands'
           }

--- a/specs/fixtures/inline_options/nuxt.config.ts
+++ b/specs/fixtures/inline_options/nuxt.config.ts
@@ -15,7 +15,7 @@ export default defineNuxtConfig({
         locales: [
           {
             code: 'en',
-            iso: 'en-US',
+            language: 'en-US',
             file: 'locale-file-en.json',
             name: 'English'
           }
@@ -32,7 +32,7 @@ export default defineNuxtConfig({
     locales: [
       {
         code: 'ja',
-        iso: 'ja-JP',
+        language: 'ja-JP',
         file: 'locale-file-ja.json',
         name: 'Japanese'
       }

--- a/specs/fixtures/issues/1888/nuxt.config.ts
+++ b/specs/fixtures/issues/1888/nuxt.config.ts
@@ -7,15 +7,15 @@ export default defineNuxtConfig({
       {
         code: 'en',
         flag: 'us',
-        iso: 'en-US',
+        language: 'en-US',
         file: 'en.json',
         name: 'English'
       },
-      { code: 'pl', flag: 'pl', iso: 'pl-PL', file: 'pl.json', name: 'Polski' },
+      { code: 'pl', flag: 'pl', language: 'pl-PL', file: 'pl.json', name: 'Polski' },
       {
         code: 'fr',
         flag: 'fr',
-        iso: 'fr-FR',
+        language: 'fr-FR',
         file: 'fr.json',
         name: 'Français'
       }

--- a/specs/fixtures/issues/2151/nuxt.config.ts
+++ b/specs/fixtures/issues/2151/nuxt.config.ts
@@ -12,13 +12,13 @@ export default defineNuxtConfig({
     locales: [
       {
         code: 'en',
-        iso: 'en',
+        language: 'en',
         name: 'English',
         file: 'en.js'
       },
       {
         code: 'ja',
-        iso: 'ja-JP',
+        language: 'ja-JP',
         name: '日本語',
         file: 'ja.js'
       }

--- a/specs/fixtures/issues/2247/nuxt.config.ts
+++ b/specs/fixtures/issues/2247/nuxt.config.ts
@@ -8,7 +8,7 @@ export default defineNuxtConfig({
       {
         code: 'en',
         country: '',
-        iso: 'en',
+        language: 'en',
         lang: 'en',
         file: 'en-en.js',
         dir: 'ltr'
@@ -16,7 +16,7 @@ export default defineNuxtConfig({
       {
         code: 'ar',
         country: '',
-        iso: 'ar',
+        language: 'ar',
         lang: 'ar',
         file: 'ar-ar.js',
         dir: 'rtl'

--- a/specs/fixtures/issues/2288/nuxt.config.ts
+++ b/specs/fixtures/issues/2288/nuxt.config.ts
@@ -8,7 +8,7 @@ export default defineNuxtConfig({
       {
         code: 'en',
         country: '',
-        iso: 'en',
+        language: 'en',
         lang: 'en',
         file: 'en-en.js',
         dir: 'ltr'
@@ -16,7 +16,7 @@ export default defineNuxtConfig({
       {
         code: 'ar',
         country: '',
-        iso: 'ar',
+        language: 'ar',
         lang: 'ar',
         file: 'ar-ar.js',
         dir: 'rtl'

--- a/specs/fixtures/issues/2590/modules/i18n-module/index.ts
+++ b/specs/fixtures/issues/2590/modules/i18n-module/index.ts
@@ -10,7 +10,7 @@ export default defineNuxtModule({
         locales: [
           {
             code: 'en',
-            iso: 'en-US',
+            language: 'en-US',
             file: 'en-US.ts',
             name: 'English'
           }

--- a/specs/fixtures/layers/layer-domain/nuxt.config.ts
+++ b/specs/fixtures/layers/layer-domain/nuxt.config.ts
@@ -10,21 +10,21 @@ export default defineNuxtConfig({
     locales: [
       {
         code: 'en',
-        iso: 'en-US',
+        language: 'en-US',
         file: 'en.json',
         domain: 'layer-en.example.com',
         name: 'English'
       },
       {
         code: 'nl',
-        iso: 'nl-NL',
+        language: 'nl-NL',
         file: 'nl.json',
         domain: 'layer-nl.example.com',
         name: 'Nederlands'
       },
       {
         code: 'ja',
-        iso: 'ja',
+        language: 'ja',
         file: 'ja.json',
         domain: 'layer-ja.example.com',
         name: 'Japanese'

--- a/specs/fixtures/layers/layer-lazy/nuxt.config.ts
+++ b/specs/fixtures/layers/layer-lazy/nuxt.config.ts
@@ -6,25 +6,25 @@ export default defineNuxtConfig({
     locales: [
       {
         code: 'en',
-        iso: 'en-US',
+        language: 'en-US',
         file: 'en.json',
         name: 'English'
       },
       {
         code: 'fr',
-        iso: 'fr-FR',
+        language: 'fr-FR',
         file: 'fr.json',
         name: 'Français'
       },
       {
         code: 'nl',
-        iso: 'nl-NL',
+        language: 'nl-NL',
         file: 'nl.json',
         name: 'Nederlands'
       },
       {
         code: 'kr',
-        iso: 'kr-KO',
+        language: 'kr-KO',
         file: 'kr.json',
         name: '한국어'
       }

--- a/specs/fixtures/layers/layer-locale-arabic/nuxt.config.ts
+++ b/specs/fixtures/layers/layer-locale-arabic/nuxt.config.ts
@@ -6,7 +6,7 @@ export default defineNuxtConfig({
     locales: [
       {
         code: 'ar',
-        iso: 'ar',
+        language: 'ar',
         file: 'ar.json',
         name: 'Arabic',
         dir: 'rtl'

--- a/specs/fixtures/layers/layer-server/nuxt.config.ts
+++ b/specs/fixtures/layers/layer-server/nuxt.config.ts
@@ -9,13 +9,13 @@ export default defineNuxtConfig({
     locales: [
       {
         code: 'en',
-        iso: 'en-US',
+        language: 'en-US',
         file: 'en.json5',
         name: 'English'
       },
       {
         code: 'ja',
-        iso: 'ja-JP',
+        language: 'ja-JP',
         file: 'ja.yaml',
         name: 'Japanese'
       }

--- a/specs/fixtures/lazy/i18n-module/index.ts
+++ b/specs/fixtures/lazy/i18n-module/index.ts
@@ -9,7 +9,7 @@ export default defineNuxtModule({
         locales: [
           {
             code: 'nl',
-            iso: 'nl-NL',
+            language: 'nl-NL',
             file: 'lazy-locale-module-nl.ts',
             name: 'Nederlands'
           }

--- a/specs/fixtures/lazy/nuxt.config.ts
+++ b/specs/fixtures/lazy/nuxt.config.ts
@@ -36,19 +36,19 @@ export default defineNuxtConfig({
     locales: [
       {
         code: 'en',
-        iso: 'en-US',
+        language: 'en-US',
         file: 'lazy-locale-en.json',
         name: 'English'
       },
       {
         code: 'en-GB',
-        iso: 'en-GB',
+        language: 'en-GB',
         files: ['lazy-locale-en.json', 'lazy-locale-en-GB.js', 'lazy-locale-en-GB.ts'],
         name: 'English (UK)'
       },
       {
         code: 'fr',
-        iso: 'fr-FR',
+        language: 'fr-FR',
         file: { path: 'lazy-locale-fr.json5', cache: false },
         name: 'Français'
       }

--- a/specs/fixtures/multi_domains_locales/nuxt.config.ts
+++ b/specs/fixtures/multi_domains_locales/nuxt.config.ts
@@ -13,27 +13,27 @@ export default defineNuxtConfig({
     locales: [
       {
         code: 'en',
-        iso: 'en',
+        language: 'en',
         name: 'English',
         domains: i18nDomains,
         defaultForDomains: ['nuxt-app.localhost']
       },
       {
         code: 'no',
-        iso: 'no-NO',
+        language: 'no-NO',
         name: 'Norwegian',
         domains: i18nDomains
       },
       {
         code: 'fr',
-        iso: 'fr-FR',
+        language: 'fr-FR',
         name: 'Français',
         domains: i18nDomains,
         defaultForDomains: ['fr.nuxt-app.localhost']
       },
       {
         code: 'ja',
-        iso: 'jp-JA',
+        language: 'jp-JA',
         name: 'Japan',
         domains: i18nDomains,
         defaultForDomains: ['ja.nuxt-app.localhost']

--- a/specs/fixtures/restructure/i18n-module/index.ts
+++ b/specs/fixtures/restructure/i18n-module/index.ts
@@ -9,7 +9,7 @@ export default defineNuxtModule({
         locales: [
           {
             code: 'nl',
-            iso: 'nl-NL',
+            language: 'nl-NL',
             file: 'lazy-locale-module-nl.ts',
             name: 'Nederlands'
           }

--- a/specs/fixtures/restructure/nuxt.config.ts
+++ b/specs/fixtures/restructure/nuxt.config.ts
@@ -38,19 +38,19 @@ export default defineNuxtConfig({
     locales: [
       {
         code: 'en',
-        iso: 'en-US',
+        language: 'en-US',
         file: 'lazy-locale-en.json',
         name: 'English'
       },
       {
         code: 'en-GB',
-        iso: 'en-GB',
+        language: 'en-GB',
         files: ['lazy-locale-en.json', 'lazy-locale-en-GB.js', 'lazy-locale-en-GB.ts'],
         name: 'English (UK)'
       },
       {
         code: 'fr',
-        iso: 'fr-FR',
+        language: 'fr-FR',
         file: { path: 'lazy-locale-fr.json5', cache: false },
         name: 'Français'
       }

--- a/specs/inline_options.spec.ts
+++ b/specs/inline_options.spec.ts
@@ -30,7 +30,7 @@ describe('inline options are handled correctly', async () => {
       consoleLogs.some(
         log =>
           log.type === 'warning' &&
-          log.text.includes('[nuxt-i18n-routing] Locale ISO code is required to generate alternate link')
+          log.text.includes('[nuxt-i18n-routing] Locale `language` ISO code is required to generate alternate link')
       )
     ).toBe(false)
   })

--- a/specs/issues/2590.spec.ts
+++ b/specs/issues/2590.spec.ts
@@ -10,7 +10,7 @@ describe('#2590', async () => {
     browser: true
   })
 
-  test('Locale ISO code is required to generate alternate link', async () => {
+  test('Locale `language` ISO code is required to generate alternate link', async () => {
     const { page } = await renderPage('/')
 
     // html tag `lang` attribute

--- a/specs/lazy_load/basic_lazy_load.spec.ts
+++ b/specs/lazy_load/basic_lazy_load.spec.ts
@@ -82,7 +82,7 @@ describe('basic lazy loading', async () => {
     // current locale
     expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('en')
 
-    // html tag `lang` attriute with iso code
+    // html tag `lang` attribute with language code
     expect(await page.getAttribute('html', 'lang')).toEqual('en-US')
   })
 
@@ -103,7 +103,7 @@ describe('basic lazy loading', async () => {
     // current locale
     expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('fr')
 
-    // html tag `lang` attriute with iso code
+    // html tag `lang` attribute with language code
     expect(await page.getAttribute('html', 'lang')).toEqual('fr-FR')
   })
 

--- a/specs/lazy_load/restructure.spec.ts
+++ b/specs/lazy_load/restructure.spec.ts
@@ -82,7 +82,7 @@ describe('basic lazy loading (restructure)', async () => {
     // current locale
     expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('en')
 
-    // html tag `lang` attriute with iso code
+    // html tag `lang` attribute with language code
     expect(await page.getAttribute('html', 'lang')).toEqual('en-US')
   })
 
@@ -103,7 +103,7 @@ describe('basic lazy loading (restructure)', async () => {
     // current locale
     expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('fr')
 
-    // html tag `lang` attriute with iso code
+    // html tag `lang` attribute with language code
     expect(await page.getAttribute('html', 'lang')).toEqual('fr-FR')
   })
 

--- a/specs/multi_domains_locales/multi_domains_locales_multi_locales.spec.ts
+++ b/specs/multi_domains_locales/multi_domains_locales_multi_locales.spec.ts
@@ -14,27 +14,27 @@ await setup({
       locales: [
         {
           code: 'en',
-          iso: 'en',
+          language: 'en',
           name: 'English',
           domains: i18nDomains,
           defaultForDomains: ['nuxt-app.localhost']
         },
         {
           code: 'no',
-          iso: 'no-NO',
+          language: 'no-NO',
           name: 'Norwegian',
           domains: i18nDomains
         },
         {
           code: 'fr',
-          iso: 'fr-FR',
+          language: 'fr-FR',
           name: 'Français',
           domains: i18nDomains,
           defaultForDomains: ['fr.nuxt-app.localhost']
         },
         {
           code: 'ja',
-          iso: 'jp-JA',
+          language: 'jp-JA',
           name: 'Japan',
           domains: i18nDomains,
           defaultForDomains: ['ja.nuxt-app.localhost']

--- a/src/runtime/shared-types.ts
+++ b/src/runtime/shared-types.ts
@@ -281,10 +281,6 @@ export interface LocaleObject<T = Locale> extends Record<string, any> {
   file?: string | LocaleFile
   files?: string[] | LocaleFile[]
   isCatchallLocale?: boolean
-  /**
-   * @deprecated in v9, use `language` instead
-   */
-  iso?: string
   language?: string
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -495,7 +495,6 @@ export type LocaleConfig = {
  */
 export const mergeConfigLocales = (configs: LocaleConfig[], baseLocales: LocaleObject[] = []) => {
   const mergedLocales = new Map<string, LocaleObject>()
-  const deprecatedIsolocales = new Set<string>()
 
   for (const locale of baseLocales) {
     mergedLocales.set(locale.code, locale)
@@ -517,12 +516,6 @@ export const mergeConfigLocales = (configs: LocaleConfig[], baseLocales: LocaleO
       const resolvedFiles = resolveRelativeLocales(locale, config)
       delete locale.file
 
-      if (locale.iso) {
-        deprecatedIsolocales.add(locale.iso)
-        locale.language = locale.iso
-        delete locale.iso
-      }
-
       // merge locale and files with existing entry
       if (merged != null) {
         merged.files ??= [] as LocaleFile[]
@@ -537,12 +530,6 @@ export const mergeConfigLocales = (configs: LocaleConfig[], baseLocales: LocaleO
 
       mergedLocales.set(code, { ...locale, files: resolvedFiles })
     }
-  }
-
-  if (deprecatedIsolocales.size) {
-    console.warn(
-      `Locales ${[...deprecatedIsolocales].join(', ')} uses deprecated \`iso\` property, this will be replaced with \`language\` in v9`
-    )
   }
 
   return Array.from(mergedLocales.values())

--- a/test/pages/utils.ts
+++ b/test/pages/utils.ts
@@ -21,9 +21,9 @@ export function getNuxtOptions(
     trailingSlash: false,
     routesNameSeparator: '___',
     locales: [
-      { code: 'en', iso: 'en-US', file: 'en.json', name: 'English' },
-      { code: 'ja', iso: 'ja-JP', file: 'ja.json', name: 'Japanses' },
-      { code: 'fr', iso: 'fr-FR', file: 'fr.json', name: 'Français' }
+      { code: 'en', language: 'en-US', file: 'en.json', name: 'English' },
+      { code: 'ja', language: 'ja-JP', file: 'ja.json', name: 'Japanses' },
+      { code: 'fr', language: 'fr-FR', file: 'fr.json', name: 'Français' }
     ] as LocaleObject[]
   }
 }

--- a/test/routing-utils.test.ts
+++ b/test/routing-utils.test.ts
@@ -173,7 +173,7 @@ describe('findBrowserLocale', () => {
     assert.ok(utils.findBrowserLocale(locales, browserLocales) === 'en-gb')
   })
 
-  test('matches ISO locale code', () => {
+  test('matches `language` locale code', () => {
     const locales = [
       { code: 'cn', language: 'zh-CN' },
       { code: 'en', language: 'en-US' }
@@ -183,7 +183,7 @@ describe('findBrowserLocale', () => {
     assert.ok(utils.findBrowserLocale(locales, browserLocales) === 'cn')
   })
 
-  test('matches full ISO code', () => {
+  test('matches full `language` code', () => {
     const locales = [
       { code: 'us', language: 'en-US' },
       { code: 'gb', language: 'en-GB' }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* #2449
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #2449

We have had warnings in V8 about this deprecation, now removing the deprecated property to prevent breaking changes during release candidate releases.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
