### PR TITLE
docs: use route names as key for custom paths

### DIFF
--- a/docs/content/docs/2.guide/3.custom-paths.md
+++ b/docs/content/docs/2.guide/3.custom-paths.md
@@ -30,9 +30,9 @@ export default defineNuxtConfig({
 })
 ```
 
-Note that each key within the `pages` object should **correspond to the relative file-based path (excluding `.vue` file extension) of the route within your `pages/` directory excluding the leading `/`**.
+Note that each key within the `pages` object should **correspond to the route name of the route to localize**.
 
-Customized route paths **must start with a `/`** and **not include the locale prefix**.
+Customized route paths **must start with a `/`** and **must not include the locale prefix**.
 
 You can now use the `localePath` function or the `<NuxtLinkLocale>` component but be sure to use named routes. For example route `/services/advanced` should be `services-advanced`:
 
@@ -62,7 +62,7 @@ const localePath = useLocalePath()
 ```
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
-Specifying a path to `localePath` is not supported, currently.
+Passing a path to `localePath` is currently not supported.
 ::
 
 #### Example 1: Basic URL localization
@@ -101,9 +101,6 @@ export default defineNuxtConfig({
   }
 })
 ```
-
-If you want customize the URL of a static vue file, you should use the file's name.
-If the view is in a sub-directory you should use folder name and vue files name with trailing slash.
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
 All URLs must start with `/`
@@ -222,7 +219,7 @@ To configure a custom path for a dynamic route, you need to use it in double squ
 ```
 
 ::callout{icon="i-heroicons-light-bulb"}
-`defineI18nRoute` compiler macro is tree-shaked out at build time and is not included in the dist files.
+`defineI18nRoute` compiler macro is tree-shaken out at build time and is not included in the dist files.
 ::
 
 

--- a/docs/content/docs/2.guide/3.custom-paths.md
+++ b/docs/content/docs/2.guide/3.custom-paths.md
@@ -69,13 +69,13 @@ Specifying a path to `localePath` is not supported, currently.
 
 You have some routes with the following `pages` directory:
 
-```
-pages/
-├── about.vue
-├── me.vue
-├── services/
-├──── index.vue
-├──── advanced.vue
+```bash
+-| pages/
+---| me.vue
+---| about.vue
+---| services/
+-----| index.vue
+-----| advanced.vue
 ```
 
 You would need to set up your `pages` property as follows:
@@ -85,16 +85,16 @@ export default defineNuxtConfig({
   i18n: {
     customRoutes: 'config',
     pages: {
-      about: {
-        fr: '/a-propos',
-      },
       me: {
         fr: '/moi',
       },
-      'services/index': {
+      about: {
+        fr: '/a-propos',
+      },
+      services: {
         fr: '/offres',
       },
-      'services/advanced': {
+      'services-advanced': {
         fr: '/offres/avancee',
       }
     }
@@ -113,16 +113,16 @@ All URLs must start with `/`
 
 You have some routes with the following `pages` directory:
 
-```
-pages/
-├── about.vue
-├── services/
-├──── coaching.vue
-├──── index.vue
-├──── development/
-├────── app.vue
-├────── website.vue
-├────── index.vue
+```bash
+-| pages/
+---| about.vue
+---| services/
+-----| index.vue
+-----| coaching.vue
+-----| development/
+-------| app.vue
+-------| index.vue
+-------| website.vue
 ```
 
 You would need to set up your `pages` property as follows:
@@ -135,19 +135,19 @@ export default defineNuxtConfig({
       about: {
         fr: '/a-propos'
       },
-      'services/index': {
+      services: {
         fr: '/offres'
       },
-      'services/development/index': {
+      'services-development': {
         fr: '/offres/developement'
       },
-      'services/development/app': {
+      'services-development-app': {
         fr: '/offres/developement/app'
       },
-      'services/development/website': {
+      'services-development-website': {
         fr: '/offres/developement/site-web'
       },
-      'services/coaching': {
+      'services-coaching': {
         fr: '/offres/formation'
       }
     }
@@ -161,11 +161,11 @@ If a custom path is missing for one of the locales, the `defaultLocale` custom p
 
 Say you have some dynamic routes like:
 
-```
-pages/
-├── blog/
-├──── [date]/
-├────── [slug].vue
+```bash
+-| pages/
+---| blog/
+-----| [date]/
+-------| [slug].vue
 ```
 
 Here's how you would configure these particular pages in the configuration:
@@ -175,7 +175,7 @@ export default defineNuxtConfig({
   i18n: {
     customRoutes: 'config',
     pages: {
-      'blog/[date]/[slug]': {
+      'blog-date-slug': {
         // params need to be put back here as you would with Nuxt Dynamic Routes
         // https://nuxt.com/docs/guide/directory-structure/pages#dynamic-routes
         ja: '/blog/tech/[date]/[slug]'
@@ -210,7 +210,7 @@ You can use the `defineI18nRoute` compiler macro to set custom paths for each pa
 
 To configure a custom path for a dynamic route, you need to use it in double square brackets in the paths similarly to how you would do it in [Nuxt Dynamic Routes](https://nuxt.com/docs/guide/directory-structure/pages#dynamic-routes):
 
-```html {}[pages/articles/[name].vue]
+```html {}[pages/articles/[name\\].vue]
 <script setup>
   defineI18nRoute({
     paths: {

--- a/docs/content/docs/5.v9/2.guide/3.custom-paths.md
+++ b/docs/content/docs/5.v9/2.guide/3.custom-paths.md
@@ -30,9 +30,9 @@ export default defineNuxtConfig({
 })
 ```
 
-Note that each key within the `pages` object should **correspond to the relative file-based path (excluding `.vue` file extension) of the route within your `pages/` directory excluding the leading `/`**.
+Note that each key within the `pages` object should **correspond to the route name of the route to localize**.
 
-Customized route paths **must start with a `/`** and **not include the locale prefix**.
+Customized route paths **must start with a `/`** and **must not include the locale prefix**.
 
 You can now use the `localePath` function or the `<NuxtLinkLocale>` component but be sure to use named routes. For example route `/services/advanced` should be `services-advanced`:
 
@@ -62,7 +62,7 @@ const localePath = useLocalePath()
 ```
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
-Specifying a path to `localePath` is not supported, currently.
+Passing a path to `localePath` is currently not supported.
 ::
 
 #### Example 1: Basic URL localization
@@ -101,9 +101,6 @@ export default defineNuxtConfig({
   }
 })
 ```
-
-If you want customize the URL of a static vue file, you should use the file's name.
-If the view is in a sub-directory you should use folder name and vue files name with trailing slash.
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
 All URLs must start with `/`
@@ -222,7 +219,7 @@ To configure a custom path for a dynamic route, you need to use it in double squ
 ```
 
 ::callout{icon="i-heroicons-light-bulb"}
-`defineI18nRoute` compiler macro is tree-shaked out at build time and is not included in the dist files.
+`defineI18nRoute` compiler macro is tree-shaken out at build time and is not included in the dist files.
 ::
 
 

--- a/docs/content/docs/5.v9/2.guide/3.custom-paths.md
+++ b/docs/content/docs/5.v9/2.guide/3.custom-paths.md
@@ -69,13 +69,13 @@ Specifying a path to `localePath` is not supported, currently.
 
 You have some routes with the following `pages` directory:
 
-```
-pages/
-├── about.vue
-├── me.vue
-├── services/
-├──── index.vue
-├──── advanced.vue
+```bash
+-| pages/
+---| me.vue
+---| about.vue
+---| services/
+-----| index.vue
+-----| advanced.vue
 ```
 
 You would need to set up your `pages` property as follows:
@@ -85,16 +85,16 @@ export default defineNuxtConfig({
   i18n: {
     customRoutes: 'config',
     pages: {
-      about: {
-        fr: '/a-propos',
-      },
       me: {
         fr: '/moi',
       },
-      'services/index': {
+      about: {
+        fr: '/a-propos',
+      },
+      services: {
         fr: '/offres',
       },
-      'services/advanced': {
+      'services-advanced': {
         fr: '/offres/avancee',
       }
     }
@@ -113,16 +113,16 @@ All URLs must start with `/`
 
 You have some routes with the following `pages` directory:
 
-```
-pages/
-├── about.vue
-├── services/
-├──── coaching.vue
-├──── index.vue
-├──── development/
-├────── app.vue
-├────── website.vue
-├────── index.vue
+```bash
+-| pages/
+---| about.vue
+---| services/
+-----| index.vue
+-----| coaching.vue
+-----| development/
+-------| app.vue
+-------| index.vue
+-------| website.vue
 ```
 
 You would need to set up your `pages` property as follows:
@@ -135,19 +135,19 @@ export default defineNuxtConfig({
       about: {
         fr: '/a-propos'
       },
-      'services/index': {
+      services: {
         fr: '/offres'
       },
-      'services/development/index': {
+      'services-development': {
         fr: '/offres/developement'
       },
-      'services/development/app': {
+      'services-development-app': {
         fr: '/offres/developement/app'
       },
-      'services/development/website': {
+      'services-development-website': {
         fr: '/offres/developement/site-web'
       },
-      'services/coaching': {
+      'services-coaching': {
         fr: '/offres/formation'
       }
     }
@@ -161,11 +161,11 @@ If a custom path is missing for one of the locales, the `defaultLocale` custom p
 
 Say you have some dynamic routes like:
 
-```
-pages/
-├── blog/
-├──── [date]/
-├────── [slug].vue
+```bash
+-| pages/
+---| blog/
+-----| [date]/
+-------| [slug].vue
 ```
 
 Here's how you would configure these particular pages in the configuration:
@@ -175,7 +175,7 @@ export default defineNuxtConfig({
   i18n: {
     customRoutes: 'config',
     pages: {
-      'blog/[date]/[slug]': {
+      'blog-date-slug': {
         // params need to be put back here as you would with Nuxt Dynamic Routes
         // https://nuxt.com/docs/guide/directory-structure/pages#dynamic-routes
         ja: '/blog/tech/[date]/[slug]'
@@ -210,7 +210,7 @@ You can use the `defineI18nRoute` compiler macro to set custom paths for each pa
 
 To configure a custom path for a dynamic route, you need to use it in double square brackets in the paths similarly to how you would do it in [Nuxt Dynamic Routes](https://nuxt.com/docs/guide/directory-structure/pages#dynamic-routes):
 
-```html {}[pages/articles/[name].vue]
+```html {}[pages/articles/[name\\].vue]
 <script setup>
   defineI18nRoute({
     paths: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I noticed the custom route paths docs have incorrect examples 😬 this may have been a source of custom paths confusion since v7 🤔
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
