### PR TITLE
fix: use NuxtLink config in components

### DIFF
--- a/src/runtime/components/NuxtLinkLocale.ts
+++ b/src/runtime/components/NuxtLinkLocale.ts
@@ -3,11 +3,12 @@ import { useLocalePath, type Locale } from '#i18n'
 import { defineComponent, computed, h } from 'vue'
 import { defineNuxtLink } from '#imports'
 import { hasProtocol } from 'ufo'
+import { nuxtLinkDefaults } from '#build/nuxt.config.mjs'
 
 import type { PropType } from 'vue'
 import type { NuxtLinkProps } from 'nuxt/app'
 
-const NuxtLinkLocale = defineNuxtLink({ componentName: 'NuxtLinkLocale' })
+const NuxtLinkLocale = defineNuxtLink({ ...nuxtLinkDefaults, componentName: 'NuxtLinkLocale' })
 
 type NuxtLinkLocaleProps = Omit<NuxtLinkProps, 'to'> & {
   to?: import('vue-router').RouteLocationNamedI18n

--- a/src/runtime/components/SwitchLocalePathLink.ts
+++ b/src/runtime/components/SwitchLocalePathLink.ts
@@ -2,10 +2,11 @@ import { SWITCH_LOCALE_PATH_LINK_IDENTIFIER } from '#build/i18n.options.mjs'
 import { useSwitchLocalePath, type Locale } from '#i18n'
 import { defineNuxtLink } from '#imports'
 import { Comment, defineComponent, h } from 'vue'
+import { nuxtLinkDefaults } from '#build/nuxt.config.mjs'
 
 import type { PropType } from 'vue'
 
-const NuxtLink = defineNuxtLink({ componentName: 'NuxtLink' })
+const NuxtLink = defineNuxtLink({ ...nuxtLinkDefaults, componentName: 'NuxtLink' })
 
 export default defineComponent({
   name: 'SwitchLocalePathLink',


### PR DESCRIPTION
### 🔗 Linked issue

#3182 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #3182 
Based on original source of [\<NuxtLink\>](https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/app/components/nuxt-link.ts), I injected  `nuxtLinkDefaults` from `#build/nuxt.config.mjs`  to `defineNuxtLink()` to use user-defined config in I18n components.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
