### PR TITLE
fix: use experimental `pages:resolved` hook if enabled

### DIFF
--- a/src/pages.ts
+++ b/src/pages.ts
@@ -1,5 +1,5 @@
 import createDebug from 'debug'
-import { addTemplate, extendPages } from '@nuxt/kit'
+import { addTemplate } from '@nuxt/kit'
 import { isString } from '@intlify/shared'
 import { parse as parseSFC, compileScript } from '@vue/compiler-sfc'
 import { walk } from 'estree-walker'
@@ -54,7 +54,9 @@ export async function setupPages({ localeCodes, options, isSSR }: I18nNuxtContex
 
   const typedRouter = await setupExperimentalTypedRoutes(options, nuxt)
 
-  extendPages(async pages => {
+  const pagesHook: Parameters<(typeof nuxt)['hook']>[0] =
+    nuxt.options.experimental.scanPageMeta === 'after-resolve' ? 'pages:resolved' : 'pages:extend'
+  nuxt.hook(pagesHook, async pages => {
     debug('pages making ...', pages)
     const ctx: NuxtPageAnalyzeContext = {
       stack: [],

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -54,9 +54,13 @@ export async function setupPages({ localeCodes, options, isSSR }: I18nNuxtContex
 
   const typedRouter = await setupExperimentalTypedRoutes(options, nuxt)
 
+  // @ts-expect-error needs nuxt 3.14.0
   const pagesHook: Parameters<(typeof nuxt)['hook']>[0] =
+    // @ts-expect-error needs nuxt 3.14.0
     nuxt.options.experimental.scanPageMeta === 'after-resolve' ? 'pages:resolved' : 'pages:extend'
-  nuxt.hook(pagesHook, async pages => {
+
+  // TODO: remove with the release of 3.14.0
+  nuxt.hook(pagesHook as 'pages:extend', async pages => {
     debug('pages making ...', pages)
     const ctx: NuxtPageAnalyzeContext = {
       stack: [],


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* #3086 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This adds support for the new `pages:resolved` hook, this should allow issues like https://github.com/nuxt-modules/i18n/issues/3086 to be resolved if they have the experimental hook enabled.

This should also resolve the failing i18n tests in ecosystem-ci.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
