### PR TITLE
fix: set publish tag to `8x`

### DIFF
--- a/scripts/release-edge.sh
+++ b/scripts/release-edge.sh
@@ -21,4 +21,4 @@ fi
 
 # Release package
 echo "⚡ Publishing edge version"
-npx npm@8.17.0 publish --access public --tolerate-republish
+npx npm@8.17.0 publish --tag 8x --access public --tolerate-republish

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -17,5 +17,5 @@ if [[ ! -z ${NPM_TOKEN} ]] ; then
 fi
 
 # Release package
-echo "⚡ Publishing with tag latest"
-npx npm@8.17.0 publish --tag latest --access public --tolerate-republish
+echo "⚡ Publishing with tag 8x"
+npx npm@8.17.0 publish --tag 8x --access public --tolerate-republish


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
In preparation of releasing v9, the publish tagging should be changed for v8 releases.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
