### PR TITLE
docs: fix path in lazy-load translations

### DIFF
--- a/docs/content/docs/2.guide/7.lazy-load-translations.md
+++ b/docs/content/docs/2.guide/7.lazy-load-translations.md
@@ -19,9 +19,10 @@ Example files structure:
 ```bash
 -| nuxt-project/
 ---| i18n/
------| en-US.json
------| es-ES.js
------| fr-FR.js
+-----| locales/
+-------| en-US.json
+-------| es-ES.js
+-------| fr-FR.js
 ---| nuxt.config.ts
 ```
 
@@ -50,7 +51,7 @@ export default defineNuxtConfig({
 })
 ```
 
-```ts [lang/fr-FR.ts]
+```ts [i18n/locales/fr-FR.ts]
 export default defineI18nLocale(async locale => {
   return {
     welcome: 'Bienvenue'
@@ -96,11 +97,12 @@ The following is an example of a lang directory containing locale files for the 
 ```bash
 -| nuxt-project/
 ---| i18n/
------| es.json    # locale messages for common Spanish
------| es-AR.json # locale messages for Argentina
------| es-UY.json # locale messages for Uruguay
------| es-US.json # locale messages for Estados Unidos
------| ...        # other countries
+-----| locales/
+-------| es.json    # locale messages for common Spanish
+-------| es-AR.json # locale messages for Argentina
+-------| es-UY.json # locale messages for Uruguay
+-------| es-US.json # locale messages for Estados Unidos
+-------| ...        # other countries
 ---| nuxt.config.ts
 ```
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

Resolves: #3213 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The default `langDir` is [`locales`](https://i18n.nuxtjs.org/docs/api/options#langdir) under [`i18n`](https://i18n.nuxtjs.org/docs/api/options#restructuredir).
The documentation of lazy-loading have incorrect paths. This PR fixes it.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
