### PR TITLE
fix: support special characters in generated messages type keys

### DIFF
--- a/src/prepare/type-generation.ts
+++ b/src/prepare/type-generation.ts
@@ -16,7 +16,7 @@ function generateInterface(obj: Record<string, unknown>, indentLevel = 1) {
     if (!Object.prototype.hasOwnProperty.call(obj, key)) continue
 
     if (typeof obj[key] === 'object' && obj[key] !== null && !Array.isArray(obj[key])) {
-      str += `${indent}${key}: {\n`
+      str += `${indent}"${key}": {\n`
       str += generateInterface(obj[key] as Record<string, unknown>, indentLevel + 1)
       str += `${indent}};\n`
     } else {
@@ -27,7 +27,7 @@ function generateInterface(obj: Record<string, unknown>, indentLevel = 1) {
       if (propertyType === 'function') {
         propertyType = '() => string'
       }
-      str += `${indent}${key}: ${propertyType};\n`
+      str += `${indent}"${key}": ${propertyType};\n`
     }
   }
   return str


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Using keys like "product-detail" would break type generation as special characters like `-` are not allowed in types/objects. Wrapping in quotation marks should cover these cases.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
