### PR TITLE
feat: configurable generated file and directory paths

### DIFF
--- a/docs/content/docs/4.api/0.options.md
+++ b/docs/content/docs/4.api/0.options.md
@@ -501,7 +501,7 @@ This feature relies on [Nuxt's `experimental.typedRoutes`](https://nuxt.com/docs
 - This changes the generated locale file paths, these paths are absolute by default in v9 (and lower) and could expose sensitive path information to production.
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
-Changing this will also change the paths in `locales` returned by `useI18n`.
+Changing this will also change the paths in `locales` returned by `useI18n()`{lang="ts"}.
 ::
 
 ## customBlocks

--- a/docs/content/docs/4.api/0.options.md
+++ b/docs/content/docs/4.api/0.options.md
@@ -495,10 +495,10 @@ This feature relies on [Nuxt's `experimental.typedRoutes`](https://nuxt.com/docs
 ### `generatedLocaleFilePathFormat`
 
 - type: `'absolute' | 'relative'`{lang="ts-type"}
-  - `'absolute'`{lang="ts-type"} - locale file paths contain the full absolute path
-  - `'relative'`{lang="ts-type"} - locale file paths are relative to the `rootDir`
+  - `'absolute'`{lang="ts-type"} - locale file and langDir paths contain the full absolute path
+  - `'relative'`{lang="ts-type"} - locale file and langDir paths are converted to be relative to the `rootDir`
 - default: `'absolute'`{lang="ts"}
-- This changes the generated locale file paths, these paths are absolute by default in v9 (and lower) and could expose sensitive path information to production.
+- This changes the generated locale file and langDir paths, these paths are absolute by default in v9 (and lower) and could expose sensitive path information to production.
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
 Changing this will also change the paths in `locales` returned by `useI18n()`{lang="ts"}.

--- a/docs/content/docs/4.api/0.options.md
+++ b/docs/content/docs/4.api/0.options.md
@@ -492,6 +492,17 @@ This feature relies on [Nuxt's `experimental.typedRoutes`](https://nuxt.com/docs
 - default: `false`{lang="ts"}
 - Generate `vue-i18n` and message types used in translation functions and `vue-i18n` configuration. Can be configured to use the `defaultLocale` (better performance) or all locales for type generation.
 
+### `generatedLocaleFilePathFormat`
+
+- type: `'absolute' | 'relative'`{lang="ts-type"}
+  - `'absolute'`{lang="ts-type"} - locale file paths contain the full absolute path
+  - `'relative'`{lang="ts-type"} - locale file paths are relative to the `rootDir`
+- default: `'absolute'`{lang="ts"}
+- This changes the generated locale file paths, these paths are absolute by default in v9 (and lower) and could expose sensitive path information to production.
+
+::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
+Changing this will also change the paths in `locales` returned by `useI18n`.
+::
 
 ## customBlocks
 

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -41,7 +41,8 @@ export default defineNuxtConfig({
       switchLocalePathLinkSSR: true,
       autoImportTranslationFunctions: true,
       typedPages: true,
-      typedOptionsAndMessages: 'default'
+      typedOptionsAndMessages: 'default',
+      generatedLocaleFilePathFormat: 'relative'
     },
     compilation: {
       strictMessage: false,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -31,7 +31,8 @@ export const DEFAULT_OPTIONS = {
     switchLocalePathLinkSSR: false,
     autoImportTranslationFunctions: false,
     typedPages: true,
-    typedOptionsAndMessages: false
+    typedOptionsAndMessages: false,
+    generatedLocaleFilePathFormat: 'absolute'
   },
   bundle: {
     compositionOnly: true,

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -109,17 +109,26 @@ export function generateLoaderOptions(
     .map(config => generateVueI18nConfiguration(config, isServer))
 
   const localeLoaders = localeInfo.map(locale => [locale.code, locale.meta?.map(meta => importMapper.get(meta.key))])
+  const pathFormat = nuxtI18nOptions.experimental?.generatedLocaleFilePathFormat ?? 'absolute'
 
   const generatedNuxtI18nOptions = {
     ...nuxtI18nOptions,
-    locales: simplifyLocaleOptions(nuxt, nuxtI18nOptions)
+    locales: simplifyLocaleOptions(nuxt, nuxtI18nOptions),
+    i18nModules:
+      nuxtI18nOptions.i18nModules?.map(x => {
+        if (pathFormat === 'absolute') return x
+        if (x.langDir == null) return x
+        return {
+          ...x,
+          langDir: relative(nuxt.options.rootDir, x.langDir)
+        }
+      }) ?? []
   }
   delete nuxtI18nOptions.vueI18n
 
   /**
    * Process locale file paths in `normalizedLocales`
    */
-  const pathFormat = nuxtI18nOptions.experimental?.generatedLocaleFilePathFormat ?? 'absolute'
   const processedNormalizedLocales = normalizedLocales.map(x => {
     if (pathFormat === 'absolute') return x
     if (x.files == null) return x

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -46,7 +46,7 @@ export function simplifyLocaleOptions(nuxt: Nuxt, options: NuxtI18nOptions) {
     }
 
     if (locale.file || (locale.files?.length ?? 0) > 0) {
-      locale.files = getLocalePaths(locale)
+      locale.files = getLocalePaths(locale).map(x => relative(nuxt.options.rootDir, x))
     } else {
       delete locale.files
     }

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -39,6 +39,7 @@ export function simplifyLocaleOptions(nuxt: Nuxt, options: NuxtI18nOptions) {
     options?.i18nModules?.some(module => isLocaleObjectsArray(module?.locales))
 
   const locales = (options.locales ?? []) as LocaleObject[]
+  const pathFormat = options.experimental?.generatedLocaleFilePathFormat ?? 'absolute'
 
   return locales.map(({ meta, ...locale }) => {
     if (!hasLocaleObjects) {
@@ -46,7 +47,11 @@ export function simplifyLocaleOptions(nuxt: Nuxt, options: NuxtI18nOptions) {
     }
 
     if (locale.file || (locale.files?.length ?? 0) > 0) {
-      locale.files = getLocalePaths(locale).map(x => relative(nuxt.options.rootDir, x))
+      locale.files = getLocalePaths(locale)
+
+      if (pathFormat === 'relative') {
+        locale.files = locale.files.map(x => relative(nuxt.options.rootDir, x))
+      }
     } else {
       delete locale.files
     }

--- a/src/prepare/runtime.ts
+++ b/src/prepare/runtime.ts
@@ -31,10 +31,10 @@ export function prepareRuntime(ctx: I18nNuxtContext, nuxt: Nuxt) {
         vueI18nConfigPaths,
         localeInfo,
         nuxtI18nOptions,
-        isServer
+        isServer,
+        normalizedLocales
       }),
       localeCodes,
-      normalizedLocales,
       dev,
       isSSG,
       parallelPlugin: options.parallelPlugin

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,6 +117,16 @@ export interface ExperimentalFeatures {
    * @remark `'all'` to generate types based on all locales
    */
   typedOptionsAndMessages?: false | 'default' | 'all'
+
+  /**
+   * Locale file paths can be formatted differently to prevent exposing sensitive paths in production.
+   *
+   * @defaultValue `'absolute'`
+   *
+   * @remark `'absolute'` locale file paths contain the full absolute path
+   * @remark `'relative'` locale file paths are relative to the `rootDir`
+   */
+  generatedLocaleFilePathFormat?: 'absolute' | 'relative'
 }
 
 export interface BundleOptions

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,12 +119,12 @@ export interface ExperimentalFeatures {
   typedOptionsAndMessages?: false | 'default' | 'all'
 
   /**
-   * Locale file paths can be formatted differently to prevent exposing sensitive paths in production.
+   * Locale file and langDir paths can be formatted differently to prevent exposing sensitive paths in production.
    *
    * @defaultValue `'absolute'`
    *
-   * @remark `'absolute'` locale file paths contain the full absolute path
-   * @remark `'relative'` locale file paths are relative to the `rootDir`
+   * @remark `'absolute'` locale file and langDir paths contain the full absolute path
+   * @remark `'relative'` locale file and langDir paths are converted to be relative to the `rootDir`
    */
   generatedLocaleFilePathFormat?: 'absolute' | 'relative'
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -490,7 +490,7 @@ export const getLocaleFiles = (locale: LocaleObject | LocaleInfo): LocaleFile[] 
   return []
 }
 
-function resolveRelativeLocales(locale: LocaleObject, config: LocaleConfig) {
+export function resolveRelativeLocales(locale: LocaleObject, config: LocaleConfig) {
   const fileEntries = getLocaleFiles(locale)
 
   return fileEntries.map(file => ({

--- a/test/__snapshots__/gen.test.ts.snap
+++ b/test/__snapshots__/gen.test.ts.snap
@@ -3,9 +3,9 @@
 exports[`basic 1`] = `
 {
   "importStrings": [
-    "import locale__test_srcDir_en_json from "../srcDir/en.json";",
-    "import locale__test_srcDir_ja_json from "../srcDir/ja.json";",
-    "import locale__test_srcDir_fr_json from "../srcDir/fr.json";",
+    "import locale_srcDir_srcDir_en_json from "srcDir/en.json";",
+    "import locale_srcDir_srcDir_ja_json from "srcDir/ja.json";",
+    "import locale_srcDir_srcDir_fr_json from "srcDir/fr.json";",
   ],
   "localeLoaders": [
     [
@@ -13,8 +13,8 @@ exports[`basic 1`] = `
       [
         {
           "cache": "true",
-          "key": ""../srcDir/en.json"",
-          "load": "() => Promise.resolve(locale__test_srcDir_en_json)",
+          "key": ""srcDir/en.json"",
+          "load": "() => Promise.resolve(locale_srcDir_srcDir_en_json)",
         },
       ],
     ],
@@ -23,8 +23,8 @@ exports[`basic 1`] = `
       [
         {
           "cache": "true",
-          "key": ""../srcDir/ja.json"",
-          "load": "() => Promise.resolve(locale__test_srcDir_ja_json)",
+          "key": ""srcDir/ja.json"",
+          "load": "() => Promise.resolve(locale_srcDir_srcDir_ja_json)",
         },
       ],
     ],
@@ -33,11 +33,40 @@ exports[`basic 1`] = `
       [
         {
           "cache": "true",
-          "key": ""../srcDir/fr.json"",
-          "load": "() => Promise.resolve(locale__test_srcDir_fr_json)",
+          "key": ""srcDir/fr.json"",
+          "load": "() => Promise.resolve(locale_srcDir_srcDir_fr_json)",
         },
       ],
     ],
+  ],
+  "normalizedLocales": [
+    {
+      "code": "en",
+      "files": [
+        {
+          "cache": true,
+          "path": "en.json",
+        },
+      ],
+    },
+    {
+      "code": "ja",
+      "files": [
+        {
+          "cache": true,
+          "path": "ja.json",
+        },
+      ],
+    },
+    {
+      "code": "fr",
+      "files": [
+        {
+          "cache": true,
+          "path": "fr.json",
+        },
+      ],
+    },
   ],
   "nuxtI18nOptions": {
     "defaultLocale": "en",
@@ -45,7 +74,132 @@ exports[`basic 1`] = `
     "locales": [],
   },
   "vueI18nConfigs": [
-    "() => import("../i18n.config.ts?hash=bffaebcb&config=1" /* webpackChunkName: "i18n_config_ts_bffaebcb" */)",
+    "() => import("/test/i18n.config.ts?hash=6354e9fa&config=1" /* webpackChunkName: "i18n_config_ts_6354e9fa" */)",
+  ],
+}
+`;
+
+exports[`files with cache configuration (relative) 1`] = `
+{
+  "importStrings": [],
+  "localeLoaders": [
+    [
+      "en",
+      [
+        {
+          "cache": "true",
+          "key": ""srcDir/test/locales/en.json"",
+          "load": "() => import("srcDir/test/locales/en.json" /* webpackChunkName: "locale_srcDir_srcDir_test_locales_en_json" */)",
+        },
+      ],
+    ],
+    [
+      "ja",
+      [
+        {
+          "cache": "true",
+          "key": ""srcDir/test/locales/ja.json"",
+          "load": "() => import("srcDir/test/locales/ja.json" /* webpackChunkName: "locale_srcDir_srcDir_test_locales_ja_json" */)",
+        },
+      ],
+    ],
+    [
+      "fr",
+      [
+        {
+          "cache": "true",
+          "key": ""srcDir/test/locales/fr.json"",
+          "load": "() => import("srcDir/test/locales/fr.json" /* webpackChunkName: "locale_srcDir_srcDir_test_locales_fr_json" */)",
+        },
+      ],
+    ],
+    [
+      "es",
+      [
+        {
+          "cache": "false",
+          "key": ""srcDir/test/locales/es.json"",
+          "load": "() => import("srcDir/test/locales/es.json" /* webpackChunkName: "locale_srcDir_srcDir_test_locales_es_json" */)",
+        },
+      ],
+    ],
+    [
+      "es-AR",
+      [
+        {
+          "cache": "false",
+          "key": ""srcDir/test/locales/es.json"",
+          "load": "() => import("srcDir/test/locales/es.json" /* webpackChunkName: "locale_srcDir_srcDir_test_locales_es_json" */)",
+        },
+        {
+          "cache": "true",
+          "key": ""srcDir/test/locales/es-AR.json"",
+          "load": "() => import("srcDir/test/locales/es-AR.json" /* webpackChunkName: "locale_srcDir_srcDir_test_locales_es_AR_json" */)",
+        },
+      ],
+    ],
+  ],
+  "normalizedLocales": [
+    {
+      "code": "en",
+      "files": [
+        {
+          "cache": true,
+          "path": "locales/en.json",
+        },
+      ],
+    },
+    {
+      "code": "ja",
+      "files": [
+        {
+          "cache": true,
+          "path": "locales/ja.json",
+        },
+      ],
+    },
+    {
+      "code": "fr",
+      "files": [
+        {
+          "cache": true,
+          "path": "locales/fr.json",
+        },
+      ],
+    },
+    {
+      "code": "es",
+      "files": [
+        {
+          "cache": false,
+          "path": "locales/es.json",
+        },
+      ],
+    },
+    {
+      "code": "es-AR",
+      "files": [
+        {
+          "cache": false,
+          "path": "locales/es.json",
+        },
+        {
+          "cache": true,
+          "path": "locales/es-AR.json",
+        },
+      ],
+    },
+  ],
+  "nuxtI18nOptions": {
+    "defaultLocale": "en",
+    "experimental": {
+      "generatedLocaleFilePathFormat": "relative",
+    },
+    "lazy": true,
+    "locales": [],
+  },
+  "vueI18nConfigs": [
+    "() => import("/test/i18n.config.ts?hash=6354e9fa&config=1" /* webpackChunkName: "i18n_config_ts_6354e9fa" */)",
   ],
 }
 `;
@@ -59,8 +213,8 @@ exports[`files with cache configuration 1`] = `
       [
         {
           "cache": "true",
-          "key": ""../srcDir/en.json"",
-          "load": "() => import("../srcDir/en.json" /* webpackChunkName: "locale__test_srcDir_en_json" */)",
+          "key": ""srcDir/test/locales/en.json"",
+          "load": "() => import("srcDir/test/locales/en.json" /* webpackChunkName: "locale_srcDir_srcDir_test_locales_en_json" */)",
         },
       ],
     ],
@@ -69,8 +223,8 @@ exports[`files with cache configuration 1`] = `
       [
         {
           "cache": "true",
-          "key": ""../srcDir/ja.json"",
-          "load": "() => import("../srcDir/ja.json" /* webpackChunkName: "locale__test_srcDir_ja_json" */)",
+          "key": ""srcDir/test/locales/ja.json"",
+          "load": "() => import("srcDir/test/locales/ja.json" /* webpackChunkName: "locale_srcDir_srcDir_test_locales_ja_json" */)",
         },
       ],
     ],
@@ -79,8 +233,8 @@ exports[`files with cache configuration 1`] = `
       [
         {
           "cache": "true",
-          "key": ""../srcDir/fr.json"",
-          "load": "() => import("../srcDir/fr.json" /* webpackChunkName: "locale__test_srcDir_fr_json" */)",
+          "key": ""srcDir/test/locales/fr.json"",
+          "load": "() => import("srcDir/test/locales/fr.json" /* webpackChunkName: "locale_srcDir_srcDir_test_locales_fr_json" */)",
         },
       ],
     ],
@@ -89,8 +243,8 @@ exports[`files with cache configuration 1`] = `
       [
         {
           "cache": "false",
-          "key": ""../srcDir/es.json"",
-          "load": "() => import("../srcDir/es.json" /* webpackChunkName: "locale__test_srcDir_es_json" */)",
+          "key": ""srcDir/test/locales/es.json"",
+          "load": "() => import("srcDir/test/locales/es.json" /* webpackChunkName: "locale_srcDir_srcDir_test_locales_es_json" */)",
         },
       ],
     ],
@@ -99,16 +253,67 @@ exports[`files with cache configuration 1`] = `
       [
         {
           "cache": "false",
-          "key": ""../srcDir/es.json"",
-          "load": "() => import("../srcDir/es.json" /* webpackChunkName: "locale__test_srcDir_es_json" */)",
+          "key": ""srcDir/test/locales/es.json"",
+          "load": "() => import("srcDir/test/locales/es.json" /* webpackChunkName: "locale_srcDir_srcDir_test_locales_es_json" */)",
         },
         {
           "cache": "true",
-          "key": ""../srcDir/es-AR.json"",
-          "load": "() => import("../srcDir/es-AR.json" /* webpackChunkName: "locale__test_srcDir_es_AR_json" */)",
+          "key": ""srcDir/test/locales/es-AR.json"",
+          "load": "() => import("srcDir/test/locales/es-AR.json" /* webpackChunkName: "locale_srcDir_srcDir_test_locales_es_AR_json" */)",
         },
       ],
     ],
+  ],
+  "normalizedLocales": [
+    {
+      "code": "en",
+      "files": [
+        {
+          "cache": true,
+          "path": "/test/locales/en.json",
+        },
+      ],
+    },
+    {
+      "code": "ja",
+      "files": [
+        {
+          "cache": true,
+          "path": "/test/locales/ja.json",
+        },
+      ],
+    },
+    {
+      "code": "fr",
+      "files": [
+        {
+          "cache": true,
+          "path": "/test/locales/fr.json",
+        },
+      ],
+    },
+    {
+      "code": "es",
+      "files": [
+        {
+          "cache": false,
+          "path": "/test/locales/es.json",
+        },
+      ],
+    },
+    {
+      "code": "es-AR",
+      "files": [
+        {
+          "cache": false,
+          "path": "/test/locales/es.json",
+        },
+        {
+          "cache": true,
+          "path": "/test/locales/es-AR.json",
+        },
+      ],
+    },
   ],
   "nuxtI18nOptions": {
     "defaultLocale": "en",
@@ -116,7 +321,7 @@ exports[`files with cache configuration 1`] = `
     "locales": [],
   },
   "vueI18nConfigs": [
-    "() => import("../i18n.config.ts?hash=bffaebcb&config=1" /* webpackChunkName: "i18n_config_ts_bffaebcb" */)",
+    "() => import("/test/i18n.config.ts?hash=6354e9fa&config=1" /* webpackChunkName: "i18n_config_ts_6354e9fa" */)",
   ],
 }
 `;
@@ -130,8 +335,8 @@ exports[`lazy 1`] = `
       [
         {
           "cache": "true",
-          "key": ""../srcDir/en.json"",
-          "load": "() => import("../srcDir/en.json" /* webpackChunkName: "locale__test_srcDir_en_json" */)",
+          "key": ""srcDir/en.json"",
+          "load": "() => import("srcDir/en.json" /* webpackChunkName: "locale_srcDir_srcDir_en_json" */)",
         },
       ],
     ],
@@ -140,8 +345,8 @@ exports[`lazy 1`] = `
       [
         {
           "cache": "true",
-          "key": ""../srcDir/ja.json"",
-          "load": "() => import("../srcDir/ja.json" /* webpackChunkName: "locale__test_srcDir_ja_json" */)",
+          "key": ""srcDir/ja.json"",
+          "load": "() => import("srcDir/ja.json" /* webpackChunkName: "locale_srcDir_srcDir_ja_json" */)",
         },
       ],
     ],
@@ -150,11 +355,40 @@ exports[`lazy 1`] = `
       [
         {
           "cache": "true",
-          "key": ""../srcDir/fr.json"",
-          "load": "() => import("../srcDir/fr.json" /* webpackChunkName: "locale__test_srcDir_fr_json" */)",
+          "key": ""srcDir/fr.json"",
+          "load": "() => import("srcDir/fr.json" /* webpackChunkName: "locale_srcDir_srcDir_fr_json" */)",
         },
       ],
     ],
+  ],
+  "normalizedLocales": [
+    {
+      "code": "en",
+      "files": [
+        {
+          "cache": true,
+          "path": "en.json",
+        },
+      ],
+    },
+    {
+      "code": "ja",
+      "files": [
+        {
+          "cache": true,
+          "path": "ja.json",
+        },
+      ],
+    },
+    {
+      "code": "fr",
+      "files": [
+        {
+          "cache": true,
+          "path": "fr.json",
+        },
+      ],
+    },
   ],
   "nuxtI18nOptions": {
     "defaultLocale": "en",
@@ -162,7 +396,7 @@ exports[`lazy 1`] = `
     "locales": [],
   },
   "vueI18nConfigs": [
-    "() => import("../i18n.config.ts?hash=bffaebcb&config=1" /* webpackChunkName: "i18n_config_ts_bffaebcb" */)",
+    "() => import("/test/i18n.config.ts?hash=6354e9fa&config=1" /* webpackChunkName: "i18n_config_ts_6354e9fa" */)",
   ],
 }
 `;
@@ -176,8 +410,8 @@ exports[`locale file in nested 1`] = `
       [
         {
           "cache": "true",
-          "key": ""../srcDir/en/main.json"",
-          "load": "() => import("../srcDir/en/main.json" /* webpackChunkName: "locale__test_srcDir_en_main_json" */)",
+          "key": ""srcDir/en/main.json"",
+          "load": "() => import("srcDir/en/main.json" /* webpackChunkName: "locale_srcDir_srcDir_en_main_json" */)",
         },
       ],
     ],
@@ -186,8 +420,8 @@ exports[`locale file in nested 1`] = `
       [
         {
           "cache": "true",
-          "key": ""../srcDir/ja/main.json"",
-          "load": "() => import("../srcDir/ja/main.json" /* webpackChunkName: "locale__test_srcDir_ja_main_json" */)",
+          "key": ""srcDir/ja/main.json"",
+          "load": "() => import("srcDir/ja/main.json" /* webpackChunkName: "locale_srcDir_srcDir_ja_main_json" */)",
         },
       ],
     ],
@@ -196,11 +430,40 @@ exports[`locale file in nested 1`] = `
       [
         {
           "cache": "true",
-          "key": ""../srcDir/fr/main.json"",
-          "load": "() => import("../srcDir/fr/main.json" /* webpackChunkName: "locale__test_srcDir_fr_main_json" */)",
+          "key": ""srcDir/fr/main.json"",
+          "load": "() => import("srcDir/fr/main.json" /* webpackChunkName: "locale_srcDir_srcDir_fr_main_json" */)",
         },
       ],
     ],
+  ],
+  "normalizedLocales": [
+    {
+      "code": "en",
+      "files": [
+        {
+          "cache": true,
+          "path": "en/main.json",
+        },
+      ],
+    },
+    {
+      "code": "ja",
+      "files": [
+        {
+          "cache": true,
+          "path": "ja/main.json",
+        },
+      ],
+    },
+    {
+      "code": "fr",
+      "files": [
+        {
+          "cache": true,
+          "path": "fr/main.json",
+        },
+      ],
+    },
   ],
   "nuxtI18nOptions": {
     "defaultLocale": "en",
@@ -208,7 +471,7 @@ exports[`locale file in nested 1`] = `
     "locales": [],
   },
   "vueI18nConfigs": [
-    "() => import("../i18n.config.ts?hash=bffaebcb&config=1" /* webpackChunkName: "i18n_config_ts_bffaebcb" */)",
+    "() => import("/test/i18n.config.ts?hash=6354e9fa&config=1" /* webpackChunkName: "i18n_config_ts_6354e9fa" */)",
   ],
 }
 `;
@@ -222,8 +485,8 @@ exports[`multiple files 1`] = `
       [
         {
           "cache": "true",
-          "key": ""../srcDir/en.json"",
-          "load": "() => import("../srcDir/en.json" /* webpackChunkName: "locale__test_srcDir_en_json" */)",
+          "key": ""srcDir/en.json"",
+          "load": "() => import("srcDir/en.json" /* webpackChunkName: "locale_srcDir_srcDir_en_json" */)",
         },
       ],
     ],
@@ -232,8 +495,8 @@ exports[`multiple files 1`] = `
       [
         {
           "cache": "true",
-          "key": ""../srcDir/ja.json"",
-          "load": "() => import("../srcDir/ja.json" /* webpackChunkName: "locale__test_srcDir_ja_json" */)",
+          "key": ""srcDir/ja.json"",
+          "load": "() => import("srcDir/ja.json" /* webpackChunkName: "locale_srcDir_srcDir_ja_json" */)",
         },
       ],
     ],
@@ -242,8 +505,8 @@ exports[`multiple files 1`] = `
       [
         {
           "cache": "true",
-          "key": ""../srcDir/fr.json"",
-          "load": "() => import("../srcDir/fr.json" /* webpackChunkName: "locale__test_srcDir_fr_json" */)",
+          "key": ""srcDir/fr.json"",
+          "load": "() => import("srcDir/fr.json" /* webpackChunkName: "locale_srcDir_srcDir_fr_json" */)",
         },
       ],
     ],
@@ -252,8 +515,8 @@ exports[`multiple files 1`] = `
       [
         {
           "cache": "true",
-          "key": ""../srcDir/es.json"",
-          "load": "() => import("../srcDir/es.json" /* webpackChunkName: "locale__test_srcDir_es_json" */)",
+          "key": ""srcDir/es.json"",
+          "load": "() => import("srcDir/es.json" /* webpackChunkName: "locale_srcDir_srcDir_es_json" */)",
         },
       ],
     ],
@@ -262,16 +525,67 @@ exports[`multiple files 1`] = `
       [
         {
           "cache": "true",
-          "key": ""../srcDir/es.json"",
-          "load": "() => import("../srcDir/es.json" /* webpackChunkName: "locale__test_srcDir_es_json" */)",
+          "key": ""srcDir/es.json"",
+          "load": "() => import("srcDir/es.json" /* webpackChunkName: "locale_srcDir_srcDir_es_json" */)",
         },
         {
           "cache": "true",
-          "key": ""../srcDir/es-AR.json"",
-          "load": "() => import("../srcDir/es-AR.json" /* webpackChunkName: "locale__test_srcDir_es_AR_json" */)",
+          "key": ""srcDir/es-AR.json"",
+          "load": "() => import("srcDir/es-AR.json" /* webpackChunkName: "locale_srcDir_srcDir_es_AR_json" */)",
         },
       ],
     ],
+  ],
+  "normalizedLocales": [
+    {
+      "code": "en",
+      "files": [
+        {
+          "cache": true,
+          "path": "en.json",
+        },
+      ],
+    },
+    {
+      "code": "ja",
+      "files": [
+        {
+          "cache": true,
+          "path": "ja.json",
+        },
+      ],
+    },
+    {
+      "code": "fr",
+      "files": [
+        {
+          "cache": true,
+          "path": "fr.json",
+        },
+      ],
+    },
+    {
+      "code": "es",
+      "files": [
+        {
+          "cache": true,
+          "path": "es.json",
+        },
+      ],
+    },
+    {
+      "code": "es-AR",
+      "files": [
+        {
+          "cache": true,
+          "path": "es.json",
+        },
+        {
+          "cache": true,
+          "path": "es-AR.json",
+        },
+      ],
+    },
   ],
   "nuxtI18nOptions": {
     "defaultLocale": "en",
@@ -279,7 +593,7 @@ exports[`multiple files 1`] = `
     "locales": [],
   },
   "vueI18nConfigs": [
-    "() => import("../i18n.config.ts?hash=bffaebcb&config=1" /* webpackChunkName: "i18n_config_ts_bffaebcb" */)",
+    "() => import("/test/i18n.config.ts?hash=6354e9fa&config=1" /* webpackChunkName: "i18n_config_ts_6354e9fa" */)",
   ],
 }
 `;
@@ -288,6 +602,7 @@ exports[`toCode: function (arrow) 1`] = `
 {
   "importStrings": [],
   "localeLoaders": [],
+  "normalizedLocales": [],
   "nuxtI18nOptions": {
     "defaultLocale": "en",
     "lazy": false,
@@ -297,18 +612,12 @@ exports[`toCode: function (arrow) 1`] = `
         "files": [
           "en.json",
         ],
-        "paths": [
-          "/path/to/en.json",
-        ],
         "testFunc": [Function],
       },
       {
         "code": "ja",
         "files": [
           "ja.json",
-        ],
-        "paths": [
-          "/path/to/ja.json",
         ],
         "testFunc": [Function],
       },
@@ -317,15 +626,12 @@ exports[`toCode: function (arrow) 1`] = `
         "files": [
           "fr.json",
         ],
-        "paths": [
-          "/path/to/fr.json",
-        ],
         "testFunc": [Function],
       },
     ],
   },
   "vueI18nConfigs": [
-    "() => import("../i18n.config.ts?hash=bffaebcb&config=1" /* webpackChunkName: "i18n_config_ts_bffaebcb" */)",
+    "() => import("/test/i18n.config.ts?hash=6354e9fa&config=1" /* webpackChunkName: "i18n_config_ts_6354e9fa" */)",
   ],
 }
 `;
@@ -334,6 +640,7 @@ exports[`toCode: function (named) 1`] = `
 {
   "importStrings": [],
   "localeLoaders": [],
+  "normalizedLocales": [],
   "nuxtI18nOptions": {
     "defaultLocale": "en",
     "lazy": false,
@@ -343,18 +650,12 @@ exports[`toCode: function (named) 1`] = `
         "files": [
           "en.json",
         ],
-        "paths": [
-          "/path/to/en.json",
-        ],
         "testFunc": [Function],
       },
       {
         "code": "ja",
         "files": [
           "ja.json",
-        ],
-        "paths": [
-          "/path/to/ja.json",
         ],
         "testFunc": [Function],
       },
@@ -363,15 +664,12 @@ exports[`toCode: function (named) 1`] = `
         "files": [
           "fr.json",
         ],
-        "paths": [
-          "/path/to/fr.json",
-        ],
         "testFunc": [Function],
       },
     ],
   },
   "vueI18nConfigs": [
-    "() => import("../i18n.config.ts?hash=bffaebcb&config=1" /* webpackChunkName: "i18n_config_ts_bffaebcb" */)",
+    "() => import("/test/i18n.config.ts?hash=6354e9fa&config=1" /* webpackChunkName: "i18n_config_ts_6354e9fa" */)",
   ],
 }
 `;
@@ -379,9 +677,9 @@ exports[`toCode: function (named) 1`] = `
 exports[`vueI18n option 1`] = `
 {
   "importStrings": [
-    "import locale__test_srcDir_en_json from "../srcDir/en.json";",
-    "import locale__test_srcDir_ja_json from "../srcDir/ja.json";",
-    "import locale__test_srcDir_fr_json from "../srcDir/fr.json";",
+    "import locale_srcDir_srcDir_en_json from "srcDir/en.json";",
+    "import locale_srcDir_srcDir_ja_json from "srcDir/ja.json";",
+    "import locale_srcDir_srcDir_fr_json from "srcDir/fr.json";",
   ],
   "localeLoaders": [
     [
@@ -389,8 +687,8 @@ exports[`vueI18n option 1`] = `
       [
         {
           "cache": "true",
-          "key": ""../srcDir/en.json"",
-          "load": "() => Promise.resolve(locale__test_srcDir_en_json)",
+          "key": ""srcDir/en.json"",
+          "load": "() => Promise.resolve(locale_srcDir_srcDir_en_json)",
         },
       ],
     ],
@@ -399,8 +697,8 @@ exports[`vueI18n option 1`] = `
       [
         {
           "cache": "true",
-          "key": ""../srcDir/ja.json"",
-          "load": "() => Promise.resolve(locale__test_srcDir_ja_json)",
+          "key": ""srcDir/ja.json"",
+          "load": "() => Promise.resolve(locale_srcDir_srcDir_ja_json)",
         },
       ],
     ],
@@ -409,11 +707,40 @@ exports[`vueI18n option 1`] = `
       [
         {
           "cache": "true",
-          "key": ""../srcDir/fr.json"",
-          "load": "() => Promise.resolve(locale__test_srcDir_fr_json)",
+          "key": ""srcDir/fr.json"",
+          "load": "() => Promise.resolve(locale_srcDir_srcDir_fr_json)",
         },
       ],
     ],
+  ],
+  "normalizedLocales": [
+    {
+      "code": "en",
+      "files": [
+        {
+          "cache": true,
+          "path": "en.json",
+        },
+      ],
+    },
+    {
+      "code": "ja",
+      "files": [
+        {
+          "cache": true,
+          "path": "ja.json",
+        },
+      ],
+    },
+    {
+      "code": "fr",
+      "files": [
+        {
+          "cache": true,
+          "path": "fr.json",
+        },
+      ],
+    },
   ],
   "nuxtI18nOptions": {
     "lazy": false,
@@ -421,9 +748,9 @@ exports[`vueI18n option 1`] = `
     "vueI18n": "vue-i18n.config.ts",
   },
   "vueI18nConfigs": [
-    "() => import("../foo/layer2/vue-i18n.options.js?hash=475488e5&config=1" /* webpackChunkName: "vue_i18n_options_js_475488e5" */)",
-    "() => import("../layer1/i18n.custom.ts?hash=0ca697e2&config=1" /* webpackChunkName: "i18n_custom_ts_0ca697e2" */)",
-    "() => import("../to/i18n.config.ts?hash=fb1304e8&config=1" /* webpackChunkName: "i18n_config_ts_fb1304e8" */)",
+    "() => import("/path/foo/layer2/vue-i18n.options.js?hash=84df1640&config=1" /* webpackChunkName: "vue_i18n_options_js_84df1640" */)",
+    "() => import("/path/layer1/i18n.custom.ts?hash=faa288dc&config=1" /* webpackChunkName: "i18n_custom_ts_faa288dc" */)",
+    "() => import("/path/to/i18n.config.ts?hash=42902d1e&config=1" /* webpackChunkName: "i18n_config_ts_42902d1e" */)",
   ],
 }
 `;

--- a/test/__snapshots__/gen.test.ts.snap
+++ b/test/__snapshots__/gen.test.ts.snap
@@ -70,6 +70,7 @@ exports[`basic 1`] = `
   ],
   "nuxtI18nOptions": {
     "defaultLocale": "en",
+    "i18nModules": [],
     "lazy": false,
     "locales": [],
   },
@@ -195,6 +196,7 @@ exports[`files with cache configuration (relative) 1`] = `
     "experimental": {
       "generatedLocaleFilePathFormat": "relative",
     },
+    "i18nModules": [],
     "lazy": true,
     "locales": [],
   },
@@ -317,6 +319,7 @@ exports[`files with cache configuration 1`] = `
   ],
   "nuxtI18nOptions": {
     "defaultLocale": "en",
+    "i18nModules": [],
     "lazy": true,
     "locales": [],
   },
@@ -392,6 +395,7 @@ exports[`lazy 1`] = `
   ],
   "nuxtI18nOptions": {
     "defaultLocale": "en",
+    "i18nModules": [],
     "lazy": true,
     "locales": [],
   },
@@ -467,6 +471,7 @@ exports[`locale file in nested 1`] = `
   ],
   "nuxtI18nOptions": {
     "defaultLocale": "en",
+    "i18nModules": [],
     "lazy": true,
     "locales": [],
   },
@@ -589,6 +594,7 @@ exports[`multiple files 1`] = `
   ],
   "nuxtI18nOptions": {
     "defaultLocale": "en",
+    "i18nModules": [],
     "lazy": true,
     "locales": [],
   },
@@ -605,6 +611,7 @@ exports[`toCode: function (arrow) 1`] = `
   "normalizedLocales": [],
   "nuxtI18nOptions": {
     "defaultLocale": "en",
+    "i18nModules": [],
     "lazy": false,
     "locales": [
       {
@@ -643,6 +650,7 @@ exports[`toCode: function (named) 1`] = `
   "normalizedLocales": [],
   "nuxtI18nOptions": {
     "defaultLocale": "en",
+    "i18nModules": [],
     "lazy": false,
     "locales": [
       {
@@ -743,6 +751,7 @@ exports[`vueI18n option 1`] = `
     },
   ],
   "nuxtI18nOptions": {
+    "i18nModules": [],
     "lazy": false,
     "locales": [],
     "vueI18n": "vue-i18n.config.ts",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* #3234
* #3188 
* #3022 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Related to #3022 but does not resolve it.

Resolves #3234 
Resolves #3188 

This only changes the paths in the generated options to be relative, this is still not desirable but better than exposing absolute paths as it could expose sensitive information.

Since this also influences the paths found in the `locales` array returned by `useI18n` I have made this a configurable option with `experimental.generatedLocaleFilePathFormat` to prevent this being a breaking change, in the future I want to look into removing the paths entirely or hashing the file paths.

I'm not sure if there are use cases for end users to have access to the `files` property on the generated locale options.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
