### PR TITLE
feat: configurable `bundle.optimizeTranslationDirective`

### DIFF
--- a/docs/content/docs/4.api/0.options.md
+++ b/docs/content/docs/4.api/0.options.md
@@ -443,6 +443,13 @@ It can be useful if you have one code base (e.g. [Nuxt Layers](https://nuxt.com/
 The value of this **option will not be merged with other Nuxt Layers**. This option should only be specified in the final project config.
 ::
 
+### `optimizeTranslationDirective`
+
+- type: `boolean`{lang="ts-type"}
+- default: `true`{lang="ts"}
+
+Whether to optimize `v-t` directive by transforming it's usage into a vue-i18n translation function, this needs to be enabled for projects using the `v-t` directive with SSR.
+
 ## experimental
 
 Experimental configuration property is an object with the following properties:

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -42,7 +42,7 @@ export async function extendBundler({ options: nuxtOptions }: I18nNuxtContext, n
       compositionOnly: nuxtOptions.bundle.compositionOnly,
       onlyLocales: nuxtOptions.bundle.onlyLocales,
       dropMessageCompiler: nuxtOptions.bundle.dropMessageCompiler,
-      optimizeTranslationDirective: true,
+      optimizeTranslationDirective: nuxtOptions.bundle.optimizeTranslationDirective,
       strictMessage: nuxtOptions.compilation.strictMessage,
       escapeHtml: nuxtOptions.compilation.escapeHtml,
       include: localeIncludePaths
@@ -75,7 +75,7 @@ export async function extendBundler({ options: nuxtOptions }: I18nNuxtContext, n
     fullInstall: nuxtOptions.bundle.fullInstall,
     onlyLocales: nuxtOptions.bundle.onlyLocales,
     dropMessageCompiler: nuxtOptions.bundle.dropMessageCompiler,
-    optimizeTranslationDirective: true,
+    optimizeTranslationDirective: nuxtOptions.bundle.optimizeTranslationDirective,
     strictMessage: nuxtOptions.compilation.strictMessage,
     escapeHtml: nuxtOptions.compilation.escapeHtml,
     defaultSFCLang: nuxtOptions.customBlocks.defaultSFCLang,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,7 +38,8 @@ export const DEFAULT_OPTIONS = {
     compositionOnly: true,
     runtimeOnly: false,
     fullInstall: true,
-    dropMessageCompiler: false
+    dropMessageCompiler: false,
+    optimizeTranslationDirective: true
   },
   compilation: {
     jit: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,7 +132,12 @@ export interface ExperimentalFeatures {
 export interface BundleOptions
   extends Pick<
     PluginOptions,
-    'compositionOnly' | 'runtimeOnly' | 'fullInstall' | 'dropMessageCompiler' | 'onlyLocales'
+    | 'compositionOnly'
+    | 'runtimeOnly'
+    | 'fullInstall'
+    | 'dropMessageCompiler'
+    | 'onlyLocales'
+    | 'optimizeTranslationDirective'
   > {}
 
 export interface CustomBlocksOptions extends Pick<PluginOptions, 'defaultSFCLang' | 'globalSFCScope'> {}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* #3241
* https://github.com/intlify/vue-i18n/pull/2045
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
It's more of a fix than a feature, since this gives users a workaround for #3241. Since we're deprecating `v-t` in future versions anyway (https://github.com/intlify/vue-i18n/pull/2045) this will allow users to opt out of its optimization. 

Checking whether the compiler is present will be a more complete (no user action required) fix (https://github.com/intlify/bundle-tools/pull/421) as it's currently breaking the reproduction/start template as well.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
