### PR TITLE
docs: fix incorrect file extension in nuxt.config.ts example (fr-FR.ts)

### DIFF
--- a/docs/content/docs/2.guide/7.lazy-load-translations.md
+++ b/docs/content/docs/2.guide/7.lazy-load-translations.md
@@ -22,7 +22,7 @@ Example files structure:
 -----| locales/
 -------| en-US.json
 -------| es-ES.js
--------| fr-FR.js
+-------| fr-FR.ts
 ---| nuxt.config.ts
 ```
 


### PR DESCRIPTION
docs: fix incorrect file extension in nuxt.config.ts example (fr-FR.ts)

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

No specific issue linked, but this concerns an error in the documentation regarding file extensions.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

An inconsistency was found in the documentation related to localization configuration examples. The documentation incorrectly references a file named fr-FR.js, while the rest of the examples and content consistently use fr-FR.ts. This discrepancy can lead to confusion for developers strictly following the provided examples.

Problem:
The documentation mentions a file named fr-FR.js, but all subsequent examples refer exclusively to fr-FR.ts.

Proposed solution:
Replace the mention of fr-FR.js with fr-FR.ts to ensure consistency and avoid confusion.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [X] I have updated the documentation accordingly.
