### PR TITLE
refactor: provide context functions from plugin

### DIFF
--- a/src/runtime/injections.ts
+++ b/src/runtime/injections.ts
@@ -6,7 +6,13 @@ import type {
   SwitchLocalePathFunction
 } from '#i18n'
 import type { localeHead } from './routing/compatibles/head'
-import type { getRouteBaseName, localePath, localeRoute, switchLocalePath } from './routing/compatibles/routing'
+import type {
+  getRouteBaseName,
+  localeLocation,
+  localePath,
+  localeRoute,
+  switchLocalePath
+} from './routing/compatibles/routing'
 
 export type NuxtI18nPluginInjections = {
   /**
@@ -60,4 +66,12 @@ export type NuxtI18nPluginInjections = {
    * @returns A path of the current route
    */
   switchLocalePath: (...args: Parameters<SwitchLocalePathFunction>) => ReturnType<typeof switchLocalePath>
+  /**
+   * @deprecated use {@link localePath} or {@link localeRoute} instead
+   */
+  resolveRoute: (...args: Parameters<LocaleRouteFunction>) => ReturnType<typeof localeRoute>
+  /**
+   * @deprecated use {@link localeRoute} instead
+   */
+  localeLocation: (...args: Parameters<LocaleRouteFunction>) => ReturnType<typeof localeLocation>
 }

--- a/src/runtime/routing/extends/i18n.ts
+++ b/src/runtime/routing/extends/i18n.ts
@@ -1,16 +1,5 @@
 import { effectScope } from '#imports'
 import { isVueI18n, getComposer } from '../../compatibility'
-import { localeHead } from '../compatibles/head'
-import {
-  getRouteBaseName,
-  localeLocation,
-  localePath,
-  localeRoute,
-  resolveRoute,
-  switchLocalePath
-} from '../compatibles/routing'
-import { wrapComposable } from '../../internal'
-import { initCommonComposableOptions } from '../../utils'
 
 import type { NuxtApp } from 'nuxt/app'
 import type { Composer, ComposerExtender, ExportedGlobalComposer, I18n, VueI18n, VueI18nExtender } from 'vue-i18n'
@@ -19,12 +8,6 @@ import type { Composer, ComposerExtender, ExportedGlobalComposer, I18n, VueI18n,
  * Internal options for the Vue I18n plugin.
  */
 interface VueI18nInternalPluginOptions {
-  /**
-   * Whether to inject some option APIs style methods into Vue instance
-   *
-   * @defaultValue `true`
-   */
-  inject?: boolean
   /**
    * @internal
    */
@@ -52,7 +35,6 @@ export function extendI18n(i18n: I18n, { extendComposer, extendComposerInstance 
   const installI18n = i18n.install.bind(i18n)
   i18n.install = (app: NuxtApp['vueApp'], ...options: VueI18nInternalPluginOptions[]) => {
     const pluginOptions = Object.assign({}, options[0])
-    pluginOptions.inject ??= true
 
     pluginOptions.__composerExtend = (c: Composer) => {
       extendComposerInstance(c, getComposer(i18n))
@@ -82,22 +64,6 @@ export function extendI18n(i18n: I18n, { extendComposer, extendComposerInstance 
     // extend Vue component instance for Vue 3
     if (i18n.mode === 'composition' && app.config.globalProperties.$i18n != null) {
       extendComposerInstance(app.config.globalProperties.$i18n, globalComposer)
-    }
-
-    // extend Vue component instance
-    if (pluginOptions.inject) {
-      const common = initCommonComposableOptions(i18n)
-      app.mixin({
-        methods: {
-          $getRouteBaseName: wrapComposable(getRouteBaseName, common),
-          $resolveRoute: wrapComposable(resolveRoute, common),
-          $localePath: wrapComposable(localePath, common),
-          $localeRoute: wrapComposable(localeRoute, common),
-          $localeLocation: wrapComposable(localeLocation, common),
-          $switchLocalePath: wrapComposable(switchLocalePath, common),
-          $localeHead: wrapComposable(localeHead, common)
-        }
-      })
     }
 
     // dispose effectScope during app unmount

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -4,24 +4,14 @@ import { isString, isFunction, isObject } from '@intlify/shared'
 import { navigateTo, useNuxtApp, useRouter, useRuntimeConfig, useState } from '#imports'
 import { NUXT_I18N_MODULE_ID, isSSG, localeCodes, localeLoaders, normalizedLocales } from '#build/i18n.options.mjs'
 import {
-  wrapComposable,
   detectBrowserLanguage,
-  defineGetter,
   getLocaleDomain,
   getDomainFromLocale,
   runtimeDetectBrowserLanguage,
   getHost
 } from './internal'
 import { loadLocale, makeFallbackLocaleCodes } from './messages'
-import { localeHead } from './routing/compatibles/head'
-import {
-  localePath,
-  localeRoute,
-  getRouteBaseName,
-  switchLocalePath,
-  DefaultPrefixable
-} from './routing/compatibles/routing'
-import { getI18nTarget } from './compatibility'
+import { localePath, switchLocalePath, DefaultPrefixable } from './routing/compatibles/routing'
 import { createLogger } from 'virtual:nuxt-i18n-logger'
 import { createLocaleFromRouteGetter } from './routing/extends/router'
 import { unref } from 'vue'
@@ -335,23 +325,6 @@ export async function navigate(
       }
     }
   }
-}
-
-export function injectNuxtHelpers(nuxt: NuxtApp, i18n: I18n) {
-  /**
-   * NOTE:
-   *  we will inject `i18n.global` to **nuxt app instance only**
-   *  as vue-i18n has already been injected into vue,
-   *
-   *  implementation borrowed from
-   *  https://github.com/nuxt/nuxt/blob/a995f724eadaa06d5443b188879ac18dfe73de2e/packages/nuxt/src/app/nuxt.ts#L295-L299
-   */
-  defineGetter(nuxt, '$i18n', getI18nTarget(i18n))
-  defineGetter(nuxt, '$getRouteBaseName', wrapComposable(getRouteBaseName))
-  defineGetter(nuxt, '$localePath', wrapComposable(localePath))
-  defineGetter(nuxt, '$localeRoute', wrapComposable(localeRoute))
-  defineGetter(nuxt, '$switchLocalePath', wrapComposable(switchLocalePath))
-  defineGetter(nuxt, '$localeHead', wrapComposable(localeHead))
 }
 
 // override prefix for route path, support domain


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This changes the way functions are added to the context, relying on Nuxt plugin returning these via the `provide` property. Ideally we can remove the type assertions, these were not required previously as we indirectly added these to the `defineNuxtPlugin` statement previously to achieve the same types.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
