### PR TITLE
fix: custom paths `pages` config should use route name as key

### DIFF
--- a/src/pages.ts
+++ b/src/pages.ts
@@ -28,6 +28,7 @@ export type AnalyzedNuxtPageMeta = {
    * Analyzed path used to retrieve configured custom paths
    */
   path: string
+  name?: string
 }
 
 export type NuxtPageAnalyzeContext = {
@@ -233,6 +234,8 @@ export function analyzeNuxtPages(ctx: NuxtPageAnalyzeContext, pages?: NuxtPage[]
 
     ctx.pages.set(page, {
       path: analyzePagePath(filePath, ctx.stack.length),
+      // if route has an index child the parent will not have a name
+      name: page.name ?? page.children?.find(x => x.path.endsWith('/index'))?.name,
       inRoot: ctx.stack.length === 0
     })
 
@@ -296,7 +299,8 @@ function getRouteOptionsFromPages(
     return options
   }
 
-  const pageOptions = pageMeta.path ? pages[pageMeta.path] : undefined
+  const valueByName = pageMeta.name ? pages[pageMeta.name] : undefined
+  const pageOptions = valueByName ?? pages[pageMeta.path]
 
   // routing disabled
   if (pageOptions === false) {

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -220,6 +220,11 @@ export function localizeRoutes(routes: NuxtPage[], options: LocalizeRoutesParams
       // remove parent path from child route
       if (parentLocalized != null) {
         localized.path = localized.path.replace(parentLocalized.path + '/', '')
+
+        // handle parent/index
+        if (localized.path === parentLocalized.path) {
+          localized.path = ''
+        }
       }
 
       // localize child routes if set

--- a/test/pages/__snapshots__/custom_route.test.ts.snap
+++ b/test/pages/__snapshots__/custom_route.test.ts.snap
@@ -318,3 +318,98 @@ exports[`Page components > with definePageMeta 1`] = `
   },
 ]
 `;
+
+exports[`pages config using route name 1`] = `
+[
+  {
+    "children": [
+      {
+        "children": [],
+        "file": "/path/to/1649/pages/account/addresses.vue",
+        "name": "account-addresses___en",
+        "path": "addresses",
+      },
+      {
+        "children": [],
+        "file": "/path/to/1649/pages/account/index.vue",
+        "name": "account___en",
+        "path": "",
+      },
+      {
+        "children": [],
+        "file": "/path/to/1649/pages/account/profile.vue",
+        "name": "account-profile___en",
+        "path": "profile",
+      },
+    ],
+    "file": "/path/to/1649/pages/account.vue",
+    "path": "/account",
+  },
+  {
+    "children": [
+      {
+        "children": [],
+        "file": "/path/to/1649/pages/account/addresses.vue",
+        "name": "account-addresses___ja",
+        "path": "addresses",
+      },
+      {
+        "children": [],
+        "file": "/path/to/1649/pages/account/index.vue",
+        "name": "account___ja",
+        "path": "",
+      },
+      {
+        "children": [],
+        "file": "/path/to/1649/pages/account/profile.vue",
+        "name": "account-profile___ja",
+        "path": "profile",
+      },
+    ],
+    "file": "/path/to/1649/pages/account.vue",
+    "path": "/ja/account",
+  },
+  {
+    "children": [
+      {
+        "children": [],
+        "file": "/path/to/1649/pages/account/addresses.vue",
+        "name": "account-addresses___fr",
+        "path": "adresses",
+      },
+      {
+        "children": [],
+        "file": "/path/to/1649/pages/account/index.vue",
+        "name": "account___fr",
+        "path": "",
+      },
+      {
+        "children": [],
+        "file": "/path/to/1649/pages/account/profile.vue",
+        "name": "account-profile___fr",
+        "path": "profil",
+      },
+    ],
+    "file": "/path/to/1649/pages/account.vue",
+    "path": "/fr/compte",
+  },
+  {
+    "children": [],
+    "file": "/path/to/1649/pages/index.vue",
+    "name": "index___en",
+    "path": "/",
+  },
+  {
+    "children": [],
+    "file": "/path/to/1649/pages/index.vue",
+    "name": "index___ja",
+    "path": "/ja",
+  },
+  {
+    "children": [],
+    "file": "/path/to/1649/pages/index.vue",
+    "name": "index___fr",
+    "path": "/fr",
+  },
+]
+`;

--- a/test/pages/analyze_nuxt_page.test.ts
+++ b/test/pages/analyze_nuxt_page.test.ts
@@ -112,21 +112,83 @@ test('analyzeNuxtPages', () => {
   analyzeNuxtPages(ctx, pages)
 
   expect(ctx.stack.length).toBe(0)
-  expect([...ctx.pages.values()]).toEqual([
-    { inRoot: true, path: '[...catch]' },
-    { inRoot: true, path: 'account' },
-    { inRoot: false, path: 'account/addresses' },
-    { inRoot: false, path: 'account/foo[id]' },
-    { inRoot: false, path: 'account/index' },
-    { inRoot: false, path: 'account/profile' },
-    { inRoot: true, path: 'blog/[date]/[slug]' },
-    { inRoot: true, path: 'foo' },
-    { inRoot: false, path: 'foo/bar' },
-    { inRoot: false, path: 'foo/bar' },
-    { inRoot: false, path: 'foo/bar/buz' },
-    { inRoot: false, path: 'foo/hoge/[piyo]' },
-    { inRoot: false, path: 'foo/qux' },
-    { inRoot: true, path: 'index' },
-    { inRoot: true, path: 'users/[[profile]]' }
-  ])
+  expect([...ctx.pages.values()]).toMatchInlineSnapshot(`
+    [
+      {
+        "inRoot": true,
+        "name": "catch",
+        "path": "[...catch]",
+      },
+      {
+        "inRoot": true,
+        "name": undefined,
+        "path": "account",
+      },
+      {
+        "inRoot": false,
+        "name": "account-addresses",
+        "path": "account/addresses",
+      },
+      {
+        "inRoot": false,
+        "name": "account-fooid",
+        "path": "account/foo[id]",
+      },
+      {
+        "inRoot": false,
+        "name": "account",
+        "path": "account/index",
+      },
+      {
+        "inRoot": false,
+        "name": "account-profile",
+        "path": "account/profile",
+      },
+      {
+        "inRoot": true,
+        "name": "blog-date-slug",
+        "path": "blog/[date]/[slug]",
+      },
+      {
+        "inRoot": true,
+        "name": "foo",
+        "path": "foo",
+      },
+      {
+        "inRoot": false,
+        "name": "foo-bar",
+        "path": "foo/bar",
+      },
+      {
+        "inRoot": false,
+        "name": "foo-bar",
+        "path": "foo/bar",
+      },
+      {
+        "inRoot": false,
+        "name": "foo-bar-buz",
+        "path": "foo/bar/buz",
+      },
+      {
+        "inRoot": false,
+        "name": "foo-hoge-piyo",
+        "path": "foo/hoge/[piyo]",
+      },
+      {
+        "inRoot": false,
+        "name": "foo-qux",
+        "path": "foo/qux",
+      },
+      {
+        "inRoot": true,
+        "name": "index",
+        "path": "index",
+      },
+      {
+        "inRoot": true,
+        "name": "users-profile",
+        "path": "users/[[profile]]",
+      },
+    ]
+  `)
 })

--- a/test/pages/custom_route.test.ts
+++ b/test/pages/custom_route.test.ts
@@ -269,3 +269,69 @@ test('#1649', () => {
 
   expect(localizedPages).toMatchSnapshot()
 })
+
+test('pages config using route name', () => {
+  const pages = [
+    {
+      path: '/account',
+      file: '/path/to/1649/pages/account.vue',
+      children: [
+        {
+          name: 'account-addresses',
+          path: 'addresses',
+          file: '/path/to/1649/pages/account/addresses.vue',
+          children: []
+        },
+        {
+          name: 'account',
+          path: '',
+          file: '/path/to/1649/pages/account/index.vue',
+          children: []
+        },
+        {
+          name: 'account-profile',
+          path: 'profile',
+          file: '/path/to/1649/pages/account/profile.vue',
+          children: []
+        }
+      ]
+    },
+    {
+      name: 'index',
+      path: '/',
+      file: '/path/to/1649/pages/index.vue',
+      children: []
+    }
+  ]
+
+  const options = getNuxtOptions({
+    account: {
+      fr: '/compte'
+    },
+    'account-profile': {
+      fr: '/compte/profil'
+    },
+    'account-addresses': {
+      fr: '/compte/adresses'
+    }
+  })
+
+  vi.spyOn(fs, 'readFileSync').mockReturnValue('')
+
+  const srcDir = '/path/to/1649'
+  const pagesDir = 'pages'
+  const ctx: NuxtPageAnalyzeContext = {
+    stack: [],
+    srcDir,
+    pagesDir,
+    pages: new Map<NuxtPage, AnalyzedNuxtPageMeta>()
+  }
+
+  analyzeNuxtPages(ctx, pages)
+  const localizedPages = localizeRoutes(pages, {
+    ...options,
+    includeUnprefixedFallback: false,
+    optionsResolver: getRouteOptionsResolver(ctx, options as Required<NuxtI18nOptions>)
+  } as Parameters<typeof localizeRoutes>[1])
+  expect(localizedPages).toMatchSnapshot()
+})


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* #3185

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #3185 

It appears the documentation is incorrect and has likely been so since v9, at the moment custom paths configuration using the `pages` property only supports using route paths (without leading `/`) as keys, this is especially problematic since the generated types with `experimental.typedPages` will give type completion for route names as keys... 

This PR resolves this by supporting both paths and names as keys, and I am planning to deprecate the path keys in the next major version. I'm not 100% sure if this has potential to collide with existing path configurations, but I haven't found scenarios in which that would be possible, if there are we may need to make this change configurable (opt-in), but supporting both would mean the existing documentation would be correct again.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
