### PR TITLE
docs: search filtering and move compiler macros

### DIFF
--- a/docs/app.vue
+++ b/docs/app.vue
@@ -19,7 +19,7 @@ provide('navigation', navigation)
 const router = useRouter()
 
 const isV7Docs = computed(() => router.currentRoute.value.path.includes('/docs/v7'))
-const isV9Docs = computed(() => router.currentRoute.value.path.includes('/docs/v9'))
+const isV8Docs = computed(() => router.currentRoute.value.path.includes('/docs/v8'))
 
 // Search
 const { data: files } = useLazyFetch<ParsedContent[]>('/api/search.json', {
@@ -28,21 +28,21 @@ const { data: files } = useLazyFetch<ParsedContent[]>('/api/search.json', {
 })
 
 const v7DocsRE = /^\/docs\/v7/
-const v9DocsRE = /^\/docs\/v9/
+const v8DocsRE = /^\/docs\/v8/
 
 const navigationV7 = computed(() => navigation.value?.[0].children.filter(x => v7DocsRE.test(String(x._path))))
-const navigationV9 = computed(() => navigation.value?.[0].children.filter(x => v9DocsRE.test(String(x._path))))
-const navigationV8 = computed(() =>
+const navigationV8 = computed(() => navigation.value?.[0].children.filter(x => v8DocsRE.test(String(x._path))))
+const navigationV9 = computed(() =>
   navigation.value?.[0].children.filter(x => {
     const to = String(x._path)
-    return !v9DocsRE.test(to) && !v7DocsRE.test(to)
+    return !v8DocsRE.test(to) && !v7DocsRE.test(to)
   })
 )
 
 const currentVersionNavigation = computed(() => {
   if (isV7Docs.value) return navigationV7.value
-  if (isV9Docs.value) return navigationV9.value
-  return navigationV8.value
+  if (isV8Docs.value) return navigationV8.value
+  return navigationV9.value
 })
 
 // Header

--- a/docs/content/docs/7.compiler-macros/1.define-i18n-route.md
+++ b/docs/content/docs/7.compiler-macros/1.define-i18n-route.md
@@ -1,6 +1,5 @@
 ---
-title: Compiler Macros
-description: Compiler Macros for Nuxt i18n module
+title: defineI18nRoute
 ---
 
 `defineI18nRoute()`{lang="ts"} is a compiler macro that you can use to set custom route paths for your **page** components located in the `pages/` directory (unless [set otherwise](https://nuxt.com/docs/api/configuration/nuxt-config#pages-1)). This way you can set custom route paths for each static or dynamic route of your Nuxt application.

--- a/docs/content/docs/7.compiler-macros/_dir.yml
+++ b/docs/content/docs/7.compiler-macros/_dir.yml
@@ -1,0 +1,1 @@
+title: Compiler Macros


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* #3315
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #3315 

The search suggestions were not being filtered correctly (still used old filtering based on `/docs/v9` structure). The `defineI18nRoute` was not shown in the search suggestions, I guess due to it mostly being documented in code blocks, by separating it into its own page it will definitely show up in the search results.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
