### PR TITLE
fix: consistent composer instance properties across scopes

### DIFF
--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -169,12 +169,13 @@ export default defineNuxtPlugin({
         }
       },
       extendComposerInstance(instance, c) {
+        // Set the extended properties on local scope composer instance
         const props: [keyof Composer, PropertyDescriptor['get']][] = [
-          ['locales', () => c.locales.value],
-          ['localeCodes', () => c.localeCodes.value],
-          ['baseUrl', () => c.baseUrl.value],
+          ['locales', () => c.locales],
+          ['localeCodes', () => c.localeCodes],
+          ['baseUrl', () => c.baseUrl],
           ['strategy', () => c.strategy],
-          ['localeProperties', () => c.localeProperties.value],
+          ['localeProperties', () => c.localeProperties],
           ['setLocale', () => async (locale: string) => Reflect.apply(c.setLocale, c, [locale])],
           ['loadLocaleMessages', () => async (locale: string) => Reflect.apply(c.loadLocaleMessages, c, [locale])],
           ['differentDomains', () => c.differentDomains],


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* #3295
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #3295

The properties on a composer instance changed when using a locale scope, I'm not sure if this was always the case or perhaps this was originally intended to better match legacy vue-i18n type/usage 🤔
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
