### PR TITLE
fix: check if resolved localized route name exists

### DIFF
--- a/specs/custom_route_paths/component.spec.ts
+++ b/specs/custom_route_paths/component.spec.ts
@@ -77,10 +77,14 @@ test('can not access to disable route path', async () => {
   // disable direct url access
   let res: Response | (Error & { status: () => number }) | null = null
   try {
-    res = await page.goto(url('/fr/ignore-routes/disable'))
+    // attempting to goto /fr/disable instead of /fr/ignore-routes/disable since
+    // that route has a catch all that would succeed
+    res = await page.goto(url('/fr/disable'))
   } catch (error: unknown) {
     res = error as Error & { status: () => number }
   }
+
+  console.log(res)
   // 404
   expect(res!.status()).toBe(404) // eslint-disable-line @typescript-eslint/no-non-null-assertion
 })

--- a/specs/fixtures/basic/nuxt.config.ts
+++ b/specs/fixtures/basic/nuxt.config.ts
@@ -2,6 +2,7 @@ import CustomModule from './module'
 
 // https://nuxt.com/docs/guide/directory-structure/nuxt.config
 export default defineNuxtConfig({
+  // devtools: { enabled: false },
   modules: [CustomModule, '@nuxtjs/i18n'],
 
   srcDir: '.',
@@ -9,6 +10,7 @@ export default defineNuxtConfig({
     restructureDir: false,
     lazy: false,
     baseUrl: 'http://localhost:3000',
+    // strategy: 'prefix',
     locales: [
       {
         code: 'en',

--- a/specs/fixtures/basic/pages/disable.vue
+++ b/specs/fixtures/basic/pages/disable.vue
@@ -1,0 +1,7 @@
+<script setup>
+defineI18nRoute(false)
+</script>
+
+<template>
+  <p>ignore localized route disable test</p>
+</template>

--- a/specs/fixtures/basic/pages/ignore-routes/[...catch].vue
+++ b/specs/fixtures/basic/pages/ignore-routes/[...catch].vue
@@ -1,0 +1,5 @@
+<script setup lang="ts"></script>
+
+<template>
+  <div>Catch all!</div>
+</template>

--- a/specs/routing_strategies/prefix.spec.ts
+++ b/specs/routing_strategies/prefix.spec.ts
@@ -150,6 +150,10 @@ describe('strategy: prefix', async () => {
     await page.locator('#goto-home').click()
     expect(await getText(page, '#home-header')).toEqual('Accueil')
 
+    // does not redirect to prefixed route for routes with disabled localization
+    await page.goto(url('/ignore-routes/disable'))
+    await waitForURL(page, '/ignore-routes/disable')
+
     await restore()
   })
 

--- a/src/runtime/routing/routing.ts
+++ b/src/runtime/routing/routing.ts
@@ -97,7 +97,12 @@ function resolveRouteObject(common: CommonComposableOptions, route: RouteLike, l
 
   // if name is falsy fallback to current route name
   route.name ||= getRouteBaseName(common, common.router.currentRoute.value)
-  route.name = getLocaleRouteName(route.name, locale, runtimeI18n)
+
+  const localizedName = getLocaleRouteName(route.name, locale, runtimeI18n)
+  // route localization may be disabled, check if localized variant exists
+  if (common.router.hasRoute(localizedName)) {
+    route.name = localizedName
+  }
 
   return route
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* #3321 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #3321 

This changes route resolution, we now check if a route exists with the localization suffix, if it doesn't it may be a route with localization disabled.

We may need to invert this conditional, check if a route exists without the localization suffix and otherwise proceed with the locale suffix, to ensure localized catchall/404 handling.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
