### PR TITLE
docs: fix broken `defineI18nLocaleDetector` links

### DIFF
--- a/docs/content/docs/2.guide/16.server-side-translations.md
+++ b/docs/content/docs/2.guide/16.server-side-translations.md
@@ -59,7 +59,7 @@ export default defineNuxtConfig({
 })
 ```
 
-For details on the locale detector function defined by `defineI18nLocaleDetector()`{lang="ts"}, see [here](/docs/api#definei18nlocaledetector).
+For details on the locale detector function defined by `defineI18nLocaleDetector()`{lang="ts"}, see [here](/docs/composables/define-i18n-locale-detector).
 
 ## `useTranslation()`{lang="ts"} on eventHandler
 

--- a/docs/content/docs/4.api/0.options.md
+++ b/docs/content/docs/4.api/0.options.md
@@ -461,7 +461,7 @@ Experimental configuration property is an object with the following properties:
 - Specify the locale detector to be called per request on the server side. You need to specify the filepath where the locale detector is defined.
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
-For more details on how to define the locale detector, see the [`defineI18nLocaleDetector()`{lang="ts"} API](/docs/api#definei18nlocaledetector)
+For more details on how to define the locale detector, see the [`defineI18nLocaleDetector()`{lang="ts"} API](/docs/composables/define-i18n-locale-detector)
 ::
 
 ### `switchLocalePathLinkSSR`


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* https://github.com/nuxt-modules/i18n/issues/3297
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Fixes the broken documentation links mentioned in https://github.com/nuxt-modules/i18n/issues/3297

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
