### PR TITLE
fix: `availableLocales` not including configured locales

### DIFF
--- a/specs/basic_usage.spec.ts
+++ b/specs/basic_usage.spec.ts
@@ -75,6 +75,21 @@ describe('basic usage', async () => {
     expect(await page.url()).include('/user/profile?foo=1')
   })
 
+  test('(#3344) `availableLocales` includes all configured locales', async () => {
+    const { page } = await renderPage('/')
+
+    // @ts-expect-error runtime types
+    expect(await page.evaluate(() => window.useNuxtApp?.().$i18n.availableLocales)).toMatchInlineSnapshot(`
+      [
+        "en",
+        "fr",
+        "ja",
+        "kr",
+        "nl",
+      ]
+    `)
+  })
+
   test('`v-t` directive SSR', async () => {
     const pageHTML = await $fetch('/')
     const pageDOM = getDom(pageHTML)

--- a/specs/basic_usage_compat_4.spec.ts
+++ b/specs/basic_usage_compat_4.spec.ts
@@ -75,6 +75,21 @@ describe('basic usage - compatibilityVersion: 4', async () => {
     expect(await page.url()).include('/user/profile?foo=1')
   })
 
+  test('(#3344) `availableLocales` includes all configured locales', async () => {
+    const { page } = await renderPage('/')
+
+    // @ts-expect-error runtime types
+    expect(await page.evaluate(() => window.useNuxtApp?.().$i18n.availableLocales)).toMatchInlineSnapshot(`
+      [
+        "en",
+        "fr",
+        "ja",
+        "kr",
+        "nl",
+      ]
+    `)
+  })
+
   test('`v-t` directive SSR', async () => {
     const pageHTML = await $fetch('/')
     const pageDOM = getDom(pageHTML)

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -66,6 +66,12 @@ export default defineNuxtPlugin({
 
     const vueI18nOptions: I18nOptions = await loadVueI18nOptions(vueI18nConfigs, useNuxtApp())
     vueI18nOptions.messages = vueI18nOptions.messages || {}
+
+    // initialize locale objects to make vue-i18n aware of available locales
+    for (const l of localeCodes) {
+      vueI18nOptions.messages[l] ??= {}
+    }
+
     vueI18nOptions.fallbackLocale = vueI18nOptions.fallbackLocale ?? false
     if (defaultLocaleDomain) {
       vueI18nOptions.locale = defaultLocaleDomain


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* #3344
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #3344

This ensures the configured locales are visible to vue-i18n which relies on the locale codes being set on the `messages` property. This was previously done by actually loading all locales, but broke during refactors/optimizations, setting the keys only should still be performant while resolving the regression.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
