### PR TITLE
fix: load fallback messages on first access

### DIFF
--- a/src/runtime/messages.ts
+++ b/src/runtime/messages.ts
@@ -1,4 +1,4 @@
-import { deepCopy, isFunction, isArray, isObject, isString } from '@intlify/shared'
+import { deepCopy, isFunction } from '@intlify/shared'
 import { createLogger } from 'virtual:nuxt-i18n-logger'
 
 import type { I18nOptions, Locale, FallbackLocale, LocaleMessages, DefineLocaleMessage } from 'vue-i18n'
@@ -35,19 +35,23 @@ export async function loadVueI18nOptions(
 }
 
 export function makeFallbackLocaleCodes(fallback: FallbackLocale, locales: Locale[]): Locale[] {
+  if (fallback === false) return []
+  if (Array.isArray(fallback)) return fallback
+
   let fallbackLocales: Locale[] = []
-  if (isArray(fallback)) {
-    fallbackLocales = fallback
-  } else if (isObject(fallback)) {
-    const targets = [...locales, 'default']
-    for (const locale of targets) {
-      if (fallback[locale]) {
-        fallbackLocales = [...fallbackLocales, ...fallback[locale].filter(Boolean)]
-      }
+  if (typeof fallback === 'string') {
+    if (locales.every(locale => locale !== fallback)) {
+      fallbackLocales.push(fallback)
     }
-  } else if (isString(fallback) && locales.every(locale => locale !== fallback)) {
-    fallbackLocales.push(fallback)
+    return fallbackLocales
   }
+
+  const targets = [...locales, 'default']
+  for (const locale of targets) {
+    if (locale in fallback == false) continue
+    fallbackLocales = [...fallbackLocales, ...fallback[locale].filter(Boolean)]
+  }
+
   return fallbackLocales
 }
 

--- a/src/runtime/plugins/route-locale-detect.ts
+++ b/src/runtime/plugins/route-locale-detect.ts
@@ -2,8 +2,9 @@ import { unref } from 'vue'
 import { hasPages } from '#build/i18n.options.mjs'
 import { addRouteMiddleware, defineNuxtPlugin, defineNuxtRouteMiddleware } from '#imports'
 import { createLogger } from 'virtual:nuxt-i18n-logger'
-import { detectLocale, detectRedirect, loadAndSetLocale, navigate } from '../utils'
+import { makeFallbackLocaleCodes } from '../messages'
 import { createLocaleFromRouteGetter } from '../routing/utils'
+import { detectLocale, detectRedirect, loadAndSetLocale, navigate } from '../utils'
 
 import type { NuxtApp } from '#app'
 import type { CompatRoute } from '../types'
@@ -22,6 +23,8 @@ export default defineNuxtPlugin({
 
       if (nuxtApp._vueI18n.__firstAccess) {
         nuxtApp._vueI18n.__setLocale(detected)
+        const fallbackLocales = makeFallbackLocaleCodes(unref(nuxtApp._vueI18n.global.fallbackLocale), [detected])
+        await Promise.all(fallbackLocales.map(x => nuxtApp.$i18n.loadLocaleMessages(x)))
         await nuxtApp.$i18n.loadLocaleMessages(detected)
       }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* #3348
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #3348

A bit puzzled how existing tests are not covering this, perhaps this is caused by earlier tests loading fallback locales server-side..
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
