### PR TITLE
docs: fix hydration error on the Usage page

### DIFF
--- a/docs/content/docs/2.guide/90.migrating.md
+++ b/docs/content/docs/2.guide/90.migrating.md
@@ -136,7 +136,7 @@ This is to ensure stability and distinction between compile / build-time and run
 
 For more details please see the [GitHub Pull request](https://github.com/nuxt-modules/i18n/pull/1948#issuecomment-1482749302)
 
-You can continue defining `vueI18n` options in `i18n.config`. Refer to the [Vue i18n](/docs/api/options) and [basic usage](/docs/getting-started/usage/#translate-with-vue-i18n) sections for examples on how to do so.
+You can continue defining `vueI18n` options in `i18n.config`. Refer to the [Vue i18n](/docs/api/options) and [basic usage](/docs/getting-started/usage#translate-with-vue-i18n) sections for examples on how to do so.
 
 ### Change the route key rules in `pages` option
 

--- a/docs/content/docs/90.v8/2.guide/18.migrating.md
+++ b/docs/content/docs/90.v8/2.guide/18.migrating.md
@@ -11,7 +11,7 @@ This is to ensure stability and distinction between compile / build-time and run
 
 For more details please see the [GitHub Pull request](https://github.com/nuxt-modules/i18n/pull/1948#issuecomment-1482749302)
 
-You can continue defining `vueI18n` options in `i18n.config`. Refer to the [Vue i18n](/docs/v8/options) and [basic usage](/docs/v8/getting-started/usage/#translate-with-vue-i18n) sections for examples on how to do so.
+You can continue defining `vueI18n` options in `i18n.config`. Refer to the [Vue i18n](/docs/v8/options) and [basic usage](/docs/v8/getting-started/usage#translate-with-vue-i18n) sections for examples on how to do so.
 
 ### Change the route key rules in `pages` option
 


### PR DESCRIPTION

### 🔗 Linked issue

#3245

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixed the hydration error on the Usage page so that refreshing the page won't lead to a 404 error.

While I'm not sure what the root cause is, I find the direct cause to be the incorrect link to the usage page, where an extra `/` is appended. I guess it somehow confuses the prerenderer.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
