### PR TITLE
fix: handle new `pages.enabled` property in nuxt

### DIFF
--- a/src/prepare/runtime.ts
+++ b/src/prepare/runtime.ts
@@ -55,7 +55,10 @@ export function prepareRuntime(ctx: I18nNuxtContext, nuxt: Nuxt) {
         isServer,
         normalizedLocales
       }),
-      hasPages: nuxt.options.pages,
+      hasPages:
+        nuxt.options.pages === true ||
+        // @ts-expect-error
+        (nuxt.options.pages && nuxt.options.pages?.enabled === true),
       localeCodes,
       dev,
       isSSG,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

https://github.com/nuxt/nuxt/pull/31101 (etc.)

This ensures that we normalise pages to a boolean - the expect error can be removed when upgrading to v3.16 types.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
