### PR TITLE
fix: use `@oxc-parser/wasm` as parser fallback

### DIFF
--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -1,3 +1,5 @@
+// Adapted from https://github.com/nuxt/nuxt/blob/6d85c15fb1783b003bb5d7cdefdd22b54f871f9d/packages/nuxt/src/core/utils/parse.ts
+
 export let parseSync: typeof import('oxc-parser').parseSync
 
 export async function initParser() {
@@ -9,6 +11,10 @@ export async function initParser() {
     const { parseSync: parse } = await import('@oxc-parser/wasm')
     parseSync = (filename, sourceText, options) =>
       // @ts-expect-error sourceType property conflict
-      parse(sourceText, { ...(options || {}), sourceFilename: filename + '.ts' })
+      parse(sourceText, {
+        ...(options || {}),
+        sourceFilename: filename.replace(/\?.*$/, '') + `.${options?.lang || 'ts'}`,
+        sourceType: 'module'
+      })
   }
 }

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -1,5 +1,4 @@
 export let parseSync: typeof import('oxc-parser').parseSync
-type ParseSyncParams = Parameters<typeof parseSync>
 
 export async function initParser() {
   try {
@@ -7,10 +6,9 @@ export async function initParser() {
   } catch (_) {
     console.warn('[nuxt-i18n]: Unable to import `oxc-parser`, falling back to `@oxc-parser/wasm`.')
 
-    const { parseSync: parser } = await import('@oxc-parser/wasm')
-    // @ts-expect-error sourceType property conflict
-    parseSync = (filename, sourceText, options?: ParseSyncParams[2]) =>
+    const { parseSync: parse } = await import('@oxc-parser/wasm')
+    parseSync = (filename, sourceText, options) =>
       // @ts-expect-error sourceType property conflict
-      parser(sourceText, { ...(options || {}), sourceFilename: filename })
+      parse(sourceText, { ...(options || {}), sourceFilename: filename + '.ts' })
   }
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We are using `@oxc-parser/wasm` as fallback when `oxc-parser` fails to import, unfortunately the function signatures are not the same.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
