### PR TITLE
fix: improve vue-i18n configuration not found warning

### DIFF
--- a/src/layers.ts
+++ b/src/layers.ts
@@ -167,12 +167,11 @@ export async function resolveLayerVueI18nConfigInfo(options: NuxtI18nOptions) {
 
   const resolveArr = nuxt.options._layers.map(async layer => {
     const i18n = getLayerI18n(layer)
-    const res = await resolveVueI18nConfigInfo(resolveI18nDir(layer, i18n || {}, true), i18n?.vueI18n)
+    const i18nDirPath = resolveI18nDir(layer, i18n || {}, true)
+    const res = await resolveVueI18nConfigInfo(i18nDirPath, i18n?.vueI18n)
 
     if (res == null && i18n?.vueI18n != null) {
-      logger.warn(
-        `Ignore Vue I18n configuration file does not exist at ${i18n.vueI18n} in ${layer.config.rootDir}. Skipping...`
-      )
+      logger.warn(`Vue I18n configuration file \`${i18n.vueI18n}\` not found in \`${i18nDirPath}\`. Skipping...`)
       return undefined
     }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* https://github.com/nuxt-modules/i18n/pull/3396#issuecomment-2708810905
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Changes the warning to properly print the directory we expect to find the vue-i18n configuration file instead of the layer root dir.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
