### PR TITLE
docs: remove typescript syntax from javascript example

### DIFF
--- a/docs/content/docs/02.guide/06.seo.md
+++ b/docs/content/docs/02.guide/06.seo.md
@@ -243,7 +243,7 @@ useHead({
     const i18nHead = useLocaleHead({ seo: { canonicalQueries: ['foo'] } })
     useHead(() => ({
       htmlAttrs: {
-        lang: i18nHead.value.htmlAttrs!.lang
+        lang: i18nHead.value.htmlAttrs.lang
       },
       link: [...(i18nHead.value.link || [])],
       meta: [...(i18nHead.value.meta || [])]


### PR DESCRIPTION
### 🔗 Linked issue

#3411 

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The use of exclamation marks should only be in effect when marking lang=ts.

### 📝 Checklist

- [x] I have linked an issue or discussion.

