### PR TITLE
fix: only optimize configured locale files

### DIFF
--- a/specs/fixtures/issues/3404/app.vue
+++ b/specs/fixtures/issues/3404/app.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    <NuxtRouteAnnouncer />
+    <NuxtPage />
+  </div>
+</template>

--- a/specs/fixtures/issues/3404/i18n/i18n.config.ts
+++ b/specs/fixtures/issues/3404/i18n/i18n.config.ts
@@ -1,0 +1,9 @@
+import en from './locales/en'
+import nl from './locales/nl'
+
+export default defineI18nConfig(() => ({
+  messages: {
+    en,
+    nl
+  }
+}))

--- a/specs/fixtures/issues/3404/i18n/locales/en/greeting.js
+++ b/specs/fixtures/issues/3404/i18n/locales/en/greeting.js
@@ -1,0 +1,3 @@
+export default {
+  hello: 'Hello!'
+}

--- a/specs/fixtures/issues/3404/i18n/locales/en/index.js
+++ b/specs/fixtures/issues/3404/i18n/locales/en/index.js
@@ -1,0 +1,5 @@
+import greeting from './greeting'
+
+export default {
+  greeting
+}

--- a/specs/fixtures/issues/3404/i18n/locales/nl/greeting.js
+++ b/specs/fixtures/issues/3404/i18n/locales/nl/greeting.js
@@ -1,0 +1,3 @@
+export default {
+  hello: 'Hallo!'
+}

--- a/specs/fixtures/issues/3404/i18n/locales/nl/index.js
+++ b/specs/fixtures/issues/3404/i18n/locales/nl/index.js
@@ -1,0 +1,5 @@
+import greeting from './greeting'
+
+export default {
+  greeting
+}

--- a/specs/fixtures/issues/3404/nuxt.config.ts
+++ b/specs/fixtures/issues/3404/nuxt.config.ts
@@ -1,0 +1,7 @@
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/i18n'],
+  i18n: {
+    locales: ['en', 'nl']
+  }
+})

--- a/specs/fixtures/issues/3404/package.json
+++ b/specs/fixtures/issues/3404/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "fixture-3404",
+  "private": true,
+  "scripts": {
+    "build": "nuxt build",
+    "dev": "nuxt dev",
+    "generate": "nuxt generate",
+    "preview": "nuxt preview"
+  },
+  "devDependencies": {
+    "@nuxtjs/i18n": "latest",
+    "nuxt": "latest"
+  }
+}

--- a/specs/fixtures/issues/3404/pages/index.vue
+++ b/specs/fixtures/issues/3404/pages/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <h1 id="translated-heading">{{ $t('greeting.hello') }}</h1>
+  </div>
+</template>

--- a/specs/issues/3404.spec.ts
+++ b/specs/issues/3404.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect, describe } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { createPage, setup, url } from '../utils'
+import { getText } from '../helper'
+
+describe('#3404', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL(`../fixtures/issues/3404`, import.meta.url)),
+    browser: true
+  })
+
+  test('resource optimization excludes files not configured in `i18n.locales.*.files`', async () => {
+    const page = await createPage('/en')
+    const heading = await getText(page, '#translated-heading')
+    expect(heading).toEqual(`Hello!`)
+
+    await page.goto(url('/nl'))
+    const heading2 = await getText(page, '#translated-heading')
+    expect(heading2).toEqual(`Hallo!`)
+  })
+})

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import createDebug from 'debug'
-import { resolve } from 'pathe'
 import { extendViteConfig, addWebpackPlugin, addBuildPlugin, addTemplate, addRspackPlugin } from '@nuxt/kit'
 import VueI18nPlugin from '@intlify/unplugin-vue-i18n'
 import { toArray } from './utils'
@@ -8,7 +7,6 @@ import { TransformMacroPlugin } from './transform/macros'
 import { ResourcePlugin } from './transform/resource'
 import { TransformI18nFunctionPlugin } from './transform/i18n-function-injection'
 import { asI18nVirtual } from './transform/utils'
-import { getLayerLangPaths } from './layers'
 
 import type { Nuxt } from '@nuxt/schema'
 import type { PluginOptions } from '@intlify/unplugin-vue-i18n'
@@ -19,13 +17,8 @@ const debug = createDebug('@nuxtjs/i18n:bundler')
 
 export async function extendBundler(ctx: I18nNuxtContext, nuxt: Nuxt) {
   const { options: nuxtOptions } = ctx
-  const langPaths = getLayerLangPaths(nuxt)
-  debug('langPaths -', langPaths)
-  const i18nModulePaths =
-    nuxtOptions?.i18nModules?.map(module => resolve(nuxt.options._layers[0].config.rootDir, module.langDir ?? '')) ?? []
-  debug('i18nModulePaths -', i18nModulePaths)
-  const localePaths = [...langPaths, ...i18nModulePaths]
-  const localeIncludePaths = localePaths.length ? localePaths.map(x => resolve(x, './**')) : undefined
+  const localePaths = [...new Set([...ctx.localeInfo.flatMap(x => x.meta!.map(m => m.path))])]
+  const localeIncludePaths = localePaths.length ? localePaths : undefined
 
   const sourceMapOptions: BundlerPluginOptions = {
     sourcemap: !!nuxt.options.sourcemap.server || !!nuxt.options.sourcemap.client

--- a/src/layers.ts
+++ b/src/layers.ts
@@ -145,22 +145,6 @@ const mergeLayerLocales = (options: NuxtI18nOptions, nuxt: Nuxt) => {
   return mergeConfigLocales(configs)
 }
 
-/**
- * Returns an array of absolute paths to each layers `langDir`
- */
-export const getLayerLangPaths = (nuxt: Nuxt) => {
-  const langPaths: string[] = []
-
-  for (const layer of nuxt.options._layers) {
-    const i18n = getLayerI18n(layer)
-    if (i18n?.restructureDir === false && i18n?.langDir == null) continue
-
-    langPaths.push(resolveLayerLangDir(layer, i18n || {}))
-  }
-
-  return langPaths
-}
-
 export async function resolveLayerVueI18nConfigInfo(options: NuxtI18nOptions) {
   const logger = useLogger(NUXT_I18N_MODULE_ID)
   const nuxt = useNuxt()

--- a/src/transform/resource.ts
+++ b/src/transform/resource.ts
@@ -9,7 +9,7 @@ import {
   NUXT_I18N_VIRTUAL_PREFIX
 } from '../constants'
 import { resolve, dirname } from 'pathe'
-import { parseSync } from '../utils/parse'
+import { findStaticImports } from 'mlly'
 import { resolvePath, tryUseNuxt } from '@nuxt/kit'
 import { transform as esbuildTransform } from 'esbuild'
 import type { SameShape, TransformOptions, TransformResult } from 'esbuild'
@@ -77,10 +77,10 @@ export const ResourcePlugin = (options: BundlerPluginOptions, ctx: I18nNuxtConte
         debug('transform', id)
         let code = _code
 
-        const parsed = parseSync(id, _code)
         // ensure imported resources are transformed as well
-        for (const x of parsed.module.staticImports) {
-          i18nPathSet.add(await resolvePath(resolve(dirname(id), x.moduleRequest.value)))
+        const staticImports = findStaticImports(_code)
+        for (const x of staticImports) {
+          i18nPathSet.add(await resolvePath(resolve(dirname(id), x.specifier)))
         }
 
         // transform typescript


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
* #3404
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #3404

This makes the locale resource filter more accurate by passing the actual locale file paths instead of scanning for files in `langDir`, this should prevent errors caused by optimizing unsupported files.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
