### PR TITLE
fix: fix access to esbuild property

### DIFF
--- a/src/transform/resource.ts
+++ b/src/transform/resource.ts
@@ -20,7 +20,7 @@ async function transform<T extends TransformOptions>(
   input: string | Uint8Array,
   options?: SameShape<TransformOptions, T>
 ): Promise<TransformResult<T>> {
-  return await esbuildTransform(input, { ...tryUseNuxt()?.options.esbuild.options, ...options })
+  return await esbuildTransform(input, { ...tryUseNuxt()?.options.esbuild?.options, ...options })
 }
 
 const debug = createDebug('@nuxtjs/i18n:transform:resource')


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt-modules/i18n/issues/3470

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

This could resolve an issue that was potentially introduced in https://github.com/nuxt-modules/i18n/pull/3428. To be honest, I am not sure of any side effects, but this should definitely address the optionals-access. If it should be superseded by a different PR, feel free to close it! :-)
