### PR TITLE
docs: layout of docs landing page on mobile screen

### DIFF
--- a/docs/pages/index.vue
+++ b/docs/pages/index.vue
@@ -21,7 +21,7 @@ const { copy, copied } = useClipboard({ source })
         v-bind="page.hero"
         class="relative"
         :ui="{
-          container: 'overflow-hidden py-10 flex flex-row items-center  gap-1',
+          container: 'overflow-hidden py-10 flex flex-col md:flex-row items-center gap-4',
           links: 'flex items-center gap-2',
           description: 'dark:text-gray-400 text-xl max-w-2xl leading-normal mb-10'
         }"
@@ -52,11 +52,11 @@ const { copy, copied } = useClipboard({ source })
           aria-label="Copy code to get started"
           :model-value="source"
           name="get-started"
-          class="mx-auto"
+          class="mx-auto w-full max-w-[300px] md:max-w-[300px]"
           disabled
           autocomplete="off"
           size="lg"
-          :ui="{ base: 'w-[300px] disabled:cursor-default', icon: { trailing: { pointer: '' } } }"
+          :ui="{ base: 'disabled:cursor-default overflow-x-auto', icon: { trailing: { pointer: '' } } }"
         >
           <template #leading>
             <UIcon name="i-ph-terminal" />


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The current mobile layout has one of the elements rendering half off the screen. See: example screenshot below.

![current mobile layout for nuxt i18n site](https://github.com/user-attachments/assets/6423f197-a106-41a9-9c59-32de316487b2)

This commit moves that component below the "Get Started" and "Star on GitHub" components on mobile screens. See: example screenshot below.

![layout-with-this-commit](https://github.com/user-attachments/assets/574cac69-1f58-4e27-9f45-4a38ce18ca55)


### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
