### PR TITLE
refactor: use `@intlify/shared` utility functions

### DIFF
--- a/src/gen.ts
+++ b/src/gen.ts
@@ -1,4 +1,5 @@
 import createDebug from 'debug'
+import { isString } from '@intlify/shared'
 import { genImport, genDynamicImport, genSafeVariableName, genString } from 'knitwork'
 import { resolve, relative, join, basename } from 'pathe'
 import { distDir, runtimeDir } from './dirs'
@@ -16,7 +17,7 @@ export function simplifyLocaleOptions(
   nuxt: Nuxt,
   options: Pick<NuxtI18nOptions, 'locales' | 'experimental' | 'i18nModules'>
 ) {
-  const isLocaleObjectsArray = (locales?: Locale[] | LocaleObject[]) => locales?.some(x => typeof x !== 'string')
+  const isLocaleObjectsArray = (locales?: Locale[] | LocaleObject[]) => locales?.some(x => !isString(x))
 
   const hasLocaleObjects =
     nuxt.options._layers.some(layer => isLocaleObjectsArray(getLayerI18n(layer)?.locales)) ||
@@ -124,7 +125,7 @@ export function generateLoaderOptions(
     return {
       ...x,
       files: x.files.map(f => {
-        if (typeof f === 'string') return relative(nuxt.options.rootDir, f)
+        if (isString(f)) return relative(nuxt.options.rootDir, f)
         return { ...f, path: relative(nuxt.options.rootDir, f.path) }
       }) as string[] | LocaleFile[]
     }
@@ -222,7 +223,7 @@ declare module 'vue-router' {
 export function generateI18nTypes(nuxt: Nuxt, { userOptions: options, normalizedLocales }: I18nNuxtContext) {
   const vueI18nTypes = options.types === 'legacy' ? ['VueI18n'] : ['ExportedGlobalComposer', 'Composer']
   const generatedLocales = simplifyLocaleOptions(nuxt, options)
-  const resolvedLocaleType = typeof generatedLocales === 'string' ? 'Locale[]' : 'LocaleObject[]'
+  const resolvedLocaleType = isString(generatedLocales) ? 'Locale[]' : 'LocaleObject[]'
   const narrowedLocaleType = normalizedLocales.map(x => JSON.stringify(x.code)).join(' | ') || 'string'
 
   const i18nType = `${vueI18nTypes.join(' & ')} & NuxtI18nRoutingCustomProperties<${resolvedLocaleType}>`

--- a/src/layers.ts
+++ b/src/layers.ts
@@ -116,7 +116,7 @@ const mergeLayerLocales = (options: NuxtI18nOptions, nuxt: Nuxt) => {
    * installing through `installModule` and should have absolute paths.
    */
   outer: for (const locale of options.locales) {
-    if (typeof locale === 'string') continue
+    if (isString(locale)) continue
 
     const files = getLocaleFiles(locale)
     if (files.length === 0) continue

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -1,5 +1,5 @@
 import { toArray } from './utils'
-import { isObject } from '@intlify/shared'
+import { isObject, isString } from '@intlify/shared'
 
 import type { Locale } from 'vue-i18n'
 import type { NuxtPage } from '@nuxt/schema'
@@ -61,7 +61,7 @@ function shouldLocalizeRoutes(options: NuxtI18nOptions) {
     // check if domains are used multiple times
     const domains = new Set<string>()
     for (const locale of options.locales || []) {
-      if (typeof locale === 'string') continue
+      if (isString(locale)) continue
       if (locale.domain) {
         if (domains.has(locale.domain)) {
           console.error(

--- a/src/runtime/components/NuxtLinkLocale.ts
+++ b/src/runtime/components/NuxtLinkLocale.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { isObject } from '@intlify/shared'
 import { useLocalePath, type Locale } from '#i18n'
 import { defineComponent, computed, h } from 'vue'
 import { defineNuxtLink } from '#imports'
@@ -59,7 +60,7 @@ export default defineComponent<NuxtLinkLocaleProps>({
 
       const destination = props.to ?? props.href
       // When `to` is a route object then it's an internal link
-      if (typeof destination === 'object') {
+      if (isObject(destination)) {
         return false
       }
 

--- a/src/runtime/messages.ts
+++ b/src/runtime/messages.ts
@@ -1,4 +1,4 @@
-import { deepCopy, isFunction } from '@intlify/shared'
+import { deepCopy, isArray, isFunction, isString } from '@intlify/shared'
 import { createLogger } from '#nuxt-i18n/logger'
 
 import type { I18nOptions, Locale, FallbackLocale, LocaleMessages, DefineLocaleMessage } from 'vue-i18n'
@@ -36,10 +36,10 @@ export async function loadVueI18nOptions(
 
 export function makeFallbackLocaleCodes(fallback: FallbackLocale, locales: Locale[]): Locale[] {
   if (fallback === false) return []
-  if (Array.isArray(fallback)) return fallback
+  if (isArray(fallback)) return fallback
 
   let fallbackLocales: Locale[] = []
-  if (typeof fallback === 'string') {
+  if (isString(fallback)) {
     if (locales.every(locale => locale !== fallback)) {
       fallbackLocales.push(fallback)
     }

--- a/src/runtime/routing/i18n.ts
+++ b/src/runtime/routing/i18n.ts
@@ -1,4 +1,5 @@
 import { effectScope } from '#imports'
+import { assign } from '@intlify/shared'
 import { isVueI18n, getComposer } from '../compatibility'
 
 import type { NuxtApp } from 'nuxt/app'
@@ -34,7 +35,7 @@ export function extendI18n(i18n: I18n, { extendComposer, extendComposerInstance 
 
   const installI18n = i18n.install.bind(i18n)
   i18n.install = (app: NuxtApp['vueApp'], ...options: VueI18nInternalPluginOptions[]) => {
-    const pluginOptions = Object.assign({}, options[0])
+    const pluginOptions = assign({}, options[0])
 
     pluginOptions.__composerExtend = (c: Composer) => {
       extendComposerInstance(c, getComposer(i18n))

--- a/src/runtime/routing/routing.ts
+++ b/src/runtime/routing/routing.ts
@@ -1,5 +1,6 @@
 import { hasProtocol, joinURL, parsePath, parseQuery, withTrailingSlash, withoutTrailingSlash } from 'ufo'
 import { DEFAULT_DYNAMIC_PARAMS_KEY } from '#build/i18n.options.mjs'
+import { assign, isObject, isString } from '@intlify/shared'
 import { isNavigationFailure } from 'vue-router'
 import { unref } from '#imports'
 
@@ -24,7 +25,7 @@ export function getRouteBaseName<Name extends keyof RouteMap = keyof RouteMap>(
   route: Name | RouteLocationGenericPath | null
 ) {
   const _route = unref(route)
-  const routeName = typeof _route === 'object' ? _route?.name : _route
+  const routeName = isObject(_route) ? _route?.name : _route
   if (_route == null || !routeName) {
     return
   }
@@ -37,7 +38,7 @@ export function getRouteBaseName<Name extends keyof RouteMap = keyof RouteMap>(
  */
 export function localePath(common: CommonComposableOptions, route: RouteLocationRaw, locale?: Locale): string {
   // return external url as is
-  if (typeof route === 'string' && hasProtocol(route, { acceptRelative: true })) {
+  if (isString(route) && hasProtocol(route, { acceptRelative: true })) {
     return route
   }
 
@@ -59,8 +60,8 @@ type RouteLike = (RouteLocationPathRaw & { name?: string }) | (RouteLocationName
  */
 function normalizeRawLocation(route: RouteLocationRaw): RouteLike {
   // return a copy of the object
-  if (typeof route !== 'string') {
-    return Object.assign({}, route)
+  if (!isString(route)) {
+    return assign({}, route)
   }
 
   // route path
@@ -161,7 +162,7 @@ export function switchLocalePath(common: CommonComposableOptions, locale: Locale
    */
   const routeCopy = {
     name,
-    params: Object.assign({}, route.params, resolvedParams),
+    params: assign({}, route.params, resolvedParams),
     fullPath: route.fullPath,
     query: route.query,
     hash: route.hash,
@@ -209,5 +210,5 @@ function resolve(common: CommonComposableOptions, route: RouteLocationPathRaw, l
     return route
   }
 
-  return common.router.resolve(Object.assign({}, route, _route, { path: targetPath }))
+  return common.router.resolve(assign({}, route, _route, { path: targetPath }))
 }

--- a/src/runtime/routing/utils.ts
+++ b/src/runtime/routing/utils.ts
@@ -1,4 +1,4 @@
-import { isFunction } from '@intlify/shared'
+import { isFunction, isString } from '@intlify/shared'
 import { localeCodes } from '#build/i18n.options.mjs'
 import { useRuntimeConfig } from '#app'
 
@@ -7,11 +7,11 @@ import type { Locale } from 'vue-i18n'
 import type { CompatRoute } from '../types'
 
 export function getNormalizedLocales(locales: Locale[] | LocaleObject[]): LocaleObject[] {
-  return locales.map(x => (typeof x === 'string' ? { code: x } : x))
+  return locales.map(x => (isString(x) ? { code: x } : x))
 }
 
 export function getRouteName(routeName?: string | symbol | number | null) {
-  if (typeof routeName === 'string') return routeName
+  if (isString(routeName)) return routeName
   if (routeName != null) return routeName.toString()
   return '(null)'
 }
@@ -77,7 +77,7 @@ interface BrowserLocale {
  * @returns The matched {@link BrowserLocale | locale info}
  */
 function matchBrowserLocale(locales: LocaleObject[], browserLocales: readonly string[]): BrowserLocale[] {
-  const matchedLocales = [] as BrowserLocale[]
+  const matchedLocales: BrowserLocale[] = []
 
   // first pass: match exact locale.
   for (const [index, browserCode] of browserLocales.entries()) {
@@ -151,7 +151,7 @@ export function createLocaleFromRouteGetter() {
   return (route: string | CompatRoute) => {
     let matches: RegExpMatchArray | null = null
 
-    if (typeof route === 'string') {
+    if (isString(route)) {
       matches = route.match(regexpPath)
       return matches?.[1] ?? ''
     }

--- a/src/runtime/server/type-generation.ts
+++ b/src/runtime/server/type-generation.ts
@@ -1,4 +1,4 @@
-import { deepCopy } from '@intlify/shared'
+import { deepCopy, isArray, isFunction, isObject } from '@intlify/shared'
 import { vueI18nConfigs, localeLoaders, nuxtI18nOptions, normalizedLocales } from '#internal/i18n/options.mjs'
 // @ts-expect-error virtual file
 import { dtsFile } from '#internal/i18n-type-generation-options'
@@ -61,7 +61,7 @@ function generateInterface(obj: Record<string, unknown>, indentLevel = 1) {
   for (const key in obj) {
     if (!Object.prototype.hasOwnProperty.call(obj, key)) continue
 
-    if (typeof obj[key] === 'object' && obj[key] !== null && !Array.isArray(obj[key])) {
+    if (isObject(obj[key]) && obj[key] !== null && !isArray(obj[key])) {
       str += `${indent}"${key}": {\n`
       str += generateInterface(obj[key] as Record<string, unknown>, indentLevel + 1)
       str += `${indent}};\n`
@@ -69,8 +69,8 @@ function generateInterface(obj: Record<string, unknown>, indentLevel = 1) {
       // str += `${indent}/**\n`
       // str += `${indent} * ${JSON.stringify(obj[key])}\n`
       // str += `${indent} */\n`
-      let propertyType = Array.isArray(obj[key]) ? 'unknown[]' : typeof obj[key]
-      if (propertyType === 'function') {
+      let propertyType = isArray(obj[key]) ? 'unknown[]' : typeof obj[key]
+      if (isFunction(propertyType)) {
         propertyType = '() => string'
       }
       str += `${indent}"${key}": ${propertyType};\n`

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import { createHash, type BinaryLike } from 'node:crypto'
 import { resolvePath, useNuxt } from '@nuxt/kit'
 import { resolve, relative, join } from 'pathe'
 import { defu } from 'defu'
-import { isString, isArray } from '@intlify/shared'
+import { isString, isArray, assign, isObject } from '@intlify/shared'
 import { NUXT_I18N_MODULE_ID, EXECUTABLE_EXTENSIONS, EXECUTABLE_EXT_RE } from './constants'
 import { parseSync } from './utils/parse'
 
@@ -48,7 +48,7 @@ export function getNormalizedLocales(locales: NuxtI18nOptions['locales']): Local
 export function resolveLocales(srcDir: string, locales: LocaleObject[], buildDir: string): LocaleInfo[] {
   const localesResolved: LocaleInfo[] = []
   for (const locale of locales) {
-    const resolved: LocaleInfo = Object.assign({ meta: [] }, locale)
+    const resolved: LocaleInfo = assign({ meta: [] }, locale)
     delete resolved.file
     delete resolved.files
 
@@ -215,7 +215,7 @@ export const mergeConfigLocales = (configs: LocaleConfig[], baseLocales: LocaleO
       const merged = mergedLocales.get(code)
 
       // set normalized locale or to existing entry
-      if (typeof locale === 'string') {
+      if (isString(locale)) {
         mergedLocales.set(code, merged ?? { language: code, code })
         continue
       }
@@ -261,7 +261,7 @@ export const mergeI18nModules = async (options: NuxtI18nOptions, nuxt: Nuxt) => 
     const layerLocales = options.locales ?? []
 
     for (const locale of layerLocales) {
-      if (typeof locale !== 'object') continue
+      if (!isObject(locale)) continue
       baseLocales.push({ ...locale, file: undefined, files: getLocaleFiles(locale) })
     }
 
@@ -278,9 +278,7 @@ function getHash(text: BinaryLike): string {
 export function getLayerI18n(configLayer: NuxtConfigLayer) {
   const layerInlineOptions = (configLayer.config.modules || []).find(
     (mod): mod is [string, NuxtI18nOptions] | undefined =>
-      isArray(mod) &&
-      typeof mod[0] === 'string' &&
-      [NUXT_I18N_MODULE_ID, `${NUXT_I18N_MODULE_ID}-edge`].includes(mod[0])
+      isArray(mod) && isString(mod[0]) && [NUXT_I18N_MODULE_ID, `${NUXT_I18N_MODULE_ID}-edge`].includes(mod[0])
   )?.[1]
 
   if (configLayer.config.i18n) {
@@ -297,7 +295,7 @@ export const applyOptionOverrides = (options: NuxtI18nOptions, nuxt: Nuxt) => {
   if (overrides) {
     delete options.overrides
     project.config.i18n = defu(overrides, project.config.i18n)
-    Object.assign(options, defu(overrides, mergedOptions))
+    assign(options, defu(overrides, mergedOptions))
   }
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Originally these were used much more in the code base but my preference was plain/native js to check if something is an array or a string etc. without obscuring the actual logic. I now see that these utilities are not just for convenience but also allow for better bundling/minification.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->
