### PR TITLE
fix: `differentDomains` with `no_prefix` missing alternate links

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,15 @@ importers:
         specifier: latest
         version: 3.16.1(@parcel/watcher@2.4.1)(@types/node@20.14.9)(better-sqlite3@11.9.1)(db0@0.3.1(better-sqlite3@11.9.1))(encoding@0.1.13)(eslint@9.23.0(jiti@2.4.2))(ioredis@5.6.0)(lightningcss@1.29.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.37.0)(terser@5.31.1)(typescript@5.7.3)(vite@6.2.2(@types/node@20.14.9)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.31.1)(yaml@2.7.0))(yaml@2.7.0)
 
+  specs/fixtures/domain-ssg:
+    devDependencies:
+      '@nuxtjs/i18n':
+        specifier: link:../../..
+        version: link:../../..
+      nuxt:
+        specifier: latest
+        version: 3.16.1(@parcel/watcher@2.4.1)(@types/node@20.14.9)(better-sqlite3@11.9.1)(db0@0.3.1(better-sqlite3@11.9.1))(encoding@0.1.13)(eslint@9.23.0(jiti@2.4.2))(ioredis@5.6.0)(lightningcss@1.29.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.37.0)(terser@5.31.1)(typescript@5.7.3)(vite@6.2.2(@types/node@20.14.9)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.31.1)(yaml@2.7.0))(yaml@2.7.0)
+
   specs/fixtures/empty_options:
     devDependencies:
       '@nuxtjs/i18n':
@@ -12520,7 +12529,7 @@ snapshots:
       unctx: 2.4.1
       unimport: 4.1.2
       unplugin: 2.2.2
-      unplugin-vue-router: 0.12.0(vue-router@4.5.0(vue@3.5.13(typescript@5.6.2)))(vue@3.5.13(typescript@5.7.3))
+      unplugin-vue-router: 0.12.0(vue-router@4.5.0(vue@3.5.13(typescript@5.7.3)))(vue@3.5.13(typescript@5.7.3))
       unstorage: 1.15.0(db0@0.3.1(better-sqlite3@11.9.1))(ioredis@5.6.0)
       untyped: 2.0.0
       vue: 3.5.13(typescript@5.7.3)
@@ -14076,7 +14085,7 @@ snapshots:
     transitivePeerDependencies:
       - vue
 
-  unplugin-vue-router@0.12.0(vue-router@4.5.0(vue@3.5.13(typescript@5.6.2)))(vue@3.5.13(typescript@5.7.3)):
+  unplugin-vue-router@0.12.0(vue-router@4.5.0(vue@3.5.13(typescript@5.7.3)))(vue@3.5.13(typescript@5.7.3)):
     dependencies:
       '@babel/types': 7.27.0
       '@vue-macros/common': 1.16.1(vue@3.5.13(typescript@5.7.3))
@@ -14094,7 +14103,7 @@ snapshots:
       unplugin-utils: 0.2.4
       yaml: 2.7.0
     optionalDependencies:
-      vue-router: 4.5.0(vue@3.5.13(typescript@5.6.2))
+      vue-router: 4.5.0(vue@3.5.13(typescript@5.7.3))
     transitivePeerDependencies:
       - vue
 

--- a/specs/fixtures/domain-ssg/app.vue
+++ b/specs/fixtures/domain-ssg/app.vue
@@ -1,0 +1,20 @@
+<template>
+  <Html :lang="head.htmlAttrs.lang" :dir="head.htmlAttrs.dir">
+    <Head>
+      <Title>Test</Title>
+      <template v-for="link in head.link" :key="link.hid">
+        <Link :id="link.hid" :rel="link.rel" :href="link.href" :hreflang="link.hreflang" />
+      </template>
+      <template v-for="meta in head.meta" :key="meta.hid">
+        <Meta :id="meta.hid" :property="meta.property" :content="meta.content" />
+      </template>
+    </Head>
+    <Body>
+      <NuxtPage />
+    </Body>
+  </Html>
+</template>
+
+<script setup lang="ts">
+const head = useLocaleHead()
+</script>

--- a/specs/fixtures/domain-ssg/nuxt.config.ts
+++ b/specs/fixtures/domain-ssg/nuxt.config.ts
@@ -1,0 +1,18 @@
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/i18n'],
+
+  i18n: {
+    strategy: 'no_prefix',
+    defaultLocale: 'en',
+    differentDomains: true,
+    locales: [
+      { code: 'en', language: 'en-US', name: 'English', domain: 'localhost:7786', isCatchallLocale: true },
+      { code: 'es', language: 'es-ES', name: 'Español', domain: 'localhost:7787' }
+    ],
+    baseUrl: 'http://localhost:3333',
+    detectBrowserLanguage: false
+  },
+
+  compatibilityDate: '2025-03-30'
+})

--- a/specs/fixtures/domain-ssg/package.json
+++ b/specs/fixtures/domain-ssg/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "fixture-domain-ssg",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "nuxi build",
+    "dev": "nuxi dev",
+    "generate": "nuxi generate",
+    "preview": "nuxi preview"
+  },
+  "devDependencies": {
+    "@nuxtjs/i18n": "latest",
+    "nuxt": "latest"
+  }
+}

--- a/specs/fixtures/domain-ssg/pages/index.vue
+++ b/specs/fixtures/domain-ssg/pages/index.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Hello</div>
+</template>

--- a/specs/ssg/different-domains.spec.ts
+++ b/specs/ssg/different-domains.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, $fetch } from '../utils'
+import { getDom } from '../helper'
+
+await setup({
+  rootDir: fileURLToPath(new URL(`../fixtures/domain-ssg`, import.meta.url)),
+  browser: true,
+  prerender: true,
+  // overrides
+  nuxtConfig: {},
+  port: [7787, 7786]
+})
+
+test('`differentDomains` with `no_prefix` has hreflang links', async () => {
+  const html = await $fetch('/')
+  const dom = getDom(html)
+  expect(
+    Array.from(dom.querySelectorAll(`[rel="alternate"]`)).map(x => ({
+      // @ts-expect-error untyped var
+      id: x.getAttribute('id'),
+      // @ts-expect-error untyped var
+      href: x.getAttribute('href')
+    }))
+  ).toMatchInlineSnapshot(`
+    [
+      {
+        "href": "http://localhost:7786",
+        "id": "i18n-xd",
+      },
+      {
+        "href": "http://localhost:7786",
+        "id": "i18n-alt-en",
+      },
+      {
+        "href": "http://localhost:7786",
+        "id": "i18n-alt-en-US",
+      },
+      {
+        "href": "http://localhost:7787",
+        "id": "i18n-alt-es",
+      },
+      {
+        "href": "http://localhost:7787",
+        "id": "i18n-alt-es-ES",
+      },
+    ]
+  `)
+})

--- a/src/runtime/routing/head.ts
+++ b/src/runtime/routing/head.ts
@@ -187,10 +187,10 @@ function _localeHead(common: CommonComposableOptions, options: Required<I18nHead
 }
 
 function getHreflangLinks(common: CommonComposableOptions, ctx: HeadContext) {
-  const { defaultLocale, strategy } = ctx.runtimeI18n
+  const { defaultLocale, strategy, differentDomains } = ctx.runtimeI18n
   const links: MetaAttrs[] = []
 
-  if (strategy === 'no_prefix') return links
+  if (strategy === 'no_prefix' && !differentDomains) return links
 
   const localeMap = new Map<string, LocaleObject>()
   for (const locale of ctx.locales) {

--- a/src/runtime/routing/head.ts
+++ b/src/runtime/routing/head.ts
@@ -219,10 +219,9 @@ function getHreflangLinks(common: CommonComposableOptions, ctx: HeadContext) {
     const localePath = switchLocalePath(common, mapLocale.code, routeWithoutQuery)
     if (!localePath) continue
 
-    const href = withQuery(
-      joinURL(ctx.baseUrl, localePath),
-      strictCanonicals ? getCanonicalQueryParams(common, ctx) : {}
-    )
+    // localized paths with domain already contain baseUrl
+    const fullPath = differentDomains && mapLocale.domain ? localePath : joinURL(ctx.baseUrl, localePath)
+    const href = withQuery(fullPath, strictCanonicals ? getCanonicalQueryParams(common, ctx) : {})
 
     links.push({ [ctx.key]: `i18n-alt-${language}`, rel: 'alternate', href, hreflang: language })
     if (defaultLocale && defaultLocale === mapLocale.code) {


### PR DESCRIPTION
Respect `differentDomains` option in `getHreflangLinks`.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue
https://github.com/nuxt-modules/i18n/issues/3480

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #3480

`getHreflangLinks` does not respect `differentDomains` when the `strategy` is set to 'no_prefix', causing the hreflang link not to be generated.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.