### PR TITLE
refactor: cleanup JSDoc and encapsulate internal types

### DIFF
--- a/src/pages.ts
+++ b/src/pages.ts
@@ -7,7 +7,7 @@ import { walk } from 'estree-walker'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { formatMessage } from './utils'
 import { getRoutePath, parseSegment } from './utils/route-parsing'
-import { localizeRoutes } from './routing'
+import { localizeRoutes, type ComputedRouteOptions, type RouteOptionsResolver } from './routing'
 import { mergeLayerPages } from './layers'
 import { resolve, parse as parsePath, dirname } from 'pathe'
 import { NUXT_I18N_COMPOSABLE_DEFINE_ROUTE } from './constants'
@@ -17,7 +17,7 @@ import { resolveOptions } from 'unplugin-vue-router/options'
 import type { Nuxt, NuxtPage } from '@nuxt/schema'
 import type { Node, ObjectExpression, ArrayExpression, Expression, PrivateName } from '@babel/types'
 import type { EditableTreeNode, Options as TypedRouterOptions } from 'unplugin-vue-router'
-import type { NuxtI18nOptions, CustomRoutePages, ComputedRouteOptions, RouteOptionsResolver } from './types'
+import type { NuxtI18nOptions, CustomRoutePages } from './types'
 import type { I18nNuxtContext } from './context'
 
 const debug = createDebug('@nuxtjs/i18n:pages')
@@ -259,7 +259,7 @@ export function getRouteOptionsResolver(
   debug('getRouteOptionsResolver useConfig', useConfig)
 
   const getter = useConfig ? getRouteOptionsFromPages : getRouteOptionsFromComponent
-  return (route, localeCodes): ComputedRouteOptions | undefined => {
+  return (route, localeCodes) => {
     const ret = getter(route, localeCodes, ctx, pages, defaultLocale)
     debug('getRouteOptionsResolver resolved', route.path, route.name, ret)
     return ret

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,5 @@
 import type { Locale, I18nOptions } from 'vue-i18n'
 import type { PluginOptions } from '@intlify/unplugin-vue-i18n'
-import type { NuxtPage } from '@nuxt/schema'
 import type { RouteMapGeneric, RouteMapI18n } from 'vue-router'
 import { STRATEGIES } from './constants'
 export type {
@@ -11,8 +10,14 @@ export type {
   STRATEGIES
 } from './constants'
 
+/**
+ * @public
+ */
 export type RedirectOnOptions = 'all' | 'root' | 'no prefix'
 
+/**
+ * @public
+ */
 export interface DetectBrowserLanguageOptions {
   alwaysRedirect?: boolean
   cookieCrossOrigin?: boolean
@@ -24,6 +29,9 @@ export interface DetectBrowserLanguageOptions {
   useCookie?: boolean
 }
 
+/**
+ * @internal
+ */
 export type LocaleType = 'static' | 'dynamic' | 'unknown'
 
 export type LocaleFile = { path: string; cache?: boolean }
@@ -33,6 +41,9 @@ export type LocaleInfo = Omit<LocaleObject, 'file' | 'files'> & {
   meta: (FileMeta & { file: LocaleFile })[]
 }
 
+/**
+ * @internal
+ */
 export type FileMeta = {
   path: string
   loadPath: string
@@ -40,11 +51,17 @@ export type FileMeta = {
   type: LocaleType
 }
 
+/**
+ * @internal
+ */
 export type VueI18nConfigPathInfo = {
   rootDir: string
   meta: FileMeta
 }
 
+/**
+ * @public
+ */
 export interface RootRedirectOptions {
   path: string
   statusCode: number
@@ -60,49 +77,37 @@ export interface ExperimentalFeatures {
   switchLocalePathLinkSSR?: boolean
   /**
    * Automatically imports/initializes `$t`, `$rt`, `$d`, `$n`, `$tm` and `$te` functions in `<script setup>` when used.
-   *
-   * @defaultValue `false`
+   * @default false
    */
   autoImportTranslationFunctions?: boolean
 
   /**
    * Generates types for i18n routing helper
-   *
-   * @defaultValue `true`
+   * @default true
    */
   typedPages?: boolean
-
   /**
    * Generates types for vue-i18n and messages
-   *
-   * @defaultValue `false`
-   *
    * @remark `'default'` to generate types based on `defaultLocale`
    * @remark `'all'` to generate types based on all locales
+   * @default false
    */
   typedOptionsAndMessages?: false | 'default' | 'all'
-
   /**
    * Locale file and langDir paths can be formatted differently to prevent exposing sensitive paths in production.
-   *
-   * @defaultValue `'absolute'`
-   *
    * @remark `'absolute'` locale file and langDir paths contain the full absolute path
    * @remark `'relative'` locale file and langDir paths are converted to be relative to the `rootDir`
+   * @default 'absolute'
    */
   generatedLocaleFilePathFormat?: 'absolute' | 'relative'
-
   /**
    * Removes non-canonical query parameters from alternate link meta tags
-   *
-   * @defaultValue `false`
+   * @default false
    */
   alternateLinkCanonicalQueries?: boolean
-
   /**
    * Hot module replacement for locale message files and vue-i18n configuration in dev mode.
-   *
-   * @defaultValue `true`
+   * @default true
    */
   hmr?: boolean
 }
@@ -131,15 +136,13 @@ export type NuxtI18nOptions<
 > = {
   /**
    * Path to a Vue I18n configuration file, the module will scan for a i18n.config{.js,.mjs,.ts} if left unset.
-   *
-   * @defaultValue `''` (empty string)
+   * @default ''
    */
   vueI18n?: string
   experimental?: ExperimentalFeatures
   /**
    * The directory to resolve i18n files from, the restructure can be disabled by setting this to `false`.
-   *
-   * @defaultValue `'i18n'`
+   * @default 'i18n'
    */
   restructureDir?: string | false
   bundle?: BundleOptions
@@ -147,21 +150,14 @@ export type NuxtI18nOptions<
   customBlocks?: CustomBlocksOptions
   /**
    * Enable when using different domains for each locale
-   *
-   * @remarks
-   * If enabled, no prefix is added to routes
-   * and `locales` must be configured as an array of `LocaleObject` objects with the `domain` property set.
-   *
-   * @defaultValue `false`
+   * @remarks If enabled, no prefix is added to routes and `locales` must be configured as an array of `LocaleObject` objects with the `domain` property set.
+   * @default false
    */
   differentDomains?: boolean
   /**
    * Enable when using different domains with different locales
-   *
-   * @remarks
-   * If enabled, `locales` must be configured as an array of `LocaleObject` objects with the `domains` and `defaultForDomains` property set.
-   *
-   * @defaultValue `false`
+   * @remarks If enabled, `locales` must be configured as an array of `LocaleObject` objects with the `domains` and `defaultForDomains` property set.
+   * @default false
    */
   multiDomainLocales?: boolean
   detectBrowserLanguage?: DetectBrowserLanguageOptions | false
@@ -170,13 +166,13 @@ export type NuxtI18nOptions<
   pages?: CustomRoutePages
   customRoutes?: 'page' | 'config'
   /**
-   * @internal
    * Do not use in projects - this is used internally for e2e tests to override default option merging.
+   * @internal
    */
   overrides?: Omit<NuxtI18nOptions<Context>, 'overrides'>
   /**
+   * Do not use in projects - this is used internally for e2e tests to override default option merging.
    * @internal
-   * Do not use in projects
    */
   i18nModules?: { langDir?: string | null; locales?: NuxtI18nOptions<Context>['locales'] }[]
   rootRedirect?: string | RootRedirectOptions
@@ -187,21 +183,16 @@ export type NuxtI18nOptions<
   /**
    * The app's default locale
    *
-   * @remarks
-   * When using `prefix_except_default` strategy, URLs for locale specified here won't have a prefix.
-   *
    * It's recommended to set this to some locale regardless of chosen strategy, as it will be used as a fallback locale when navigating to a non-existent route
    *
-   * @defaultValue '' (empty string)
+   * @remarks When using `prefix_except_default` strategy, routes for `defaultLocale` have no prefix.
+   * @default ''
    */
   defaultLocale?: Locale
   /**
    * List of locales supported by your app
-   *
-   * @remarks
-   * Can either be an array of string codes (e.g. `['en', 'fr']`) or an array of {@link LocaleObject} for more complex configurations
-   *
-   * @defaultValue []
+   * @remarks Can either be an array of string codes (e.g. `['en', 'fr']`) or an array of {@link LocaleObject} for more complex configurations
+   * @default []
    */
   locales?: ConfiguredLocaleType
   /**
@@ -209,40 +200,33 @@ export type NuxtI18nOptions<
    *
    * @remarks
    * Can be set to one of the following:
-   *
    * - `no_prefix`: routes won't have a locale prefix
    * - `prefix_except_default`: locale prefix added for every locale except default
    * - `prefix`: locale prefix added for every locale
    * - `prefix_and_default`: locale prefix added for every locale and default
    *
-   * @defaultValue 'prefix_except_default'
+   * @default 'prefix_except_default'
    */
   strategy?: Strategies
   /**
    * Whether to use trailing slash
-   *
-   * @defaultValue false
+   * @default false
    */
   trailingSlash?: boolean
   /**
-   * Internal separator used for generated route names for each locale. You shouldn't need to change this
-   *
-   * @defaultValue '___'
+   * Internal separator used for generated route names for each locale - you shouldn't need to change this
+   * @default '___'
    */
   routesNameSeparator?: string
   /**
    * Internal suffix added to generated route names for default locale
-   *
-   * @remarks
-   * if strategy is prefix_and_default. You shouldn't need to change this.
-   *
-   * @defaultValue 'default'
+   * @remarks Relevant if strategy is `prefix_and_default` - you shouldn't need to change this.
+   * @default 'default'
    */
   defaultLocaleRouteNameSuffix?: string
   /**
    * Default direction direction
-   *
-   * @defaultValue 'ltr'
+   * @default 'ltr'
    */
   defaultDirection?: Directions
   /**
@@ -255,7 +239,7 @@ export type NuxtI18nOptions<
    *
    * Useful to make base URL dynamic based on request headers.
    *
-   * @defaultValue ''
+   * @default ''
    */
   baseUrl?: string | BaseUrlResolveHandler<Context>
 }
@@ -264,34 +248,36 @@ export type VueI18nConfig = () => Promise<{ default: I18nOptions | (() => I18nOp
 
 /**
  * Routing strategy
- *
  * @public
  */
 export type Strategies = (typeof STRATEGIES)[keyof typeof STRATEGIES]
 
 /**
  * Direction
- *
  * @public
  */
 export type Directions = 'ltr' | 'rtl' | 'auto'
 
 /**
  * Locale object
- *
  * @public
  */
 export interface LocaleObject<T = Locale> extends Record<string, unknown> {
+  /** Code used for route prefixing and argument in i18n utility functions. */
   code: T
+  /** User facing name */
   name?: string
+  /** Writing direction */
   dir?: Directions
+  /** Language tag - see IETF's BCP47 - required when using SEO features */
+  language?: string
+  /** Override default SEO catch-all and force this locale to be catch-all for its locale group */
+  isCatchallLocale?: boolean
   domain?: string
   domains?: string[]
   defaultForDomains?: string[]
   file?: string | LocaleFile
   files?: string[] | LocaleFile[]
-  isCatchallLocale?: boolean
-  language?: string
 }
 
 /**
@@ -300,105 +286,51 @@ export interface LocaleObject<T = Locale> extends Record<string, unknown> {
 export type BaseUrlResolveHandler<Context = unknown> = (context: Context) => string
 
 /**
- * Options to compute route localizing
- *
- * @remarks
- * The route options that is compute the route to be localized on {@link localizeRoutes}
- *
- * @public
- */
-export interface ComputedRouteOptions {
-  locales: readonly Locale[]
-  paths: Record<Locale, string>
-}
-
-/**
- * Resolver for route localizing options
- *
- * @public
- */
-export type RouteOptionsResolver = (route: NuxtPage, localeCodes: Locale[]) => ComputedRouteOptions | undefined
-
-/**
- * Localize route path prefix judgment options used in {@link LocalizeRoutesPrefixable}
- *
- * @public
- */
-export interface PrefixLocalizedRouteOptions {
-  /**
-   * Current locale
-   */
-  locale: Locale
-  /**
-   * Default locale
-   */
-  defaultLocale?: Locale | undefined
-  /**
-   * The parent route of the route to be resolved
-   */
-  parent: NuxtPage | undefined
-  /**
-   * The path of route
-   */
-  path: string
-}
-
-/**
  * SEO Attribute options.
- *
  * @public
  */
 export interface SeoAttributesOptions {
   /**
    * An array of strings corresponding to query params you would like to include in your canonical URL.
-   *
-   * @defaultValue []
+   * @default []
    */
   canonicalQueries?: string[]
 }
 
 /**
- * Options for {@link localeHead} function.
- *
- * @public
+ * @public Options for {@link localeHead} function.
  */
 export interface I18nHeadOptions {
   /**
    * Adds a `lang` attribute to the HTML element.
-   *
-   * @defaultValue true
+   * @default true
    */
   lang?: boolean
   /**
    * Adds a `dir` attribute to the HTML element.
-   *
-   * @defaultValue true
+   * @default true
    */
   dir?: boolean
   /**
    * Adds various SEO tags.
-   *
-   * @defaultValue true
+   * @default true
    */
   seo?: boolean | SeoAttributesOptions
   /**
    * Identifier attribute of `<meta>` tag
-   *
-   * @defaultValue 'hid'
+   * @default 'hid'
    */
   key?: string
 }
 
 /**
  * Meta attributes for head properties.
- *
  * @public
  */
 export type MetaAttrs = Record<string, string>
 
 /**
  * I18n header meta info.
- *
  * @public
  */
 export interface I18nHeadMetaInfo {
@@ -414,80 +346,66 @@ export interface I18nPublicRuntimeConfig {
 
   /**
    * Overwritten at build time, used to pass generated options to runtime
-   *
    * @internal
    */
   domainLocales: { [key: Locale]: { domain: string | undefined } }
-
   /**
    * Overwritten at build time, used to pass generated options to runtime
-   *
    * @internal
    */
   experimental: NonNullable<NuxtI18nOptions['experimental']>
   /**
    * Overwritten at build time, used to pass generated options to runtime
-   *
    * @internal
    */
   locales: NonNullable<Required<NuxtI18nOptions<unknown>>['locales']>
   /**
    * Overwritten at build time, used to pass generated options to runtime
-   *
    * @internal
    */
   differentDomains: Required<NuxtI18nOptions>['differentDomains']
   /**
    * Overwritten at build time, used to pass generated options to runtime
-   *
    * @internal
    */
   skipSettingLocaleOnNavigate: Required<NuxtI18nOptions>['skipSettingLocaleOnNavigate']
   /**
    * Overwritten at build time, used to pass generated options to runtime
-   *
    * @internal
    */
   defaultLocale: Required<NuxtI18nOptions>['defaultLocale']
   /**
    * Overwritten at build time, used to pass generated options to runtime
-   *
    * @internal
    */
   lazy: Required<NuxtI18nOptions>['lazy']
   /**
    * Overwritten at build time, used to pass generated options to runtime
-   *
    * @internal
    */
   defaultDirection: Required<NuxtI18nOptions>['defaultDirection']
   /**
    * Overwritten at build time, used to pass generated options to runtime
-   *
    * @internal
    */
   detectBrowserLanguage: Required<NuxtI18nOptions>['detectBrowserLanguage']
   /**
    * Overwritten at build time, used to pass generated options to runtime
-   *
    * @internal
    */
   strategy: Required<NuxtI18nOptions>['strategy']
   /**
    * Overwritten at build time, used to pass generated options to runtime
-   *
    * @internal
    */
   routesNameSeparator: Required<NuxtI18nOptions>['routesNameSeparator']
   /**
    * Overwritten at build time, used to pass generated options to runtime
-   *
    * @internal
    */
   defaultLocaleRouteNameSuffix: Required<NuxtI18nOptions>['defaultLocaleRouteNameSuffix']
   /**
    * Overwritten at build time, used to pass generated options to runtime
-   *
    * @internal
    */
   trailingSlash: Required<NuxtI18nOptions>['trailingSlash']


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Should remove some exported types which were of no use to end-users, these were used in internal functions.

Also formats JSDoc for some consistency and size improvements
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->
