### PR TITLE
feat: strip i18n file paths from build

### DIFF
--- a/docs/content/docs/04.api/00.options.md
+++ b/docs/content/docs/04.api/00.options.md
@@ -500,6 +500,7 @@ This feature relies on [Nuxt's `experimental.typedRoutes`](https://nuxt.com/docs
 - type: `'absolute' | 'relative'`{lang="ts-type"}
   - `'absolute'`{lang="ts-type"} - locale file and langDir paths contain the full absolute path
   - `'relative'`{lang="ts-type"} - locale file and langDir paths are converted to be relative to the `rootDir`
+  - `'off'`{lang="ts-type"} - locale file and langDir paths are used at build-time and stripped from the final build - this will be the default in v10 and will fully replace the absolute and relative configs
 - default: `'absolute'`{lang="ts"}
 - This changes the generated locale file and langDir paths, these paths are absolute by default in v9 (and lower) and could expose sensitive path information to production.
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,7 +99,7 @@ export interface ExperimentalFeatures {
    * @remark `'relative'` locale file and langDir paths are converted to be relative to the `rootDir`
    * @default 'absolute'
    */
-  generatedLocaleFilePathFormat?: 'absolute' | 'relative'
+  generatedLocaleFilePathFormat?: 'absolute' | 'relative' | 'off'
   /**
    * Removes non-canonical query parameters from alternate link meta tags
    * @default false

--- a/test/__snapshots__/gen.test.ts.snap
+++ b/test/__snapshots__/gen.test.ts.snap
@@ -79,6 +79,104 @@ exports[`basic 1`] = `
 }
 `;
 
+exports[`files with cache configuration (off) 1`] = `
+{
+  "localeLoaders": {
+    "en": [
+      {
+        "cache": true,
+        "importString": "import locale_en_46json_e9231b3b from "#nuxt-i18n/e9231b3b";",
+        "key": ""locale_en_46json_e9231b3b"",
+        "load": "() => import("#nuxt-i18n/e9231b3b" /* webpackChunkName: "locale_en_46json_e9231b3b" */)",
+        "relative": "srcDir/test/locales/en.json",
+        "specifier": "#nuxt-i18n/e9231b3b",
+      },
+    ],
+    "es": [
+      {
+        "cache": false,
+        "importString": "import locale_es_46json_4fad0583 from "#nuxt-i18n/4fad0583";",
+        "key": ""locale_es_46json_4fad0583"",
+        "load": "() => import("#nuxt-i18n/4fad0583" /* webpackChunkName: "locale_es_46json_4fad0583" */)",
+        "relative": "srcDir/test/locales/es.json",
+        "specifier": "#nuxt-i18n/4fad0583",
+      },
+    ],
+    "es-AR": [
+      {
+        "cache": false,
+        "importString": "import locale_es_46json_4fad0583 from "#nuxt-i18n/4fad0583";",
+        "key": ""locale_es_46json_4fad0583"",
+        "load": "() => import("#nuxt-i18n/4fad0583" /* webpackChunkName: "locale_es_46json_4fad0583" */)",
+        "relative": "srcDir/test/locales/es.json",
+        "specifier": "#nuxt-i18n/4fad0583",
+      },
+      {
+        "cache": true,
+        "importString": "import locale_es_45AR_46json_5c77b60d from "#nuxt-i18n/5c77b60d";",
+        "key": ""locale_es_45AR_46json_5c77b60d"",
+        "load": "() => import("#nuxt-i18n/5c77b60d" /* webpackChunkName: "locale_es_45AR_46json_5c77b60d" */)",
+        "relative": "srcDir/test/locales/es-AR.json",
+        "specifier": "#nuxt-i18n/5c77b60d",
+      },
+    ],
+    "fr": [
+      {
+        "cache": true,
+        "importString": "import locale_fr_46json_5627016f from "#nuxt-i18n/5627016f";",
+        "key": ""locale_fr_46json_5627016f"",
+        "load": "() => import("#nuxt-i18n/5627016f" /* webpackChunkName: "locale_fr_46json_5627016f" */)",
+        "relative": "srcDir/test/locales/fr.json",
+        "specifier": "#nuxt-i18n/5627016f",
+      },
+    ],
+    "ja": [
+      {
+        "cache": true,
+        "importString": "import locale_ja_46json_354e4128 from "#nuxt-i18n/354e4128";",
+        "key": ""locale_ja_46json_354e4128"",
+        "load": "() => import("#nuxt-i18n/354e4128" /* webpackChunkName: "locale_ja_46json_354e4128" */)",
+        "relative": "srcDir/test/locales/ja.json",
+        "specifier": "#nuxt-i18n/354e4128",
+      },
+    ],
+  },
+  "normalizedLocales": [
+    {
+      "code": "en",
+    },
+    {
+      "code": "ja",
+    },
+    {
+      "code": "fr",
+    },
+    {
+      "code": "es",
+    },
+    {
+      "code": "es-AR",
+    },
+  ],
+  "nuxtI18nOptions": {
+    "defaultLocale": "en",
+    "experimental": {
+      "generatedLocaleFilePathFormat": "off",
+    },
+    "i18nModules": [],
+    "lazy": true,
+    "locales": [],
+  },
+  "vueI18nConfigs": [
+    {
+      "importer": "() => import("#nuxt-i18n/6354e9fa" /* webpackChunkName: "config_i18n_46config_46ts_6354e9fa" */)",
+      "relative": "/test/i18n.config.ts",
+      "specifier": "#nuxt-i18n/6354e9fa",
+    },
+  ],
+}
+`;
+
 exports[`files with cache configuration (relative) 1`] = `
 {
   "localeLoaders": {
@@ -639,21 +737,30 @@ exports[`toCode: function (arrow) 1`] = `
       {
         "code": "en",
         "files": [
-          "en.json",
+          {
+            "cache": true,
+            "path": "en.json",
+          },
         ],
         "testFunc": [Function],
       },
       {
         "code": "ja",
         "files": [
-          "ja.json",
+          {
+            "cache": true,
+            "path": "ja.json",
+          },
         ],
         "testFunc": [Function],
       },
       {
         "code": "fr",
         "files": [
-          "fr.json",
+          {
+            "cache": true,
+            "path": "fr.json",
+          },
         ],
         "testFunc": [Function],
       },
@@ -681,21 +788,30 @@ exports[`toCode: function (named) 1`] = `
       {
         "code": "en",
         "files": [
-          "en.json",
+          {
+            "cache": true,
+            "path": "en.json",
+          },
         ],
         "testFunc": [Function],
       },
       {
         "code": "ja",
         "files": [
-          "ja.json",
+          {
+            "cache": true,
+            "path": "ja.json",
+          },
         ],
         "testFunc": [Function],
       },
       {
         "code": "fr",
         "files": [
-          "fr.json",
+          {
+            "cache": true,
+            "path": "fr.json",
+          },
         ],
         "testFunc": [Function],
       },

--- a/test/gen.test.ts
+++ b/test/gen.test.ts
@@ -239,6 +239,47 @@ test('files with cache configuration (relative)', async () => {
   expect(code).toMatchSnapshot()
 })
 
+test('files with cache configuration (off)', async () => {
+  const locales = getMockLocales([
+    {
+      code: 'es',
+      files: [{ path: 'es.json', cache: false }]
+    },
+    {
+      code: 'es-AR',
+      files: [
+        { path: 'es.json', cache: false },
+        { path: 'es-AR.json', cache: true }
+      ]
+    }
+  ])
+
+  for (const l of locales) {
+    // @ts-ignore
+    l.files = resolveRelativeLocales(l, { langDir: 'locales' })
+  }
+  const localeInfo = await resolveLocales('srcDir', locales, '.nuxt')
+  const vueI18nConfig = await resolveVueI18nConfigInfo('/test', NUXT_I18N_VUE_I18N_CONFIG.meta.loadPath, '.nuxt')
+
+  const code = generateLoaderOptions(
+    {
+      vueI18nConfigPaths: [vueI18nConfig].filter((x): x is Required<VueI18nConfigPathInfo> => x != null),
+      localeInfo,
+      normalizedLocales: getNormalizedLocales(locales),
+      options: {
+        ...NUXT_I18N_OPTIONS,
+        lazy: true,
+        experimental: {
+          generatedLocaleFilePathFormat: 'off'
+        }
+      }
+    },
+    { ...makeNuxtOptions(localeInfo), options: { ...makeNuxtOptions(localeInfo).options, rootDir: '/test' } }
+  )
+
+  expect(code).toMatchSnapshot()
+})
+
 test('locale file in nested', async () => {
   const locales = [
     {


### PR DESCRIPTION
### 🔗 Linked issue
* #3506
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Resolves #3506

In v10 we will be removing i18n file paths from the build (including the i18n options), the paths potentially cause issues with crawlers and could expose sensitive information. The module has no use for these paths after build and are obscured with hashed virtual files.

By setting the `experimental.generatedLocaleFilePathFormat` option to `'off'` you can opt-into this behavior, this will be the default behavior in v10 and the `experimental.generatedLocaleFilePathFormat` option will be dropped entirely.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->
