### PR TITLE
docs: usage page rework

### DIFF
--- a/docs/content/docs/01.getting-started/02.usage.md
+++ b/docs/content/docs/01.getting-started/02.usage.md
@@ -5,7 +5,7 @@ description: The basics to get started with the Nuxt i18n module
 
 ## Basic setup
 
-To get started we configure the project `locales` and the `defaultLocale` in the nuxt config.
+Let's start by configuring the project `locales` and the `defaultLocale` in the nuxt config.
 
 For this project we configure the locales with the following properties:
 
@@ -48,7 +48,7 @@ Nuxt I18n has a (configurable) folder structure from which the locale files are 
 
 ::
 
-With this configuration we can add a basic language switcher and translate our first message:
+With this configuration we can add a basic language switcher and translate our first message using:
 
 <!-- prettier-ignore -->
 ```vue [pages/index.vue]

--- a/docs/content/docs/01.getting-started/02.usage.md
+++ b/docs/content/docs/01.getting-started/02.usage.md
@@ -1,72 +1,81 @@
 ---
 title: Usage
-description: The basics to get started with the Nuxt i18n module is to translate with Vue I18n via the `vueI18n` option.
+description: The basics to get started with the Nuxt i18n module
 ---
 
-## Translate with Vue I18n
+## Basic setup
 
-The basics to get started with **Nuxt i18n module** is to **translate with Vue I18n via the `vueI18n` option**
+To get started we configure the project `locales` and the `defaultLocale` in the nuxt config.
+
+For this project we configure the locales with the following properties:
+
+- `code`: required property, the locale code is used throughout Nuxt I18n and is used as the identifier for the locale.
+- `name`: name of the locale, this is a user-friendly way to identify the locale.
+- `file`: a file that provides translation messages in the form of an object.
+
+The `defaultLocale` should be set to the `code` of one of the configured locales, setting this is optional but recommended as it will be used as fallback when navigating to a non-existent route.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   modules: ['@nuxtjs/i18n'],
   i18n: {
-    vueI18n: './i18n.config.ts' // if you are using custom path, default
+    defaultLocale: 'en',
+    locales: [
+      { code: 'en', name: 'English', file: 'en.json' },
+      { code: 'nl', name: 'Nederlands', file: 'nl.json' }
+    ]
   }
 })
 ```
 
-```ts [i18n/i18n.config.ts]
-export default defineI18nConfig(() => ({
-  legacy: false,
-  locale: 'en',
-  messages: {
-    en: {
-      welcome: 'Welcome'
-    },
-    fr: {
-      welcome: 'Bienvenue'
-    }
-  }
-}))
+A typical project has at least one `file` for each configured locale, this file provides the translation messages in the form of an object.
+
+Nuxt I18n has a (configurable) folder structure from which the locale files are sourced, the locale files should be created in `<rootDir>/i18n/locales` by default.
+
+::code-group
+
+```json [i18n/locales/en.json]
+{
+  "welcome": "Welcome"
+}
 ```
 
-The `i18n.config` file exports the same options as the `createI18n`{lang="ts-type"} function of Vue I18n. The configuration is passed to the `createI18n` function via the Nuxt plugin (runtime) of this module internally. For more details about configuration, see the [Vue I18n documentation](https://vue-i18n.intlify.dev/api/general.html#createi18n).
+```json [i18n/locales/nl.json]
+{
+  "welcome": "Welkom"
+}
+```
 
-::callout{icon="i-heroicons-light-bulb"}
-The following documentation explains how to use the Nuxt i18n module using Vue I18n Composition API. :br
-For more information on how to use Vue I18n Composition API, please see the docs [here](https://vue-i18n.intlify.dev/guide/advanced/composition.html).
 ::
 
-Now, put (or edit) the following the page component in `pages` directory of your project:
+With this configuration we can add a basic language switcher and translate our first message:
 
+<!-- prettier-ignore -->
 ```vue [pages/index.vue]
 <script setup>
-const { setLocale } = useI18n()
+const { locales, setLocale } = useI18n()
 </script>
 
 <template>
   <div>
-    <div>
-      <button @click="setLocale('en')">en</button>
-      <button @click="setLocale('fr')">fr</button>
-      <p>{{ $t('welcome') }}</p>
-    </div>
+    <button v-for="locale in locales" @click="setLocale(locale.code)">
+      {{ locale.name }}
+    </button>
+    <h1>{{ $t('welcome') }}</h1>
   </div>
 </template>
 ```
 
-You now have a really simple Vue I18n based translation environment ready to go! The `<button>` elements can be used to switch between the English and French languages, by clicking either of the buttons you can see the word "welcome" translate and the page URL change to its corresponding language.
+Using the configured locales we created a simple language-switcher, by clicking a `<button>` element you can switch between English and Dutch and see the "welcome" message and page URL change to its corresponding language.
 
-::callout{icon="i-heroicons-light-bulb"}
-For more information about **Vue I18n**, you can refer to its documentation [here](https://vue-i18n.intlify.dev/).
-::
+You now have a basic setup to get started with fully localizing your Nuxt Application!
 
 ## Auto Imports
 
-Some composable functions provided by `@nuxtjs/i18n` such as `useI18n` are [auto-imported by Nuxt](https://nuxt.com/docs/guide/concepts/auto-imports#auto-imports).
-If you want to import them explicitly, you can use `#imports` as follows:
+Some composable functions such as `useI18n` are [auto-imported by Nuxt](https://nuxt.com/docs/guide/concepts/auto-imports#auto-imports).
+If you have disabled `autoImports` you will need to import these explicitly from `#imports` as follows:
 
+<!-- prettier-ignore -->
 ```vue
 <script setup>
 import { useI18n, useLocalePath } from '#imports'
@@ -74,70 +83,84 @@ import { useI18n, useLocalePath } from '#imports'
 </script>
 ```
 
-## Link localizing
+## Route localization
 
-The **Nuxt i18n module** extends the integrated Vue I18n to give us some i18n features for Nuxt application. In here, we introduce one of those features, the link localization with extending Nuxt pages and routing.
+Nuxt I18n generates localized routes for each locale, in the most basic setup this comes in the form of a prefixed variant of each route with a locale code.
 
-### Configurations
+When linking to routes within your app, you will need to get the localized route for the current locale. This is done with utility functions provided by Nuxt I18n.
 
-You'll need to additionally set the `defaultLocale` and `locales` options, as in the following configuration.
+### Resolving a localized route with `$localePath`
 
-For localizing links, you can use the code provided from the `locales` option as the URL path prefix, except for `defaultLocale` (read more on [routing](/docs/guide)).
+The `$localePath` function is used to get the localized route for a given route, this function is returned by `useLocalePath` for usage outside `<template>`.
 
-```diff [nuxt.config.ts]
-export default defineNuxtConfig({
-  modules: ['@nuxtjs/i18n'],
+This function accepts two parameters:
 
-  i18n: {
-+   locales: ['en', 'fr'], // used in URL path prefix
-+   defaultLocale: 'en', // default locale of your project for Nuxt pages and routings
-  }
-})
+- `route`: name of a route or a route object with a name property
+- `locale`: locale code in which the route should be localized, defaults to the current locale
+
+::code-group
+
+<!-- prettier-ignore -->
+```vue [page.vue (global function)]
+<template>
+  <NuxtLink :to="$localePath('index')">{{ $t('home') }}</NuxtLink>
+  <NuxtLink :to="$localePath('index', 'en')">Homepage in English</NuxtLink>
+  <NuxtLink :to="$localePath('user-profile')">Route to {{ $t('profile') }}</NuxtLink>
+  <NuxtLink :to="$localePath({ name: 'category-slug', params: { slug: category.slug } })">
+    {{ category.title }}
+  </NuxtLink>
+</template>
 ```
 
-When rendering internal links in your app using `<NuxtLink>`, you need to get proper URLs for the current locale. To do this, the **Nuxt i18n module** provides some helper composables:
-
-### URL path
-
-You can localize URL paths using `useLocalePath`.
-
-`useLocalePath` is a composable which returns a function used to get the localized URL for a given path. The first parameter can either be the path or name of the route or an object for more complex routes. A locale code can be passed as the second parameter to generate a link for a specific language:
-
-```vue
+<!-- prettier-ignore -->
+```vue [page.vue (composable)]
 <script setup>
 const localePath = useLocalePath()
 </script>
 
 <template>
   <NuxtLink :to="localePath('index')">{{ $t('home') }}</NuxtLink>
-  <NuxtLink :to="localePath('/')">{{ $t('home') }}</NuxtLink>
   <NuxtLink :to="localePath('index', 'en')">Homepage in English</NuxtLink>
-  <NuxtLink :to="localePath('/user/profile')">Route by path to: {{ $t('profile') }}</NuxtLink>
-  <NuxtLink :to="localePath('user-profile')">Route by name to: {{ $t('profile') }}</NuxtLink>
+  <NuxtLink :to="localePath('user-profile')">Route to {{ $t('profile') }}</NuxtLink>
   <NuxtLink :to="localePath({ name: 'category-slug', params: { slug: category.slug } })">
     {{ category.title }}
   </NuxtLink>
 </template>
 ```
 
-Note that `localePath` can use the route's unprefixed path, which must start with `'/'` or the route's base name to generate the localized URL. The base name corresponds to the names Nuxt generates when parsing your `pages` directory, more info in [Nuxt docs](https://nuxt.com/docs/guide/directory-structure/pages).
+::
 
-### Language switching path
+Since localized routes can change based on your configuration, using route names ensures accurate resolution. Nuxt I18n generates types to facilitate this, providing type safety and improved developer experience. To utilize these types, enable `typedPages` in your Nuxt configuration.
 
-You can localize the language of the current path using `useSwitchLocalePath`.
+The route name corresponds to the names Nuxt generates when parsing your `pages` directory, more info in [Nuxt docs](https://nuxt.com/docs/guide/directory-structure/pages).
 
-`useSwitchLocalePath` is a composable function which returns a link to the current page in another language:
+### Switching between languages
 
-```vue
+The `$switchLocalePath` function returns the localized version of the route to the current page, it accepts a locale code in which the current route should be localized.
+
+::code-group
+
+<!-- prettier-ignore -->
+```vue [page.vue (global function)]
+<template>
+  <NuxtLink :to="$switchLocalePath('en')">English</NuxtLink>
+  <NuxtLink :to="$switchLocalePath('nl')">Nederlands</NuxtLink>
+</template>
+```
+
+<!-- prettier-ignore -->
+```vue [page.vue (composable)]
 <script setup>
 const switchLocalePath = useSwitchLocalePath()
 </script>
 
 <template>
   <NuxtLink :to="switchLocalePath('en')">English</NuxtLink>
-  <NuxtLink :to="switchLocalePath('fr')">Français</NuxtLink>
+  <NuxtLink :to="switchLocalePath('nl')">Nederlands</NuxtLink>
 </template>
 ```
+
+::
 
 ### URL path with Route object
 
@@ -147,6 +170,7 @@ You can localize advanced URL paths using `useLocaleRoute`. This is useful if yo
 
 It works like `useLocalePath` but returns a route resolved by Vue Router rather than a full route path. This can be useful as the path returned from `useLocalePath` may not carry all information from the provided input (for example, route params that the page doesn't specify).
 
+<!-- prettier-ignore -->
 ```vue
 <script setup>
 const localeRoute = useLocaleRoute()

--- a/docs/content/docs/01.getting-started/03.vue-i18n.md
+++ b/docs/content/docs/01.getting-started/03.vue-i18n.md
@@ -1,0 +1,51 @@
+---
+title: Vue I18n Configuration
+description: Configuring runtime options for Vue I18n
+---
+
+## Vue I18n Configuration
+
+While some options are shared between Nuxt I18n and Vue I18n, there is a range of options which are specific to Vue I18n, for example:
+
+- `fallbackWarn`: To ontrol fallback warnings.
+- `missingWarn`: To control missing localization warnings.
+- `formatter`: To provide a custom message formatting function.
+- `numberFormats`: To configure custom number formatting.
+- `datetimeFormats`: To configure custom date time formatting.
+- ... more!
+
+These are just a few examples of the runtime options available in Vue I18n, please check out [the documentation of Vue I18n](https://vue-i18n.intlify.dev/) to explore the full range of available options.
+
+Vue I18n specific options cannot be configured in `nuxt.config` and have no overlap with the features used by or provided by Nuxt I18n.
+
+## Adding a Vue I18n config file
+
+To configure the options you can create a `i18n.config.ts` file in the `<rootDir>/i18n` directory, this file should have a default export with a function returning the Vue I18n options.
+
+Nuxt I18n provides a macro function `defineI18nConfig` to improve the types, but a plain function would suffice too:
+
+```ts [i18n/i18n.config.ts]
+export default defineI18nConfig(() => {
+  return {
+    // vue-i18n options
+  }
+})
+```
+
+The config file is resolved from `<rootDir>/i18n`, and automatically looks for and loads the config file using the default filename of `i18n.config`. This can be configured using the `vueI18n` options.
+
+## When to use
+
+Use `i18n.config.ts` when you need to configure Vue I18n options that involve runtime functions or data that cannot be serialized for build-time processing. This is often the case when:
+
+- You need to dynamically load or manipulate localization data based on user input or external APIs.
+- You are using custom formatting functions or other non-serializable options.
+- You need to use Vue I18n options that are not supported by Nuxt I18n's build-time configuration.
+
+## Nuxt config benefits
+
+While it is possible to configure the same (or functionally the same) options configurable in `nuxt.config.ts` (`messages` - instead of `locales`, `defaultLocale`, etc.) it is recommended to keep as much of the configuration as Nuxt I18n supports on the `i18n` key inside `nuxt.config`.
+
+Nuxt I18n will use these options during the build step and can configure and optimize functionalities by integrating with other libraries such as `@intlify/unplugin-vue-i18n`.
+
+The Vue I18n config file will be loaded at runtime on each request which can increase server response times, especially in high-traffic applications. This is because the server needs to parse and process the configuration for every incoming request and merge them with those set by Nuxt I18n, rather than doing it once at build time.


### PR DESCRIPTION
### 🔗 Linked issue
* #3362 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Resolves #3362 

This changes the usage page to introduce internationalization using nuxt-i18n specific features first. 

I don't want to remove the vue-i18n guide entirely, but it seems users first implement things this way before running into the features that need config at build-time to function properly.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->
