### PR TITLE
chore!: drop `bundle.optimizeTranslationDirective`

### DIFF
--- a/docs/content/docs/02.guide/90.migrating.md
+++ b/docs/content/docs/02.guide/90.migrating.md
@@ -3,6 +3,11 @@ title: Migration Guide
 description: Follow this guide to upgrade from one major version to the other.
 ---
 
+## Upgrading from `nuxtjs/i18n` v9.x to v10.x
+
+### Drop `bundle.optimizeTranslationDirective`
+This feature has been disabled and the option to enable it has been removed, see [the discussion in this issue](https://github.com/nuxt-modules/i18n/issues/3238#issuecomment-2672492536) for context on this change.
+
 ## Upgrading from `nuxtjs/i18n` v8.x to v9.x
 
 ### Upgrade to Vue I18n v10

--- a/docs/content/docs/04.api/00.options.md
+++ b/docs/content/docs/04.api/00.options.md
@@ -438,13 +438,6 @@ It can be useful if you have one code base (e.g. [Nuxt Layers](https://nuxt.com/
 The value of this **option will not be merged with other Nuxt Layers**. This option should only be specified in the final project config.
 ::
 
-### `optimizeTranslationDirective`
-
-- type: `boolean`{lang="ts-type"}
-- default: `true`{lang="ts"}
-
-Whether to optimize `v-t` directive by transforming it's usage into a vue-i18n translation function, this needs to be enabled for projects using the `v-t` directive with SSR.
-
 ## experimental
 
 Experimental configuration property is an object with the following properties:

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -67,7 +67,7 @@ export function createLogger(label) {
     defaultSFCLang: options.customBlocks.defaultSFCLang,
     globalSFCScope: options.customBlocks.globalSFCScope,
     dropMessageCompiler: options.bundle.dropMessageCompiler,
-    optimizeTranslationDirective: options.bundle.optimizeTranslationDirective
+    optimizeTranslationDirective: false
   }
   addBuildPlugin({
     vite: () => VueI18nPlugin.vite(vueI18nPluginOptions),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,8 +39,7 @@ export const DEFAULT_OPTIONS = {
     compositionOnly: true,
     runtimeOnly: false,
     fullInstall: true,
-    dropMessageCompiler: false,
-    optimizeTranslationDirective: true
+    dropMessageCompiler: false
   },
   compilation: {
     strictMessage: true,

--- a/src/prepare/options.ts
+++ b/src/prepare/options.ts
@@ -20,16 +20,6 @@ export function prepareOptions({ debug, logger, options }: I18nNuxtContext, nuxt
     )
   }
 
-  if (
-    !nuxt.options?._prepare &&
-    !nuxt.options?.test &&
-    nuxt.options.i18n?.bundle?.optimizeTranslationDirective == null
-  ) {
-    logger.warn(
-      '`bundle.optimizeTranslationDirective` is enabled by default, we recommend disabling this feature as it causes issues and will be deprecated in v10.\nExplicitly setting this option to `true` or `false` disables this warning, for more details see: https://github.com/nuxt-modules/i18n/issues/3238#issuecomment-2672492536'
-    )
-  }
-
   if (options.experimental.autoImportTranslationFunctions && nuxt.options.imports.autoImport === false) {
     logger.warn(
       'Disabling `autoImports` in Nuxt is not compatible with `experimental.autoImportTranslationFunctions`, either enable `autoImports` or disable `experimental.autoImportTranslationFunctions`.'

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,12 +122,7 @@ export interface ExperimentalFeatures {
 export interface BundleOptions
   extends Pick<
     PluginOptions,
-    | 'compositionOnly'
-    | 'runtimeOnly'
-    | 'fullInstall'
-    | 'dropMessageCompiler'
-    | 'onlyLocales'
-    | 'optimizeTranslationDirective'
+    'compositionOnly' | 'runtimeOnly' | 'fullInstall' | 'dropMessageCompiler' | 'onlyLocales'
   > {}
 
 export interface CustomBlocksOptions extends Pick<PluginOptions, 'defaultSFCLang' | 'globalSFCScope'> {}


### PR DESCRIPTION
### 🔗 Linked issue
* #3435 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Drops the option `bundle.optimizeTranslationDirective` and disables it by default.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->
