### PR TITLE
fix: setup auto-imports outside `modules:done` hook

### DIFF
--- a/src/alias.ts
+++ b/src/alias.ts
@@ -19,10 +19,7 @@ const debug = createDebug('@nuxtjs/i18n:alias')
 
 export function setupAlias({ userOptions: options, isDev, isPrepare }: I18nNuxtContext, nuxt: Nuxt) {
   const modules = {
-    [VUE_I18N_PKG]:
-      isDev || isPrepare
-        ? `${VUE_I18N_PKG}/dist/vue-i18n.mjs`
-        : `${VUE_I18N_PKG}/dist/vue-i18n${options.bundle?.runtimeOnly ? '.runtime' : ''}.mjs`,
+    [VUE_I18N_PKG]: `${VUE_I18N_PKG}/dist/vue-i18n${!isDev && !isPrepare && options.bundle?.runtimeOnly ? '.runtime' : ''}.mjs`,
     [SHARED_PKG]: `${SHARED_PKG}/dist/shared.mjs`,
     [MESSAGE_COMPILER_PKG]: `${MESSAGE_COMPILER_PKG}/dist/message-compiler.mjs`,
     [CORE_BASE_PKG]: `${CORE_BASE_PKG}/dist/core-base.mjs`,

--- a/src/module.ts
+++ b/src/module.ts
@@ -44,6 +44,11 @@ export default defineNuxtModule<NuxtI18nOptions>({
     prepareOptions(ctx, nuxt)
 
     /**
+     * auto imports
+     */
+    prepareAutoImports(ctx)
+
+    /**
      * allow other modules to setup first in case these use i18n hooks
      */
     nuxt.hook('modules:done', async () => {
@@ -100,11 +105,6 @@ export default defineNuxtModule<NuxtI18nOptions>({
        * setup nitro
        */
       await setupNitro(ctx, nuxt)
-
-      /**
-       * auto imports
-       */
-      prepareAutoImports(ctx, nuxt)
 
       /**
        * transpile @nuxtjs/i18n

--- a/src/prepare/auto-imports.ts
+++ b/src/prepare/auto-imports.ts
@@ -1,18 +1,14 @@
-import type { Nuxt } from '@nuxt/schema'
 import {
   NUXT_I18N_COMPOSABLE_DEFINE_CONFIG,
   NUXT_I18N_COMPOSABLE_DEFINE_LOCALE,
   NUXT_I18N_COMPOSABLE_DEFINE_ROUTE,
   VUE_I18N_PKG
 } from '../constants'
-import { addComponent, addImports } from '@nuxt/kit'
+import { addComponent, addImports, resolveModule } from '@nuxt/kit'
 import { runtimeDir } from '../dirs'
 import type { I18nNuxtContext } from '../context'
 
-export function prepareAutoImports({ debug, resolver }: I18nNuxtContext, nuxt: Nuxt) {
-  const vueI18nPath = nuxt.options.alias[VUE_I18N_PKG]
-  debug('vueI18nPath for auto-import', vueI18nPath)
-
+export function prepareAutoImports({ resolver, userOptions: options, isDev, isPrepare }: I18nNuxtContext) {
   addComponent({
     name: 'NuxtLinkLocale',
     filePath: resolver.resolve(runtimeDir, 'components/NuxtLinkLocale')
@@ -23,8 +19,9 @@ export function prepareAutoImports({ debug, resolver }: I18nNuxtContext, nuxt: N
     filePath: resolver.resolve(runtimeDir, 'components/SwitchLocalePathLink')
   })
 
+  const vueI18nPath = `${VUE_I18N_PKG}/dist/vue-i18n${!isDev && !isPrepare && options.bundle?.runtimeOnly ? '.runtime' : ''}.mjs`
   addImports([
-    { name: 'useI18n', from: vueI18nPath },
+    { name: 'useI18n', from: resolveModule(vueI18nPath) },
     ...[
       'useRouteBaseName',
       'useLocalePath',


### PR DESCRIPTION
### 🔗 Linked issue
* #3519
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Resolves #3519 

Looks like more care must be taken while changing a module to remove order dependence https://github.com/nuxt/nuxt/issues/31674
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->
