### PR TITLE
fix: handle default key in loaded messages

### DIFF
--- a/specs/fixtures/layers/layer-lazy/locales/en.json
+++ b/specs/fixtures/layers/layer-lazy/locales/en.json
@@ -1,3 +1,4 @@
 {
+  "default": "#3533",
   "hello": "Hello world!"
 }

--- a/src/runtime/messages.ts
+++ b/src/runtime/messages.ts
@@ -1,4 +1,4 @@
-import { deepCopy, isArray, isFunction, isString } from '@intlify/shared'
+import { deepCopy, isArray, isFunction, isString, toTypeString } from '@intlify/shared'
 import { createLogger } from '#nuxt-i18n/logger'
 
 import type { I18nOptions, Locale, FallbackLocale, LocaleMessages, DefineLocaleMessage } from 'vue-i18n'
@@ -80,6 +80,8 @@ export async function loadInitialMessages<Context extends NuxtApp = NuxtApp>(
   return messages
 }
 
+const isModule = (val: unknown): val is { default: unknown } => toTypeString(val) === '[object Module]'
+
 async function loadMessage(
   locale: Locale,
   { key, load }: LocaleLoader,
@@ -89,7 +91,7 @@ async function loadMessage(
   let message: LocaleMessages<DefineLocaleMessage> | null = null
   try {
     __DEBUG__ && logger.log({ locale })
-    const getter = await load().then(r => ('default' in r ? r.default : r))
+    const getter = await load().then(x => (isModule(x) ? x.default : x))
     if (isFunction(getter)) {
       message = await nuxt.runWithContext(() => getter(locale))
       __DEBUG__ && logger.log('dynamic load', logger.level >= 999 ? message : '')


### PR DESCRIPTION
### 🔗 Linked issue
* #3533
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Resolves #3533

Checking for `default` to differentiate objects from modules in the loaded messages is not enough, using stringified prototype tag is more accurate.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->
