### PR TITLE
refactor: reduce build-time i18n context size

### DIFF
--- a/src/alias.ts
+++ b/src/alias.ts
@@ -17,9 +17,9 @@ import type { I18nNuxtContext } from './context'
 
 const debug = createDebug('@nuxtjs/i18n:alias')
 
-export function setupAlias({ userOptions: options, isDev, isPrepare }: I18nNuxtContext, nuxt: Nuxt) {
+export function setupAlias({ userOptions: options }: I18nNuxtContext, nuxt: Nuxt) {
   const modules = {
-    [VUE_I18N_PKG]: `${VUE_I18N_PKG}/dist/vue-i18n${!isDev && !isPrepare && options.bundle?.runtimeOnly ? '.runtime' : ''}.mjs`,
+    [VUE_I18N_PKG]: `${VUE_I18N_PKG}/dist/vue-i18n${!nuxt.options.dev && !nuxt.options._prepare && options.bundle?.runtimeOnly ? '.runtime' : ''}.mjs`,
     [SHARED_PKG]: `${SHARED_PKG}/dist/shared.mjs`,
     [MESSAGE_COMPILER_PKG]: `${MESSAGE_COMPILER_PKG}/dist/message-compiler.mjs`,
     [CORE_BASE_PKG]: `${CORE_BASE_PKG}/dist/core-base.mjs`,

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,56 +1,29 @@
+import { createResolver } from '@nuxt/kit'
 import type { Resolver } from '@nuxt/kit'
 import type { LocaleInfo, LocaleObject, NuxtI18nOptions, VueI18nConfigPathInfo } from './types'
-import type { Nuxt } from '@nuxt/schema'
-import { createResolver, useLogger } from '@nuxt/kit'
-import { NUXT_I18N_MODULE_ID } from './constants'
-import createDebug from 'debug'
 
 export interface I18nNuxtContext {
   resolver: Resolver
-  logger: ReturnType<(typeof import('@nuxt/kit'))['useLogger']>
-  debug: ReturnType<typeof import('debug')>
   userOptions: NuxtI18nOptions
   options: Required<NuxtI18nOptions>
-  isDev: boolean
-  isSSR: boolean
-  isPrepare: boolean
-  isSSG: boolean
-  isBuild: boolean
-  isTest: boolean
-  // serialized boolean value
-  hasPages: string
   normalizedLocales: LocaleObject<string>[]
   localeCodes: string[]
   localeInfo: LocaleInfo[]
   vueI18nConfigPaths: Required<VueI18nConfigPathInfo>[]
 }
 
-const debug = createDebug('@nuxtjs/i18n:context')
 const resolver = createResolver(import.meta.url)
 
-export function createContext(userOptions: NuxtI18nOptions, nuxt: Nuxt): I18nNuxtContext {
+export function createContext(userOptions: NuxtI18nOptions): I18nNuxtContext {
   const options = userOptions as Required<NuxtI18nOptions>
 
   return {
-    resolver,
-    logger: useLogger(NUXT_I18N_MODULE_ID),
-    debug,
-    userOptions,
     options,
-    isDev: nuxt.options.dev,
-    isSSR: nuxt.options.ssr,
-    isPrepare: nuxt.options._prepare,
-    isSSG: nuxt.options._generate,
-    isBuild: nuxt.options._build,
-    isTest: nuxt.options.test,
-    // pages is initially undefined - has correct value when writing i18n.options template
-    get hasPages() {
-      // eslint-disable-next-line @typescript-eslint/no-base-to-string
-      return nuxt.options.pages.toString()
-    },
-    normalizedLocales: undefined!,
-    localeCodes: undefined!,
+    resolver,
+    userOptions,
     localeInfo: undefined!,
+    localeCodes: undefined!,
+    normalizedLocales: undefined!,
     vueI18nConfigPaths: undefined!
   }
 }

--- a/src/layers.ts
+++ b/src/layers.ts
@@ -1,10 +1,16 @@
 import createDebug from 'debug'
-import { getLayerI18n, mergeConfigLocales, resolveVueI18nConfigInfo, formatMessage, getLocaleFiles } from './utils'
+import { useNuxt } from '@nuxt/kit'
+import {
+  getLayerI18n,
+  mergeConfigLocales,
+  resolveVueI18nConfigInfo,
+  formatMessage,
+  getLocaleFiles,
+  logger
+} from './utils'
 
-import { useLogger, useNuxt } from '@nuxt/kit'
 import { isAbsolute, parse, resolve } from 'pathe'
 import { assign, isString } from '@intlify/shared'
-import { NUXT_I18N_MODULE_ID } from './constants'
 
 import type { LocaleConfig } from './utils'
 import type { Nuxt, NuxtConfigLayer } from '@nuxt/schema'
@@ -13,7 +19,6 @@ import type { LocaleObject, NuxtI18nOptions, VueI18nConfigPathInfo } from './typ
 const debug = createDebug('@nuxtjs/i18n:layers')
 
 export function checkLayerOptions(_options: NuxtI18nOptions, nuxt: Nuxt) {
-  const logger = useLogger(NUXT_I18N_MODULE_ID)
   const project = nuxt.options._layers[0]
   const layers = nuxt.options._layers
 
@@ -118,10 +123,7 @@ export function applyLayerOptions(options: NuxtI18nOptions, nuxt: Nuxt) {
   options.locales = mergeConfigLocales(configs)
 }
 
-export async function resolveLayerVueI18nConfigInfo(options: NuxtI18nOptions) {
-  const logger = useLogger(NUXT_I18N_MODULE_ID)
-  const nuxt = useNuxt()
-
+export async function resolveLayerVueI18nConfigInfo(options: NuxtI18nOptions, nuxt = useNuxt()) {
   const resolved = await Promise.all(
     nuxt.options._layers.map(async layer => {
       const i18n = getLayerI18n(layer)

--- a/src/module.ts
+++ b/src/module.ts
@@ -33,7 +33,7 @@ export default defineNuxtModule<NuxtI18nOptions>({
   },
   defaults: DEFAULT_OPTIONS,
   async setup(i18nOptions, nuxt) {
-    const ctx = createContext(i18nOptions, nuxt)
+    const ctx = createContext(i18nOptions)
 
     await initParser()
 

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -47,10 +47,10 @@ type NarrowedNuxtPage = Omit<NuxtPage, 'redirect' | 'children'> & {
   children?: NarrowedNuxtPage[]
 }
 
-export async function setupPages({ localeCodes, options, isSSR }: I18nNuxtContext, nuxt: Nuxt) {
+export async function setupPages({ localeCodes, options }: I18nNuxtContext, nuxt: Nuxt) {
   if (!localeCodes.length) return
 
-  let includeUnprefixedFallback = !isSSR
+  let includeUnprefixedFallback = !nuxt.options.ssr
   nuxt.hook('nitro:init', () => {
     debug('enable includeUprefixedFallback')
     includeUnprefixedFallback = options.strategy !== 'prefix'

--- a/src/prepare/auto-imports.ts
+++ b/src/prepare/auto-imports.ts
@@ -4,11 +4,11 @@ import {
   NUXT_I18N_COMPOSABLE_DEFINE_ROUTE,
   VUE_I18N_PKG
 } from '../constants'
-import { addComponent, addImports, resolveModule } from '@nuxt/kit'
+import { addComponent, addImports, resolveModule, useNuxt } from '@nuxt/kit'
 import { runtimeDir } from '../dirs'
 import type { I18nNuxtContext } from '../context'
 
-export function prepareAutoImports({ resolver, userOptions: options, isDev, isPrepare }: I18nNuxtContext) {
+export function prepareAutoImports({ resolver, userOptions: options }: I18nNuxtContext, nuxt = useNuxt()) {
   addComponent({
     name: 'NuxtLinkLocale',
     filePath: resolver.resolve(runtimeDir, 'components/NuxtLinkLocale')
@@ -19,7 +19,7 @@ export function prepareAutoImports({ resolver, userOptions: options, isDev, isPr
     filePath: resolver.resolve(runtimeDir, 'components/SwitchLocalePathLink')
   })
 
-  const vueI18nPath = `${VUE_I18N_PKG}/dist/vue-i18n${!isDev && !isPrepare && options.bundle?.runtimeOnly ? '.runtime' : ''}.mjs`
+  const vueI18nPath = `${VUE_I18N_PKG}/dist/vue-i18n${!nuxt.options.dev && !nuxt.options._prepare && options.bundle?.runtimeOnly ? '.runtime' : ''}.mjs`
   addImports([
     { name: 'useI18n', from: resolveModule(vueI18nPath) },
     ...[

--- a/src/prepare/locale-info.ts
+++ b/src/prepare/locale-info.ts
@@ -1,10 +1,10 @@
 import type { I18nNuxtContext } from '../context'
 import type { Nuxt } from '@nuxt/schema'
-import { filterLocales, getNormalizedLocales, mergeI18nModules, resolveLocales } from '../utils'
+import { debug, filterLocales, getNormalizedLocales, mergeI18nModules, resolveLocales } from '../utils'
 import { applyLayerOptions, resolveLayerVueI18nConfigInfo } from '../layers'
 
 export async function resolveLocaleInfo(ctx: I18nNuxtContext, nuxt: Nuxt) {
-  const { options, debug } = ctx
+  const { options } = ctx
 
   /**
    * collect and merge locales from layers and module hooks

--- a/src/prepare/options.ts
+++ b/src/prepare/options.ts
@@ -1,9 +1,9 @@
 import type { I18nNuxtContext } from '../context'
 import type { Nuxt } from '@nuxt/schema'
-import { applyOptionOverrides, formatMessage } from '../utils'
+import { applyOptionOverrides, debug, formatMessage, logger } from '../utils'
 import { checkLayerOptions } from '../layers'
 
-export function prepareOptions({ debug, logger, options }: I18nNuxtContext, nuxt: Nuxt) {
+export function prepareOptions({ options }: I18nNuxtContext, nuxt: Nuxt) {
   applyOptionOverrides(options, nuxt)
   debug('options', options)
   checkLayerOptions(options, nuxt)

--- a/src/prepare/runtime.ts
+++ b/src/prepare/runtime.ts
@@ -23,7 +23,7 @@ export function prepareRuntime(ctx: I18nNuxtContext, nuxt: Nuxt) {
   nuxt.options.build.transpile.push('#i18n-kit/head')
   nuxt.options.build.transpile.push('#i18n-kit/routing')
 
-  if (ctx.isDev && options.hmr) {
+  if (nuxt.options.dev && options.hmr) {
     addVitePlugin({
       name: 'i18n:options-hmr',
       configureServer(server) {

--- a/src/prepare/strategy.ts
+++ b/src/prepare/strategy.ts
@@ -1,8 +1,8 @@
 import type { I18nNuxtContext } from '../context'
 import type { Nuxt } from '@nuxt/schema'
 
-export function prepareStrategy({ options, isSSG, normalizedLocales }: I18nNuxtContext, nuxt: Nuxt) {
-  if (options.strategy === 'prefix' && isSSG) {
+export function prepareStrategy({ options, normalizedLocales }: I18nNuxtContext, nuxt: Nuxt) {
+  if (options.strategy === 'prefix' && nuxt.options._generate) {
     const localizedEntryPages = normalizedLocales.map(x => ['/', x.code].join(''))
     nuxt.hook('nitro:config', config => {
       config.prerender ??= {}

--- a/src/prepare/type-generation.ts
+++ b/src/prepare/type-generation.ts
@@ -6,8 +6,8 @@ import { dirname } from 'pathe'
 import type { Nuxt } from '@nuxt/schema'
 import type { I18nNuxtContext } from '../context'
 
-export async function prepareTypeGeneration({ resolver, options, isDev }: I18nNuxtContext, nuxt: Nuxt) {
-  if (options.experimental.typedOptionsAndMessages === false || !isDev) return
+export async function prepareTypeGeneration({ resolver, options }: I18nNuxtContext, nuxt: Nuxt) {
+  if (options.experimental.typedOptionsAndMessages === false || !nuxt.options.dev) return
 
   const declarationFile = './types/i18n-messages.d.ts'
   const dtsFile = resolver.resolve(nuxt.options.buildDir, declarationFile)

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,3 +1,4 @@
+import { useNuxt } from '@nuxt/kit'
 import { generateLoaderOptions } from './gen'
 import { genArrayFromRaw, genObjectFromRaw, genObjectFromValues, genString } from 'knitwork'
 import {
@@ -113,9 +114,13 @@ function genVueI18nConfigHMR(configs: TemplateNuxtI18nOptions['vueI18nConfigs'])
   return statements.join('\n\n')
 }
 
-export function generateTemplateNuxtI18nOptions(ctx: I18nNuxtContext, opts: TemplateNuxtI18nOptions): string {
+export function generateTemplateNuxtI18nOptions(
+  ctx: I18nNuxtContext,
+  opts: TemplateNuxtI18nOptions,
+  nuxt = useNuxt()
+): string {
   const codeHMR =
-    ctx.isDev &&
+    nuxt.options.dev &&
     opts.nuxtI18nOptions.hmr &&
     [
       `if(import.meta.hot) {`,
@@ -137,6 +142,9 @@ export function generateTemplateNuxtI18nOptions(ctx: I18nNuxtContext, opts: Temp
     localeLoaderEntries[locale] = val.map(({ key, load, cache }) => ({ key, load, cache }))
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-base-to-string
+  const hasPages = nuxt.options.pages.toString()
+
   return `
 // @ts-nocheck
 ${(!ctx.options.lazy && [...importStrings].join('\n')) || ''}
@@ -153,8 +161,8 @@ export const normalizedLocales = ${genArrayFromRaw(opts.normalizedLocales.map(x 
 
 export const NUXT_I18N_MODULE_ID = ${genString(NUXT_I18N_MODULE_ID)}
 export const parallelPlugin = ${ctx.options.parallelPlugin}
-export const isSSG = ${ctx.isSSG}
-export const hasPages = ${ctx.hasPages}
+export const isSSG = ${nuxt.options._generate}
+export const hasPages = ${hasPages}
 
 export const DEFAULT_COOKIE_KEY = ${genString(DEFAULT_COOKIE_KEY)}
 export const DYNAMIC_PARAMS_KEY = ${genString(DYNAMIC_PARAMS_KEY)}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,9 @@
+import { defu } from 'defu'
+import createDebug from 'debug'
 import { readFileSync, existsSync } from 'node:fs'
 import { createHash, type BinaryLike } from 'node:crypto'
-import { resolvePath, useNuxt } from '@nuxt/kit'
+import { resolvePath, useLogger, useNuxt } from '@nuxt/kit'
 import { resolve, relative, join } from 'pathe'
-import { defu } from 'defu'
 import { isString, isArray, assign, isObject } from '@intlify/shared'
 import { NUXT_I18N_MODULE_ID, EXECUTABLE_EXTENSIONS, EXECUTABLE_EXT_RE } from './constants'
 import { parseSync } from './utils/parse'
@@ -268,3 +269,6 @@ export const applyOptionOverrides = (options: NuxtI18nOptions, nuxt: Nuxt) => {
 export function toArray<T>(value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value]
 }
+
+export const logger = useLogger(NUXT_I18N_MODULE_ID)
+export const debug = createDebug(NUXT_I18N_MODULE_ID)

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -9,7 +9,8 @@ vi.mock('pathe', async () => {
   return { ...mod, resolve: vi.fn((...args: string[]) => mod.normalize(args.join('/'))) }
 })
 
-vi.mock('@nuxt/kit', () => {
+vi.mock('@nuxt/kit', async importOriginal => {
+  const actual = await importOriginal()
   const resolveFiles = () => {
     return [
       ['en', 'json'],
@@ -19,7 +20,11 @@ vi.mock('@nuxt/kit', () => {
       ['nl', 'js']
     ].map(pair => `/path/to/project/locales/${pair[0]}.${pair[1]}`)
   }
-  return { resolveFiles }
+  return {
+    // @ts-expect-error import actual
+    ...actual,
+    resolveFiles
+  }
 })
 
 vi.mock('node:fs')


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Some of the properties on the context only rename nuxt options, it should be easier to mock and understand the original values by directly accessing these properties from `useNuxt`
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->
