### PR TITLE
refactor: move `overrides` logic out of module

### DIFF
--- a/specs/utils/nuxt.ts
+++ b/specs/utils/nuxt.ts
@@ -68,9 +68,9 @@ export async function loadFixture(testContext: VitestContext) {
          * The `overrides` option is only used for testing, it is used to option overrides to the project layer in a fixture.
          */
         (_, nuxt) => {
-          const project = nuxt.options._layers[0]
-          const { overrides, ...mergedOptions } = nuxt.options.i18n
-          if (overrides) {
+          if (nuxt.options?.i18n?.overrides) {
+            const project = nuxt.options._layers[0]
+            const { overrides, ...mergedOptions } = nuxt.options.i18n
             delete nuxt.options.i18n.overrides
             project.config.i18n = defu(overrides, project.config.i18n)
             Object.assign(nuxt.options.i18n, defu(overrides, mergedOptions))

--- a/specs/utils/nuxt.ts
+++ b/specs/utils/nuxt.ts
@@ -63,6 +63,20 @@ export async function loadFixture(testContext: VitestContext) {
 
     ctx.options.nuxtConfig = defu(ctx.options.nuxtConfig, {
       buildDir,
+      modules: [
+        /**
+         * The `overrides` option is only used for testing, it is used to option overrides to the project layer in a fixture.
+         */
+        (_, nuxt) => {
+          const project = nuxt.options._layers[0]
+          const { overrides, ...mergedOptions } = nuxt.options.i18n
+          if (overrides) {
+            delete nuxt.options.i18n.overrides
+            project.config.i18n = defu(overrides, project.config.i18n)
+            Object.assign(nuxt.options.i18n, defu(overrides, mergedOptions))
+          }
+        }
+      ],
       // NOTE: the following code is added for prerender
       _generate: ctx.options.prerender,
       nitro: {

--- a/src/prepare/options.ts
+++ b/src/prepare/options.ts
@@ -1,10 +1,9 @@
 import type { I18nNuxtContext } from '../context'
 import type { Nuxt } from '@nuxt/schema'
-import { applyOptionOverrides, debug, formatMessage, logger } from '../utils'
+import { debug, formatMessage, logger } from '../utils'
 import { checkLayerOptions } from '../layers'
 
 export function prepareOptions({ options }: I18nNuxtContext, nuxt: Nuxt) {
-  applyOptionOverrides(options, nuxt)
   debug('options', options)
   checkLayerOptions(options, nuxt)
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -255,17 +255,6 @@ export function getLayerI18n(configLayer: NuxtConfigLayer) {
   return layerInlineOptions
 }
 
-export const applyOptionOverrides = (options: NuxtI18nOptions, nuxt: Nuxt) => {
-  const project = nuxt.options._layers[0]
-  const { overrides, ...mergedOptions } = options
-
-  if (overrides) {
-    delete options.overrides
-    project.config.i18n = defu(overrides, project.config.i18n)
-    assign(options, defu(overrides, mergedOptions))
-  }
-}
-
 export function toArray<T>(value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value]
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This moves the logic that handles `overrides` out of the module, it is now only used during the tests within this repository. IT is possible users were using this property in their projects, but this property is undocumented and the JSDoc marks this as internal and not to be used.

Moving this to the tests should make the option handling more predictable and reduce the module size by a tiny bit.

We should consider removing the types for the `overrides` property entirely.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->
