### PR TITLE
fix!: remove `nuxtI18nOptions` from generated options files

### DIFF
--- a/docs/content/docs/02.guide/90.migrating.md
+++ b/docs/content/docs/02.guide/90.migrating.md
@@ -48,6 +48,11 @@ This feature has been disabled and the option to enable it has been removed, see
 ### Drop `experimental.generatedLocaleFilePathFormat`
 File paths (e.g. locale files, vue-i18n configs) configured for this module are now removed entirely making this option obsolete.
 
+### Removed `nuxtI18nOptions` from generated options files.
+The generated options files in your projects are meant for internal use by this module at runtime and should never be used, more properties may be removed in the future.
+
+The `nuxtI18nOptions` export has been removed from the generated options files (`#build/i18n.options.mjs` and `#internal/i18n/options.mjs`), since it is no longer used by the module and might expose vulnerable information in the final build.
+
 ## Upgrading from `nuxtjs/i18n` v8.x to v9.x
 
 ### Upgrade to Vue I18n v10

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -1,4 +1,4 @@
-import { assign, isString } from '@intlify/shared'
+import { isString } from '@intlify/shared'
 import { genImport, genDynamicImport, genSafeVariableName, genString } from 'knitwork'
 import { resolve, relative, join, basename } from 'pathe'
 import { getLayerI18n } from './utils'
@@ -80,25 +80,12 @@ export function generateLoaderOptions(
     vueI18nConfigs.push({ specifier, importer, relative: relative(nuxt.options.buildDir, config.path) })
   }
 
-  const nuxtI18nOptions = assign({}, ctx.options, {
-    locales: simplifyLocaleOptions(nuxt, ctx.options),
-    i18nModules: (ctx.options.i18nModules ?? []).map(x => {
-      delete x.langDir
-      x.locales = (x.locales ?? []).map(locale => (isString(locale) ? locale : stripLocaleFiles(locale))) as
-        | string[]
-        | LocaleObject[]
-      return x
-    })
-  })
-  // @ts-expect-error is required
-  delete nuxtI18nOptions.vueI18n
-
   /**
    * Process locale file paths in `normalizedLocales`
    */
   const normalizedLocales = ctx.normalizedLocales.map(x => stripLocaleFiles(x))
 
-  return { localeLoaders, nuxtI18nOptions, vueI18nConfigs, normalizedLocales }
+  return { localeLoaders, vueI18nConfigs, normalizedLocales }
 }
 
 /**

--- a/src/template.ts
+++ b/src/template.ts
@@ -155,8 +155,6 @@ export const localeLoaders = ${genObjectFromRaw(localeLoaderEntries)}
 
 export const vueI18nConfigs = ${genArrayFromRaw(opts.vueI18nConfigs.map(x => x.importer))}
 
-export const nuxtI18nOptions = ${genObjectFromValues(opts.nuxtI18nOptions)}
-
 export const normalizedLocales = ${genArrayFromRaw(opts.normalizedLocales.map(x => genObjectFromValues(x, '  ')))}
 
 export const NUXT_I18N_MODULE_ID = ${genString(NUXT_I18N_MODULE_ID)}

--- a/test/__snapshots__/gen.test.ts.snap
+++ b/test/__snapshots__/gen.test.ts.snap
@@ -45,12 +45,6 @@ exports[`basic 1`] = `
       "code": "fr",
     },
   ],
-  "nuxtI18nOptions": {
-    "defaultLocale": "en",
-    "i18nModules": [],
-    "lazy": false,
-    "locales": [],
-  },
   "vueI18nConfigs": [
     {
       "importer": "() => import("#nuxt-i18n/c3216fe6" /* webpackChunkName: "config_to_c3216fe6" */)",
@@ -140,12 +134,6 @@ exports[`files with cache configuration 1`] = `
       "code": "es-AR",
     },
   ],
-  "nuxtI18nOptions": {
-    "defaultLocale": "en",
-    "i18nModules": [],
-    "lazy": true,
-    "locales": [],
-  },
   "vueI18nConfigs": [
     {
       "importer": "() => import("#nuxt-i18n/c3216fe6" /* webpackChunkName: "config_to_c3216fe6" */)",
@@ -201,12 +189,6 @@ exports[`lazy 1`] = `
       "code": "fr",
     },
   ],
-  "nuxtI18nOptions": {
-    "defaultLocale": "en",
-    "i18nModules": [],
-    "lazy": true,
-    "locales": [],
-  },
   "vueI18nConfigs": [
     {
       "importer": "() => import("#nuxt-i18n/c3216fe6" /* webpackChunkName: "config_to_c3216fe6" */)",
@@ -262,12 +244,6 @@ exports[`locale file in nested 1`] = `
       "code": "fr",
     },
   ],
-  "nuxtI18nOptions": {
-    "defaultLocale": "en",
-    "i18nModules": [],
-    "lazy": true,
-    "locales": [],
-  },
   "vueI18nConfigs": [
     {
       "importer": "() => import("#nuxt-i18n/c3216fe6" /* webpackChunkName: "config_to_c3216fe6" */)",
@@ -357,12 +333,6 @@ exports[`multiple files 1`] = `
       "code": "es-AR",
     },
   ],
-  "nuxtI18nOptions": {
-    "defaultLocale": "en",
-    "i18nModules": [],
-    "lazy": true,
-    "locales": [],
-  },
   "vueI18nConfigs": [
     {
       "importer": "() => import("#nuxt-i18n/c3216fe6" /* webpackChunkName: "config_to_c3216fe6" */)",
@@ -377,25 +347,6 @@ exports[`toCode: function (arrow) 1`] = `
 {
   "localeLoaders": {},
   "normalizedLocales": [],
-  "nuxtI18nOptions": {
-    "defaultLocale": "en",
-    "i18nModules": [],
-    "lazy": false,
-    "locales": [
-      {
-        "code": "en",
-        "testFunc": [Function],
-      },
-      {
-        "code": "ja",
-        "testFunc": [Function],
-      },
-      {
-        "code": "fr",
-        "testFunc": [Function],
-      },
-    ],
-  },
   "vueI18nConfigs": [
     {
       "importer": "() => import("#nuxt-i18n/c3216fe6" /* webpackChunkName: "config_to_c3216fe6" */)",
@@ -410,25 +361,6 @@ exports[`toCode: function (named) 1`] = `
 {
   "localeLoaders": {},
   "normalizedLocales": [],
-  "nuxtI18nOptions": {
-    "defaultLocale": "en",
-    "i18nModules": [],
-    "lazy": false,
-    "locales": [
-      {
-        "code": "en",
-        "testFunc": [Function],
-      },
-      {
-        "code": "ja",
-        "testFunc": [Function],
-      },
-      {
-        "code": "fr",
-        "testFunc": [Function],
-      },
-    ],
-  },
   "vueI18nConfigs": [
     {
       "importer": "() => import("#nuxt-i18n/c3216fe6" /* webpackChunkName: "config_to_c3216fe6" */)",
@@ -484,11 +416,6 @@ exports[`vueI18n option 1`] = `
       "code": "fr",
     },
   ],
-  "nuxtI18nOptions": {
-    "i18nModules": [],
-    "lazy": false,
-    "locales": [],
-  },
   "vueI18nConfigs": [
     {
       "importer": "() => import("#nuxt-i18n/c3216fe6" /* webpackChunkName: "config_to_c3216fe6" */)",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Removes export meant for internal use, still documented since I vaguely recall users using it.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->
