### PR TITLE
docs: update localeDetector example cookie name with nuxt-i18n default

### DIFF
--- a/docs/content/docs/02.guide/16.server-side-translations.md
+++ b/docs/content/docs/02.guide/16.server-side-translations.md
@@ -27,7 +27,7 @@ export default defineI18nLocaleDetector((event, config) => {
   }
 
   // try to get locale from cookie
-  const cookie = tryCookieLocale(event, { lang: '', name: 'i18n_locale' }) // disable locale default value with `lang` option
+  const cookie = tryCookieLocale(event, { lang: '', name: 'i18n_redirected' }) // disable locale default value with `lang` option
   if (cookie) {
     return cookie.toString()
   }


### PR DESCRIPTION
### 📚 Description

Align the localeDetector example cookie name in the docs with the @nuxtjs/i18n default '`i18n_redirected`' for consistency.
