### PR TITLE
fix: use right way to get `bundle.optimizeTranslationDirective` option

### DIFF
--- a/src/prepare/options.ts
+++ b/src/prepare/options.ts
@@ -20,11 +20,7 @@ export function prepareOptions({ debug, logger, options }: I18nNuxtContext, nuxt
     )
   }
 
-  if (
-    !nuxt.options?._prepare &&
-    !nuxt.options?.test &&
-    nuxt.options.i18n?.bundle?.optimizeTranslationDirective == null
-  ) {
+  if (!nuxt.options?._prepare && !nuxt.options?.test && options.bundle.optimizeTranslationDirective == null) {
     logger.warn(
       '`bundle.optimizeTranslationDirective` is enabled by default, we recommend disabling this feature as it causes issues and will be deprecated in v10.\nExplicitly setting this option to `true` or `false` disables this warning, for more details see: https://github.com/nuxt-modules/i18n/issues/3238#issuecomment-2672492536'
     )


### PR DESCRIPTION
### 📚 Description

As know nuxt have two way to pass options for modules.

The first way is dedicated key at the first level of config.

```
modules: [
  "@nuxtjs/i18n",
],

i18n: {
  // place options here
},
```

The second way is to pass the options as the second element of the array.

```
{
  modules: [
    [
      "@nuxtjs/i18n",
      {
        // place options here
      },
    ],
  ],
}
```

This PR used correct way to get `optimizeTranslationDirective` option to suppress warning in stdout.
