### PR TITLE
refactor: remove internal helper function `runtimeDetectBrowserLanguage`

### DIFF
--- a/src/runtime/composables/index.ts
+++ b/src/runtime/composables/index.ts
@@ -1,6 +1,5 @@
-import { useNuxtApp, useCookie } from '#imports'
+import { useNuxtApp, useCookie, useRuntimeConfig } from '#imports'
 import { ref } from 'vue'
-import { runtimeDetectBrowserLanguage } from '../internal'
 import { _useLocaleHead, _useSetI18nParams } from '../routing/head'
 import { useComposableContext } from '../utils'
 import { localePath, localeRoute, switchLocalePath } from '../routing/routing'
@@ -210,14 +209,14 @@ export function useBrowserLocale(): string | null {
  */
 export function useCookieLocale(): Ref<string> {
   const locale: Ref<string> = ref('')
-  const detect = runtimeDetectBrowserLanguage()
+  const detect = useRuntimeConfig().public.i18n.detectBrowserLanguage
 
   if (!detect || !detect.useCookie) {
     return locale
   }
 
   const locales = useNuxtApp()._nuxtI18n.getLocales()
-  const code = useCookie(detect.cookieKey!).value
+  const code = useCookie(detect.cookieKey).value
   if (code && locales.some(x => x.code === code)) {
     locale.value = code
   }

--- a/src/runtime/internal.ts
+++ b/src/runtime/internal.ts
@@ -42,7 +42,7 @@ export function getBrowserLocale(): string | undefined {
 }
 
 export function createI18nCookie() {
-  const detect = runtimeDetectBrowserLanguage()
+  const detect = (useRuntimeConfig().public.i18n as I18nPublicRuntimeConfig).detectBrowserLanguage
   const cookieKey = (detect && detect.cookieKey) || DEFAULT_COOKIE_KEY
   const date = new Date()
   const cookieOptions: CookieOptions<string | null | undefined> & { readonly: false } = {
@@ -114,7 +114,7 @@ export function detectBrowserLanguage(
   locale: Locale = ''
 ): DetectBrowserLanguageResult {
   const logger = /*#__PURE__*/ createLogger('detectBrowserLanguage')
-  const _detect = runtimeDetectBrowserLanguage()
+  const _detect = useRuntimeConfig().public.i18n.detectBrowserLanguage
 
   // feature is disabled
   if (!_detect) {
@@ -167,11 +167,4 @@ export function detectBrowserLanguage(
 
   // use fallback locale when no locale matched
   return { locale: _detect.fallbackLocale || '', from: 'fallback' }
-}
-
-export function runtimeDetectBrowserLanguage(
-  opts: I18nPublicRuntimeConfig = useRuntimeConfig().public.i18n as I18nPublicRuntimeConfig
-) {
-  if (opts?.detectBrowserLanguage === false) return false
-  return opts?.detectBrowserLanguage
 }

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -18,7 +18,7 @@ import {
   createNuxtI18nDev,
   createComposableContext
 } from '../utils'
-import { getLocaleCookie, createI18nCookie, runtimeDetectBrowserLanguage, getBrowserLocale } from '../internal'
+import { getLocaleCookie, createI18nCookie, getBrowserLocale } from '../internal'
 import { createLocaleFromRouteGetter } from '#i18n-kit/routing'
 import { extendI18n } from '../routing/i18n'
 import { createLogger } from '#nuxt-i18n/logger'
@@ -90,7 +90,7 @@ export default defineNuxtPlugin({
     }
 
     const localeCookie = createI18nCookie()
-    const detectBrowserOptions = runtimeDetectBrowserLanguage()
+    const detectBrowserOptions = runtimeI18n.detectBrowserLanguage
     // extend i18n instance
     extendI18n(i18n, {
       extendComposer(composer) {

--- a/src/runtime/plugins/ssg-detect.ts
+++ b/src/runtime/plugins/ssg-detect.ts
@@ -2,7 +2,7 @@ import { unref } from 'vue'
 import { isSSG } from '#build/i18n.options.mjs'
 import { defineNuxtPlugin, useNuxtApp } from '#imports'
 import { createLogger } from '#nuxt-i18n/logger'
-import { detectBrowserLanguage, runtimeDetectBrowserLanguage } from '../internal'
+import { detectBrowserLanguage } from '../internal'
 
 export default defineNuxtPlugin({
   name: 'i18n:plugin:ssg-detect',
@@ -10,7 +10,7 @@ export default defineNuxtPlugin({
   enforce: 'post',
   setup() {
     const nuxt = useNuxtApp()
-    if (!isSSG || nuxt.$i18n.strategy !== 'no_prefix' || !runtimeDetectBrowserLanguage()) return
+    if (!isSSG || nuxt.$i18n.strategy !== 'no_prefix' || !nuxt.$config.public.i18n.detectBrowserLanguage) return
 
     const logger = /*#__PURE__*/ createLogger('plugin:i18n:ssg-detect')
     const localeCookie = nuxt.$i18n.getLocaleCookie()

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -12,7 +12,7 @@ import {
 } from '#build/i18n.options.mjs'
 import { getComposer, getI18nTarget } from './compatibility'
 import { getHost, getLocaleDomain } from './domain'
-import { detectBrowserLanguage, runtimeDetectBrowserLanguage } from './internal'
+import { detectBrowserLanguage } from './internal'
 import { loadAndSetLocaleMessages, loadLocale, loadVueI18nOptions, makeFallbackLocaleCodes } from './messages'
 import { normalizeRouteName, getRouteBaseName as _getRouteBaseName, getLocalizedRouteName } from '#i18n-kit/routing'
 import {
@@ -172,8 +172,8 @@ export function createComposableContext({
 export async function loadAndSetLocale(newLocale: Locale, initial: boolean = false): Promise<boolean> {
   const logger = /*#__PURE__*/ createLogger('loadAndSetLocale')
   const nuxtApp = useNuxtApp()
-  const { differentDomains, skipSettingLocaleOnNavigate } = nuxtApp.$config.public.i18n
-  const opts = runtimeDetectBrowserLanguage()
+  const runtimeI18n = nuxtApp.$config.public.i18n as I18nPublicRuntimeConfig
+  const { differentDomains, skipSettingLocaleOnNavigate, detectBrowserLanguage: opts } = runtimeI18n
 
   const oldLocale = unref(nuxtApp.$i18n.locale)
   const localeCodes = unref(nuxtApp.$i18n.localeCodes)
@@ -249,8 +249,9 @@ export function detectLocale(
   localeCookie: string | undefined
 ) {
   const nuxtApp = useNuxtApp()
-  const { strategy, defaultLocale, differentDomains, multiDomainLocales } = nuxtApp.$config.public.i18n
-  const _detectBrowserLanguage = runtimeDetectBrowserLanguage()
+
+  const runtimeI18n = nuxtApp.$config.public.i18n as I18nPublicRuntimeConfig
+  const { strategy, defaultLocale, differentDomains, multiDomainLocales, detectBrowserLanguage: _detect } = runtimeI18n
   const logger = /*#__PURE__*/ createLogger('detectLocale')
 
   const detectedBrowser = detectBrowserLanguage(route, localeCookie, currentLocale)
@@ -271,12 +272,12 @@ export function detectLocale(
     detected ||= routeLocale
   }
 
-  __DEBUG__ && logger.log('2/3', { detected, detectBrowserLanguage: _detectBrowserLanguage })
+  __DEBUG__ && logger.log('2/3', { detected, detectBrowserLanguage: _detect })
 
   const cookieLocale =
     (localeCodes.includes(detectedBrowser.locale) || (localeCookie && localeCodes.includes(localeCookie))) &&
-    _detectBrowserLanguage &&
-    _detectBrowserLanguage.useCookie &&
+    _detect &&
+    _detect.useCookie &&
     localeCookie
   detected ||= cookieLocale || currentLocale || defaultLocale || ''
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
It is unfortunate that the runtime config types are based on the serialized/generated types and not based on the actual provided types. The helper function was used to narrow the type and make it more predictable (using type assertions), but does not functionally do much other than obscure the source of the returned config.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->
