### PR TITLE
refactor: move `runWithContext` mock to messages logic

### DIFF
--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -3,7 +3,6 @@ import { defineI18nMiddleware } from '@intlify/h3'
 import { localeCodes, vueI18nConfigs, localeLoaders } from '#internal/i18n/options.mjs'
 import { defineNitroPlugin } from 'nitropack/dist/runtime/plugin'
 import { localeDetector as _localeDetector } from '#internal/i18n/locale.detector.mjs'
-import { nuxtMock } from './utils'
 import { loadVueI18nOptions, loadInitialMessages, makeFallbackLocaleCodes, loadAndSetLocaleMessages } from '../messages'
 
 import type { H3Event } from 'h3'
@@ -13,7 +12,7 @@ import type { CoreContext } from '@intlify/h3'
 // eslint-disable-next-line @typescript-eslint/no-misused-promises
 export default defineNitroPlugin(async nitro => {
   // `defineI18nMiddleware` options (internally, options passed to`createCoreContext` in intlify / core) are compatible with vue-i18n options
-  const options = await loadVueI18nOptions(vueI18nConfigs, nuxtMock)
+  const options = await loadVueI18nOptions(vueI18nConfigs)
   options.messages = options.messages || {}
   const fallbackLocale = (options.fallbackLocale = options.fallbackLocale ?? false)
 
@@ -21,18 +20,13 @@ export default defineNitroPlugin(async nitro => {
   const initialLocale = runtimeI18n.defaultLocale || options.locale || 'en-US'
 
   // load initial locale messages for intlify/h3
-  options.messages = await loadInitialMessages(
-    options.messages,
-    localeLoaders,
-    {
-      localeCodes,
-      initialLocale,
-      lazy: runtimeI18n.lazy,
-      defaultLocale: runtimeI18n.defaultLocale,
-      fallbackLocale: options.fallbackLocale
-    },
-    nuxtMock
-  )
+  options.messages = await loadInitialMessages(options.messages, localeLoaders, {
+    localeCodes,
+    initialLocale,
+    lazy: runtimeI18n.lazy,
+    defaultLocale: runtimeI18n.defaultLocale,
+    fallbackLocale: options.fallbackLocale
+  })
 
   const localeDetector = async (
     event: H3Event,
@@ -46,10 +40,10 @@ export default defineNitroPlugin(async nitro => {
       if (fallbackLocale) {
         const fallbackLocales = makeFallbackLocaleCodes(fallbackLocale, [locale])
         await Promise.all(
-          fallbackLocales.map(locale => loadAndSetLocaleMessages(locale, localeLoaders, i18nContext.messages, nuxtMock))
+          fallbackLocales.map(locale => loadAndSetLocaleMessages(locale, localeLoaders, i18nContext.messages))
         )
       }
-      await loadAndSetLocaleMessages(locale, localeLoaders, i18nContext.messages, nuxtMock)
+      await loadAndSetLocaleMessages(locale, localeLoaders, i18nContext.messages)
     }
     return locale
   }

--- a/src/runtime/server/type-generation.ts
+++ b/src/runtime/server/type-generation.ts
@@ -2,7 +2,6 @@ import { deepCopy, isArray, isFunction, isObject } from '@intlify/shared'
 import { vueI18nConfigs, localeLoaders, normalizedLocales } from '#internal/i18n/options.mjs'
 import { dtsFile } from '#internal/i18n-type-generation-options'
 import { loadLocale, loadVueI18nOptions } from '../messages'
-import { nuxtMock } from './utils'
 import { writeFile } from 'fs/promises'
 import { useRuntimeConfig } from '#imports'
 
@@ -25,7 +24,7 @@ export default async () => {
     numberFormats: {}
   }
 
-  const vueI18nConfig: I18nOptions = await loadVueI18nOptions(vueI18nConfigs, nuxtMock)
+  const vueI18nConfig: I18nOptions = await loadVueI18nOptions(vueI18nConfigs)
   for (const locale of targetLocales) {
     deepCopy(vueI18nConfig.messages?.[locale] || {}, merged.messages)
     deepCopy(vueI18nConfig.numberFormats?.[locale] || {}, merged.numberFormats)
@@ -35,7 +34,7 @@ export default async () => {
   const loaderPromises: Promise<void>[] = []
   for (const locale in localeLoaders) {
     if (!targetLocales.includes(locale)) continue
-    loaderPromises.push(loadLocale(locale, localeLoaders, (_, message) => deepCopy(message, merged.messages), nuxtMock))
+    loaderPromises.push(loadLocale(locale, localeLoaders, (_, message) => deepCopy(message, merged.messages)))
   }
 
   await Promise.all(loaderPromises)

--- a/src/runtime/server/utils.ts
+++ b/src/runtime/server/utils.ts
@@ -1,4 +1,0 @@
-import type { NuxtApp } from 'nuxt/app'
-
-// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-export const nuxtMock: { runWithContext: NuxtApp['runWithContext'] } = { runWithContext: async fn => await fn() }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Moves the mock/stub out of server utils and into messages logic (the only place where it is needed). This should reduce the build size by a tiny bit since a runtime file was removed.

Some care must be taken when using the messages functions in Nuxt contexts, the mock/stub is now a fallback/default parameter value and omitting it will not give an obvious warning.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->
