### PR TITLE
perf!: move options to compile-time constants

### DIFF
--- a/docs/content/docs/02.guide/90.migrating.md
+++ b/docs/content/docs/02.guide/90.migrating.md
@@ -65,6 +65,23 @@ Reasons for removal:
 * These are no longer used by the module and might expose vulnerable information in the final build
 * Some options are now used as static values for better tree-shaking resulting in a smaller project build.
 
+### Removed options from runtime config
+Several options set in the runtime config were only used to transfer build-time configuration to runtime and changing these at runtime could cause issues.
+
+Instead of setting these on runtime config we now treat them as compiler constants, this way we can tree-shake any unused logic from a project build.
+
+The following options have been removed from runtime config:
+* `defaultDirection`
+* `strategy`
+  * You can access this on `useI18n()`{lang="ts"} or `$i18n`{lang="ts"}
+* `lazy`
+* `routeNameSeparator`
+* `defaultLocaleRouteNameSuffix`
+* `differentDomains`
+* `multiDomainLocales`
+  * Enabling this requires certain properties on locales at build-time, we do not see the use case for setting this at runtime.
+* `trailingSlash`
+
 
 ## Upgrading from `nuxtjs/i18n` v8.x to v9.x
 

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -124,7 +124,15 @@ export function getDefineConfig(options: NuxtI18nOptions, server = false, nuxt =
     __DYNAMIC_PARAMS_KEY__: JSON.stringify(DYNAMIC_PARAMS_KEY),
     __DEFAULT_COOKIE_KEY__: JSON.stringify(DEFAULT_COOKIE_KEY),
     __NUXT_I18N_MODULE_ID__: JSON.stringify(NUXT_I18N_MODULE_ID),
-    __SWITCH_LOCALE_PATH_LINK_IDENTIFIER__: JSON.stringify(SWITCH_LOCALE_PATH_LINK_IDENTIFIER)
+    __SWITCH_LOCALE_PATH_LINK_IDENTIFIER__: JSON.stringify(SWITCH_LOCALE_PATH_LINK_IDENTIFIER),
+    __I18N_STRATEGY__: JSON.stringify(options.strategy),
+    __LAZY_LOCALES__: String(options.lazy),
+    __DIFFERENT_DOMAINS__: String(options.differentDomains),
+    __MULTI_DOMAIN_LOCALES__: String(options.multiDomainLocales),
+    __ROUTE_NAME_SEPARATOR__: JSON.stringify(options.routesNameSeparator),
+    __ROUTE_NAME_DEFAULT_SUFFIX__: JSON.stringify(options.defaultLocaleRouteNameSuffix),
+    __TRAILING_SLASH__: String(options.trailingSlash),
+    __DEFAULT_DIRECTION__: JSON.stringify(options.defaultDirection)
   }
 
   if (nuxt.options.ssr || !server) {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -9,9 +9,17 @@ declare let __TEST__: boolean
 
 declare let __IS_SSG__: boolean
 declare let __HAS_PAGES__: boolean
+declare let __TRAILING_SLASH__: boolean
 declare let __PARALLEL_PLUGIN__: boolean
+declare let __DIFFERENT_DOMAINS__: boolean
+declare let __MULTI_DOMAIN_LOCALES__: boolean
+declare let __LAZY_LOCALES__: boolean
 
 declare let __DYNAMIC_PARAMS_KEY__: string
 declare let __DEFAULT_COOKIE_KEY__: string
 declare let __NUXT_I18N_MODULE_ID__: string
 declare let __SWITCH_LOCALE_PATH_LINK_IDENTIFIER__: string
+declare let __I18N_STRATEGY__: 'no_prefix' | 'prefix' | 'prefix_except_default' | 'prefix_and_default'
+declare let __ROUTE_NAME_SEPARATOR__: string
+declare let __ROUTE_NAME_DEFAULT_SUFFIX__: string
+declare let __DEFAULT_DIRECTION__: string

--- a/src/prepare/runtime-config.ts
+++ b/src/prepare/runtime-config.ts
@@ -11,21 +11,12 @@ export function prepareRuntimeConfig({ options }: I18nNuxtContext, nuxt: Nuxt) {
   nuxt.options.runtimeConfig.public.i18n = defu(nuxt.options.runtimeConfig.public.i18n, {
     baseUrl: options.baseUrl,
     defaultLocale: options.defaultLocale,
-    defaultDirection: options.defaultDirection,
-    strategy: options.strategy,
-    lazy: options.lazy,
     rootRedirect: options.rootRedirect,
-    routesNameSeparator: options.routesNameSeparator,
-    defaultLocaleRouteNameSuffix: options.defaultLocaleRouteNameSuffix,
     skipSettingLocaleOnNavigate: options.skipSettingLocaleOnNavigate,
-    differentDomains: options.differentDomains,
-    trailingSlash: options.trailingSlash,
     locales: options.locales,
     detectBrowserLanguage: options.detectBrowserLanguage ?? DEFAULT_OPTIONS.detectBrowserLanguage,
     experimental: options.experimental,
-    multiDomainLocales: options.multiDomainLocales,
     domainLocales: {} as I18nPublicRuntimeConfig['domainLocales']
-    // TODO: we should support more i18n module options. welcome PRs :-)
   })
 
   nuxt.options.runtimeConfig.public.i18n.locales = simplifyLocaleOptions(nuxt, assign({}, options))

--- a/src/runtime/compatibility.ts
+++ b/src/runtime/compatibility.ts
@@ -2,33 +2,15 @@
  * Utility functions to support both VueI18n and Composer instances
  */
 
-import { isRef } from 'vue'
-
 import type { Composer, I18n, VueI18n } from 'vue-i18n'
 
-function isI18nInstance(i18n: I18n | VueI18n | Composer): i18n is I18n {
-  return i18n != null && 'global' in i18n && 'mode' in i18n
-}
-
-function isComposer(target: I18n | VueI18n | Composer): target is Composer {
-  return target != null && !('__composer' in target) && 'locale' in target && isRef(target.locale)
-}
-
-export function isVueI18n(target: I18n | VueI18n | Composer): target is VueI18n {
-  return target != null && '__composer' in target
-}
-
 export function getI18nTarget(i18n: I18n | VueI18n | Composer) {
-  return isI18nInstance(i18n) ? i18n.global : i18n
+  return i18n != null && 'global' in i18n && 'mode' in i18n ? i18n.global : i18n
 }
 
 export function getComposer(i18n: I18n | VueI18n | Composer): Composer {
   const target = getI18nTarget(i18n)
-
-  if (isComposer(target)) return target
-  if (isVueI18n(target)) return target.__composer
-
-  return target
+  return '__composer' in target ? target.__composer : target
 }
 
 declare module 'vue-i18n' {

--- a/src/runtime/internal.ts
+++ b/src/runtime/internal.ts
@@ -122,24 +122,23 @@ export function detectBrowserLanguage(
   }
 
   const nuxtApp = useNuxtApp()
-  const strategy = nuxtApp.$i18n.strategy
   const firstAccess = nuxtApp._vueI18n.__firstAccess
 
   __DEBUG__ && logger.log({ firstAccess })
 
   // detection ignored during nuxt generate
-  if (__IS_SSG__ && firstAccess && strategy === 'no_prefix' && import.meta.server) {
+  if (__IS_SSG__ && firstAccess && __I18N_STRATEGY__ === 'no_prefix' && import.meta.server) {
     return { locale: '', error: 'detect_ignore_on_ssg' }
   }
 
   // detection only on first access
   if (!firstAccess) {
-    return { locale: strategy === 'no_prefix' ? locale : '', error: 'first_access_only' }
+    return { locale: __I18N_STRATEGY__ === 'no_prefix' ? locale : '', error: 'first_access_only' }
   }
 
-  __DEBUG__ && logger.log({ locale, path: getCompatRoutePath(route), strategy, ..._detect })
+  __DEBUG__ && logger.log({ locale, path: getCompatRoutePath(route), strategy: __I18N_STRATEGY__, ..._detect })
 
-  if (strategy !== 'no_prefix') {
+  if (__I18N_STRATEGY__ !== 'no_prefix') {
     const path = getCompatRoutePath(route)
 
     // detection only on root

--- a/src/runtime/plugins/route-locale-detect.ts
+++ b/src/runtime/plugins/route-locale-detect.ts
@@ -12,7 +12,6 @@ export default defineNuxtPlugin({
   async setup() {
     const logger = /*#__PURE__*/ createLogger('plugin:route-locale-detect')
     const nuxt = useNuxtApp()
-    const currentRoute = nuxt.$router.currentRoute
 
     async function handleRouteDetect(to: CompatRoute) {
       let detected = detectLocale(
@@ -37,7 +36,7 @@ export default defineNuxtPlugin({
       return detected
     }
 
-    await handleRouteDetect(currentRoute.value)
+    await handleRouteDetect(nuxt.$router.currentRoute.value)
 
     // app has no pages - do not register route middleware
     if (!__HAS_PAGES__) return

--- a/src/runtime/plugins/ssg-detect.ts
+++ b/src/runtime/plugins/ssg-detect.ts
@@ -8,7 +8,7 @@ export default defineNuxtPlugin({
   dependsOn: ['i18n:plugin', 'i18n:plugin:route-locale-detect'],
   enforce: 'post',
   setup() {
-    const nuxt = useNuxtApp()
+    const nuxt = /*#__PURE__*/ useNuxtApp()
     if (!__IS_SSG__ || __I18N_STRATEGY__ !== 'no_prefix' || !nuxt.$config.public.i18n.detectBrowserLanguage) return
 
     const logger = /*#__PURE__*/ createLogger('plugin:i18n:ssg-detect')

--- a/src/runtime/plugins/ssg-detect.ts
+++ b/src/runtime/plugins/ssg-detect.ts
@@ -9,7 +9,7 @@ export default defineNuxtPlugin({
   enforce: 'post',
   setup() {
     const nuxt = useNuxtApp()
-    if (!__IS_SSG__ || nuxt.$i18n.strategy !== 'no_prefix' || !nuxt.$config.public.i18n.detectBrowserLanguage) return
+    if (!__IS_SSG__ || __I18N_STRATEGY__ !== 'no_prefix' || !nuxt.$config.public.i18n.detectBrowserLanguage) return
 
     const logger = /*#__PURE__*/ createLogger('plugin:i18n:ssg-detect')
     const localeCookie = nuxt.$i18n.getLocaleCookie()

--- a/src/runtime/plugins/switch-locale-path-ssr.ts
+++ b/src/runtime/plugins/switch-locale-path-ssr.ts
@@ -1,21 +1,21 @@
 import { defineNuxtPlugin, useNuxtApp } from '#imports'
 import { useSwitchLocalePath } from '#i18n'
 
+const switchLocalePathLinkWrapperExpr = new RegExp(
+  [
+    `<!--${__SWITCH_LOCALE_PATH_LINK_IDENTIFIER__}-\\[(\\w+)\\]-->`,
+    `.+?`,
+    `<!--/${__SWITCH_LOCALE_PATH_LINK_IDENTIFIER__}-->`
+  ].join(''),
+  'g'
+)
+
 // Replace `SwitchLocalePathLink` href in rendered html for SSR support
 export default defineNuxtPlugin({
   name: 'i18n:plugin:switch-locale-path-ssr',
   dependsOn: ['i18n:plugin'],
   setup() {
     const nuxt = useNuxtApp()
-    const switchLocalePathLinkWrapperExpr = new RegExp(
-      [
-        `<!--${__SWITCH_LOCALE_PATH_LINK_IDENTIFIER__}-\\[(\\w+)\\]-->`,
-        `.+?`,
-        `<!--/${__SWITCH_LOCALE_PATH_LINK_IDENTIFIER__}-->`
-      ].join(''),
-      'g'
-    )
-
     const switchLocalePath = useSwitchLocalePath()
     nuxt.hook('app:rendered', ctx => {
       if (ctx.renderResult?.html == null) return

--- a/src/runtime/routing/head.ts
+++ b/src/runtime/routing/head.ts
@@ -33,7 +33,7 @@ function createHeadContext(
     getRouteBaseName: ctx.getRouteBaseName,
     getCurrentRoute: () => ctx.router.currentRoute.value,
     getCurrentLanguage: () => currentLocale.language,
-    getCurrentDirection: () => currentLocale.dir || routingOptions.defaultDirection,
+    getCurrentDirection: () => currentLocale.dir || __DEFAULT_DIRECTION__,
     getLocaleRoute: route => localeRoute(ctx, route),
     getLocalizedRoute: (locale, route) => switchLocalePath(ctx, locale, route),
     getRouteWithoutQuery: () =>

--- a/src/runtime/routing/i18n.ts
+++ b/src/runtime/routing/i18n.ts
@@ -1,6 +1,6 @@
 import { effectScope } from '#imports'
 import { assign } from '@intlify/shared'
-import { isVueI18n, getComposer } from '../compatibility'
+import { getComposer } from '../compatibility'
 
 import type { NuxtApp } from 'nuxt/app'
 import type { Composer, ComposerExtender, ExportedGlobalComposer, I18n, VueI18n, VueI18nExtender } from 'vue-i18n'
@@ -50,7 +50,7 @@ export function extendI18n(i18n: I18n, { extendComposer, extendComposerInstance 
     const globalComposer = getComposer(i18n)
     scope.run(() => {
       extendComposer(globalComposer)
-      if (i18n.mode === 'legacy' && isVueI18n(i18n.global)) {
+      if (i18n.mode === 'legacy' && '__composer' in i18n.global) {
         extendComposerInstance(i18n.global, getComposer(i18n.global))
       }
     })

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -23,7 +23,6 @@ export default defineNitroPlugin(async nitro => {
   options.messages = await loadInitialMessages(options.messages, localeLoaders, {
     localeCodes,
     initialLocale,
-    lazy: runtimeI18n.lazy,
     defaultLocale: runtimeI18n.defaultLocale,
     fallbackLocale: options.fallbackLocale
   })
@@ -36,7 +35,7 @@ export default defineNitroPlugin(async nitro => {
       defaultLocale: initialLocale,
       fallbackLocale: options.fallbackLocale
     })
-    if (runtimeI18n.lazy) {
+    if (__LAZY_LOCALES__) {
       if (fallbackLocale) {
         const fallbackLocales = makeFallbackLocaleCodes(fallbackLocale, [locale])
         await Promise.all(

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -81,11 +81,9 @@ export function createComposableContext({
   const router = useRouter()
   const nuxt = useNuxtApp()
   const i18n = getI18nTarget(_i18n)
-  const { defaultLocale } = runtimeI18n
 
   const routeByPathResolver = createLocalizedRouteByPathResolver(router)
-  const getLocalizedRouteName = createLocaleRouteNameGetter(defaultLocale)
-  const formatTrailingSlash = __TRAILING_SLASH__ ? withTrailingSlash : withoutTrailingSlash
+  const getLocalizedRouteName = createLocaleRouteNameGetter(runtimeI18n.defaultLocale)
 
   function getRouteBaseName(route: RouteRecordNameGeneric | RouteLocationGenericPath | null) {
     return _getRouteBaseName(route, __ROUTE_NAME_SEPARATOR__)
@@ -112,18 +110,18 @@ export function createComposableContext({
       return route
     }
 
-    if (!__DIFFERENT_DOMAINS__ && prefixable(locale, defaultLocale)) {
+    if (!__DIFFERENT_DOMAINS__ && prefixable(locale, runtimeI18n.defaultLocale)) {
       route.path = '/' + locale + route.path
     }
 
-    route.path = formatTrailingSlash(route.path, true)
+    route.path = (__TRAILING_SLASH__ ? withTrailingSlash : withoutTrailingSlash)(route.path, true)
     return route
   }
 
   return {
     router,
     getRoutingOptions: () => ({
-      defaultLocale,
+      defaultLocale: runtimeI18n.defaultLocale,
       strictCanonicals: runtimeI18n.experimental.alternateLinkCanonicalQueries ?? true,
       hreflangLinks: !(__I18N_STRATEGY__ === 'no_prefix' && !__DIFFERENT_DOMAINS__)
     }),

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -432,7 +432,7 @@ export function createBaseUrlGetter(nuxt: NuxtApp) {
     }
   }
 
-  const localeCode = /*#__PURE__*/ isFunction(defaultLocale) ? (defaultLocale() as string) : defaultLocale
+  const localeCode = isFunction(defaultLocale) ? /*#__PURE__*/ (defaultLocale() as string) : defaultLocale
   return (): string => {
     if (__DIFFERENT_DOMAINS__ && localeCode) {
       const domain = nuxt._i18nGetDomainFromLocale(localeCode)

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -20,7 +20,7 @@ import { unref } from 'vue'
 import type { I18n, Locale, I18nOptions } from 'vue-i18n'
 import type { NuxtApp } from '#app'
 import type { RouteLocationPathRaw, RouteLocationResolvedGeneric, Router, RouteRecordNameGeneric } from 'vue-router'
-import type { I18nPublicRuntimeConfig, LocaleObject, Strategies } from '#internal-i18n-types'
+import type { I18nPublicRuntimeConfig, LocaleObject } from '#internal-i18n-types'
 import type { CompatRoute, I18nRouteMeta, RouteLocationGenericPath } from './types'
 
 export function formatMessage(message: string) {
@@ -35,10 +35,8 @@ export function formatMessage(message: string) {
  */
 export type ComposableContext = {
   router: Router
-  getRoutingOptions: () => Pick<
-    I18nPublicRuntimeConfig,
-    'strategy' | 'differentDomains' | 'routesNameSeparator' | 'defaultLocale' | 'trailingSlash' | 'defaultDirection'
-  > & {
+  getRoutingOptions: () => {
+    defaultLocale: string
     /** Use `canonicalQueries` for alternate links */
     strictCanonicals: boolean
     /** Enable/disable hreflangLinks */
@@ -83,15 +81,14 @@ export function createComposableContext({
   const router = useRouter()
   const nuxt = useNuxtApp()
   const i18n = getI18nTarget(_i18n)
-  const { strategy, differentDomains, routesNameSeparator, defaultLocale, trailingSlash, defaultDirection } =
-    runtimeI18n
+  const { defaultLocale } = runtimeI18n
 
-  const routeByPathResolver = createLocalizedRouteByPathResolver(runtimeI18n.strategy, router)
-  const getLocalizedRouteName = createLocaleRouteNameGetter(runtimeI18n)
-  const formatTrailingSlash = trailingSlash ? withTrailingSlash : withoutTrailingSlash
+  const routeByPathResolver = createLocalizedRouteByPathResolver(router)
+  const getLocalizedRouteName = createLocaleRouteNameGetter(defaultLocale)
+  const formatTrailingSlash = __TRAILING_SLASH__ ? withTrailingSlash : withoutTrailingSlash
 
   function getRouteBaseName(route: RouteRecordNameGeneric | RouteLocationGenericPath | null) {
-    return _getRouteBaseName(route, routesNameSeparator)
+    return _getRouteBaseName(route, __ROUTE_NAME_SEPARATOR__)
   }
 
   function resolveLocalizedRouteByName(route: RouteLikeWithName, locale: string) {
@@ -115,7 +112,7 @@ export function createComposableContext({
       return route
     }
 
-    if (!differentDomains && prefixable(locale, defaultLocale, strategy)) {
+    if (!__DIFFERENT_DOMAINS__ && prefixable(locale, defaultLocale)) {
       route.path = '/' + locale + route.path
     }
 
@@ -126,14 +123,9 @@ export function createComposableContext({
   return {
     router,
     getRoutingOptions: () => ({
-      strategy,
-      differentDomains,
-      routesNameSeparator,
       defaultLocale,
-      trailingSlash,
-      defaultDirection,
       strictCanonicals: runtimeI18n.experimental.alternateLinkCanonicalQueries ?? true,
-      hreflangLinks: !(strategy === 'no_prefix' && !differentDomains)
+      hreflangLinks: !(__I18N_STRATEGY__ === 'no_prefix' && !__DIFFERENT_DOMAINS__)
     }),
     getLocale: () => unref(i18n.locale),
     getLocales: () => {
@@ -147,7 +139,7 @@ export function createComposableContext({
       return params[locale]
     },
     afterSwitchLocalePath: (path, locale) => {
-      if (differentDomains) {
+      if (__DIFFERENT_DOMAINS__) {
         const domain = getDomainFromLocale(locale)
         return (domain && joinURL(domain, path)) || path
       }
@@ -165,7 +157,7 @@ export async function loadAndSetLocale(newLocale: Locale, initial: boolean = fal
   const logger = /*#__PURE__*/ createLogger('loadAndSetLocale')
   const nuxtApp = useNuxtApp()
   const runtimeI18n = nuxtApp.$config.public.i18n as I18nPublicRuntimeConfig
-  const { differentDomains, skipSettingLocaleOnNavigate, detectBrowserLanguage: opts } = runtimeI18n
+  const { skipSettingLocaleOnNavigate, detectBrowserLanguage: opts } = runtimeI18n
 
   const oldLocale = unref(nuxtApp.$i18n.locale)
   const localeCodes = unref(nuxtApp.$i18n.localeCodes)
@@ -199,7 +191,7 @@ export async function loadAndSetLocale(newLocale: Locale, initial: boolean = fal
   }
 
   // no change if different domains option enabled
-  if (!initial && differentDomains) {
+  if (!initial && __DIFFERENT_DOMAINS__) {
     syncCookie()
     return false
   }
@@ -243,7 +235,7 @@ export function detectLocale(
   const nuxtApp = useNuxtApp()
 
   const runtimeI18n = nuxtApp.$config.public.i18n as I18nPublicRuntimeConfig
-  const { strategy, defaultLocale, differentDomains, multiDomainLocales, detectBrowserLanguage: _detect } = runtimeI18n
+  const { defaultLocale, detectBrowserLanguage: _detect } = runtimeI18n
   const logger = /*#__PURE__*/ createLogger('detectLocale')
 
   const detectedBrowser = detectBrowserLanguage(route, localeCookie, currentLocale)
@@ -255,12 +247,12 @@ export function detectLocale(
   }
 
   let detected: string = ''
-  __DEBUG__ && logger.log('1/3', { detected, strategy })
+  __DEBUG__ && logger.log('1/3', { detected, strategy: __I18N_STRATEGY__ })
 
   // detect locale by route
-  if (differentDomains || multiDomainLocales) {
-    detected ||= getLocaleDomain(normalizedLocales, strategy, route)
-  } else if (strategy !== 'no_prefix') {
+  if (__DIFFERENT_DOMAINS__ || __MULTI_DOMAIN_LOCALES__) {
+    detected ||= getLocaleDomain(normalizedLocales, route)
+  } else if (__I18N_STRATEGY__ !== 'no_prefix') {
     detected ||= routeLocale
   }
 
@@ -294,7 +286,7 @@ type DetectRedirectOptions = {
  */
 export function detectRedirect({ to, from, locale, routeLocale }: DetectRedirectOptions, inMiddleware = false): string {
   // no locale change detected from routing
-  if (routeLocale === locale || useNuxtApp().$i18n.strategy === 'no_prefix') {
+  if (routeLocale === locale || __I18N_STRATEGY__ === 'no_prefix') {
     return ''
   }
 
@@ -329,14 +321,13 @@ type NavigateArgs = {
 }
 
 export async function navigate({ nuxt, locale, route, redirectPath }: NavigateArgs, enableNavigate = false) {
-  const { rootRedirect, differentDomains, multiDomainLocales, skipSettingLocaleOnNavigate, locales, strategy } = nuxt
-    .$config.public.i18n as I18nPublicRuntimeConfig
+  const { rootRedirect, skipSettingLocaleOnNavigate, locales } = nuxt.$config.public.i18n as I18nPublicRuntimeConfig
   const logger = /*#__PURE__*/ createLogger('navigate')
 
   __DEBUG__ &&
     logger.log('options', {
       rootRedirect,
-      differentDomains,
+      differentDomains: __DIFFERENT_DOMAINS__,
       skipSettingLocaleOnNavigate,
       enableNavigate,
       isSSG: __IS_SSG__
@@ -366,7 +357,7 @@ export async function navigate({ nuxt, locale, route, redirectPath }: NavigateAr
     }
   }
 
-  if (multiDomainLocales && strategy === 'prefix_except_default') {
+  if (__MULTI_DOMAIN_LOCALES__ && __I18N_STRATEGY__ === 'prefix_except_default') {
     const host = getHost()
     const currentDomain = locales.find(locale => {
       if (isString(locale)) return
@@ -396,7 +387,7 @@ export async function navigate({ nuxt, locale, route, redirectPath }: NavigateAr
     return
   }
 
-  if (differentDomains) {
+  if (__DIFFERENT_DOMAINS__) {
     const state = useRedirectState()
     __DEBUG__ && logger.log('redirect', { state: state.value, redirectPath })
     if (state.value && state.value !== redirectPath) {
@@ -414,12 +405,15 @@ export async function navigate({ nuxt, locale, route, redirectPath }: NavigateAr
   }
 }
 
-export function prefixable(currentLocale: string, defaultLocale: string, strategy: Strategies): boolean {
+export function prefixable(currentLocale: string, defaultLocale: string): boolean {
   return (
     // strategy has no prefixes
-    strategy !== 'no_prefix' &&
+    __I18N_STRATEGY__ !== 'no_prefix' &&
     // strategy should not prefix default locale
-    !(currentLocale === defaultLocale && (strategy === 'prefix_and_default' || strategy === 'prefix_except_default'))
+    !(
+      currentLocale === defaultLocale &&
+      (__I18N_STRATEGY__ === 'prefix_and_default' || __I18N_STRATEGY__ === 'prefix_except_default')
+    )
   )
 }
 
@@ -428,7 +422,7 @@ export function prefixable(currentLocale: string, defaultLocale: string, strateg
  */
 export function createBaseUrlGetter(nuxt: NuxtApp) {
   const logger = /*#__PURE__*/ createLogger('extendBaseUrl')
-  const { baseUrl, defaultLocale, differentDomains } = nuxt.$config.public.i18n as I18nPublicRuntimeConfig
+  const { baseUrl, defaultLocale } = nuxt.$config.public.i18n as I18nPublicRuntimeConfig
 
   if (isFunction(baseUrl)) {
     return (): string => {
@@ -439,10 +433,9 @@ export function createBaseUrlGetter(nuxt: NuxtApp) {
   }
 
   const localeCode = isFunction(defaultLocale) ? (defaultLocale() as string) : defaultLocale
-  const getDomainFromLocale = nuxt._i18nGetDomainFromLocale
   return (): string => {
-    if (differentDomains && localeCode) {
-      const domain = getDomainFromLocale(localeCode)
+    if (__DIFFERENT_DOMAINS__ && localeCode) {
+      const domain = nuxt._i18nGetDomainFromLocale(localeCode)
       if (domain) {
         __DEBUG__ && logger.log('using differentDomains -', { domain })
         return domain
@@ -459,29 +452,19 @@ export function createBaseUrlGetter(nuxt: NuxtApp) {
  * Returns a getter function which returns a localized route name for the given route and locale.
  * The returned function can vary based on the strategy and domain configuration.
  */
-export function createLocaleRouteNameGetter({
-  strategy,
-  differentDomains,
-  defaultLocale,
-  routesNameSeparator,
-  defaultLocaleRouteNameSuffix
-}: {
-  strategy: Strategies
-  differentDomains: boolean
+export function createLocaleRouteNameGetter(
   defaultLocale: string
-  routesNameSeparator: string
-  defaultLocaleRouteNameSuffix: string
-}): (name: RouteRecordNameGeneric | null, locale: string) => string {
+): (name: RouteRecordNameGeneric | null, locale: string) => string {
   // no route localization
-  if (strategy === 'no_prefix' && !differentDomains) {
+  if (__I18N_STRATEGY__ === 'no_prefix' && !__DIFFERENT_DOMAINS__) {
     return routeName => normalizeRouteName(routeName)
   }
 
   const localizeRouteName = (name: string, locale: string, isDefault: boolean) =>
-    getLocalizedRouteName(name, locale, isDefault, routesNameSeparator, defaultLocaleRouteNameSuffix)
+    getLocalizedRouteName(name, locale, isDefault, __ROUTE_NAME_SEPARATOR__, __ROUTE_NAME_DEFAULT_SUFFIX__)
 
   // default locale routes have default suffix
-  if (strategy === 'prefix_and_default') {
+  if (__I18N_STRATEGY__ === 'prefix_and_default') {
     return (name, locale) => localizeRouteName(normalizeRouteName(name), locale, locale === defaultLocale)
   }
 
@@ -493,34 +476,31 @@ export function createLocaleRouteNameGetter({
  * Factory function which returns a resolver function based on the routing strategy.
  */
 export function createLocalizedRouteByPathResolver(
-  strategy: Strategies,
   router: Router
 ): (route: RouteLocationPathRaw, locale: Locale) => RouteLocationPathRaw | RouteLocationResolvedGeneric {
-  switch (strategy) {
-    case 'no_prefix':
-      return route => route
-    case 'prefix_and_default':
-    case 'prefix_except_default':
-    default:
-      return route => router.resolve(route)
-    case 'prefix':
-      /**
-       * The `router.resolve` function prints warnings when resolving non-existent paths and `router.hasRoute` only accepts named routes.
-       * The path passed to `localePath` is not prefixed which will trigger vue-router warnings since all routes are prefixed.
-       * We work around this by manually prefixing the path and finding the route in `router.options.routes`.
-       */
-      return (route, locale) => {
-        const restPath = route.path.slice(1)
-        const targetPath = route.path[0] + locale + (restPath && '/' + restPath)
-        const _route = router.options.routes.find(r => r.path === targetPath)
-
-        if (_route == null) {
-          return route
-        }
-
-        return router.resolve(assign({}, route, _route, { path: targetPath }))
-      }
+  if (__I18N_STRATEGY__ === 'no_prefix') {
+    return route => route
   }
+  if (__I18N_STRATEGY__ === 'prefix') {
+    /**
+     * The `router.resolve` function prints warnings when resolving non-existent paths and `router.hasRoute` only accepts named routes.
+     * The path passed to `localePath` is not prefixed which will trigger vue-router warnings since all routes are prefixed.
+     * We work around this by manually prefixing the path and finding the route in `router.options.routes`.
+     */
+    return (route, locale) => {
+      const restPath = route.path.slice(1)
+      const targetPath = route.path[0] + locale + (restPath && '/' + restPath)
+      const _route = router.options.routes.find(r => r.path === targetPath)
+
+      if (_route == null) {
+        return route
+      }
+
+      return router.resolve(assign({}, route, _route, { path: targetPath }))
+    }
+  }
+  // strategy is prefix_except_default or prefix_and_default
+  return route => router.resolve(route)
 }
 
 // collect unique keys of passed objects

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -432,7 +432,7 @@ export function createBaseUrlGetter(nuxt: NuxtApp) {
     }
   }
 
-  const localeCode = isFunction(defaultLocale) ? (defaultLocale() as string) : defaultLocale
+  const localeCode = /*#__PURE__*/ isFunction(defaultLocale) ? (defaultLocale() as string) : defaultLocale
   return (): string => {
     if (__DIFFERENT_DOMAINS__ && localeCode) {
       const domain = nuxt._i18nGetDomainFromLocale(localeCode)

--- a/src/types.ts
+++ b/src/types.ts
@@ -336,8 +336,12 @@ export interface I18nHeadMetaInfo {
 export interface I18nPublicRuntimeConfig {
   baseUrl: NuxtI18nOptions['baseUrl']
   rootRedirect: NuxtI18nOptions['rootRedirect']
-  multiDomainLocales?: NuxtI18nOptions['multiDomainLocales']
 
+  /**
+   * Overwritten at build time, used to pass generated options to runtime
+   * @internal
+   */
+  multiDomainLocales?: NuxtI18nOptions['multiDomainLocales']
   /**
    * Overwritten at build time, used to pass generated options to runtime
    * @internal

--- a/test/pages/localize_routes.test.ts
+++ b/test/pages/localize_routes.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { createMemoryHistory, createRouter } from 'vue-router'
 
 import { getNuxtOptions } from './utils'
@@ -9,6 +9,12 @@ import type { NuxtPage } from '@nuxt/schema'
 import type { LocaleObject } from '../../src/types'
 import { LocalizableRoute } from '../../src/kit/gen'
 
+beforeEach(() => {
+  vi.stubGlobal('__MULTI_DOMAIN_LOCALES__', false)
+  vi.stubGlobal('__ROUTE_NAME_SEPARATOR__', '___')
+  vi.stubGlobal('__ROUTE_NAME_DEFAULT_SUFFIX__', 'default')
+})
+globalThis.__ROUTE_NAME_SEPARATOR__ = '___'
 const nuxtOptions = getNuxtOptions({})
 nuxtOptions.locales = nuxtOptions.locales?.filter(x => (x as LocaleObject).code !== 'fr') as LocaleObject[]
 delete nuxtOptions.defaultLocale
@@ -146,6 +152,7 @@ describe('localizeRoutes', function () {
   })
 
   describe('strategy: "prefix_and_default"', function () {
+    vi.stubGlobal('__I18N_STRATEGY__', 'prefix_and_default')
     it('should be localized routing', function () {
       const routes: NuxtPage[] = [
         {
@@ -183,6 +190,8 @@ describe('localizeRoutes', function () {
     })
   })
 
+  vi.stubGlobal('__MULTI_DOMAIN_LOCALES__', true)
+  vi.stubGlobal('__I18N_STRATEGY__', 'prefix_and_default')
   // low confidence test
   describe('strategy: "prefix_and_default" + multiDomainLocales', function () {
     it('should be localized routing', function () {
@@ -224,20 +233,12 @@ describe('localizeRoutes', function () {
 
       const router = createRouter({ routes: localizedRoutes as any, history: createMemoryHistory() })
       expect(router.getRoutes().map(x => ({ name: x.name, path: x.path, children: x.children }))).toMatchSnapshot()
-      setupMultiDomainLocales(
-        {
-          multiDomainLocales: true,
-          strategy: 'prefix_except_default',
-          routesNameSeparator: '___',
-          defaultLocaleRouteNameSuffix: 'default'
-        },
-        'en',
-        router
-      )
+      setupMultiDomainLocales('en', router)
 
       expect(router.getRoutes().map(x => ({ name: x.name, path: x.path, children: x.children }))).toMatchSnapshot()
     })
   })
+  vi.stubGlobal('__MULTI_DOMAIN_LOCALES__', false)
 
   describe('strategy: "prefix_except_default"', function () {
     it('should be localized routing', function () {
@@ -332,3 +333,4 @@ describe('localizeRoutes', function () {
     })
   })
 })
+vi.unstubAllGlobals()

--- a/test/routing-utils.test.ts
+++ b/test/routing-utils.test.ts
@@ -9,17 +9,31 @@ const ROUTE_GEN_CONFIG = {
 }
 
 const routeNameGetters = {
-  noPrefix: createLocaleRouteNameGetter({ strategy: 'no_prefix', differentDomains: false, ...ROUTE_GEN_CONFIG }),
-  prefixAndDefault: createLocaleRouteNameGetter({
-    strategy: 'prefix_and_default',
-    differentDomains: false,
-    ...ROUTE_GEN_CONFIG
-  }),
-  prefixExceptDefault: createLocaleRouteNameGetter({
-    strategy: 'prefix_except_default',
-    differentDomains: false,
-    ...ROUTE_GEN_CONFIG
-  })
+  // noPrefix: createLocaleRouteNameGetter({ strategy: 'no_prefix', differentDomains: false, ...ROUTE_GEN_CONFIG }),
+  noPrefix: (...args) => {
+    globalThis['__I18N_STRATEGY__'] = 'no_prefix'
+    globalThis['__DIFFERENT_DOMAINS__'] = false
+    globalThis['__ROUTE_NAME_SEPARATOR__'] = ROUTE_GEN_CONFIG.routesNameSeparator
+    globalThis['__ROUTE_NAME_DEFAULT_SUFFIX__'] = ROUTE_GEN_CONFIG.defaultLocaleRouteNameSuffix
+    globalThis['__TRAILING_SLASH__'] = ROUTE_GEN_CONFIG.defaultLocaleRouteNameSuffix
+    return createLocaleRouteNameGetter(ROUTE_GEN_CONFIG.defaultLocale)(...args)
+  },
+  prefixAndDefault: (...args) => {
+    globalThis['__I18N_STRATEGY__'] = 'prefix_and_default'
+    globalThis['__DIFFERENT_DOMAINS__'] = false
+    globalThis['__ROUTE_NAME_SEPARATOR__'] = ROUTE_GEN_CONFIG.routesNameSeparator
+    globalThis['__ROUTE_NAME_DEFAULT_SUFFIX__'] = ROUTE_GEN_CONFIG.defaultLocaleRouteNameSuffix
+    globalThis['__TRAILING_SLASH__'] = ROUTE_GEN_CONFIG.defaultLocaleRouteNameSuffix
+    return createLocaleRouteNameGetter(ROUTE_GEN_CONFIG.defaultLocale)(...args)
+  },
+  prefixExceptDefault: (...args) => {
+    globalThis['__I18N_STRATEGY__'] = 'prefix_except_default'
+    globalThis['__DIFFERENT_DOMAINS__'] = false
+    globalThis['__ROUTE_NAME_SEPARATOR__'] = ROUTE_GEN_CONFIG.routesNameSeparator
+    globalThis['__ROUTE_NAME_DEFAULT_SUFFIX__'] = ROUTE_GEN_CONFIG.defaultLocaleRouteNameSuffix
+    globalThis['__TRAILING_SLASH__'] = ROUTE_GEN_CONFIG.defaultLocaleRouteNameSuffix
+    return createLocaleRouteNameGetter(ROUTE_GEN_CONFIG.defaultLocale)(...args)
+  }
 }
 
 describe('getLocaleRouteName', () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Several options set in the runtime config were only used to transfer build-time configuration to runtime and changing these at runtime could cause issues.

Instead of setting these on runtime config we now treat them as compiler constants, this way we can tree-shake any unused logic from a project build.

The following options have been removed from runtime config:
* `defaultDirection`
* `strategy`
  * You can access this on `useI18n()`{lang="ts"} or `$i18n`{lang="ts"}
* `lazy`
* `routeNameSeparator`
* `defaultLocaleRouteNameSuffix`
* `differentDomains`
* `multiDomainLocales`
  * Enabling this requires certain properties on locales at build-time, not sure about the use case for setting this at runtime.
* `trailingSlash`
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->
