### PR TITLE
test: set runtime config using IPC signal

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -8,7 +8,8 @@
         "src/runtime/{plugins,components,composables}/**",
         "src/runtime/server/**",
         "src/runtime/kit/**",
-        "scripts/*"
+        "scripts/*",
+        "specs/utils/nitro-plugin.ts"
       ],
       "ignoreUnresolved": [
         // virtuals

--- a/specs/basic-usage-tests.ts
+++ b/specs/basic-usage-tests.ts
@@ -157,14 +157,12 @@ export function basicUsageTests() {
 
     expect(await getText(page, '#runtime-config')).toEqual('Hello from runtime config!')
 
-    const restore = await startServerWithRuntimeConfig({
+    await startServerWithRuntimeConfig({
       public: { runtimeValue: 'The environment variable has changed!' }
     })
 
     await gotoPath(page, '/')
     expect(await getText(page, '#runtime-config')).toEqual('The environment variable has changed!')
-
-    await restore()
   })
 
   test('layer provides locale `nl` and translation for key `hello`', async () => {
@@ -389,7 +387,7 @@ export function basicUsageTests() {
   test('render seo tags with baseUrl', async () => {
     const configDomain = 'https://runtime-config-domain.com'
 
-    const restore = await startServerWithRuntimeConfig({
+    await startServerWithRuntimeConfig({
       public: {
         i18n: {
           baseUrl: configDomain
@@ -407,8 +405,6 @@ export function basicUsageTests() {
     expect(dom.querySelector('#i18n-alt-fr')?.getAttribute('href')).toEqual(
       'https://runtime-config-domain.com/fr?canonical='
     )
-
-    await restore()
   })
 
   test('render seo tags with `experimental.alternateLinkCanonicalQueries`', async () => {
@@ -534,15 +530,13 @@ export function basicUsageTests() {
   })
 
   test('(#2000) Should be able to load large vue-i18n messages', async () => {
-    const restore = await startServerWithRuntimeConfig({
+    await startServerWithRuntimeConfig({
       public: { longTextTest: true }
     })
 
     const { page } = await renderPage('/nl/long-text')
 
     expect(await getText(page, '#long-text')).toEqual('hallo,'.repeat(8 * 500))
-
-    await restore()
   })
 
   test('(#2094) vue-i18n messages are loaded from config exported as variable', async () => {

--- a/specs/basic_usage.spec.ts
+++ b/specs/basic_usage.spec.ts
@@ -32,14 +32,17 @@ describe('basic usage', async () => {
   describe('language switching', async () => {
     beforeAll(async () => {
       setTestContext(ctx)
-      await startServerWithRuntimeConfig({
-        public: {
-          i18n: {
-            skipSettingLocaleOnNavigate: true,
-            detectBrowserLanguage: false
+      await startServerWithRuntimeConfig(
+        {
+          public: {
+            i18n: {
+              skipSettingLocaleOnNavigate: true,
+              detectBrowserLanguage: false
+            }
           }
-        }
-      })
+        },
+        true
+      )
     })
 
     languageSwitchingTests()

--- a/specs/basic_usage_compat_4.spec.ts
+++ b/specs/basic_usage_compat_4.spec.ts
@@ -32,14 +32,17 @@ describe('basic usage - compatibilityVersion: 4', async () => {
   describe('language switching', async () => {
     beforeAll(async () => {
       setTestContext(ctx)
-      await startServerWithRuntimeConfig({
-        public: {
-          i18n: {
-            skipSettingLocaleOnNavigate: true,
-            detectBrowserLanguage: false
+      await startServerWithRuntimeConfig(
+        {
+          public: {
+            i18n: {
+              skipSettingLocaleOnNavigate: true,
+              detectBrowserLanguage: false
+            }
           }
-        }
-      })
+        },
+        true
+      )
     })
 
     languageSwitchingTests()

--- a/specs/browser_language_detection/prefix_except_default.spec.ts
+++ b/specs/browser_language_detection/prefix_except_default.spec.ts
@@ -21,7 +21,7 @@ await setup({
 
 describe('`detectBrowserLanguage` using strategy `prefix_except_default`', async () => {
   test('(#2262) redirect using browser cookie with `alwaysRedirect: true`', async () => {
-    const restore = await startServerWithRuntimeConfig({
+    await startServerWithRuntimeConfig({
       public: {
         i18n: {
           detectBrowserLanguage: {
@@ -52,8 +52,6 @@ describe('`detectBrowserLanguage` using strategy `prefix_except_default`', async
     await page.locator('#nuxt-locale-link-en').click()
     expect(await getText(page, '#lang-switcher-current-locale code')).toEqual('en')
     expect(await ctx.cookies()).toMatchObject([{ name: 'i18n_redirected', value: 'en' }])
-
-    await restore()
   })
 
   describe('(#2255) detect browser language and redirect on root', async () => {

--- a/specs/helper.ts
+++ b/specs/helper.ts
@@ -150,38 +150,6 @@ export async function waitForURL(page: Page, path: string) {
   }
 }
 
-function flattenObject(obj: Record<string, unknown> = {}) {
-  const flattened: Record<string, unknown> = {}
-
-  for (const key of Object.keys(obj)) {
-    const entry = obj[key]
-
-    if (typeof entry !== 'object' || entry == null) {
-      flattened[key] = obj[key]
-      continue
-    }
-
-    const flatObject = flattenObject(entry as Record<string, unknown>)
-    for (const x of Object.keys(flatObject)) {
-      flattened[key + '_' + x] = flatObject[x]
-    }
-  }
-
-  return flattened
-}
-
-export function convertObjectToConfig(obj: Record<string, unknown>) {
-  const makeEnvKey = (str: string) => `NUXT_${snakeCase(str).toUpperCase()}`
-
-  const env: Record<string, unknown> = {}
-  const flattened = flattenObject(obj)
-  for (const key in flattened) {
-    env[makeEnvKey(key)] = flattened[key]
-  }
-
-  return env
-}
-
 export async function startServerWithRuntimeConfig(env: Record<string, unknown>, skipRestore = false) {
   const ctx = useTestContext()
   const identifier = (ctx.url ?? '') + Math.random().toString(36).slice(2, 10)

--- a/specs/routing_strategies/no_prefix.spec.ts
+++ b/specs/routing_strategies/no_prefix.spec.ts
@@ -30,11 +30,14 @@ await setup({
 
 describe('strategy: no_prefix', async () => {
   beforeAll(async () => {
-    await startServerWithRuntimeConfig({
-      public: {
-        i18n: { detectBrowserLanguage: false }
-      }
-    })
+    await startServerWithRuntimeConfig(
+      {
+        public: {
+          i18n: { detectBrowserLanguage: false }
+        }
+      },
+      true
+    )
   })
 
   test('cannot access with locale prefix: /ja', async () => {

--- a/specs/routing_strategies/prefix.spec.ts
+++ b/specs/routing_strategies/prefix.spec.ts
@@ -22,11 +22,14 @@ await setup({
 describe('strategy: prefix', async () => {
   beforeEach(async () => {
     // use original fixture `detectBrowserLanguage` value as default for tests, overwrite here needed
-    await startServerWithRuntimeConfig({
-      public: {
-        i18n: { detectBrowserLanguage: false }
-      }
-    })
+    await startServerWithRuntimeConfig(
+      {
+        public: {
+          i18n: { detectBrowserLanguage: false }
+        }
+      },
+      true
+    )
   })
 
   test.each([
@@ -120,7 +123,7 @@ describe('strategy: prefix', async () => {
   })
 
   test('(#1889) navigation to page with `defineI18nRoute(false)`', async () => {
-    const restore = await startServerWithRuntimeConfig({
+    await startServerWithRuntimeConfig({
       public: {
         i18n: {
           detectBrowserLanguage: {
@@ -153,8 +156,6 @@ describe('strategy: prefix', async () => {
     // does not redirect to prefixed route for routes with disabled localization
     await page.goto(url('/ignore-routes/disable'))
     await waitForURL(page, '/ignore-routes/disable')
-
-    await restore()
   })
 
   test('should not transform `defineI18nRoute()` inside template', async () => {
@@ -165,7 +166,7 @@ describe('strategy: prefix', async () => {
   })
 
   test("(#2132) should redirect on root url with `redirectOn: 'no prefix'`", async () => {
-    const restore = await startServerWithRuntimeConfig({
+    await startServerWithRuntimeConfig({
       public: {
         i18n: {
           detectBrowserLanguage: {
@@ -183,8 +184,6 @@ describe('strategy: prefix', async () => {
 
     await gotoPath(page, '/en')
     expect(await getText(page, '#home-header')).toEqual('Homepage')
-
-    await restore()
   })
 
   test('(#2020) pass query parameter', async () => {

--- a/specs/routing_strategies/root_redirect.spec.ts
+++ b/specs/routing_strategies/root_redirect.spec.ts
@@ -19,7 +19,7 @@ await setup({
 
 describe('rootRedirect', async () => {
   test('can redirect to rootRedirect option path', async () => {
-    const restore = await startServerWithRuntimeConfig({
+    await startServerWithRuntimeConfig({
       public: {
         i18n: {
           rootRedirect: 'fr'
@@ -29,12 +29,10 @@ describe('rootRedirect', async () => {
 
     const res = await fetch('/')
     expect(res.url).toBe(url('/fr'))
-
-    await restore()
   })
 
   test('(#2758) `statusCode` in `rootRedirect` should work with strategy "prefix"', async () => {
-    const restore = await startServerWithRuntimeConfig({
+    await startServerWithRuntimeConfig({
       public: {
         i18n: {
           rootRedirect: { statusCode: 418, path: 'test-route' }
@@ -45,7 +43,5 @@ describe('rootRedirect', async () => {
     const res = await fetch(url('/'))
     expect(res.status).toEqual(418)
     expect(res.headers.get('location')).toEqual('/en/test-route')
-
-    await restore()
   })
 })

--- a/specs/utils/nitro-plugin.ts
+++ b/specs/utils/nitro-plugin.ts
@@ -1,0 +1,73 @@
+import { defineNitroPlugin, useRuntimeConfig } from 'nitropack/runtime'
+import { snakeCase } from 'scule'
+
+// duplicate from helper.ts - due to nuxt import impound/protection
+function flattenObject(obj: Record<string, unknown> = {}) {
+  const flattened: Record<string, unknown> = {}
+
+  for (const key of Object.keys(obj)) {
+    const entry = obj[key]
+
+    if (typeof entry !== 'object' || entry == null) {
+      flattened[key] = obj[key]
+      continue
+    }
+
+    const flatObject = flattenObject(entry as Record<string, unknown>)
+    for (const x of Object.keys(flatObject)) {
+      flattened[key + '_' + x] = flatObject[x]
+    }
+  }
+
+  return flattened
+}
+
+// duplicate from helper.ts - due to nuxt import impound/protection
+export function convertObjectToConfig(obj: Record<string, unknown>) {
+  const makeEnvKey = (str: string) => `NUXT_${snakeCase(str).toUpperCase()}`
+
+  const env: Record<string, unknown> = {}
+  const flattened = flattenObject(obj)
+  for (const key in flattened) {
+    env[makeEnvKey(key)] = flattened[key]
+  }
+
+  return env
+}
+
+export default defineNitroPlugin(async nitroApp => {
+  const config = useRuntimeConfig()
+  const tempKeys = new Set<string>()
+
+  const handler = (msg: { type: string; value: Record<string, string>; identifier: string }) => {
+    if (msg.type === 'update:runtime-config') {
+      const identifier = msg.identifier
+
+      // cleanup temporary keys
+      for (const k of tempKeys) {
+        delete process.env[k]
+      }
+
+      const envConfig = convertObjectToConfig(msg.value)
+      for (const [k, val] of Object.entries(envConfig)) {
+        // collect keys which are newly introduced to cleanup later
+        if (k in process.env === false) {
+          tempKeys.add(k)
+        }
+
+        // @ts-expect-error untyped
+        process.env[k] = val
+      }
+
+      process!.send!({ type: 'confirm:runtime-config', identifier, value: config }, undefined, {
+        keepOpen: true
+      })
+    }
+  }
+
+  process.on('message', handler)
+
+  nitroApp.hooks.hook('close', () => {
+    process.off('message', handler)
+  })
+})

--- a/specs/utils/nitro-plugin.ts
+++ b/specs/utils/nitro-plugin.ts
@@ -1,7 +1,6 @@
 import { defineNitroPlugin, useRuntimeConfig } from 'nitropack/runtime'
 import { snakeCase } from 'scule'
 
-// duplicate from helper.ts - due to nuxt import impound/protection
 function flattenObject(obj: Record<string, unknown> = {}) {
   const flattened: Record<string, unknown> = {}
 
@@ -22,7 +21,6 @@ function flattenObject(obj: Record<string, unknown> = {}) {
   return flattened
 }
 
-// duplicate from helper.ts - due to nuxt import impound/protection
 export function convertObjectToConfig(obj: Record<string, unknown>) {
   const makeEnvKey = (str: string) => `NUXT_${snakeCase(str).toUpperCase()}`
 

--- a/specs/utils/nuxt.ts
+++ b/specs/utils/nuxt.ts
@@ -4,6 +4,7 @@ import * as _kit from '@nuxt/kit'
 import { useTestContext } from './context'
 import { resolve } from 'node:path'
 import { relative } from 'pathe'
+import { fileURLToPath } from 'node:url'
 
 import type { VitestContext } from './types'
 
@@ -64,10 +65,15 @@ export async function loadFixture(testContext: VitestContext) {
     ctx.options.nuxtConfig = defu(ctx.options.nuxtConfig, {
       buildDir,
       modules: [
-        /**
-         * The `overrides` option is only used for testing, it is used to option overrides to the project layer in a fixture.
-         */
         (_, nuxt) => {
+          /**
+           * Register nitro plugin for IPC communication to update runtime config
+           */
+          nuxt.options.nitro.plugins ||= []
+          nuxt.options.nitro.plugins.push(fileURLToPath(new URL('./nitro-plugin', import.meta.url)))
+          /**
+           * The `overrides` option is only used for testing, it is used to option overrides to the project layer in a fixture.
+           */
           if (nuxt.options?.i18n?.overrides) {
             const project = nuxt.options._layers[0]
             const { overrides, ...mergedOptions } = nuxt.options.i18n

--- a/specs/utils/server.ts
+++ b/specs/utils/server.ts
@@ -72,7 +72,7 @@ export async function startServer(env: Record<string, unknown> = {}) {
     ctx.serverProcess = x('node', [resolve(ctx.nuxt!.options.nitro.output!.dir!, 'server/index.mjs')], {
       throwOnError: true,
       nodeOptions: {
-        stdio: 'inherit',
+        stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
         env: {
           ...process.env,
           PORT: String(ports[0]),


### PR DESCRIPTION
### 🔗 Linked issue
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Tried this about two years ago with https://github.com/nuxt/test-utils/pull/670, now with a bit more experience I think I managed to have something working.

This changes the way runtime config is set during tests, previously we restarted the server with new environment variables, this PR changes this to use IPC signals to update the process environment variables (and restore it after the test) while the server is running.


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->
