### PR TITLE
feat: support custom routes via `definePageMeta`

### DIFF
--- a/docs/content/docs/02.guide/03.custom-paths.md
+++ b/docs/content/docs/02.guide/03.custom-paths.md
@@ -183,11 +183,9 @@ export default defineNuxtConfig({
 })
 ```
 
-
-## `definePageMeta`
+## `definePageMeta` {#page-component}
 
 You can use the `i18n` property in `definePageMeta()`{lang="ts"} to set custom paths for each page component.
-
 ```vue {}[pages/about.vue]
 <script setup>
 definePageMeta({

--- a/docs/content/docs/02.guide/03.custom-paths.md
+++ b/docs/content/docs/02.guide/03.custom-paths.md
@@ -3,7 +3,7 @@ title: Custom Route Paths
 description: Customize the names of the paths for specific locale.
 ---
 
-In some cases, you might want to translate URLs in addition to having them prefixed with the locale code. There are two methods of configuring custom paths, through [Module configuration](#module-configuration) or from within each [Page component](#page-component).
+In some cases, you might want to translate URLs in addition to having them prefixed with the locale code. There are two methods of configuring custom paths, through [Module configuration](#module-configuration) or from within each [Page component](#definepagemeta).
 
 Which method is used is configured by setting the [`customRoutes` options](/docs/api/options#customroutes) this is set to `'page'`{lang="ts-type"} by default. Using both methods at the same time is not possible.
 
@@ -183,10 +183,10 @@ export default defineNuxtConfig({
 })
 ```
 
-## `definePageMeta` {#page-component}
+## `definePageMeta`
 
 You can use the `i18n` property in `definePageMeta()`{lang="ts"} to set custom paths for each page component.
-```vue {}[pages/about.vue]
+```vue [pages/about.vue]
 <script setup>
 definePageMeta({
   i18n: {
@@ -202,7 +202,7 @@ definePageMeta({
 
 To configure a custom path for a dynamic route, you need to use it in double square brackets in the paths similar to how you would do it in [Nuxt Dynamic Routes](https://nuxt.com/docs/guide/directory-structure/pages#dynamic-routes):
 
-```vue {}[pages/articles/[name].vue]
+```vue [pages/articles/[name].vue]
 <script setup>
 definePageMeta({
   i18n: {
@@ -223,7 +223,7 @@ This method is deprecated in favor of `definePageMeta()`{lang="ts"} and will be 
 
 You can use the `defineI18nRoute()`{lang="ts"} compiler macro to set custom paths for each page component.
 
-```vue {}[pages/about.vue]
+```vue [pages/about.vue]
 <script setup>
 defineI18nRoute({
   paths: {
@@ -237,7 +237,7 @@ defineI18nRoute({
 
 To configure a custom path for a dynamic route, you need to use it in double square brackets in the paths similar to how you would do it in [Nuxt Dynamic Routes](https://nuxt.com/docs/guide/directory-structure/pages#dynamic-routes):
 
-```vue {}[pages/articles/[name].vue]
+```vue [pages/articles/[name].vue]
 <script setup>
 defineI18nRoute({
   paths: {

--- a/docs/content/docs/02.guide/03.custom-paths.md
+++ b/docs/content/docs/02.guide/03.custom-paths.md
@@ -183,12 +183,44 @@ export default defineNuxtConfig({
 })
 ```
 
-## Page component
+
+## `definePageMeta`
+
+You can use the `i18n` property in `definePageMeta()`{lang="ts"} to set custom paths for each page component.
+
+```vue {}[pages/about.vue]
+<script setup>
+definePageMeta({
+  i18n: {
+    paths: {
+      en: '/about-us', // -> accessible at /about-us (no prefix since it's the default locale)
+      fr: '/a-propos', // -> accessible at /fr/a-propos
+      es: '/sobre' // -> accessible at /es/sobre
+    }
+  }
+})
+</script>
+```
+
+To configure a custom path for a dynamic route, you need to use it in double square brackets in the paths similar to how you would do it in [Nuxt Dynamic Routes](https://nuxt.com/docs/guide/directory-structure/pages#dynamic-routes):
+
+```vue {}[pages/articles/[name].vue]
+<script setup>
+definePageMeta({
+  i18n: {
+    paths: {
+      en: '/articles/[name]',
+      es: '/artículo/[name]'
+    }
+  }
+})
+</script>
+```
+
+## `defineI18nRoute`
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="warning" title="notice"}
-Note for those updating to `v8.0.1`{lang="sh"} or higher
-:br :br
-Path parameters parsing has been changed to match that of [Nuxt 3](https://nuxt.com/docs/guide/directory-structure/pages#dynamic-routes), you will have to update your custom paths (e.g. `'/example/:param'`{lang="ts-type"} should now be `'/example/[param]'`{lang="ts-type"})
+This method is deprecated in favor of `definePageMeta()`{lang="ts"} and will be removed in v11.
 ::
 
 You can use the `defineI18nRoute()`{lang="ts"} compiler macro to set custom paths for each page component.
@@ -205,7 +237,7 @@ defineI18nRoute({
 </script>
 ```
 
-To configure a custom path for a dynamic route, you need to use it in double square brackets in the paths similarly to how you would do it in [Nuxt Dynamic Routes](https://nuxt.com/docs/guide/directory-structure/pages#dynamic-routes):
+To configure a custom path for a dynamic route, you need to use it in double square brackets in the paths similar to how you would do it in [Nuxt Dynamic Routes](https://nuxt.com/docs/guide/directory-structure/pages#dynamic-routes):
 
 ```vue {}[pages/articles/[name].vue]
 <script setup>

--- a/docs/content/docs/02.guide/04.ignoring-localized-routes.md
+++ b/docs/content/docs/02.guide/04.ignoring-localized-routes.md
@@ -13,7 +13,17 @@ If you'd like some pages to be available in some languages only, you can configu
 
 ::code-group
 
-```vue [pages/about.vue]
+```vue [about-meta.vue]
+// pages/about.vue
+<script setup>
+definePageMeta({
+  i18n: { locales: ['fr', 'es'] }
+})
+</script>
+```
+
+```vue [about-macro.vue]
+// pages/about.vue
 <script setup>
 defineI18nRoute({
   locales: ['fr', 'es']
@@ -37,7 +47,15 @@ i18n: {
 
 ::code-group
 
-```vue [pages/about.vue]
+```vue [about-meta.vue]
+// pages/about.vue
+<script setup>
+definePageMeta({ i18n: false })
+</script>
+```
+
+```vue [about-macro.vue]
+// pages/about.vue
 <script setup>
 defineI18nRoute(false)
 </script>

--- a/docs/content/docs/02.guide/90.migrating.md
+++ b/docs/content/docs/02.guide/90.migrating.md
@@ -10,10 +10,29 @@ We have upgrade from Vue I18n v10 to v11, this major version bump deprecates the
 
 Check the documentation detailing the breaking changes [here](https://vue-i18n.intlify.dev/guide/migration/breaking11.html).
 
+### Custom routes via `definePageMeta()`{lang="ts"}
+We have added support for setting custom routes for pages using the `definePageMeta()`{lang="ts"} API, which is now the recommended way to set custom routes for pages.
+This method is enabled by setting `customRoutes: 'meta'`{lang="ts"} in the module options.
+
+To migrate from the `defineI18nRoute()`{lang="ts"} macro, you can simply replace it with `definePageMeta()`{lang="ts"} and set the `i18n` property with the same options:
+```vue [pages/about.vue]
+<script setup>
+definePageMeta({
+  i18n: {
+    paths: {
+      en: '/about-us',
+      fr: '/a-propos',
+    }
+  }
+})
+</script>
+```
+
+
 ### Lazy loading
 The `lazy` option has been removed and lazy loading of locale messages is now the default behavior.
 
-### `finalizePendingLocaleChange()`{lang="ts"} signature changed
+### Signature changed for `finalizePendingLocaleChange()`{lang="ts"}
 The function signature for `finalizePendingLocaleChange()`{lang="ts"} has been corrected from `() => Promise<void>`{lang="ts-type"} to `() => void`{lang="ts-type"}.
 This change was made since the function does not rely on any async operations and should not be awaited, and should prevent unnecessary function coloring.
 

--- a/docs/content/docs/04.api/00.options.md
+++ b/docs/content/docs/04.api/00.options.md
@@ -183,10 +183,14 @@ Routes generation strategy. Can be set to one of the following:
 
 ## customRoutes
 
-- type: `'page' | 'config'`{lang="ts-type"}
+- type: `'meta' | 'page' | 'config'`{lang="ts-type"}
 - default: `'page'`{lang="ts-type"}
 
-Whether [custom paths](/docs/guide/custom-paths) are extracted from page files
+Whether [custom paths](/docs/guide/custom-paths) are extracted from page files or configured in the module configuration:
+
+- `'meta'`{lang="ts-type"}: custom paths are extracted from the `definePageMeta()`{lang="ts"} function in page components.
+- `'page'`{lang="ts-type"}: custom paths are extracted from the `defineI18nRoute()`{lang="ts"} macro in page components.
+- `'config'`{lang="ts-type"}: custom paths are configured in the `pages` option of the module configuration.
 
 ## pages
 

--- a/specs/fixtures/basic_usage/pages/about/index.vue
+++ b/specs/fixtures/basic_usage/pages/about/index.vue
@@ -13,16 +13,6 @@ const code = computed(() => {
 definePageMeta({
   title: 'about'
 })
-
-/*
-// TODO: defineNuxtI18n macro
-defineNuxtI18n({
-  paths: {
-    en: '/about-us',
-    fr: '/a-propos'
-  }
-})
-*/
 </script>
 
 <template>

--- a/specs/fixtures/basic_usage_compat_4/app/pages/about/index.vue
+++ b/specs/fixtures/basic_usage_compat_4/app/pages/about/index.vue
@@ -13,16 +13,6 @@ const code = computed(() => {
 definePageMeta({
   title: 'about'
 })
-
-/*
-// TODO: defineNuxtI18n macro
-defineNuxtI18n({
-  paths: {
-    en: '/about-us',
-    fr: '/a-propos'
-  }
-})
-*/
 </script>
 
 <template>

--- a/specs/fixtures/lazy/pages/about/index.vue
+++ b/specs/fixtures/lazy/pages/about/index.vue
@@ -8,16 +8,6 @@ const localePath = useLocalePath()
 const code = computed(() => {
   return localeProperties.value.code
 })
-
-/*
-// TODO: defineNuxtI18n macro
-defineNuxtI18n({
-  paths: {
-    en: '/about-us',
-    fr: '/a-propos'
-  }
-})
-*/
 </script>
 
 <template>

--- a/specs/fixtures/restructure/pages/about/index.vue
+++ b/specs/fixtures/restructure/pages/about/index.vue
@@ -8,16 +8,6 @@ const localePath = useLocalePath()
 const code = computed(() => {
   return localeProperties.value.code
 })
-
-/*
-// TODO: defineNuxtI18n macro
-defineNuxtI18n({
-  paths: {
-    en: '/about-us',
-    fr: '/a-propos'
-  }
-})
-*/
 </script>
 
 <template>

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -3,6 +3,7 @@ import { genDynamicImport, genSafeVariableName, genString } from 'knitwork'
 import { resolve, relative, join, basename } from 'pathe'
 import { getLayerI18n } from './utils'
 import { asI18nVirtual } from './transform/utils'
+import { resolveModule } from '@nuxt/kit'
 
 import type { Nuxt } from '@nuxt/schema'
 import type { NuxtI18nOptions, LocaleObject } from './types'
@@ -199,6 +200,7 @@ import type { Strategies, Directions, LocaleObject } from '${relative(
     join(nuxt.options.buildDir, 'types'),
     resolve(distDir, 'types.d.mts')
   )}'
+import type { I18nRoute } from '#i18n'
 
 declare module 'vue-i18n' {
   interface ComposerCustom extends ComposerCustomProperties<${resolvedLocaleType}> {}
@@ -214,10 +216,25 @@ declare module '@intlify/core-base' {
   }
 }
 
+interface I18nMeta {
+  i18n?: I18nRoute | false
+}
+
 declare module '#app' {
   interface NuxtApp {
     $i18n: ${i18nType}
   }
+  interface PageMeta extends I18nMeta {}
+}
+
+
+// NOTE: this is a workaround for Nuxt <3.16.2
+declare module '${resolve(resolveModule('nuxt'), '../pages/runtime/composables')}' {
+  interface PageMeta extends I18nMeta {}
+}
+
+declare module 'vue-router' {
+  interface RouteMeta extends I18nMeta {}
 }
 
 ${typedRouterAugmentations}

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,7 +162,7 @@ export type NuxtI18nOptions<
   detectBrowserLanguage?: DetectBrowserLanguageOptions | false
   langDir?: string | null
   pages?: CustomRoutePages
-  customRoutes?: 'page' | 'config'
+  customRoutes?: 'page' | 'config' | 'meta'
   /**
    * Do not use in projects - this is used internally for e2e tests to override default option merging.
    * @internal

--- a/test/fixtures/custom_route/dynamic/pages/articles/[name].vue
+++ b/test/fixtures/custom_route/dynamic/pages/articles/[name].vue
@@ -8,4 +8,14 @@ defineI18nRoute({
     ja: '/記事/[name]'
   }
 })
+
+definePageMeta({
+  i18n: {
+    paths: {
+      en: '/articles/[name]',
+      fr: '/articles/[name]',
+      ja: '/記事/[name]'
+    }
+  }
+})
 </script>

--- a/test/fixtures/custom_route/js/pages/about.vue
+++ b/test/fixtures/custom_route/js/pages/about.vue
@@ -8,6 +8,16 @@ defineI18nRoute({
     ja: '/about-ja'
   }
 })
+
+definePageMeta({
+  i18n: {
+    paths: {
+      en: '/about-us',
+      fr: '/a-propos',
+      ja: '/about-ja'
+    }
+  }
+})
 </script>
 
 <template>

--- a/test/fixtures/custom_route/simple/pages/about.vue
+++ b/test/fixtures/custom_route/simple/pages/about.vue
@@ -8,4 +8,14 @@ defineI18nRoute({
     ja: '/about-ja'
   }
 })
+
+definePageMeta({
+  i18n: {
+    paths: {
+      en: '/about-us',
+      fr: '/a-propos',
+      ja: '/about-ja'
+    }
+  }
+})
 </script>

--- a/test/fixtures/custom_route/with_meta/pages/about.vue
+++ b/test/fixtures/custom_route/with_meta/pages/about.vue
@@ -10,6 +10,13 @@ defineI18nRoute({
 })
 
 definePageMeta({
-  layout: false
+  layout: false,
+  i18n: {
+    paths: {
+      en: '/about-us',
+      fr: '/a-propos',
+      ja: '/about-ja'
+    }
+  }
 })
 </script>

--- a/test/fixtures/ignore_route/disable/pages/about.vue
+++ b/test/fixtures/ignore_route/disable/pages/about.vue
@@ -2,4 +2,5 @@
 import { defineI18nRoute } from '#i18n'
 
 defineI18nRoute(false)
+definePageMeta({ i18n: false })
 </script>

--- a/test/fixtures/ignore_route/pick/dynamic/pages/articles/[name].vue
+++ b/test/fixtures/ignore_route/pick/dynamic/pages/articles/[name].vue
@@ -4,4 +4,9 @@ import { defineI18nRoute } from '#i18n'
 defineI18nRoute({
   locales: ['fr']
 })
+definePageMeta({
+  i18n: {
+    locales: ['fr']
+  }
+})
 </script>

--- a/test/fixtures/ignore_route/pick/simple/pages/about.vue
+++ b/test/fixtures/ignore_route/pick/simple/pages/about.vue
@@ -4,4 +4,9 @@ import { defineI18nRoute } from '#i18n'
 defineI18nRoute({
   locales: ['fr', 'ja']
 })
+definePageMeta({
+  i18n: {
+    locales: ['fr']
+  }
+})
 </script>

--- a/test/mocks/i18n.options.ts
+++ b/test/mocks/i18n.options.ts
@@ -1,1 +1,3 @@
 export const localeCodes = []
+export const normalizedLocales = []
+export const vueI18nConfigs = []

--- a/test/pages/__snapshots__/custom_route.test.ts.snap
+++ b/test/pages/__snapshots__/custom_route.test.ts.snap
@@ -95,6 +95,157 @@ exports[`#1649 1`] = `
 ]
 `;
 
+exports[`Extract page meta > 'JavaScript' (meta) 1`] = `
+[
+  {
+    "children": [],
+    "meta": {
+      "i18n": {
+        "paths": {
+          "en": "/about-us",
+          "fr": "/a-propos",
+          "ja": "/about-ja",
+        },
+      },
+    },
+    "name": "about___en",
+    "path": "/about-us",
+  },
+  {
+    "children": [],
+    "meta": {
+      "i18n": {
+        "paths": {
+          "en": "/about-us",
+          "fr": "/a-propos",
+          "ja": "/about-ja",
+        },
+      },
+    },
+    "name": "about___ja",
+    "path": "/ja/about-ja",
+  },
+]
+`;
+
+exports[`Extract page meta > 'dynamic route' (meta) 1`] = `
+[
+  {
+    "children": [],
+    "meta": {
+      "i18n": {
+        "paths": {
+          "en": "/articles/[name]",
+          "fr": "/articles/[name]",
+          "ja": "/記事/[name]",
+        },
+      },
+    },
+    "name": "name___en",
+    "path": "/articles/:name()",
+  },
+  {
+    "children": [],
+    "meta": {
+      "i18n": {
+        "paths": {
+          "en": "/articles/[name]",
+          "fr": "/articles/[name]",
+          "ja": "/記事/[name]",
+        },
+      },
+    },
+    "name": "name___ja",
+    "path": "/ja/%E8%A8%98%E4%BA%8B/:name()",
+  },
+]
+`;
+
+exports[`Extract page meta > 'ignore custom route' (meta) 1`] = `
+[
+  {
+    "children": [],
+    "meta": {
+      "i18n": false,
+    },
+    "name": "about",
+    "path": "/about",
+  },
+]
+`;
+
+exports[`Extract page meta > 'simple' (meta) 1`] = `
+[
+  {
+    "children": [],
+    "meta": {
+      "i18n": {
+        "paths": {
+          "en": "/about-us",
+          "fr": "/a-propos",
+          "ja": "/about-ja",
+        },
+      },
+    },
+    "name": "about___en",
+    "path": "/about-us",
+  },
+  {
+    "children": [],
+    "meta": {
+      "i18n": {
+        "paths": {
+          "en": "/about-us",
+          "fr": "/a-propos",
+          "ja": "/about-ja",
+        },
+      },
+    },
+    "name": "about___ja",
+    "path": "/ja/about-ja",
+  },
+]
+`;
+
+exports[`Extract page meta > 'with definePageMeta' (meta) 1`] = `
+[
+  {
+    "children": [],
+    "meta": {
+      "__nuxt_dynamic_meta_key": Set {
+        "meta",
+      },
+      "i18n": {
+        "paths": {
+          "en": "/about-us",
+          "fr": "/a-propos",
+          "ja": "/about-ja",
+        },
+      },
+    },
+    "name": "about___en",
+    "path": "/about-us",
+  },
+  {
+    "children": [],
+    "meta": {
+      "__nuxt_dynamic_meta_key": Set {
+        "meta",
+      },
+      "i18n": {
+        "paths": {
+          "en": "/about-us",
+          "fr": "/a-propos",
+          "ja": "/about-ja",
+        },
+      },
+    },
+    "name": "about___ja",
+    "path": "/ja/about-ja",
+  },
+]
+`;
+
 exports[`Module configuration > dynamic parameters 1`] = `
 [
   {
@@ -248,7 +399,7 @@ exports[`Module configuration > the part of URL 1`] = `
 ]
 `;
 
-exports[`Page components > JavaScript 1`] = `
+exports[`Page components > 'JavaScript' 1`] = `
 [
   {
     "children": [],
@@ -265,7 +416,7 @@ exports[`Page components > JavaScript 1`] = `
 ]
 `;
 
-exports[`Page components > dynamic route 1`] = `
+exports[`Page components > 'dynamic route' 1`] = `
 [
   {
     "children": [],
@@ -285,7 +436,16 @@ exports[`Page components > dynamic route 1`] = `
 ]
 `;
 
-exports[`Page components > simple 1`] = `
+exports[`Page components > 'ignore custom route' 1`] = `
+[
+  {
+    "children": [],
+    "path": "/about",
+  },
+]
+`;
+
+exports[`Page components > 'simple' 1`] = `
 [
   {
     "children": [],
@@ -302,7 +462,7 @@ exports[`Page components > simple 1`] = `
 ]
 `;
 
-exports[`Page components > with definePageMeta 1`] = `
+exports[`Page components > 'with definePageMeta' 1`] = `
 [
   {
     "children": [],


### PR DESCRIPTION
### Related
- https://github.com/nuxt/nuxt/discussions/28826


### Todo
- [x] Implement feature
- [x] Update docs
- [x] Add tests 

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description



Adds a new way to set custom routes in pages, instead of using `defineI18nRoute` the same configuration can be set on the `i18n` key in `definePageMeta`.

```html
// my-page.vue
<script setup lang="ts">
// with configuration `customRoutes: 'meta'`
definePageMeta({
  i18n: {
    paths: {
      en: '/my-page',
      ja: '/my-page-japanese'
    }
  }
})
// with configuration `customRoutes: 'page'`
defineI18nRoute({
  paths: {
    en: '/my-page',
    ja: '/my-page-japanese'
  }
})
</script>
```

If this works well, we will probably deprecate the `defineI18nRoute` and remove it in v11.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for extracting i18n route options from the meta property of Nuxt pages.
  - You can now specify i18n route metadata directly in page meta fields.
  - The customRoutes option now accepts 'meta' in addition to 'page' and 'config'.
  - Introduced explicit page metadata calls to define localized i18n routes in various page fixtures.
  - Added the ability to disable i18n on a per-page basis via page meta configuration.

- **Bug Fixes**
  - Improved compatibility with older Nuxt versions when handling i18n route metadata.

- **Tests**
  - Refactored and extended tests for custom route handling, including new integration tests for page meta extraction during Nuxt build.

- **Documentation**
  - Updated docs to introduce definePageMeta() for custom localized routes, replacing the deprecated defineI18nRoute() macro.
  - Expanded examples for ignoring localized routes using both definePageMeta() and defineI18nRoute() styles.
  - Enhanced migration guide with instructions for migrating to definePageMeta() for custom routes.
  - Clarified API docs to reflect 'meta' as a valid customRoutes option value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->