### PR TITLE
refactor: nest internal properties on `_nuxtI18nCtx` property

### DIFF
--- a/src/runtime/internal.ts
+++ b/src/runtime/internal.ts
@@ -108,17 +108,17 @@ export function detectBrowserLanguage(
   }
 
   const nuxtApp = useNuxtApp()
-  const firstAccess = nuxtApp._vueI18n.__firstAccess
+  const ctx = nuxtApp._nuxtI18nCtx
 
-  __DEBUG__ && logger.log({ firstAccess })
+  __DEBUG__ && logger.log({ firstAccess: ctx.firstAccess })
 
   // detection ignored during nuxt generate
-  if (__IS_SSG__ && firstAccess && __I18N_STRATEGY__ === 'no_prefix' && import.meta.server) {
+  if (__IS_SSG__ && ctx.firstAccess && __I18N_STRATEGY__ === 'no_prefix' && import.meta.server) {
     return { locale: '', error: 'detect_ignore_on_ssg' }
   }
 
   // detection only on first access
-  if (!firstAccess) {
+  if (!ctx.firstAccess) {
     return { locale: __I18N_STRATEGY__ === 'no_prefix' ? locale : '', error: 'first_access_only' }
   }
 

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -2,8 +2,8 @@ import { computed, isRef, ref, watch } from 'vue'
 import { createI18n, type LocaleMessages, type DefineLocaleMessage } from 'vue-i18n'
 
 import { defineNuxtPlugin, prerenderRoutes, useNuxtApp, useState } from '#imports'
-import { localeCodes, normalizedLocales, localeLoaders } from '#build/i18n.options.mjs'
-import { getLocaleMessagesMergedCached } from '../messages'
+import { localeCodes, normalizedLocales, localeLoaders, vueI18nConfigs } from '#build/i18n.options.mjs'
+import { getLocaleMessagesMergedCached, loadVueI18nOptions } from '../messages'
 import {
   loadAndSetLocale,
   detectRedirect,
@@ -22,7 +22,6 @@ import { useLocalePath, useLocaleRoute, useRouteBaseName, useSwitchLocalePath } 
 import { createDomainFromLocaleGetter, getDefaultLocaleForDomain, setupMultiDomainLocales } from '../domain'
 import { parse } from 'devalue'
 import { deepCopy } from '@intlify/shared'
-import { setupVueI18nOptions } from '../shared/vue-i18n'
 
 import type { Locale, I18nOptions, Composer, TranslateOptions } from 'vue-i18n'
 import type { NuxtApp } from '#app'
@@ -76,9 +75,14 @@ export default defineNuxtPlugin({
 
     __DEBUG__ && logger.log('defaultLocale on setup', runtimeI18n.defaultLocale)
 
-    const vueI18nOptions: I18nOptions = await setupVueI18nOptions()
+    const vueI18nOptions: I18nOptions = await loadVueI18nOptions(vueI18nConfigs)
     if (defaultLocaleDomain) {
       vueI18nOptions.locale = defaultLocaleDomain
+    }
+
+    // initialize locale objects to make vue-i18n aware of available locales
+    for (const l of localeCodes) {
+      vueI18nOptions.messages![l] ??= {}
     }
 
     let preloadedMessages: LocaleMessages<DefineLocaleMessage> | undefined

--- a/src/runtime/plugins/route-locale-detect.ts
+++ b/src/runtime/plugins/route-locale-detect.ts
@@ -11,23 +11,24 @@ export default defineNuxtPlugin({
   async setup() {
     const logger = /*#__PURE__*/ createLogger('plugin:route-locale-detect')
     const nuxt = useNuxtApp()
+    const ctx = nuxt._nuxtI18nCtx
 
     async function handleRouteDetect(to: CompatRoute) {
       let detected = detectLocale(
         to,
-        nuxt._vueI18n.__localeFromRoute(to),
+        ctx.getLocaleFromRoute(to),
         unref(nuxt.$i18n.locale),
         nuxt.$i18n.getLocaleCookie()
       )
 
-      if (nuxt._vueI18n.__firstAccess) {
-        nuxt._vueI18n.__setLocale(detected)
-        if (!nuxt._i18nPreloaded) {
-          await nuxt._i18nLoadAndSetMessages(detected)
+      if (ctx.firstAccess) {
+        ctx.setLocale(detected)
+        if (!ctx.preloaded) {
+          await ctx.loadLocaleMessages(detected)
         }
       }
 
-      const modified = await nuxt.runWithContext(() => loadAndSetLocale(detected, nuxt._vueI18n.__firstAccess))
+      const modified = await nuxt.runWithContext(() => loadAndSetLocale(detected, ctx.firstAccess))
       if (modified) {
         detected = unref(nuxt.$i18n.locale)
       }
@@ -48,10 +49,10 @@ export default defineNuxtPlugin({
         const locale = await nuxt.runWithContext(() => handleRouteDetect(to))
 
         const redirectPath = await nuxt.runWithContext(() =>
-          detectRedirect({ to, from, locale, routeLocale: nuxt._vueI18n.__localeFromRoute(to) }, true)
+          detectRedirect({ to, from, locale, routeLocale: ctx.getLocaleFromRoute(to) }, true)
         )
 
-        nuxt._vueI18n.__firstAccess = false
+        ctx.firstAccess = false
 
         __DEBUG__ && logger.log('redirectPath on locale-changing middleware', redirectPath)
 

--- a/src/runtime/plugins/ssg-detect.ts
+++ b/src/runtime/plugins/ssg-detect.ts
@@ -9,6 +9,7 @@ export default defineNuxtPlugin({
   enforce: 'post',
   setup() {
     const nuxt = /*#__PURE__*/ useNuxtApp()
+    const ctx = nuxt._nuxtI18nCtx
     if (!__IS_SSG__ || __I18N_STRATEGY__ !== 'no_prefix' || !nuxt.$config.public.i18n.detectBrowserLanguage) return
 
     const logger = /*#__PURE__*/ createLogger('plugin:i18n:ssg-detect')
@@ -25,7 +26,7 @@ export default defineNuxtPlugin({
       __DEBUG__ && logger.log('app:mounted: detectBrowserLanguage (locale, reason, error) -', Object.values(detected))
 
       await nuxt.$i18n.setLocale(detected.locale)
-      nuxt._vueI18n.__firstAccess = false
+      ctx.firstAccess = false
     })
   }
 })

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -157,11 +157,16 @@ declare module '#app' {
   interface NuxtApp {
     /** @internal */
     _vueI18n: I18n
-    /** @internal */
-    _i18nGetDomainFromLocale: (locale: Locale) => string | undefined
-    _i18nLoadAndSetMessages: (locale: Locale) => Promise<void>
-    _i18nPreloaded: boolean
 
+    /** @internal */
+    _nuxtI18nCtx: {
+      preloaded: boolean
+      firstAccess: boolean
+      setLocale: (locale: string) => void
+      getDomainFromLocale: (locale: Locale) => string | undefined
+      getLocaleFromRoute: (route: string | CompatRoute) => string
+      loadLocaleMessages: (locale: Locale) => Promise<void>
+    }
     /** @internal */
     _nuxtI18n: ComposableContext
   }
@@ -171,8 +176,6 @@ declare module 'vue-i18n' {
   interface I18n {
     /** @internal */ __pendingLocale?: string
     /** @internal */ __pendingLocalePromise?: Promise<void>
-    /** @internal */ __firstAccess: boolean
-    /** @internal */ __localeFromRoute: (route: string | CompatRoute) => string
     /**
      * Sets the value of the locale property on VueI18n or Composer instance
      *
@@ -180,8 +183,6 @@ declare module 'vue-i18n' {
      * locale property directly without triggering other side effects
      * @internal
      */
-    __setLocale: (locale: string) => void
     __resolvePendingLocalePromise?: () => void
-    loadLocaleMessages: (locale: Locale) => Promise<void>
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Centralized all locale-related state and methods into a unified context object, improving encapsulation and clarity for locale handling.
  - Replaced scattered internal properties with a single context object for managing locale detection, switching, and message loading.

- **Chores**
  - Updated internal structure to simplify and streamline i18n management, with no impact on user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->