### PR TITLE
fix: exclude virtuals from resource plugin

### DIFF
--- a/src/transform/resource.ts
+++ b/src/transform/resource.ts
@@ -84,6 +84,7 @@ export const ResourcePlugin = (options: BundlerPluginOptions, ctx: I18nNuxtConte
           // ensure imported resources are transformed as well
           const staticImports = findStaticImports(_code)
           for (const x of staticImports) {
+            if (x.specifier.startsWith('\0')) continue
             i18nPathSet.add(await resolvePath(resolve(dirname(id), x.specifier)))
           }
 


### PR DESCRIPTION
### 🔗 Linked issue
* #3595 

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Resolves #3595 

I'm not aware of cases where locale files can include messages from virtual files, if there is any then this will need to be revisited.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of static imports by skipping those with specifiers starting with a null character, ensuring only valid imports are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->