### PR TITLE
refactor: extract preload logic into plugin

### DIFF
--- a/src/prepare/runtime.ts
+++ b/src/prepare/runtime.ts
@@ -9,6 +9,7 @@ export function prepareRuntime(ctx: I18nNuxtContext, nuxt: Nuxt) {
   const { options, resolver } = ctx
   // for core plugin
   addPlugin(resolver.resolve('./runtime/plugins/i18n'))
+  addPlugin(resolver.resolve('./runtime/plugins/preload'))
   addPlugin(resolver.resolve('./runtime/plugins/route-locale-detect'))
   addPlugin(resolver.resolve('./runtime/plugins/ssg-detect'))
   addPlugin(resolver.resolve('./runtime/plugins/switch-locale-path-ssr'))

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -1,9 +1,9 @@
 import { computed, isRef, ref, watch } from 'vue'
-import { createI18n, type LocaleMessages, type DefineLocaleMessage } from 'vue-i18n'
+import { createI18n } from 'vue-i18n'
 
 import { defineNuxtPlugin, prerenderRoutes, useNuxtApp, useState } from '#imports'
 import { localeCodes, normalizedLocales, localeLoaders } from '#build/i18n.options.mjs'
-import { getLocaleMessagesMergedCached } from '../shared/messages'
+import { getFallbackLocaleCodes, getLocaleMessagesMergedCached } from '../shared/messages'
 import {
   loadAndSetLocale,
   detectRedirect,
@@ -20,16 +20,14 @@ import { getI18nTarget } from '../compatibility'
 import { localeHead } from '../routing/head'
 import { useLocalePath, useLocaleRoute, useRouteBaseName, useSwitchLocalePath } from '../composables'
 import { createDomainFromLocaleGetter, getDefaultLocaleForDomain, setupMultiDomainLocales } from '../domain'
-import { parse } from 'devalue'
-import { deepCopy } from '@intlify/shared'
 import { setupVueI18nOptions } from '../shared/vue-i18n'
+import { isLocaleWithFallbacksCacheable } from '../shared/cache'
 
-import type { Locale, I18nOptions, Composer, TranslateOptions } from 'vue-i18n'
+import type { Locale, I18nOptions, Composer } from 'vue-i18n'
 import type { NuxtApp } from '#app'
 import type { LocaleObject, I18nPublicRuntimeConfig, I18nHeadOptions } from '#internal-i18n-types'
 import type { CompatRoute } from '../types'
 
-const dynamicResourcesSSG = !__I18N_FULL_STATIC__ && (import.meta.prerender || __IS_SSG__)
 const useLocaleConfigs = () =>
   useState<Record<string, { cacheable: boolean; fallbacks: string[] }>>('i18n:cached-locale-configs', () => ({}))
 
@@ -37,6 +35,7 @@ function createNuxtI18nContext() {
   return {
     firstAccess: undefined! as boolean,
     preloaded: undefined! as boolean,
+    dynamicResourcesSSG: !__I18N_FULL_STATIC__ && (import.meta.prerender || __IS_SSG__),
     setLocale: undefined! as (locale: string) => void,
     getLocaleFromRoute: undefined! as (route: string | CompatRoute) => string,
     getDomainFromLocale: undefined! as (locale: Locale) => string | undefined,
@@ -71,63 +70,26 @@ export default defineNuxtPlugin({
     runtimeI18n.defaultLocale = defaultLocaleDomain
     __DEBUG__ && logger.log('defaultLocale on setup', runtimeI18n.defaultLocale)
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const vueI18nOptions: I18nOptions = nuxt.ssrContext?.event?.context?.vueI18n || (await setupVueI18nOptions())
+    const vueI18nOptions: I18nOptions = await setupVueI18nOptions()
     if (defaultLocaleDomain) {
       vueI18nOptions.locale = defaultLocaleDomain
     }
 
-    // initialize locale objects to make vue-i18n aware of available locales
-    for (const l of localeCodes) {
-      vueI18nOptions.messages![l] ??= {}
-    }
-
-    let preloadedMessages: LocaleMessages<DefineLocaleMessage> | undefined
-    // retrieve loaded messages from server-side if enabled
     if (import.meta.server) {
-      const serverI18n = nuxt.ssrContext!.event.context.nuxtI18n
-      if (serverI18n?.localeConfigs) {
-        serverLocaleConfigs.value = serverI18n.localeConfigs
-      }
-      if (serverI18n?.messages && Object.keys(serverI18n.messages).length) {
-        vueI18nOptions.messages = serverI18n.messages
-        ctx.preloaded = true
-      }
-    }
-
-    if (import.meta.client) {
-      const content = document.querySelector(`[data-nuxt-i18n="${nuxt._id}"]`)?.textContent
-      if (content) {
-        preloadedMessages = parse(content) as LocaleMessages<DefineLocaleMessage> | undefined
-      }
-      if (preloadedMessages && Object.keys(preloadedMessages).length && dynamicResourcesSSG) {
-        try {
-          const msg = await Promise.all(
-            Object.keys(preloadedMessages).map(async locale => ({
-              [locale]: await getLocaleMessagesMergedCached(locale, localeLoaders[locale])
-            }))
-          )
-          for (const m of msg) {
-            deepCopy(m, preloadedMessages)
-          }
-        } catch (e) {
-          console.log('Error loading messages', e)
-        }
-      }
-    }
-
-    if (preloadedMessages) {
-      __DEBUG__ && logger.log('preloaded full static messages', ctx.preloaded)
+      const localeConfigs: Record<string, { fallbacks: string[]; cacheable: boolean }> = {}
       for (const locale of localeCodes) {
-        if (preloadedMessages[locale]) {
-          deepCopy(preloadedMessages[locale], vueI18nOptions.messages![locale])
-        }
+        const fallbacks = getFallbackLocaleCodes(vueI18nOptions.fallbackLocale!, [locale])
+        const cacheable = isLocaleWithFallbacksCacheable(locale, fallbacks)
+        localeConfigs[locale] = { fallbacks, cacheable }
       }
-      ctx.preloaded = true
+      serverLocaleConfigs.value = localeConfigs
+      if (nuxt.ssrContext?.event.context.nuxtI18n) {
+        nuxt.ssrContext.event.context.nuxtI18n.localeConfigs = localeConfigs
+      }
     }
 
     ctx.loadLocaleMessages = async (locale: string) => {
-      if (dynamicResourcesSSG || import.meta.dev) {
+      if (ctx.dynamicResourcesSSG || import.meta.dev) {
         const locales = ctx.getLocaleConfig(locale)?.fallbacks ?? []
         if (!locales.includes(locale)) {
           locales.push(locale)
@@ -178,49 +140,6 @@ export default defineNuxtPlugin({
     }
 
     nuxt._nuxtI18n = createComposableContext({ i18n, getDomainFromLocale: ctx.getDomainFromLocale, runtimeI18n })
-
-    if (__I18N_STRIP_UNUSED__ && !__IS_SSG__) {
-      const _ctx = nuxt._nuxtI18n
-      if (import.meta.server) {
-        const serverI18n = import.meta.server ? nuxt.ssrContext!.event.context.nuxtI18n : undefined
-        const target = i18n.global
-
-        const originalT = target.t.bind(target)
-        type TParams = Parameters<typeof originalT>
-        target.t = (
-          key,
-          listOrNamed?: string | number | unknown[] | Record<string, unknown>,
-          opts?: TranslateOptions<string> | number | string
-        ) => {
-          const locale = ((typeof opts === 'object' && opts?.locale) || _ctx.getLocale()) as string
-          serverI18n?.trackKey(key, locale)
-          return originalT(key, listOrNamed as TParams[1], opts as TParams[2])
-        }
-
-        const originalTe = target.te.bind(target)
-        target.te = (key, locale) => {
-          serverI18n?.trackKey(key, locale || _ctx.getLocale())
-          return originalTe(key, locale)
-        }
-
-        const originalTm = target.tm.bind(target)
-        target.tm = key => {
-          serverI18n?.trackKey(key, _ctx.getLocale())
-          return originalTm(key)
-        }
-      }
-
-      if (import.meta.client) {
-        /**
-         * Ensure messages are loaded before switching page for the first time
-         */
-        const unsub = nuxt.$router.beforeResolve(async (to, from) => {
-          if (to.path === from.path) return
-          await ctx.loadLocaleMessages(_ctx.getLocale())
-          unsub()
-        })
-      }
-    }
 
     // HMR helper functionality
     if (import.meta.dev) {

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -3,7 +3,7 @@ import { createI18n } from 'vue-i18n'
 
 import { defineNuxtPlugin, prerenderRoutes, useNuxtApp, useState } from '#imports'
 import { localeCodes, normalizedLocales, localeLoaders } from '#build/i18n.options.mjs'
-import { getFallbackLocaleCodes, getLocaleMessagesMergedCached } from '../shared/messages'
+import { getLocaleMessagesMergedCached } from '../shared/messages'
 import {
   loadAndSetLocale,
   detectRedirect,
@@ -21,8 +21,8 @@ import { getI18nTarget } from '../compatibility'
 import { localeHead } from '../routing/head'
 import { useLocalePath, useLocaleRoute, useRouteBaseName, useSwitchLocalePath } from '../composables'
 import { createDomainFromLocaleGetter, getDefaultLocaleForDomain, setupMultiDomainLocales } from '../domain'
+import { createLocaleConfigs } from '../shared/locales'
 import { setupVueI18nOptions } from '../shared/vue-i18n'
-import { isLocaleWithFallbacksCacheable } from '../shared/cache'
 
 import type { Locale, I18nOptions, Composer, VueI18n, TranslateOptions } from 'vue-i18n'
 import type { NuxtApp } from '#app'
@@ -78,12 +78,7 @@ export default defineNuxtPlugin({
     }
 
     if (import.meta.server) {
-      const localeConfigs: Record<string, { fallbacks: string[]; cacheable: boolean }> = {}
-      for (const locale of localeCodes) {
-        const fallbacks = getFallbackLocaleCodes(vueI18nOptions.fallbackLocale!, [locale])
-        const cacheable = isLocaleWithFallbacksCacheable(locale, fallbacks)
-        localeConfigs[locale] = { fallbacks, cacheable }
-      }
+      const localeConfigs = createLocaleConfigs(vueI18nOptions.fallbackLocale!)
       serverLocaleConfigs.value = localeConfigs
       if (nuxt.ssrContext?.event.context.nuxtI18n) {
         nuxt.ssrContext.event.context.nuxtI18n.localeConfigs = localeConfigs

--- a/src/runtime/plugins/preload.ts
+++ b/src/runtime/plugins/preload.ts
@@ -11,6 +11,7 @@ export default defineNuxtPlugin({
   name: 'i18n:plugin:preload',
   dependsOn: ['i18n:plugin'],
   async setup() {
+    if (!__I18N_PRELOAD__) return
     const nuxt = useNuxtApp()
     const i18n = nuxt._vueI18n
 

--- a/src/runtime/plugins/preload.ts
+++ b/src/runtime/plugins/preload.ts
@@ -1,0 +1,115 @@
+import { parse } from 'devalue'
+import { deepCopy } from '@intlify/shared'
+import { useNuxtApp, defineNuxtPlugin, type NuxtApp } from '#app'
+import { localeCodes, localeLoaders } from '#build/i18n.options.mjs'
+import { getLocaleMessagesMergedCached } from '../shared/messages'
+
+import type { TranslateOptions, Composer } from 'vue-i18n'
+import type { LocaleMessages, DefineLocaleMessage } from 'vue-i18n'
+import { unref } from 'vue'
+import type { H3EventContext } from 'h3'
+import type { ComposableContext } from '../utils'
+
+export default defineNuxtPlugin({
+  name: 'i18n:plugin:preload',
+  dependsOn: ['i18n:plugin'],
+  async setup() {
+    const nuxt = useNuxtApp()
+    const i18n = nuxt._vueI18n
+
+    // retrieve loaded messages from server-side if enabled
+    if (import.meta.server) {
+      for (const locale of localeCodes) {
+        try {
+          const messages = await $fetch(`/_i18n/${locale}/messages.json`)
+          for (const locale of Object.keys(messages)) {
+            nuxt.$i18n.mergeLocaleMessage(locale, messages[locale])
+          }
+        } catch (e) {
+          console.log('Error loading messages', e)
+        }
+      }
+
+      nuxt._nuxtI18nCtx.preloaded = true
+
+      const serverI18n = nuxt.ssrContext?.event.context.nuxtI18n
+      // set server context messages
+      if (serverI18n) {
+        // wrap translation functions to track translation keys used during SSR
+        if (__I18N_STRIP_UNUSED__) {
+          wrapTranslationFunctions(i18n.global as Composer, nuxt._nuxtI18n, serverI18n)
+        }
+
+        const msg = unref(i18n.global.messages) as LocaleMessages<DefineLocaleMessage>
+        serverI18n.messages ??= {}
+        for (const k in msg) {
+          serverI18n.messages[k] = msg[k]
+        }
+      }
+    }
+
+    if (import.meta.client) {
+      await mergePayloadMessages(nuxt._nuxtI18nCtx, i18n.global as Composer, nuxt)
+
+      /**
+       * Ensure messages are loaded before switching page for the first time
+       */
+      const unsub = nuxt.$router.beforeResolve(async (to, from) => {
+        if (to.path === from.path) return
+        await nuxt._nuxtI18nCtx.loadLocaleMessages(nuxt._nuxtI18n.getLocale())
+        unsub()
+      })
+    }
+  }
+})
+
+function wrapTranslationFunctions(i18n: Composer, ctx: ComposableContext, serverI18n: H3EventContext['nuxtI18n']) {
+  const originalT = i18n.t.bind(i18n)
+  type TParams = Parameters<typeof originalT>
+  i18n.t = (
+    key: string,
+    listOrNamed?: string | number | unknown[] | Record<string, unknown>,
+    opts?: TranslateOptions<string> | number | string
+  ) => {
+    const locale = ((typeof opts === 'object' && opts?.locale) || ctx.getLocale()) as string
+    serverI18n?.trackKey(key, locale)
+    // @ts-expect-error type mismatch
+    return originalT(key, listOrNamed as TParams[1], opts)
+  }
+
+  const originalTe = i18n.te.bind(i18n)
+  i18n.te = (key, locale) => {
+    serverI18n?.trackKey(key, locale || ctx.getLocale())
+    return originalTe(key, locale)
+  }
+
+  const originalTm = i18n.tm.bind(i18n)
+  i18n.tm = key => {
+    serverI18n?.trackKey(key, ctx.getLocale())
+    return originalTm(key)
+  }
+}
+
+async function mergePayloadMessages(nuxtI18nCtx: NuxtApp['_nuxtI18nCtx'], i18n: Composer, nuxt = useNuxtApp()) {
+  const content = document.querySelector(`[data-nuxt-i18n="${nuxt._id}"]`)?.textContent
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const preloadedMessages: LocaleMessages<DefineLocaleMessage> = content && parse(content)
+
+  const preloadedKeys = Object.keys(preloadedMessages || {})
+  if (preloadedMessages && preloadedKeys.length && nuxtI18nCtx.dynamicResourcesSSG) {
+    try {
+      const msg = await Promise.all(
+        preloadedKeys.map(async locale => {
+          const m = await getLocaleMessagesMergedCached(locale, localeLoaders[locale])
+          return { [locale]: m }
+        })
+      )
+      for (const m of msg) {
+        deepCopy(m, i18n.messages)
+      }
+      nuxtI18nCtx.preloaded = true
+    } catch (e) {
+      console.log('Error loading messages', e)
+    }
+  }
+}

--- a/src/runtime/plugins/route-locale-detect.ts
+++ b/src/runtime/plugins/route-locale-detect.ts
@@ -7,7 +7,7 @@ import type { CompatRoute } from '../types'
 
 export default defineNuxtPlugin({
   name: 'i18n:plugin:route-locale-detect',
-  dependsOn: ['i18n:plugin'],
+  dependsOn: !__I18N_PRELOAD__ ? ['i18n:plugin'] : ['i18n:plugin', 'i18n:plugin:preload'],
   async setup() {
     const logger = /*#__PURE__*/ createLogger('plugin:route-locale-detect')
     const nuxt = useNuxtApp()

--- a/src/runtime/plugins/ssg-detect.ts
+++ b/src/runtime/plugins/ssg-detect.ts
@@ -5,7 +5,9 @@ import { detectBrowserLanguage } from '../internal'
 
 export default defineNuxtPlugin({
   name: 'i18n:plugin:ssg-detect',
-  dependsOn: ['i18n:plugin', 'i18n:plugin:route-locale-detect'],
+  dependsOn: !__I18N_PRELOAD__
+    ? ['i18n:plugin', 'i18n:plugin:route-locale-detect']
+    : ['i18n:plugin', 'i18n:plugin:route-locale-detect', 'i18n:plugin:preload'],
   enforce: 'post',
   setup() {
     const nuxt = /*#__PURE__*/ useNuxtApp()

--- a/src/runtime/server/context.ts
+++ b/src/runtime/server/context.ts
@@ -24,15 +24,10 @@ if (import.meta.dev) {
 export const fetchMessages = async (locale: string) =>
   await $fetch<LocaleMessages<DefineLocaleMessage>>(`/_i18n/${locale}/messages.json`, { headers })
 
-type ContextParams = Pick<NonNullable<H3EventContext['nuxtI18n']>, 'getFallbackLocales' | 'localeConfigs'>
-export function createI18nContext({
-  getFallbackLocales,
-  localeConfigs
-}: ContextParams): NonNullable<H3EventContext['nuxtI18n']> {
+export function createI18nContext(): NonNullable<H3EventContext['nuxtI18n']> {
   return {
     messages: {},
-    getFallbackLocales,
-    localeConfigs,
+    localeConfigs: {},
     trackMap: {},
     trackKey(key, locale) {
       this.trackMap[locale] ??= new Set<string>()
@@ -57,15 +52,10 @@ declare module 'h3' {
     /** @internal */
     nuxtI18n?: {
       /**
-       * Get the fallback locales for the specified locale
-       * @internal
-       */
-      getFallbackLocales: (locale: string) => string[]
-      /**
        * Cached locale configurations based on runtime config
        * @internal
        */
-      localeConfigs: Record<string, ServerLocaleConfig>
+      localeConfigs?: Record<string, ServerLocaleConfig>
       /**
        * The loaded messages for the current request, used to insert into the rendered HTML for hydration
        * @internal

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -4,12 +4,10 @@ import { defineNitroPlugin } from 'nitropack/runtime'
 import { tryUseI18nContext, createI18nContext } from './context'
 import { createUserLocaleDetector } from './utils/locale-detector'
 import { pickNested } from './utils/messages-utils'
-import { isLocaleWithFallbacksCacheable } from './utils/cache'
-import { getFallbackLocaleCodes } from '../shared/messages'
+import { createLocaleConfigs } from '../shared/locales'
 import { setupVueI18nOptions } from '../shared/vue-i18n'
 // @ts-expect-error virtual file
 import { appId } from '#internal/nuxt.config.mjs'
-import { localeCodes } from '#internal/i18n/options.mjs'
 import { localeDetector } from '#internal/i18n/locale.detector.mjs'
 
 import type { H3Event } from 'h3'
@@ -17,15 +15,7 @@ import type { CoreOptions } from '@intlify/core'
 
 export default defineNitroPlugin(async nitro => {
   const options = await setupVueI18nOptions()
-
-  const getFallbackLocales = (locale: string) => getFallbackLocaleCodes(options.fallbackLocale, [locale])
-
-  const localeConfigs: Record<string, { cacheable: boolean; fallbacks: string[] }> = {}
-  for (const locale of localeCodes) {
-    const fallbacks = getFallbackLocales(locale)
-    const cacheable = isLocaleWithFallbacksCacheable(locale, fallbacks)
-    localeConfigs[locale] = { fallbacks, cacheable }
-  }
+  const localeConfigs = createLocaleConfigs(options.fallbackLocale)
 
   nitro.hooks.hook('request', async (event: H3Event) => {
     event.context.nuxtI18n = createI18nContext()

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -1,37 +1,22 @@
 import { stringify } from 'devalue'
 import { defineI18nMiddleware } from '@intlify/h3'
-import { getRequestHeader } from 'h3'
-import { deepCopy } from '@intlify/shared'
 import { defineNitroPlugin } from 'nitropack/runtime'
 import { tryUseI18nContext, createI18nContext } from './context'
-import { createDefaultLocaleDetector, createUserLocaleDetector } from './utils/locale-detector'
+import { createUserLocaleDetector } from './utils/locale-detector'
 import { pickNested } from './utils/messages-utils'
 import { isLocaleWithFallbacksCacheable } from './utils/cache'
-import { getAllMergedMessages, getMergedMessages } from './utils/messages'
 import { getFallbackLocaleCodes } from '../shared/messages'
+import { setupVueI18nOptions } from '../shared/vue-i18n'
 // @ts-expect-error virtual file
 import { appId } from '#internal/nuxt.config.mjs'
+import { localeCodes } from '#internal/i18n/options.mjs'
 import { localeDetector } from '#internal/i18n/locale.detector.mjs'
-import { createLocaleFromRouteGetter } from '#i18n-kit/routing'
-import { setupVueI18nOptions } from '../shared/vue-i18n'
 
 import type { H3Event } from 'h3'
 import type { CoreOptions } from '@intlify/core'
 
 export default defineNitroPlugin(async nitro => {
   const options = await setupVueI18nOptions()
-  const localeCodes = Object.keys(options.messages)
-
-  const localeFromRoute = createLocaleFromRouteGetter({
-    separator: __ROUTE_NAME_SEPARATOR__,
-    defaultSuffix: __ROUTE_NAME_DEFAULT_SUFFIX__,
-    localeCodes
-  })
-
-  const defaultLocaleDetector = createDefaultLocaleDetector({
-    defaultLocale: options.locale,
-    tryRouteLocale: (event: H3Event) => localeFromRoute(event.path) || null
-  })
 
   const getFallbackLocales = (locale: string) => getFallbackLocaleCodes(options.fallbackLocale, [locale])
 
@@ -43,25 +28,12 @@ export default defineNitroPlugin(async nitro => {
   }
 
   nitro.hooks.hook('request', async (event: H3Event) => {
-    const ctx = createI18nContext({ getFallbackLocales, localeConfigs })
-    event.context.nuxtI18n = ctx
-    event.context.vueI18nOptions = options
-
-    for (const locale of localeCodes) {
-      ctx.messages[locale] ??= {}
-      deepCopy(options.messages[locale], ctx.messages[locale])
-    }
-
-    // skip if the request is internal
-    if (getRequestHeader(event, 'x-nuxt-i18n')) return
-
-    const locale = defaultLocaleDetector(event)
-    const messages = await getMergedMessages(locale, localeConfigs?.[locale]?.fallbacks ?? [])
-    deepCopy(messages, ctx.messages)
+    event.context.nuxtI18n = createI18nContext()
+    event.context.nuxtI18n.localeConfigs = localeConfigs
   })
 
-  if (__I18N_PRELOAD__) {
-    nitro.hooks.hook('render:html', (htmlContext, { event }) => {
+  nitro.hooks.hook('render:html', (htmlContext, { event }) => {
+    if (__I18N_PRELOAD__) {
       const ctx = tryUseI18nContext(event)
       if (ctx == null || Object.keys(ctx.messages ?? {}).length == 0) return
 
@@ -96,11 +68,12 @@ export default defineNitroPlugin(async nitro => {
       } catch (_) {
         console.log(_)
       }
-    })
-  }
+    }
+  })
 
   // enable server-side translations and user locale-detector
   if (localeDetector != null) {
+    const options = await setupVueI18nOptions()
     const i18nMiddleware = defineI18nMiddleware({
       ...(options as CoreOptions),
       locale: createUserLocaleDetector(options.locale, options.fallbackLocale)

--- a/src/runtime/server/routes/messages.ts
+++ b/src/runtime/server/routes/messages.ts
@@ -17,7 +17,7 @@ const _messagesHandler = defineEventHandler(async (event: H3Event) => {
   }
 
   const ctx = useI18nContext(event)
-  if (locale in ctx.localeConfigs === false) {
+  if (ctx.localeConfigs && locale in ctx.localeConfigs === false) {
     throw createError({ status: 404, message: `Locale '${locale}' not found.` })
   }
 

--- a/src/runtime/shared/cache.ts
+++ b/src/runtime/shared/cache.ts
@@ -1,0 +1,15 @@
+import { localeLoaders } from '#build/i18n.options.mjs'
+
+/**
+ * Check if the loaders for the specified locale are all cacheable
+ */
+function isLocaleCacheable(locale: string) {
+  return localeLoaders[locale] != null && localeLoaders[locale].every(loader => loader.cache !== false)
+}
+
+/**
+ * Check if the loaders for the specified locale and fallback locales are all cacheable
+ */
+export function isLocaleWithFallbacksCacheable(locale: string, fallbackLocales: string[]) {
+  return isLocaleCacheable(locale) && fallbackLocales.every(fallbackLocale => isLocaleCacheable(fallbackLocale))
+}

--- a/src/runtime/shared/locales.ts
+++ b/src/runtime/shared/locales.ts
@@ -1,0 +1,17 @@
+import { localeCodes } from '#build/i18n.options.mjs'
+import { getFallbackLocaleCodes } from './messages'
+import { isLocaleWithFallbacksCacheable } from './cache'
+import type { FallbackLocale } from 'vue-i18n'
+
+type LocaleConfig = { cacheable: boolean; fallbacks: string[] }
+export function createLocaleConfigs(fallbackLocale: FallbackLocale): Record<string, LocaleConfig> {
+  const localeConfigs: Record<string, LocaleConfig> = {}
+
+  for (const locale of localeCodes) {
+    const fallbacks = getFallbackLocaleCodes(fallbackLocale, [locale])
+    const cacheable = isLocaleWithFallbacksCacheable(locale, fallbacks)
+    localeConfigs[locale] = { fallbacks, cacheable }
+  }
+
+  return localeConfigs
+}

--- a/src/runtime/shared/vue-i18n.ts
+++ b/src/runtime/shared/vue-i18n.ts
@@ -13,9 +13,10 @@ export const setupVueI18nOptions = async (): Promise<ResolvedI18nOptions> => {
   const options = await loadVueI18nOptions(vueI18nConfigs)
 
   options.locale = runtimeI18n.defaultLocale || options.locale || 'en-US'
-  options.fallbackLocale = options.fallbackLocale ?? false
-
+  options.fallbackLocale ??= false
   options.messages ??= {}
+
+  // initialize locale objects to make vue-i18n aware of available locales
   for (const locale of _localeCodes) {
     options.messages[locale] ??= {}
   }

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -162,6 +162,7 @@ declare module '#app' {
     _nuxtI18nCtx: {
       preloaded: boolean
       firstAccess: boolean
+      dynamicResourcesSSG: boolean
       setLocale: (locale: string) => void
       getDomainFromLocale: (locale: Locale) => string | undefined
       getLocaleFromRoute: (route: string | CompatRoute) => string


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a plugin to preload internationalization (i18n) messages, improving initial load performance and ensuring translation keys are tracked during server-side rendering.
  - Added cacheability checks for locale loaders to optimize caching of i18n resources.
- **Improvements**
  - Simplified i18n setup and message loading logic for better maintainability and efficiency.
  - Streamlined server-side i18n context creation and handling of locale configurations.
  - Enhanced client-side message merging and dynamic resource loading for static sites.
  - Reduced complexity in server request handling by deferring locale detection and message merging to middleware.
  - Updated plugin dependencies to conditionally include the preload plugin, optimizing loading order.
- **Bug Fixes**
  - Improved error handling during message loading to prevent failures from impacting the user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->