### PR TITLE
refactor: rework internal nuxt i18n context

### DIFF
--- a/src/runtime/composables/index.ts
+++ b/src/runtime/composables/index.ts
@@ -281,7 +281,7 @@ export function useI18nPreloadKeys(keys: string[]): void {
     }
 
     const locale = useComposableContext().getLocale()
-    if (locale) {
+    if (!locale) {
       console.warn('useI18nPreloadKeys(): Could not resolve locale during server-side render.')
       return
     }

--- a/src/runtime/composables/index.ts
+++ b/src/runtime/composables/index.ts
@@ -214,8 +214,7 @@ export function useCookieLocale(): Ref<string> {
   if (!detect || !detect.useCookie) {
     return locale
   }
-
-  const locales = useNuxtApp()._nuxtI18n.getLocales()
+  const locales = useComposableContext().getLocales()
   const code = useCookie(detect.cookieKey).value
   if (code && locales.some(x => x.code === code)) {
     locale.value = code
@@ -281,7 +280,7 @@ export function useI18nPreloadKeys(keys: string[]): void {
       return
     }
 
-    const locale = useNuxtApp()._nuxtI18n.getLocale()
+    const locale = useComposableContext().getLocale()
     if (locale) {
       console.warn('useI18nPreloadKeys(): Could not resolve locale during server-side render.')
       return

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -1,0 +1,116 @@
+import { isRef, unref } from 'vue'
+
+import { useNuxtApp, useState } from '#imports'
+import { localeCodes, localeLoaders } from '#build/i18n.options.mjs'
+import { getLocaleMessagesMergedCached } from './shared/messages'
+import { createBaseUrlGetter } from './utils'
+import { createLocaleFromRouteGetter } from '#i18n-kit/routing'
+import { getI18nTarget } from './compatibility'
+import { createDomainFromLocaleGetter } from './domain'
+import { joinURL } from 'ufo'
+
+import type { Locale, I18n } from 'vue-i18n'
+import type { NuxtApp } from '#app'
+import type { LocaleObject } from '#internal-i18n-types'
+import type { CompatRoute } from './types'
+import { isString } from '@intlify/shared'
+
+export const useLocaleConfigs = () =>
+  useState<Record<string, { cacheable: boolean; fallbacks: string[] }>>('i18n:cached-locale-configs', () => ({}))
+
+/**
+ * @internal
+ */
+export type NuxtI18nContext = {
+  /** Locale messages attached during SSR and loaded during hydration */
+  preloaded: boolean
+  /** Initial request/visit */
+  firstAccess: boolean
+  /** SSG with dynamic locale resources */
+  dynamicResourcesSSG: boolean
+  getVueI18n: () => I18n
+  /** Load locale messages */
+  loadLocaleMessages: (locale: Locale) => Promise<void>
+  /** Get current locale */
+  getLocale: () => string
+  /** Set locale directly  */
+  setLocale: (locale: string) => void
+  /** Get normalized runtime locales */
+  getLocales: () => LocaleObject[]
+  /** Get locale from route path or object */
+  getLocaleFromRoute: (route: string | CompatRoute) => string
+  /** Get current base URL */
+  getBaseUrl: () => string
+  /** Get domain associated with locale */
+  getDomainFromLocale: (locale: Locale) => string | undefined
+}
+
+export function createNuxtI18nContext(nuxt: NuxtApp, _i18n: I18n): NuxtI18nContext {
+  const i18n = getI18nTarget(_i18n)
+  const serverLocaleConfigs = useLocaleConfigs()
+
+  const dynamicResourcesSSG = !__I18N_FULL_STATIC__ && (import.meta.prerender || __IS_SSG__)
+  /** Get computed config for locale */
+  const getLocaleConfig = (locale: string) => serverLocaleConfigs.value[locale]
+  const getDomainFromLocale = createDomainFromLocaleGetter(nuxt)
+  const baseUrl = createBaseUrlGetter(nuxt, getDomainFromLocale)
+
+  return {
+    firstAccess: true,
+    preloaded: false,
+    dynamicResourcesSSG,
+    getVueI18n: () => _i18n,
+    getLocale: () => unref(i18n.locale),
+    setLocale: (locale: string) => {
+      if (isRef(i18n.locale)) {
+        i18n.locale.value = locale
+      } else {
+        i18n.locale = locale
+      }
+    },
+    getLocales: () => unref(i18n.locales).map(x => (isString(x) ? { code: x } : x)),
+    getLocaleFromRoute: createLocaleFromRouteGetter({
+      separator: __ROUTE_NAME_SEPARATOR__,
+      defaultSuffix: __ROUTE_NAME_DEFAULT_SUFFIX__,
+      localeCodes
+    }),
+    getBaseUrl: () => joinURL(baseUrl(), nuxt.$config.app.baseURL),
+    getDomainFromLocale,
+    loadLocaleMessages: async (locale: string) => {
+      if (dynamicResourcesSSG || import.meta.dev) {
+        const locales = getLocaleConfig(locale)?.fallbacks ?? []
+        if (!locales.includes(locale)) {
+          locales.push(locale)
+        }
+        for (const entry of locales) {
+          i18n.mergeLocaleMessage(
+            entry,
+            await nuxt.runWithContext(() => getLocaleMessagesMergedCached(entry, localeLoaders[entry]))
+          )
+        }
+        return
+      }
+
+      const headers = new Headers()
+      if (!getLocaleConfig(locale)?.cacheable) {
+        headers.set('Cache-Control', 'no-cache')
+      }
+
+      try {
+        const messages = await $fetch(`/_i18n/${locale}/messages.json`, { headers })
+        for (const locale of Object.keys(messages)) {
+          i18n.mergeLocaleMessage(locale, messages[locale])
+        }
+      } catch (e) {
+        console.warn('Failed to load messages for locale', locale, e)
+      }
+    }
+  }
+}
+
+export function useNuxtI18nContext(nuxt: NuxtApp = useNuxtApp()) {
+  if (nuxt._nuxtI18nCtx == null) {
+    throw new Error('Nuxt I18n context has not been set up yet.')
+  }
+  return nuxt._nuxtI18nCtx
+}

--- a/src/runtime/plugins/preload.ts
+++ b/src/runtime/plugins/preload.ts
@@ -1,9 +1,9 @@
 import { parse } from 'devalue'
 import { unref } from 'vue'
-import { useNuxtApp, defineNuxtPlugin, type NuxtApp } from '#app'
+import { useNuxtApp, defineNuxtPlugin } from '#app'
 import { localeCodes, localeLoaders } from '#build/i18n.options.mjs'
 import { getLocaleMessagesMergedCached } from '../shared/messages'
-import { useNuxtI18nContext } from '../context'
+import { useNuxtI18nContext, type NuxtI18nContext } from '../context'
 
 import type { Composer, VueI18n } from 'vue-i18n'
 import type { LocaleMessages, DefineLocaleMessage } from 'vue-i18n'
@@ -63,7 +63,7 @@ export default defineNuxtPlugin({
 /**
  * Merge preloaded messages from serialized messages payload
  */
-async function mergePayloadMessages(ctx: NuxtApp['_nuxtI18nCtx'], i18n: Composer | VueI18n, nuxt = useNuxtApp()) {
+async function mergePayloadMessages(ctx: NuxtI18nContext, i18n: Composer | VueI18n, nuxt = useNuxtApp()) {
   const content = document.querySelector(`[data-nuxt-i18n="${nuxt._id}"]`)?.textContent
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const preloadedMessages: LocaleMessages<DefineLocaleMessage> = content && parse(content)

--- a/src/runtime/plugins/route-locale-detect.ts
+++ b/src/runtime/plugins/route-locale-detect.ts
@@ -4,6 +4,7 @@ import { createLogger } from '#nuxt-i18n/logger'
 import { detectLocale, detectRedirect, loadAndSetLocale, navigate } from '../utils'
 
 import type { CompatRoute } from '../types'
+import { useNuxtI18nContext } from '../context'
 
 export default defineNuxtPlugin({
   name: 'i18n:plugin:route-locale-detect',
@@ -11,7 +12,7 @@ export default defineNuxtPlugin({
   async setup() {
     const logger = /*#__PURE__*/ createLogger('plugin:route-locale-detect')
     const nuxt = useNuxtApp()
-    const ctx = nuxt._nuxtI18nCtx
+    const ctx = useNuxtI18nContext(nuxt)
 
     async function handleRouteDetect(to: CompatRoute) {
       let detected = detectLocale(to, ctx.getLocaleFromRoute(to))

--- a/src/runtime/plugins/ssg-detect.ts
+++ b/src/runtime/plugins/ssg-detect.ts
@@ -1,5 +1,6 @@
 import { defineNuxtPlugin, useNuxtApp } from '#imports'
 import { createLogger } from '#nuxt-i18n/logger'
+import { useNuxtI18nContext } from '../context'
 import { detectLocale } from '../utils'
 
 export default defineNuxtPlugin({
@@ -10,11 +11,10 @@ export default defineNuxtPlugin({
   enforce: 'post',
   setup() {
     const nuxt = /*#__PURE__*/ useNuxtApp()
-    const ctx = nuxt._nuxtI18nCtx
     if (!__IS_SSG__ || __I18N_STRATEGY__ !== 'no_prefix' || !nuxt.$config.public.i18n.detectBrowserLanguage) return
 
     const logger = /*#__PURE__*/ createLogger('plugin:i18n:ssg-detect')
-
+    const ctx = useNuxtI18nContext(nuxt)
     // NOTE: avoid hydration mismatch for SSG mode
     nuxt.hook('app:mounted', async () => {
       const detected = detectLocale(nuxt.$router.currentRoute.value, '')

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,9 +1,10 @@
 import type { NuxtApp } from '#app'
 import type { ComputedRef } from 'vue'
 import type { Directions, LocaleObject, Strategies } from '#internal-i18n-types'
-import type { I18n, Locale, Composer, VueI18n, ExportedGlobalComposer } from 'vue-i18n'
+import type { Locale, Composer, VueI18n, ExportedGlobalComposer } from 'vue-i18n'
 import type { RouteLocationAsRelative, RouteLocationNormalizedGeneric, RouteRecordNameGeneric } from 'vue-router'
 import type { ComposableContext } from './utils'
+import type { NuxtI18nContext } from './context'
 
 export type CompatRoute = Omit<RouteLocationNormalizedGeneric, 'name'> & {
   name: RouteRecordNameGeneric | null
@@ -156,19 +157,7 @@ export interface ComposerCustomProperties<
 declare module '#app' {
   interface NuxtApp {
     /** @internal */
-    _vueI18n: I18n
-
-    /** @internal */
-    _nuxtI18nCtx: {
-      preloaded: boolean
-      firstAccess: boolean
-      dynamicResourcesSSG: boolean
-      setLocale: (locale: string) => void
-      getDomainFromLocale: (locale: Locale) => string | undefined
-      getLocaleFromRoute: (route: string | CompatRoute) => string
-      getLocaleConfig: (locale: Locale) => { cacheable: boolean; fallbacks: string[] } | undefined
-      loadLocaleMessages: (locale: Locale) => Promise<void>
-    }
+    _nuxtI18nCtx: NuxtI18nContext
     /** @internal */
     _nuxtI18n: ComposableContext
   }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Recent changes have introduced some fragmented logic, this PR aims to organize context logic and prevent composable context usage outside of composable functions.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Centralized management of locale and internationalization (i18n) state with a new context system, improving consistency across the app.

- **Refactor**
  - Replaced direct access to internal i18n properties with a composable context, enhancing encapsulation and maintainability.
  - Simplified plugin and utility setup by using unified context methods for locale and message management.
  - Updated function signatures to align with the new context-based approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->