### PR TITLE
fix: remove side-effects from `getLocaleCookie`

### DIFF
--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -117,8 +117,7 @@ export default defineNuxtPlugin({
         composer.differentDomains = __DIFFERENT_DOMAINS__
         composer.defaultLocale = runtimeI18n.defaultLocale
         composer.getBrowserLocale = () => getBrowserLocale()
-        composer.getLocaleCookie = () =>
-          getLocaleCookie(localeCookie, runtimeI18n.detectBrowserLanguage, composer.defaultLocale)
+        composer.getLocaleCookie = () => getLocaleCookie(localeCookie, runtimeI18n.detectBrowserLanguage)
         composer.setLocaleCookie = (locale: string) => {
           if (!runtimeI18n.detectBrowserLanguage || !runtimeI18n.detectBrowserLanguage.useCookie) return
           localeCookie.value = locale


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Honestly not entirely sure why tests are not failing without these side effects, perhaps previous reworks have made locale detection and cooking syncing more reliable 🤔
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified cookie creation and retrieval logic for language preferences, making functions more concise and focused.
  - Removed default locale fallback and side effects when reading language preference cookies.
  - Improved internal handling of language detection options for a cleaner experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->