### PR TITLE
refactor: remove dead code for different domains redirection

### DIFF
--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -1,6 +1,6 @@
 import { isEqual, joinURL, withoutTrailingSlash, withTrailingSlash } from 'ufo'
 import { isFunction, isString } from '@intlify/shared'
-import { navigateTo, useNuxtApp, useRouter, useState } from '#imports'
+import { navigateTo, useNuxtApp, useRouter } from '#imports'
 import { localeCodes, normalizedLocales, vueI18nConfigs } from '#build/i18n.options.mjs'
 import { getComposer } from './compatibility'
 import { getHost, getLocaleDomain } from './domain'
@@ -247,9 +247,6 @@ export function detectRedirect(to: CompatRoute, locale: string): string {
   return redirectPath
 }
 
-// composable function for redirect loop avoiding
-const useRedirectState = () => useState<string>(__NUXT_I18N_MODULE_ID__ + ':redirect', () => '')
-
 const PERMISSIVE_LOCALE_PATH_RE = new RegExp(`^(?:/(${localeCodes.join('|')}))?(/.*|$)`, 'i')
 /**
  * Returns the prefix and path of a route.
@@ -307,18 +304,7 @@ export async function navigate(redirectPath: string, routePath: string, locale: 
     return
   }
 
-  if (__DIFFERENT_DOMAINS__) {
-    const state = useRedirectState()
-    if (state.value && state.value !== redirectPath) {
-      if (import.meta.client) {
-        state.value = '' // reset redirect path
-        window.location.assign(redirectPath)
-      }
-      if (import.meta.server) {
-        state.value = redirectPath // set redirect path
-      }
-    }
-  } else if (redirectPath) {
+  if (!__DIFFERENT_DOMAINS__ && redirectPath) {
     return navigateTo(redirectPath)
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
It appears the `useRedirectState` value is never set to a truthy value, so the code in `navigate` is not hit, from what I can tell this has been like this since v8 🤔
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified redirect logic by removing domain-specific handling and related state management. Redirects now use a unified approach without tracking redirect paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->