### PR TITLE
fix: index route for ssg with strategy prefix

### DIFF
--- a/src/pages.ts
+++ b/src/pages.ts
@@ -88,7 +88,7 @@ export async function setupPages({ localeCodes, options }: I18nNuxtContext, nuxt
 
       // keep root when using prefixed routing without prerendering
       const indexPage = pages.find(x => x.path === '/')
-      if (!nuxt.options._generate && options.strategy === 'prefix' && indexPage != null) {
+      if (options.strategy === 'prefix' && indexPage != null) {
         localizedPages.unshift(indexPage as NarrowedNuxtPage)
       }
 

--- a/src/prepare/strategy.ts
+++ b/src/prepare/strategy.ts
@@ -3,15 +3,10 @@ import type { Nuxt } from '@nuxt/schema'
 
 export function prepareStrategy({ options, normalizedLocales }: I18nNuxtContext, nuxt: Nuxt) {
   if (options.strategy === 'prefix' && nuxt.options._generate) {
+    // add localized routes as entry pages for prerendering
     const localizedEntryPages = normalizedLocales.map(x => ['/', x.code].join(''))
     nuxt.hook('nitro:config', config => {
       config.prerender ??= {}
-
-      // ignore `/` which is added by nitro by default
-      config.prerender.ignore ??= []
-      config.prerender.ignore.push(/^\/$/)
-
-      // add localized routes as entry pages for prerendering
       config.prerender.routes ??= []
       config.prerender.routes.push(...localizedEntryPages)
     })

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -304,6 +304,10 @@ export function navigate(redirectPath: string, routePath: string, locale: string
   const { rootRedirect, skipSettingLocaleOnNavigate } = nuxt.$config.public.i18n as I18nPublicRuntimeConfig
   const ctx = useNuxtI18nContext(nuxt)
 
+  if (__I18N_STRATEGY__ === 'prefix' && __IS_SSG__ && routePath === '/') {
+    return
+  }
+
   if (routePath === '/' && rootRedirect) {
     let redirectCode = 302
     if (isString(rootRedirect)) {


### PR DESCRIPTION
### 🔗 Linked issue
* #3624
* #2790
* Possibly #2820
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This PR changes the index route handling when using the prefix strategy with SSG, instead of being removed from the output, it will be replaced with a basic language detection and redirection script.

This PR lacks documentation and tests, it may take a while until this is finished, stable release of v10 has priority over this.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic client-side redirection from the root path to the appropriate locale-prefixed page during static site generation when using the 'prefix' strategy.
- **Bug Fixes**
  - Improved navigation logic to prevent unwanted redirects from the root path in specific static site scenarios.
- **Refactor**
  - Simplified the logic for including the root index page in localized page lists.
  - Updated prerendering behavior to rely on default handling for the root path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->