### PR TITLE
refactor: simplify route locale parsing

### DIFF
--- a/src/runtime/kit/routing.ts
+++ b/src/runtime/kit/routing.ts
@@ -1,20 +1,5 @@
+import { createPathIndexLanguageParser } from '@intlify/utils'
 import type { RouteName, RouteObject } from './types'
-
-export function getRouteNameLocaleRegex(
-  options: { localeCodes: string[]; separator: string; defaultSuffix: string },
-  localesPattern: string = getLocalesPattern(options.localeCodes)
-) {
-  const defaultSuffixPattern = `(?:${options.separator}${options.defaultSuffix})?`
-  return new RegExp(`${options.separator}${localesPattern}${defaultSuffixPattern}$`, 'i')
-}
-
-/**
- * Convenience function to return the first match of the regex or empty string
- * @internal
- */
-export function createNameLocaleRegexMatcher(re: RegExp) {
-  return (val: string) => val.match(re)?.[1] ?? ''
-}
 
 /**
  * Normalizes {@link RouteName} to string
@@ -56,59 +41,28 @@ export function getLocalizedRouteName(
   return routeName + separator + locale
 }
 
-/**
- * Match locale code from route path (e.g. `/en/about` => `en`)
- * @internal
- */
-export function getRoutePathLocaleRegex(
-  localeCodes: string[],
-  localesPattern: string = getLocalesPattern(localeCodes)
-) {
-  return new RegExp(`^/${localesPattern}(?:/|$)`, 'i')
-}
+const pathLanguageParser = createPathIndexLanguageParser(0)
+export const getLocaleFromRoutePath = (path: string) => pathLanguageParser(path)
+export const getLocaleFromRouteName = (name: string, separator: string = '___') => name.split(separator).at(1) ?? ''
 
-function getLocalesPattern(localeCodes: string[]) {
-  return `(${localeCodes.join('|')})`
+function normalizeInput(input: RouteName | RouteObject) {
+  if (typeof input === 'object') {
+    return String(input?.name || input?.path || '')
+  }
+  return String(input)
 }
 
 /**
  * NOTE: this likely needs to be implemented on the utility function consumer side
  * @internal
  */
-export function createLocaleFromRouteGetter(options: {
-  localeCodes: string[]
-  separator: string
-  defaultSuffix: string
-}) {
-  const localesPattern = getLocalesPattern(options.localeCodes)
-  const regexpName = getRouteNameLocaleRegex(options, localesPattern)
-  const regexpPath = getRoutePathLocaleRegex(options.localeCodes, localesPattern)
-
-  const matchPath = createNameLocaleRegexMatcher(regexpPath)
-  const matchName = createNameLocaleRegexMatcher(regexpName)
-
-  /**
-   * extract locale code from route name or path
-   */
+export function createLocaleFromRouteGetter(separator: string = '___') {
+  // extract locale code from route name or path
   return (route: RouteName | RouteObject) => {
-    if (typeof route === 'string') {
-      return matchPath(route)
+    const input = normalizeInput(route)
+    if (input[0] === '/') {
+      return getLocaleFromRoutePath(input)
     }
-
-    if (typeof route === 'symbol') {
-      return matchPath(String(route))
-    }
-
-    // extract from route name
-    if (route?.name) {
-      return matchName(normalizeRouteName(route.name))
-    }
-
-    // extract from path
-    if (route?.path) {
-      return matchPath(route.path)
-    }
-
-    return ''
+    return getLocaleFromRouteName(input, separator)
   }
 }

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -6,7 +6,7 @@ import { getComposer } from './compatibility'
 import { getHost, getLocaleDomain } from './domain'
 import { loadVueI18nOptions } from './shared/messages'
 import { createLocaleRouteNameGetter, createLocalizedRouteByPathResolver } from './routing/utils'
-import { getRouteBaseName as _getRouteBaseName, getRoutePathLocaleRegex } from '#i18n-kit/routing'
+import { getRouteBaseName as _getRouteBaseName } from '#i18n-kit/routing'
 import {
   localePath,
   switchLocalePath,
@@ -165,9 +165,7 @@ export async function loadAndSetLocale(locale: Locale): Promise<string> {
   return locale
 }
 
-const LOCALE_PATH_RE = getRoutePathLocaleRegex(localeCodes)
-
-function skipDetect(detect: DetectBrowserLanguageOptions, path: string): boolean {
+function skipDetect(detect: DetectBrowserLanguageOptions, path: string, pathLocale: string): boolean {
   // no routes - force detection
   if (!__I18N_ROUTING__) {
     return false
@@ -179,7 +177,7 @@ function skipDetect(detect: DetectBrowserLanguageOptions, path: string): boolean
   }
 
   // detection only on unprefixed route
-  if (detect.redirectOn === 'no prefix' && !detect.alwaysRedirect && path.match(LOCALE_PATH_RE)) {
+  if (detect.redirectOn === 'no prefix' && !detect.alwaysRedirect && pathLocale) {
     return true
   }
 
@@ -190,11 +188,11 @@ export function detectLocale(route: string | CompatRoute): string {
   const nuxtApp = useNuxtApp()
   const path = getCompatRoutePath(route)
   const ctx = useNuxtI18nContext(nuxtApp)
-  const { detectBrowserLanguage, defaultLocale } = nuxtApp.$config.public.i18n as I18nPublicRuntimeConfig
-  const { fallbackLocale } = detectBrowserLanguage || {}
+  const { detectBrowserLanguage: detectBrowser, defaultLocale } = nuxtApp.$config.public.i18n as I18nPublicRuntimeConfig
+  const { fallbackLocale } = detectBrowser || {}
 
   function* detect() {
-    if (ctx.firstAccess && detectBrowserLanguage && !skipDetect(detectBrowserLanguage, path)) {
+    if (ctx.firstAccess && detectBrowser && !skipDetect(detectBrowser, path, ctx.getLocaleFromRoute(path))) {
       // cookie
       yield ctx.getLocaleCookie()
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Further adoption of `@intlify/utils` functions and moving away from regex matching to simpler solutions.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined locale extraction from route names and paths by replacing complex regex logic with direct string parsing and dedicated helper functions.
  - Simplified internal logic for locale validation and detection, resulting in more efficient and maintainable code.
- **Bug Fixes**
  - Improved handling of unsupported locales, ensuring that only valid locales are processed and preventing unnecessary operations for unsupported ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->