### PR TITLE
fix: `<NuxtLinkLocale>` not localizing paths when setting `target` prop

### DIFF
--- a/specs/basic-usage-tests.ts
+++ b/specs/basic-usage-tests.ts
@@ -42,6 +42,9 @@ export function basicUsageTests() {
     expect(await page.locator('#nuxt-link-locale-usages .external-url a').getAttribute('href')).toEqual(
       'https://nuxt.com/'
     )
+    expect(await page.locator('#nuxt-link-locale-usages .target-blank-with-locale a').getAttribute('href')).toEqual(
+      '/fr/about'
+    )
 
     // Language switching path localizing with `useSwitchLocalePath`
     expect(await page.locator('#switch-locale-path-usages .switch-to-en a').getAttribute('href')).toEqual('/')

--- a/specs/fixtures/basic_usage/pages/index.vue
+++ b/specs/fixtures/basic_usage/pages/index.vue
@@ -168,6 +168,9 @@ useHead(() => ({
         <li class="external-url">
           <NuxtLinkLocale :to="'https://nuxt.com/'">Nuxt.com</NuxtLinkLocale>
         </li>
+        <li class="target-blank-with-locale">
+          <NuxtLinkLocale to="about" locale="fr" target="_blank">About us in French (new tab)</NuxtLinkLocale>
+        </li>
       </ul>
     </section>
     <section id="switch-locale-path-usages">

--- a/specs/fixtures/basic_usage_compat_4/app/pages/index.vue
+++ b/specs/fixtures/basic_usage_compat_4/app/pages/index.vue
@@ -168,6 +168,9 @@ useHead(() => ({
         <li class="external-url">
           <NuxtLinkLocale :to="'https://nuxt.com/'">Nuxt.com</NuxtLinkLocale>
         </li>
+        <li class="target-blank-with-locale">
+          <NuxtLinkLocale to="about" locale="fr" target="_blank">About us in French (new tab)</NuxtLinkLocale>
+        </li>
       </ul>
     </section>
     <section id="switch-locale-path-usages">


### PR DESCRIPTION
### 🔗 Linked issue
* #3252 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Resolves #3252 

These changes specifically target #3252 but does not fully sync the `<NuxtLinkLocale>` component with the latest implementation of `<NuxtLink>` as it appears to be a bit involved.

There may be other (unknown to me) issues that have already been resolved upstream in Nuxt's component, but until time is taken to go through its changes in depth, we will resolve issues as they come up (proper labeling will help with this https://github.com/nuxt-modules/i18n/issues?q=sort%3Aupdated-desc+state%3Aopen+label%3A%22nuxt-link-locale%22). 
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a localized link that opens the French "About" page in a new browser tab.

- **Bug Fixes**
  - Improved detection of external links to better handle absolute URLs.

- **Refactor**
  - Simplified and optimized internal logic for resolving localized routes and checking for prop conflicts.

- **Tests**
  - Added a test to verify that the new localized link correctly points to the French "About" page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->