### PR TITLE
fix: `switchLocalePath` missing `app.baseURL` when using `differentDomains`

### DIFF
--- a/specs/different_domains/different_domains_base_path.spec.ts
+++ b/specs/different_domains/different_domains_base_path.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect, describe } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, $fetch, undiciRequest } from '../utils'
+import { getDom } from '../helper'
+
+await setup({
+  rootDir: fileURLToPath(new URL(`../fixtures/different_domains`, import.meta.url)),
+  // overrides
+  nuxtConfig: {
+    extends: [fileURLToPath(new URL(`../fixtures/layers/layer-domain`, import.meta.url))],
+    app: {
+      baseURL: '/base-path'
+    },
+    i18n: {
+      baseUrl: 'http://localhost:3000',
+      locales: [
+        {
+          code: 'en',
+          language: 'en',
+          name: 'English',
+          domain: 'en.nuxt-app.localhost'
+        },
+        {
+          code: 'fr',
+          language: 'fr-FR',
+          name: 'Français',
+          domain: 'fr.nuxt-app.localhost'
+        },
+        {
+          code: 'kr',
+          language: 'ko-KR',
+          name: '한국어',
+          domain: 'kr.nuxt-app.localhost'
+        }
+      ],
+      differentDomains: true,
+      strategy: 'no_prefix',
+      detectBrowserLanguage: {
+        useCookie: true
+      },
+      customRoutes: 'config',
+      pages: {
+        'localized-route': {
+          en: '/localized-in-english',
+          fr: '/localized-in-french',
+          ja: '/localized-in-japanese',
+          nl: '/localized-in-dutch'
+        }
+      }
+    }
+  }
+})
+
+test('(#3628) `switchLocalePath` includes `app.baseURL`', async () => {
+  const res = await undiciRequest('/base-path')
+  const dom = getDom(await res.body.text())
+  expect(dom?.querySelector('#switch-locale-path-usages .switch-to-kr a')?.getAttribute('href')).toEqual(
+    `http://kr.nuxt-app.localhost/base-path`
+  )
+})

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -49,7 +49,7 @@ export type NuxtI18nContext = {
   /** Get locale from route path or object */
   getLocaleFromRoute: (route: string | CompatRoute) => string
   /** Get current base URL */
-  getBaseUrl: () => string
+  getBaseUrl: (locale?: string) => string
   /** Get domain associated with locale */
   getDomainFromLocale: (locale: Locale) => string | undefined
 }
@@ -110,7 +110,12 @@ export function createNuxtI18nContext(nuxt: NuxtApp, _i18n: I18n, defaultLocale:
         localeCookie.value = locale
       }
     },
-    getBaseUrl: () => joinURL(baseUrl(), nuxt.$config.app.baseURL),
+    getBaseUrl: (locale?: string) => {
+      if (locale) {
+        return joinURL(getDomainFromLocale(locale) || baseUrl(), nuxt.$config.app.baseURL)
+      }
+      return joinURL(baseUrl(), nuxt.$config.app.baseURL)
+    },
     getBrowserLocale: () => {
       // from navigator or request header
       const languages = import.meta.client

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -120,8 +120,7 @@ export function createComposableContext(runtimeI18n: I18nPublicRuntimeConfig): C
     },
     afterSwitchLocalePath: (path, locale) => {
       if (__DIFFERENT_DOMAINS__) {
-        const domain = ctx.getDomainFromLocale(locale)
-        return (domain && joinURL(domain, path)) || path
+        return joinURL(ctx.getBaseUrl(locale), path)
       }
       return path
     },


### PR DESCRIPTION
### 🔗 Linked issue
* #3628 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Resolves #3628 

Probably need to revisit `baseUrl` implementation, and consider deprecating the `baseUrl` as a function config option.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved locale switching to support domain-specific base URLs in multi-domain setups with a base path.
- **Bug Fixes**
	- Ensured that locale switch links correctly include the app’s base path when switching between domains.
- **Tests**
	- Added tests to verify that locale switching respects both domain-specific locales and the global base path configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->