### PR TITLE
fix: `<NuxtLinkLocale>` losing route `state`

### DIFF
--- a/specs/basic-usage-tests.ts
+++ b/specs/basic-usage-tests.ts
@@ -46,6 +46,11 @@ export function basicUsageTests() {
       '/fr/about'
     )
 
+    expect(await page.evaluate(() => history.state.hello)).toEqual(undefined)
+    await page.locator('#nuxt-link-locale-usages .state a').clickNavigate()
+    expect(await page.evaluate(() => history.state.hello)).toEqual('world')
+    await page.goBackNavigate()
+
     // Language switching path localizing with `useSwitchLocalePath`
     expect(await page.locator('#switch-locale-path-usages .switch-to-en a').getAttribute('href')).toEqual('/')
     expect(await page.locator('#switch-locale-path-usages .switch-to-fr a').getAttribute('href')).toEqual('/fr')

--- a/specs/fixtures/basic_usage/pages/index.vue
+++ b/specs/fixtures/basic_usage/pages/index.vue
@@ -171,6 +171,11 @@ useHead(() => ({
         <li class="target-blank-with-locale">
           <NuxtLinkLocale to="about" locale="fr" target="_blank">About us in French (new tab)</NuxtLinkLocale>
         </li>
+        <li class="state">
+          <NuxtLinkLocale :to="{ path: '/', query: { foo: 'bar' }, state: { hello: 'world' } }"
+            >Index with state</NuxtLinkLocale
+          >
+        </li>
       </ul>
     </section>
     <section id="switch-locale-path-usages">

--- a/specs/fixtures/basic_usage_compat_4/app/pages/index.vue
+++ b/specs/fixtures/basic_usage_compat_4/app/pages/index.vue
@@ -171,6 +171,11 @@ useHead(() => ({
         <li class="target-blank-with-locale">
           <NuxtLinkLocale to="about" locale="fr" target="_blank">About us in French (new tab)</NuxtLinkLocale>
         </li>
+        <li class="state">
+          <NuxtLinkLocale :to="{ path: '/', query: { foo: 'bar' }, state: { hello: 'world' } }"
+            >Index with state</NuxtLinkLocale
+          >
+        </li>
       </ul>
     </section>
     <section id="switch-locale-path-usages">

--- a/src/runtime/components/NuxtLinkLocale.ts
+++ b/src/runtime/components/NuxtLinkLocale.ts
@@ -45,7 +45,13 @@ export default defineComponent<NuxtLinkLocaleProps>({
 
     const resolvedPath = computed(() => {
       const destination = props.to ?? props.href
-      return destination != null ? localeRoute(destination, props.locale) : destination
+      const resolved = destination != null ? localeRoute(destination, props.locale) : destination
+      if (resolved && isObject(props.to)) {
+        // @ts-expect-error missing property type
+        resolved.state = props.to?.state
+      }
+
+      return destination != null ? resolved : destination
     })
 
     // Resolving link type

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -2,12 +2,18 @@ import type { NuxtApp } from '#app'
 import type { ComputedRef } from 'vue'
 import type { Directions, LocaleObject, Strategies } from '#internal-i18n-types'
 import type { Locale, Composer, VueI18n, ExportedGlobalComposer } from 'vue-i18n'
-import type { RouteLocationAsRelative, RouteLocationNormalizedGeneric, RouteRecordNameGeneric } from 'vue-router'
+import type {
+  HistoryState,
+  RouteLocationAsRelative,
+  RouteLocationNormalizedGeneric,
+  RouteRecordNameGeneric
+} from 'vue-router'
 import type { ComposableContext } from './utils'
 import type { NuxtI18nContext } from './context'
 
 export type CompatRoute = Omit<RouteLocationNormalizedGeneric, 'name'> & {
   name: RouteRecordNameGeneric | null
+  state?: HistoryState
 }
 
 export type RouteLocationGenericPath = Omit<RouteLocationAsRelative, 'path' | 'name'> & {


### PR DESCRIPTION
### 🔗 Linked issue
* #3547
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Resolves #3547
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for passing a custom state object when using localized links, enabling enhanced control over browser history state during navigation.

- **Tests**
  - Extended test coverage to verify correct handling and preservation of browser history state when interacting with localized links.

- **Documentation**
  - Updated example pages to showcase usage of the new state property with localized links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->