### PR TITLE
fix: do not fetch from server route if ssr is disabled

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -124,6 +124,7 @@ export function getDefineConfig({ options, fullStatic }: I18nNuxtContext, server
   const common = {
     __DEBUG__: String(!!options.debug),
     __TEST__: String(!!options.debug),
+    __IS_SSR__: String(nuxt.options.ssr),
     __IS_SSG__: String(nuxt.options._generate),
     __PARALLEL_PLUGIN__: String(options.parallelPlugin),
     __DYNAMIC_PARAMS_KEY__: JSON.stringify(DYNAMIC_PARAMS_KEY),

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -8,6 +8,7 @@ declare let __DEBUG__: boolean
 declare let __TEST__: boolean
 
 declare let __IS_SSG__: boolean
+declare let __IS_SSR__: boolean
 declare let __TRAILING_SLASH__: boolean
 declare let __PARALLEL_PLUGIN__: boolean
 declare let __DIFFERENT_DOMAINS__: boolean

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -73,7 +73,7 @@ export function createNuxtI18nContext(nuxt: NuxtApp, _i18n: I18n, defaultLocale:
   const detectBrowserLanguage = runtimeI18n.detectBrowserLanguage || {}
   const localeCookie = createI18nCookie(detectBrowserLanguage)
 
-  const dynamicResourcesSSG = !__I18N_FULL_STATIC__ && (import.meta.prerender || __IS_SSG__)
+  const dynamicResourcesSSG = !__IS_SSR__ || (!__I18N_FULL_STATIC__ && (import.meta.prerender || __IS_SSG__))
   /** Get computed config for locale */
   const getLocaleConfig = (locale: string) => serverLocaleConfigs.value[locale]
   const getDomainFromLocale = createDomainFromLocaleGetter()


### PR DESCRIPTION
### 🔗 Linked issue
* #3645 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Resolves #3645 
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new environment flag to indicate when server-side rendering is enabled.
- **Enhancements**
  - Expanded the conditions under which dynamic resource loading is enabled in non-SSR environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->