### PR TITLE
fix!: remove deprecated functions and warn incorrect hook usage

### DIFF
--- a/docs/content/docs/02.guide/02.runtime-hooks.md
+++ b/docs/content/docs/02.guide/02.runtime-hooks.md
@@ -9,7 +9,7 @@ description: Nuxt i18n module provides runtime hooks that you can use to perform
 
 ### `'i18n:beforeLocaleSwitch'`{lang="ts-type"}
 
-Called before the app's locale is switched. Can be used to override the new locale by returning a new locale code.
+Called before the app's locale is switched, the `newLocale` property can be overridden to change the locale being switched to.
 
 Parameters:
 
@@ -27,7 +27,7 @@ Parameters:
 
 - `context`
   - type: `NuxtApp`{lang="ts-type"}
-  - The Nuxt app
+  - The Nuxt app, this property is deprecated, the same can be achieved by using `const context = useNuxtApp()` outside the hook scope instead.
 
 Returns: `string | null`{lang="ts-type"}
 
@@ -52,13 +52,18 @@ A typical usage would be to define those callbacks via a plugin where you can ac
 ```ts [/plugins/i18n.ts]
 export default defineNuxtPlugin(nuxtApp => {
   // called right before setting a new locale
-  nuxtApp.hook('i18n:beforeLocaleSwitch', ({ oldLocale, newLocale, initialSetup, context }) => {
-    console.log('onBeforeLanguageSwitch', oldLocale, newLocale, initialSetup)
+  nuxtApp.hook('i18n:beforeLocaleSwitch', (switch) => {
+    console.log('onBeforeLanguageSwitch', switch.oldLocale, switch.newLocale, switch.initialSetup)
+
+    // You can override the new locale by setting it to a different value
+    if(switch.newLocale === 'fr') {
+      switch.newLocale = 'en'
+    }
   })
 
   // called right after a new locale has been set
-  nuxtApp.hook('i18n:localeSwitched', ({ oldLocale, newLocale }) => {
-    console.log('onLanguageSwitched', oldLocale, newLocale)
+  nuxtApp.hook('i18n:localeSwitched', (switch) => {
+    console.log('onLanguageSwitched', switch.oldLocale, switch.newLocale)
   })
 })
 ```

--- a/docs/content/docs/02.guide/90.migrating.md
+++ b/docs/content/docs/02.guide/90.migrating.md
@@ -89,6 +89,15 @@ These options are stable and are now enabled by default, some have been renamed 
 #### `experimental.autoImportTranslationFunctions`{lang="yml"}
 * Now configurable with the `autoDeclare` option
 
+### Dropped `$i18n`{lang="ts"} and `useI18n()`{lang="ts"} functions
+The following i18n functions have been removed from the module, they were deprecated in v9.
+
+#### `onLanguageSwitched()`{lang="ts"}
+* This function actually called the hook instead of subscribing to it, leading to unpredictable behavior. Use the [`'i18n:languageSwitched'`{lang="ts"}](/docs/guide/runtime-hooks) hook instead.
+
+#### `onBeforeLanguageSwitch()`{lang="ts"}
+* This function actually called the hook instead of subscribing to it, leading to unpredictable behavior. Use the [`'i18n:beforeLanguageSwitch'`{lang="ts"}](/docs/guide/runtime-hooks) hook instead.
+
 
 ### Dropped context functions
 The following functions have been removed from the Nuxt context.

--- a/src/module.ts
+++ b/src/module.ts
@@ -133,6 +133,7 @@ export interface ModuleRuntimeHooks {
     oldLocale: Locale
     newLocale: Locale
     initialSetup: boolean
+    /** @deprecated use `const context = useNuxtApp()` outside hook scope instead */
     context: Context
   }) => HookResult
 

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -13,7 +13,6 @@ import { setupVueI18nOptions } from '../shared/vue-i18n'
 import { createNuxtI18nContext, useLocaleConfigs, useNuxtI18nContext, type NuxtI18nContext } from '../context'
 
 import type { Locale, I18nOptions, Composer, TranslateOptions } from 'vue-i18n'
-import type { NuxtApp } from '#app'
 import type { LocaleObject, I18nPublicRuntimeConfig, I18nHeadOptions } from '#internal-i18n-types'
 import type { H3EventContext } from 'h3'
 
@@ -96,16 +95,6 @@ export default defineNuxtPlugin({
         composer.getLocaleCookie = ctx.getLocaleCookie
         composer.setLocaleCookie = ctx.setLocaleCookie
 
-        composer.onBeforeLanguageSwitch = (oldLocale, newLocale, initialSetup, context) =>
-          nuxt.callHook('i18n:beforeLocaleSwitch', {
-            oldLocale,
-            newLocale,
-            initialSetup,
-            context
-          }) as Promise<Locale | void>
-        composer.onLanguageSwitched = (oldLocale, newLocale) =>
-          nuxt.callHook('i18n:localeSwitched', { oldLocale, newLocale }) as Promise<void>
-
         composer.finalizePendingLocaleChange = () => {
           if (!i18n.__pendingLocale) return
 
@@ -134,16 +123,6 @@ export default defineNuxtPlugin({
           ['getBrowserLocale', () => () => Reflect.apply(c.getBrowserLocale, c, [])],
           ['getLocaleCookie', () => () => Reflect.apply(c.getLocaleCookie, c, [])],
           ['setLocaleCookie', () => (locale: string) => Reflect.apply(c.setLocaleCookie, c, [locale])],
-          [
-            'onBeforeLanguageSwitch',
-            () => (oldLocale: string, newLocale: string, initialSetup: boolean, context: NuxtApp) =>
-              Reflect.apply(c.onBeforeLanguageSwitch, c, [oldLocale, newLocale, initialSetup, context])
-          ],
-          [
-            'onLanguageSwitched',
-            () => (oldLocale: string, newLocale: string) =>
-              Reflect.apply(c.onLanguageSwitched, c, [oldLocale, newLocale])
-          ],
           ['finalizePendingLocaleChange', () => () => Reflect.apply(c.finalizePendingLocaleChange, c, [])],
           ['waitForPendingLocaleChange', () => () => Reflect.apply(c.waitForPendingLocaleChange, c, [])]
         ]

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -1,4 +1,3 @@
-import type { NuxtApp } from '#app'
 import type { ComputedRef } from 'vue'
 import type { Directions, LocaleObject, Strategies } from '#internal-i18n-types'
 import type { Locale, Composer, VueI18n, ExportedGlobalComposer } from 'vue-i18n'
@@ -22,34 +21,6 @@ export type RouteLocationGenericPath = Omit<RouteLocationAsRelative, 'path' | 'n
 }
 
 export type I18nRouteMeta = Partial<Record<Locale, false | Record<string, unknown>>>
-
-/**
- * Called before the app's locale is switched.
- *
- * @remarks
- * Can be used to override the new locale by returning a new locale code.
- *
- * @param oldLocale - The app's locale before the switch.
- * @param newLocale - The app's locale after the switch.
- * @param initialSetup - Set to `true` if it's the initial locale switch that triggers on app load. It's a special case since the locale is not technically set yet so we're switching from no locale to locale.
- * @param context - the Nuxt app instance.
- *
- * @returns The new locale to switch, or `undefined` to keep the new locale.
- */
-type BeforeLanguageSwitchHandler = (
-  oldLocale: Locale,
-  newLocale: Locale,
-  initialSetup: boolean,
-  context: NuxtApp
-) => Promise<Locale | void>
-
-/**
- * Called after the app's locale is switched.
- *
- * @param oldLocale - The app's locale before the switch
- * @param newLocale - The app's locale after the switch.
- */
-type LanguageSwitchedHandler = (oldLocale: Locale, newLocale: Locale) => Promise<void>
 
 /**
  * @template ConfiguredLocaleType - The type of the locales configuration. Can be an array of string codes or an array of {@link LocaleObject}.
@@ -127,27 +98,6 @@ export interface ComposerCustomProperties<
    * @param locale - A {@link Locale}
    */
   setLocaleCookie: (locale: Locale) => void
-  /**
-   * Called before the app's locale is switched.
-   *
-   * @remarks
-   * Can be used to override the new locale by returning a new locale code.
-   *
-   * @param oldLocale - The app's locale before the switch.
-   * @param newLocale - The app's locale after the switch.
-   * @param initialSetup - Set to `true` if it's the initial locale switch that triggers on app load. It's a special case since the locale is not technically set yet so we're switching from no locale to locale.
-   * @param context - the Nuxt app instance.
-   *
-   * @returns The new locale to switch, or `undefined` to keep the new locale.
-   */
-  onBeforeLanguageSwitch: BeforeLanguageSwitchHandler
-  /**
-   * Called after the app's locale is switched.
-   *
-   * @param oldLocale - The app's locale before the switch
-   * @param newLocale - The app's locale after the switch.
-   */
-  onLanguageSwitched: LanguageSwitchedHandler
   /**
    * Switches locale to the pending locale, used when navigation locale switch is prevented by the `skipSettingLocaleOnNavigate` option.
    */

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -177,8 +177,6 @@ export async function loadAndSetLocale(locale: Locale): Promise<string> {
   const ctx = useNuxtI18nContext()
   const oldLocale = ctx.getLocale()
 
-  // call `i18n:beforeLocaleSwitch` which may return an override
-  // TODO: remove in v11, this is deprecated in favor of `i18n:localeDetected`
   const data = { oldLocale, newLocale: locale, initialSetup: ctx.firstAccess, nuxt }
   // @ts-expect-error context is not typed
   let override = (await nuxt.callHook('i18n:beforeLocaleSwitch', data)) as string | undefined


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This removes the deprecated i18n functions, these were deprecated in v9 already (though the types did not correctly reflect that, their documentation was removed as well).

This also improves the `i18n:beforeLanguageSwitch` hook, previously it relied on returning a locale to override the locale being switched to, this is still supported but a warning will be logged. The correct way is to mutate the argument property, this way if there are multiple listeners to the hook these will receive the correct newLocale.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated guides and migration documentation to clarify removal of deprecated i18n functions and hooks, and to provide revised usage examples for runtime hooks.
  - Marked the `context` parameter as deprecated in relevant documentation, with guidance on the recommended alternative.

- **Bug Fixes**
  - Improved consistency and clarity in locale switching by standardizing the usage of runtime hooks and deprecating direct hook returns.

- **Refactor**
  - Removed deprecated `onBeforeLanguageSwitch` and `onLanguageSwitched` hooks and related type definitions from the codebase.
  - Updated internal handling to rely exclusively on Nuxt runtime hooks for locale switching events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->