### PR TITLE
fix!: trigger `i18n:localeSwitched` when pending locale switches

### DIFF
--- a/docs/content/docs/02.guide/08.lang-switcher.md
+++ b/docs/content/docs/02.guide/08.lang-switcher.md
@@ -92,8 +92,8 @@ export default defineNuxtConfig({
 <script setup lang="ts">
 const { finalizePendingLocaleChange } = useI18n()
 
-const onBeforeEnter = () => {
-  finalizePendingLocaleChange()
+const onBeforeEnter = async () => {
+  await finalizePendingLocaleChange()
 }
 </script>
 
@@ -160,8 +160,8 @@ definePageMeta({
   }
 })
 
-route.meta.pageTransition.onBeforeEnter = () => {
-  finalizePendingLocaleChange()
+route.meta.pageTransition.onBeforeEnter = async () => {
+  await finalizePendingLocaleChange()
 }
 </script>
 

--- a/docs/content/docs/02.guide/90.migrating.md
+++ b/docs/content/docs/02.guide/90.migrating.md
@@ -43,10 +43,6 @@ If this mode proves stable it will become the default in v11, please try it out 
 ### Lazy loading
 The `lazy` option has been removed and lazy loading of locale messages is now the default behavior.
 
-### Signature changed for `finalizePendingLocaleChange()`{lang="ts"}
-The function signature for `finalizePendingLocaleChange()`{lang="ts"} has been corrected from `() => Promise<void>`{lang="ts-type"} to `() => void`{lang="ts-type"}.
-This change was made since the function does not rely on any async operations and should not be awaited, and should prevent unnecessary function coloring.
-
 ### Arguments changed `useLocaleHead()`{lang="ts"} and `$localeHead()`{lang="ts"}
 The `key` property has been removed and can no longer be configured, this is necessary for predictable and consistent localized head tag management.
 

--- a/docs/content/docs/04.api/04.vue-i18n.md
+++ b/docs/content/docs/04.api/04.vue-i18n.md
@@ -51,7 +51,7 @@ Returns browser locale code filtered against the ones defined in options.
 
 - **Arguments**:
   - no arguments
-- **Returns**: `void`{lang="ts-type"}
+- **Returns**: `Promise<void>`{lang="ts-type"}
 
 Switches locale to the pending locale, used when navigation locale switch is prevented by the [`skipSettingLocaleOnNavigate`](/docs/api/options#skipsettinglocaleonnavigate) option. See [Wait for page transition](/docs/guide/lang-switcher#wait-for-page-transition) for more information.
 

--- a/specs/basic-usage-tests.ts
+++ b/specs/basic-usage-tests.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest'
-import { $fetch, url } from './utils'
+import { $fetch, url, useTestContext } from './utils'
 import {
   assertLocaleHeadWithDom,
   assetLocaleHead,
@@ -317,28 +317,40 @@ export function basicUsageTests() {
   test('<NuxtLink> triggers runtime hooks', async () => {
     const { page, consoleLogs } = await renderPage('/kr')
 
-    expect(consoleLogs.find(log => log.text.includes('onBeforeLanguageSwitch kr fr true'))).toBeTruthy()
-    expect(consoleLogs.find(log => log.text.includes('onLanguageSwitched kr fr'))).toBeTruthy()
-    expect(consoleLogs.find(log => log.text.includes('onBeforeLanguageSwitch fr fr false'))).toBeTruthy()
-
-    // current locale
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+    await page.waitForFunction(() => !window.useNuxtApp?.().isHydrating)
+    consoleLogs.length = 0
 
     // navigate to about page
     await page.locator('#link-about').clickNavigate()
     await page.waitForURL(url('/fr/about'))
 
-    // navigate to home page
-    await page.locator('#link-home').clickNavigate()
-    await page.waitForURL(url('/fr'))
+    expect(consoleLogs[0].text).toEqual('i18n:beforeLocaleSwitch fr fr false')
   })
 
   test('setLocale triggers runtime hooks', async () => {
+    let output: string[] = []
+    const ctx = useTestContext()
+    ctx.serverProcess?.process?.on(
+      'message',
+      (msg: any) => msg.type === 'i18n:test-log' && msg.id === ctx.url?.split(':')[2]! && output.push(msg.data)
+    )
+    await new Promise(resolve => setTimeout(resolve, 1)) // wait for process to be ready
+    output.length = 0
+
     const { page, consoleLogs } = await renderPage('/kr')
 
-    expect(consoleLogs.find(log => log.text.includes('onBeforeLanguageSwitch kr fr true'))).toBeTruthy()
-    expect(consoleLogs.find(log => log.text.includes('onLanguageSwitched kr fr'))).toBeTruthy()
-    expect(consoleLogs.find(log => log.text.includes('onBeforeLanguageSwitch fr fr false'))).toBeTruthy()
+    // overrides and redirects to `fr`
+    expect(output).toMatchInlineSnapshot(`
+      [
+        "i18n:beforeLocaleSwitch kr fr true",
+        "i18n:localeSwitched kr fr",
+        "i18n:beforeLocaleSwitch fr fr false",
+        "i18n:beforeLocaleSwitch fr fr true",
+      ]
+    `)
+
+    // client-side enters on `fr` locale
+    expect(consoleLogs.find(log => log.text.includes('i18n:beforeLocaleSwitch fr fr true'))).toBeTruthy()
 
     // current locale
     expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')

--- a/specs/fixtures/basic_usage/app.vue
+++ b/specs/fixtures/basic_usage/app.vue
@@ -8,7 +8,7 @@ const skipSettingLocale = useRuntimeConfig().public.i18n.skipSettingLocaleOnNavi
 const pageTransition = {
   name: 'my',
   mode: 'out-in',
-  onBeforeEnter: () => finalizePendingLocaleChange()
+  onBeforeEnter: async () => await finalizePendingLocaleChange()
 }
 </script>
 

--- a/specs/fixtures/basic_usage_compat_4/app/app.vue
+++ b/specs/fixtures/basic_usage_compat_4/app/app.vue
@@ -8,7 +8,7 @@ const skipSettingLocale = useRuntimeConfig().public.i18n.skipSettingLocaleOnNavi
 const pageTransition = {
   name: 'my',
   mode: 'out-in',
-  onBeforeEnter: () => finalizePendingLocaleChange()
+  onBeforeEnter: async () => await finalizePendingLocaleChange()
 }
 </script>
 

--- a/specs/fixtures/common/components/LangSwitcher.vue
+++ b/specs/fixtures/common/components/LangSwitcher.vue
@@ -42,7 +42,7 @@ const switchLocalePath = useSwitchLocalePath()
         :id="`set-locale-link-${locale.code}`"
         :key="`b-${index}`"
         href="javascript:void(0)"
-        @click.prevent="setLocale(locale.code)"
+        @click.prevent="async () => await setLocale(locale.code)"
         >{{ locale.name }}</a
       >
     </section>

--- a/specs/fixtures/issues/1888/app.vue
+++ b/specs/fixtures/issues/1888/app.vue
@@ -6,7 +6,7 @@
       v-for="locale in availableLocales"
       :id="locale.code"
       :key="locale.code"
-      @click="$i18n.setLocale(locale.code)"
+      @click="async () => await $i18n.setLocale(locale.code)"
     >
       {{ locale.name }}
     </button>

--- a/specs/fixtures/issues/2590/app.vue
+++ b/specs/fixtures/issues/2590/app.vue
@@ -5,34 +5,11 @@
 </template>
 
 <script setup lang="ts">
-const { locale, locales, setLocale } = useI18n()
+const _i18n = useI18n()
 
 const head = useLocaleHead()
 
 useHead(() => ({
   htmlAttrs: head.value.htmlAttrs
 }))
-
-const availableLocales = computed(() => {
-  return (locales.value as LocaleObject[])
-    .filter(item => {
-      return item.code !== locale.value
-    })
-    .map(item => {
-      return {
-        label: item.name,
-        key: item.code
-      }
-    })
-})
-
-const currentLocale = computed(() => {
-  return (locales.value as LocaleObject[]).filter(item => {
-    return item.code === locale.value
-  })
-})
-
-function changeLocal(code: any) {
-  setLocale(code)
-}
 </script>

--- a/specs/fixtures/plugins/i18nHooks.ts
+++ b/specs/fixtures/plugins/i18nHooks.ts
@@ -1,21 +1,24 @@
 import { defineNuxtPlugin } from '#imports'
 
+function log(...args: any[]) {
+  if (import.meta.server && process.send) {
+    process.send({ type: 'i18n:test-log', id: process.env.PORT, data: Array.from(args).join(' ') })
+    // !import.meta.CI && console.log(...args)
+  } else {
+    console.log(...args)
+  }
+}
+
 export default defineNuxtPlugin(nuxtApp => {
-  nuxtApp.hook('i18n:beforeLocaleSwitch', ({ oldLocale, newLocale, initialSetup }) => {
-    let overrideLocale = newLocale
-
-    if (newLocale === 'kr') {
-      overrideLocale = 'fr'
+  nuxtApp.hook('i18n:beforeLocaleSwitch', data => {
+    if (data.newLocale === 'kr') {
+      data.newLocale = 'fr'
     }
 
-    console.log('onBeforeLanguageSwitch', oldLocale, overrideLocale, initialSetup)
-
-    if (overrideLocale !== newLocale) {
-      return overrideLocale
-    }
+    log('i18n:beforeLocaleSwitch', data.oldLocale, data.newLocale, data.initialSetup)
   })
 
   nuxtApp.hook('i18n:localeSwitched', ({ oldLocale, newLocale }) => {
-    console.log('onLanguageSwitched', oldLocale, newLocale)
+    log('i18n:localeSwitched', oldLocale, newLocale)
   })
 })

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -38,7 +38,7 @@ export type NuxtI18nContext = {
   /** Get current locale */
   getLocale: () => string
   /** Set locale directly  */
-  setLocale: (locale: string) => void
+  setLocale: (locale: string) => Promise<void>
   /** Get normalized runtime locales */
   getLocales: () => LocaleObject[]
   /** Get locale from locale cookie */
@@ -88,12 +88,14 @@ export function createNuxtI18nContext(nuxt: NuxtApp, _i18n: I18n, defaultLocale:
     getVueI18n: () => _i18n,
     getDefaultLocale: () => defaultLocale,
     getLocale: () => unref(i18n.locale),
-    setLocale: (locale: string) => {
+    setLocale: async (locale: string) => {
+      const oldLocale = unref(i18n.locale)
       if (isRef(i18n.locale)) {
         i18n.locale.value = locale
       } else {
         i18n.locale = locale
       }
+      await nuxt.callHook('i18n:localeSwitched', { newLocale: locale, oldLocale })
     },
     getLocales: () => unref(i18n.locales).map(x => (isString(x) ? { code: x } : x)),
     getLocaleFromRoute: route => {

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -95,17 +95,15 @@ export default defineNuxtPlugin({
         composer.getLocaleCookie = ctx.getLocaleCookie
         composer.setLocaleCookie = ctx.setLocaleCookie
 
-        composer.finalizePendingLocaleChange = () => {
+        composer.finalizePendingLocaleChange = async () => {
           if (!i18n.__pendingLocale) return
 
-          ctx.setLocale(i18n.__pendingLocale)
+          await ctx.setLocale(i18n.__pendingLocale)
           i18n.__resolvePendingLocalePromise?.()
           i18n.__pendingLocale = undefined
         }
         composer.waitForPendingLocaleChange = async () => {
-          if (i18n.__pendingLocale && i18n.__pendingLocalePromise) {
-            await i18n.__pendingLocalePromise
-          }
+          await i18n?.__pendingLocalePromise
         }
       },
       extendComposerInstance(instance, c) {

--- a/src/runtime/plugins/route-locale-detect.ts
+++ b/src/runtime/plugins/route-locale-detect.ts
@@ -10,7 +10,7 @@ export default defineNuxtPlugin({
     const ctx = useNuxtI18nContext(nuxt)
 
     const detected = detectLocale(nuxt.$router.currentRoute.value)
-    await loadAndSetLocale(detected)
+    await nuxt.runWithContext(() => loadAndSetLocale(detected))
 
     // no pages or no prefixes - do not register route middleware
     if (!__I18N_ROUTING__) return
@@ -24,7 +24,7 @@ export default defineNuxtPlugin({
 
         ctx.firstAccess = false
 
-        return await nuxt.runWithContext(() => navigate(redirectPath, to.path, locale))
+        return nuxt.runWithContext(() => navigate(redirectPath, to.path, locale))
       }),
       { global: true }
     )

--- a/src/runtime/plugins/ssg-detect.ts
+++ b/src/runtime/plugins/ssg-detect.ts
@@ -16,7 +16,7 @@ export default defineNuxtPlugin({
     // NOTE: avoid hydration mismatch for SSG mode
     nuxt.hook('app:mounted', async () => {
       const detected = detectLocale(nuxt.$router.currentRoute.value)
-      await nuxt.$i18n.setLocale(detected)
+      await nuxt.runWithContext(() => nuxt.$i18n.setLocale(detected))
       ctx.firstAccess = false
     })
   }

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -101,7 +101,7 @@ export interface ComposerCustomProperties<
   /**
    * Switches locale to the pending locale, used when navigation locale switch is prevented by the `skipSettingLocaleOnNavigate` option.
    */
-  finalizePendingLocaleChange: () => void
+  finalizePendingLocaleChange: () => Promise<void>
   /**
    * Returns a promise that will be resolved once the pending locale is set.
    */

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -202,8 +202,7 @@ export async function loadAndSetLocale(locale: Locale): Promise<string> {
 
     // update locale
     if (changed) {
-      ctx.setLocale(locale)
-      await nuxt.callHook('i18n:localeSwitched', { newLocale: locale, oldLocale })
+      await ctx.setLocale(locale)
     }
   }
 
@@ -300,7 +299,7 @@ function getRoutePrefixAndPath(routePath: string): { prefix?: string; unprefixed
   return { prefix, unprefixed }
 }
 
-export async function navigate(redirectPath: string, routePath: string, locale: string, force = false) {
+export function navigate(redirectPath: string, routePath: string, locale: string, force = false) {
   const nuxt = useNuxtApp()
   const { rootRedirect, skipSettingLocaleOnNavigate } = nuxt.$config.public.i18n as I18nPublicRuntimeConfig
   const ctx = useNuxtI18nContext(nuxt)


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Makes the hook more reliable, it looks like it was previously not triggered when `skipSettingLocaleOnNavigate` was enabled.  These changes resolves issues with redirection, since most of that is now correctly handled server-side, instead of redirecting client-side which caused hydration mismatches.

This also reverts a previous breaking change, fortunately we are not at the release candidate stage yet, referring to #3626 
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Locale changes during page transitions are now fully completed before proceeding, improving reliability in language switching.
- **Bug Fixes**
	- Ensured asynchronous operations related to locale switching are properly awaited throughout the app.
- **Documentation**
	- Updated API documentation to reflect asynchronous behavior of locale change methods.
	- Removed outdated migration notes regarding locale change function signatures.
- **Tests**
	- Enhanced tests to verify server-side and client-side locale switch events more accurately.
- **Refactor**
	- Streamlined internal handling of locale switching and navigation to ensure consistency and proper context execution.
	- Simplified event handling for language switch actions to properly await locale changes.
	- Improved logging mechanism for locale switch lifecycle events.
	- Suppressed specific non-critical Vue Router warnings in test logs for cleaner output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->