### PR TITLE
fix!: deprecate function support for `baseUrl` option

### DIFF
--- a/docs/content/docs/02.guide/90.migrating.md
+++ b/docs/content/docs/02.guide/90.migrating.md
@@ -72,6 +72,8 @@ The following options have been deprecated and will be removed in v11:
 #### `defaultLocaleRouteNameSuffix`{lang="yml"}
 * This was documented as internal, use cases for end-users are unclear.
 
+#### Function configuration for `baseUrl`{lang="yml"}
+* The `baseUrl` option will no longer support function configuration in v11, it must be a string. Use runtime config or rely on multi domain locales to set the base URL.
 
 ### Promoted options
 These options are stable and are now enabled by default, some have been renamed to better reflect their purpose. 

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -304,6 +304,8 @@ export function createBaseUrlGetter(
   getDomainFromLocale: (locale: string) => string | undefined
 ): () => string {
   if (isFunction(baseUrl)) {
+    import.meta.dev &&
+      console.warn('[nuxt-i18n] Configuring baseUrl as a function is deprecated and will be removed in v11.')
     return (): string => baseUrl(nuxt)
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -238,10 +238,6 @@ export type NuxtI18nOptions<
    *
    * By default VueRouter's base URL will be used and only if that is not available, fallback URL will be used.
    *
-   * Can also be a function (will be passed a Nuxt Context as a parameter) that returns a string.
-   *
-   * Useful to make base URL dynamic based on request headers.
-   *
    * @default ''
    */
   baseUrl?: string | BaseUrlResolveHandler<Context>
@@ -308,6 +304,7 @@ export interface LocaleObject<T = Locale> {
 
 /**
  * @public
+ * @deprecated Configuring baseUrl as a function is deprecated and will be removed in the v11.
  */
 export type BaseUrlResolveHandler<Context = unknown> = (context: Context) => string
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated migration guide to clarify that the `baseUrl` option must be a string in the upcoming version and can no longer be a function.
  - Added deprecation notice for function-based `baseUrl` usage in documentation comments.

- **Bug Fixes**
  - Added a warning in development mode when configuring `baseUrl` as a function, indicating its deprecation for future versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->