### PR TITLE
fix: wrap default `<NuxtLink>` in `<NuxtLinkLocale>`

### DIFF
--- a/src/runtime/components/NuxtLinkLocale.ts
+++ b/src/runtime/components/NuxtLinkLocale.ts
@@ -2,14 +2,11 @@
 import { isObject } from '@intlify/shared'
 import { useLocaleRoute, type Locale } from '#i18n'
 import { defineComponent, computed, h } from 'vue'
-import { defineNuxtLink } from '#imports'
+import { NuxtLink } from '#components'
 import { hasProtocol } from 'ufo'
-import { nuxtLinkDefaults } from '#build/nuxt.config.mjs'
 
 import type { PropType } from 'vue'
 import type { NuxtLinkProps } from 'nuxt/app'
-
-const NuxtLinkLocale = defineNuxtLink({ ...nuxtLinkDefaults, componentName: 'NuxtLinkLocale' })
 
 type NuxtLinkLocaleProps = Omit<NuxtLinkProps, 'to'> & {
   to?: import('vue-router').RouteLocationNamedI18n
@@ -18,9 +15,8 @@ type NuxtLinkLocaleProps = Omit<NuxtLinkProps, 'to'> & {
 
 export default defineComponent<NuxtLinkLocaleProps>({
   name: 'NuxtLinkLocale',
-
   props: {
-    ...NuxtLinkLocale.props,
+    ...NuxtLink.props,
     locale: {
       type: String as PropType<Locale>,
       default: undefined,
@@ -94,6 +90,6 @@ export default defineComponent<NuxtLinkLocaleProps>({
       return _props as NuxtLinkProps
     }
 
-    return () => h(NuxtLinkLocale, getNuxtLinkProps(), slots.default)
+    return () => h(NuxtLink, getNuxtLinkProps(), slots.default)
   }
 })


### PR DESCRIPTION
### 🔗 Linked issue
* #3402 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Resolves #3402 

The `<NuxtLinkLocale>` component is technically a wrapper around `<NuxtLink>`, we can use the existing component provided by Nuxt rather than creating one, and prevent repeated names in the component render tree.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the internal implementation of the locale-aware link component to use the standard NuxtLink component directly. There are no visible changes to the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->