### PR TITLE
fix: remove unused runtime config property types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -360,70 +360,15 @@ export interface I18nHeadMetaInfo {
 export interface I18nPublicRuntimeConfig {
   baseUrl: NuxtI18nOptions['baseUrl']
   rootRedirect: NuxtI18nOptions['rootRedirect']
-
-  /**
-   * Overwritten at build time, used to pass generated options to runtime
-   * @internal
-   */
-  multiDomainLocales?: NuxtI18nOptions['multiDomainLocales']
-  /**
-   * Overwritten at build time, used to pass generated options to runtime
-   * @internal
-   */
   domainLocales: { [key: Locale]: { domain: string | undefined } }
-  /**
-   * Overwritten at build time, used to pass generated options to runtime
-   * @internal
-   */
-  experimental: NonNullable<NuxtI18nOptions['experimental']>
-  /**
-   * Overwritten at build time, used to pass generated options to runtime
-   * @internal
-   */
+  /** @internal Overwritten at build time, used to pass generated options to runtime */
   locales: NonNullable<Required<NuxtI18nOptions<unknown>>['locales']>
-  /**
-   * Overwritten at build time, used to pass generated options to runtime
-   * @internal
-   */
-  differentDomains: Required<NuxtI18nOptions>['differentDomains']
-  /**
-   * Overwritten at build time, used to pass generated options to runtime
-   * @internal
-   */
-  skipSettingLocaleOnNavigate: Required<NuxtI18nOptions>['skipSettingLocaleOnNavigate']
-  /**
-   * Overwritten at build time, used to pass generated options to runtime
-   * @internal
-   */
+  /** @internal Overwritten at build time, used to pass generated options to runtime */
   defaultLocale: Required<NuxtI18nOptions>['defaultLocale']
-  /**
-   * Overwritten at build time, used to pass generated options to runtime
-   * @internal
-   */
-  defaultDirection: Required<NuxtI18nOptions>['defaultDirection']
-  /**
-   * Overwritten at build time, used to pass generated options to runtime
-   * @internal
-   */
+  /** @internal Overwritten at build time, used to pass generated options to runtime */
+  experimental: NonNullable<NuxtI18nOptions['experimental']>
+  /** @internal Overwritten at build time, used to pass generated options to runtime */
   detectBrowserLanguage: Required<NuxtI18nOptions>['detectBrowserLanguage']
-  /**
-   * Overwritten at build time, used to pass generated options to runtime
-   * @internal
-   */
-  strategy: Required<NuxtI18nOptions>['strategy']
-  /**
-   * Overwritten at build time, used to pass generated options to runtime
-   * @internal
-   */
-  routesNameSeparator: Required<NuxtI18nOptions>['routesNameSeparator']
-  /**
-   * Overwritten at build time, used to pass generated options to runtime
-   * @internal
-   */
-  defaultLocaleRouteNameSuffix: Required<NuxtI18nOptions>['defaultLocaleRouteNameSuffix']
-  /**
-   * Overwritten at build time, used to pass generated options to runtime
-   * @internal
-   */
-  trailingSlash: Required<NuxtI18nOptions>['trailingSlash']
+  /** @internal Overwritten at build time, used to pass generated options to runtime */
+  skipSettingLocaleOnNavigate: Required<NuxtI18nOptions>['skipSettingLocaleOnNavigate']
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Actually removes the types for the (now) unused runtime config properties, these are already documented in migration docs.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined and simplified runtime configuration options for internationalization by removing deprecated or unused fields.
  - Improved internal documentation for configuration properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->