### PR TITLE
refactor: use `createLogger` from `@nuxt/kit`

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "@nuxt/kit": "^3.17.4",
     "@rollup/plugin-yaml": "^4.1.2",
     "@vue/compiler-sfc": "^3.5.16",
-    "debug": "^4.4.1",
     "defu": "^6.1.4",
     "devalue": "^5.1.1",
     "esbuild": "^0.25.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,9 +40,6 @@ importers:
       '@vue/compiler-sfc':
         specifier: ^3.5.16
         version: 3.5.16
-      debug:
-        specifier: ^4.4.1
-        version: 4.4.1
       defu:
         specifier: ^6.1.4
         version: 6.1.4

--- a/src/alias.ts
+++ b/src/alias.ts
@@ -1,5 +1,4 @@
 import { directoryToURL, resolveModule } from '@nuxt/kit'
-import createDebug from 'debug'
 import {
   VUE_I18N_PKG,
   SHARED_PKG,
@@ -14,8 +13,6 @@ import {
 
 import type { Nuxt } from '@nuxt/schema'
 import type { I18nNuxtContext } from './context'
-
-const debug = createDebug('@nuxtjs/i18n:alias')
 
 export function setupAlias({ userOptions: options }: I18nNuxtContext, nuxt: Nuxt) {
   const modules = {
@@ -40,6 +37,5 @@ export function setupAlias({ userOptions: options }: I18nNuxtContext, nuxt: Nuxt
     if (!module) throw new Error(`Could not resolve module "${moduleFile}"`)
     nuxt.options.alias[moduleName] = module
     nuxt.options.build.transpile.push(moduleName)
-    debug(`${moduleName} alias`, nuxt.options.alias[moduleName])
   }
 }

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -4,9 +4,6 @@ declare namespace NodeJS {
   }
 }
 
-declare let __DEBUG__: boolean
-declare let __TEST__: boolean
-
 declare let __IS_SSG__: boolean
 declare let __IS_SSR__: boolean
 declare let __TRAILING_SLASH__: boolean

--- a/src/layers.ts
+++ b/src/layers.ts
@@ -1,4 +1,3 @@
-import createDebug from 'debug'
 import { useNuxt } from '@nuxt/kit'
 import { getLayerI18n, mergeConfigLocales, resolveVueI18nConfigInfo, getLocaleFiles, logger } from './utils'
 
@@ -9,8 +8,6 @@ import type { LocaleConfig } from './utils'
 import type { Nuxt, NuxtConfigLayer } from '@nuxt/schema'
 import type { FileMeta, LocaleObject, NuxtI18nOptions } from './types'
 import type { I18nNuxtContext } from './context'
-
-const debug = createDebug('@nuxtjs/i18n:layers')
 
 export function checkLayerOptions(_options: NuxtI18nOptions, nuxt: Nuxt) {
   const project = nuxt.options._layers[0]
@@ -97,7 +94,6 @@ export function applyLayerOptions(ctx: I18nNuxtContext, nuxt: Nuxt) {
 
   configs.unshift(...installModuleConfigMap.values())
 
-  debug('merged locales', configs)
   ctx.options.locales = mergeConfigLocales(configs)
 }
 

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -1,4 +1,3 @@
-import createDebug from 'debug'
 import { resolveModuleExportNames } from 'mlly'
 import { defu } from 'defu'
 import { resolve } from 'pathe'
@@ -21,8 +20,6 @@ import { resolveI18nDir } from './layers'
 import type { Nuxt } from '@nuxt/schema'
 import type { LocaleInfo } from './types'
 import type { I18nNuxtContext } from './context'
-
-const debug = createDebug('@nuxtjs/i18n:nitro')
 
 export async function setupNitro(ctx: I18nNuxtContext, nuxt: Nuxt) {
   const [enableServerIntegration, localeDetectionPath] = await resolveLocaleDetectorPath(nuxt)
@@ -69,7 +66,6 @@ export { localeDetector }`
     }
 
     nitroConfig.replace = Object.assign({}, nitroConfig.replace, getDefineConfig(ctx, true))
-    debug('nitro.replace', nitroConfig.replace)
   })
 
   // `defineI18nLocale`, `defineI18nConfig`

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -1,4 +1,3 @@
-import createDebug from 'debug'
 import { addTemplate } from '@nuxt/kit'
 import { readFileSync } from 'node:fs'
 import { isString } from '@intlify/shared'
@@ -19,8 +18,6 @@ import type { NuxtI18nOptions } from './types'
 import type { I18nNuxtContext } from './context'
 import type { ComputedRouteOptions, RouteOptionsResolver } from './kit/gen'
 import type { I18nRoute } from './runtime/composables'
-
-const debug = createDebug('@nuxtjs/i18n:pages')
 
 export type AnalyzedNuxtPageMeta = {
   /**
@@ -49,7 +46,6 @@ export async function setupPages({ localeCodes, options, normalizedLocales }: I1
 
   let includeUnprefixedFallback = !nuxt.options.ssr
   nuxt.hook('nitro:init', () => {
-    debug('enable includeUprefixedFallback')
     includeUnprefixedFallback = options.strategy !== 'prefix'
   })
 
@@ -61,7 +57,6 @@ export async function setupPages({ localeCodes, options, normalizedLocales }: I1
   nuxt.hook(
     nuxt.options.experimental.scanPageMeta === 'after-resolve' ? 'pages:resolved' : 'pages:extend',
     async pages => {
-      debug('pages (before)', pages)
       const ctx: NuxtPageAnalyzeContext = {
         stack: [],
         config: options.pages,
@@ -96,8 +91,6 @@ export async function setupPages({ localeCodes, options, normalizedLocales }: I1
         pages.length = 0
         pages.unshift(...localizedPages)
       }
-
-      debug('pages (after)', pages)
     }
   )
 }

--- a/src/prepare/locale-info.ts
+++ b/src/prepare/locale-info.ts
@@ -2,7 +2,7 @@ import type { I18nNuxtContext } from '../context'
 import type { Nuxt } from '@nuxt/schema'
 import { isString } from '@intlify/shared'
 import { applyLayerOptions, resolveLayerVueI18nConfigInfo } from '../layers'
-import { debug, filterLocales, mergeI18nModules, resolveLocales } from '../utils'
+import { filterLocales, mergeI18nModules, resolveLocales } from '../utils'
 
 export async function resolveLocaleInfo(ctx: I18nNuxtContext, nuxt: Nuxt) {
   /**
@@ -18,11 +18,9 @@ export async function resolveLocaleInfo(ctx: I18nNuxtContext, nuxt: Nuxt) {
   ctx.normalizedLocales = ctx.options.locales.map(x => (isString(x) ? { code: x, language: x } : x))
   ctx.localeCodes = ctx.normalizedLocales.map(locale => locale.code)
   ctx.localeInfo = resolveLocales(nuxt.options.srcDir, ctx.normalizedLocales)
-  debug('localeInfo', ctx.localeInfo)
 
   /**
    * resolve vue-i18n config path
    */
   ctx.vueI18nConfigPaths = await resolveLayerVueI18nConfigInfo(ctx.options)
-  debug('VueI18nConfigPaths', ctx.vueI18nConfigPaths)
 }

--- a/src/prepare/options.ts
+++ b/src/prepare/options.ts
@@ -1,10 +1,9 @@
 import type { I18nNuxtContext } from '../context'
 import type { Nuxt } from '@nuxt/schema'
-import { debug, logger } from '../utils'
+import { logger } from '../utils'
 import { checkLayerOptions } from '../layers'
 
 export function prepareOptions({ options }: I18nNuxtContext, nuxt: Nuxt) {
-  debug('options', options)
   checkLayerOptions(options, nuxt)
 
   /**

--- a/src/transform/i18n-function-injection.ts
+++ b/src/transform/i18n-function-injection.ts
@@ -5,7 +5,6 @@
  * - license: MIT
  */
 
-import createDebug from 'debug'
 import MagicString from 'magic-string'
 import { walk } from 'estree-walker'
 import { createUnplugin } from 'unplugin'
@@ -14,8 +13,6 @@ import { isVue } from './utils'
 import { parseSync } from 'oxc-parser'
 import type { CallExpression, Pattern, Program } from 'estree'
 import type { BundlerPluginOptions } from './utils'
-
-const debug = createDebug('@nuxtjs/i18n:function:injection')
 
 const TRANSLATION_FUNCTIONS = ['$t', '$rt', '$d', '$n', '$tm', '$te']
 const TRANSLATION_FUNCTIONS_RE = /\$(t|rt|d|n|tm|te)\s*\(\s*/
@@ -43,8 +40,6 @@ export const TransformI18nFunctionPlugin = (options: BundlerPluginOptions) =>
           code: { include: TRANSLATION_FUNCTIONS_RE }
         },
         handler(code, id) {
-          debug('transform', id)
-
           // only transform if translation functions are present
           const script = extractScriptContent(code)
           if (!script) {
@@ -117,8 +112,6 @@ export const TransformI18nFunctionPlugin = (options: BundlerPluginOptions) =>
 
           const s = new MagicString(code)
           if (missingFunctionDeclarators.size > 0) {
-            debug(`injecting ${Array.from(missingFunctionDeclarators).join(', ')} declaration to ${id}`)
-
             // only add variables when used without having been declared
             const assignments: string[] = []
             for (const missing of missingFunctionDeclarators) {
@@ -134,9 +127,6 @@ export const TransformI18nFunctionPlugin = (options: BundlerPluginOptions) =>
           }
 
           if (s.hasChanged()) {
-            debug('transformed: id -> ', id)
-            debug('transformed: code -> ', s.toString())
-
             return {
               code: s.toString(),
               map: options.sourcemap ? s.generateMap({ hires: true }) : undefined

--- a/src/transform/macros.ts
+++ b/src/transform/macros.ts
@@ -6,7 +6,6 @@
  * - license: MIT
  */
 
-import createDebug from 'debug'
 import MagicString from 'magic-string'
 import { createUnplugin } from 'unplugin'
 import { parse as parseSFC } from '@vue/compiler-sfc'
@@ -14,8 +13,6 @@ import { VIRTUAL_PREFIX_HEX, isVue } from './utils'
 import { NUXT_I18N_COMPOSABLE_DEFINE_ROUTE } from '../constants'
 
 import type { BundlerPluginOptions } from './utils'
-
-const debug = createDebug('@nuxtjs/i18n:transform:macros')
 
 const I18N_MACRO_FN_RE = new RegExp(`\\b${NUXT_I18N_COMPOSABLE_DEFINE_ROUTE}\\s*\\(\\s*`)
 
@@ -42,9 +39,7 @@ export const TransformMacroPlugin = (options: BundlerPluginOptions) =>
         filter: {
           code: { include: I18N_MACRO_FN_RE }
         },
-        handler(code, id) {
-          debug('transform', id)
-
+        handler(code) {
           const parsed = parseSFC(code, { sourceMap: false })
           // only transform <script>
           const script = parsed.descriptor.scriptSetup ?? parsed.descriptor.script
@@ -66,9 +61,6 @@ export const TransformMacroPlugin = (options: BundlerPluginOptions) =>
           }
 
           if (s.hasChanged()) {
-            debug('transformed: id -> ', id)
-            debug('transformed: code -> ', s.toString())
-
             return {
               code: s.toString(),
               map: options.sourcemap ? s.generateMap({ hires: true }) : undefined

--- a/src/transform/resource.ts
+++ b/src/transform/resource.ts
@@ -1,4 +1,3 @@
-import createDebug from 'debug'
 import MagicString from 'magic-string'
 import { createUnplugin } from 'unplugin'
 import { asI18nVirtual, VIRTUAL_PREFIX_HEX } from './utils'
@@ -23,15 +22,11 @@ async function transform<T extends TransformOptions>(
   return await esbuildTransform(input, { ...tryUseNuxt()?.options.esbuild?.options, ...options })
 }
 
-const debug = createDebug('@nuxtjs/i18n:transform:resource')
-
 const pattern = [NUXT_I18N_COMPOSABLE_DEFINE_LOCALE, NUXT_I18N_COMPOSABLE_DEFINE_CONFIG].join('|')
 const DEFINE_I18N_FN_RE = new RegExp(`\\b(${pattern})\\s*\\((.+)\\s*\\)`, 'gms')
 
 export const ResourcePlugin = (options: BundlerPluginOptions, ctx: I18nNuxtContext) =>
   createUnplugin(() => {
-    debug('options', options)
-
     // TODO: track all i18n files found in configuration
     const i18nFileMetas = [...ctx.localeInfo.flatMap(x => x.meta), ...ctx.vueI18nConfigPaths]
     const i18nPathSet = new Set<string>()
@@ -63,7 +58,6 @@ export const ResourcePlugin = (options: BundlerPluginOptions, ctx: I18nNuxtConte
         }
 
         if (i18nPathSet.has(id)) {
-          debug('transformInclude', id)
           return /\.([c|m]?[j|t]s)$/.test(id)
         }
       },
@@ -78,7 +72,6 @@ export const ResourcePlugin = (options: BundlerPluginOptions, ctx: I18nNuxtConte
           }
         },
         async handler(_code, id) {
-          debug('transform', id)
           let code = _code
 
           // ensure imported resources are transformed as well

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
 import { defu } from 'defu'
-import createDebug from 'debug'
 import { readFileSync, existsSync } from 'node:fs'
 import { createHash, type BinaryLike } from 'node:crypto'
 import { resolvePath, useLogger } from '@nuxt/kit'
@@ -240,5 +239,4 @@ export function toArray<T>(value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value]
 }
 
-export const logger = useLogger(NUXT_I18N_MODULE_ID)
-export const debug = createDebug(NUXT_I18N_MODULE_ID)
+export const logger = useLogger('nuxt-i18n')


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Removes most of the logging, the debug logging was noisy and most the same information can be understood using Nuxt devtools
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed all internal debug logging and the "debug" dependency, resulting in a cleaner build and reduced console output.
  - Updated logging to use a unified logger for error reporting.
  - Removed unused global variables related to debugging and testing from the environment declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->