### PR TITLE
refactor: move `i18nModules` to internal build context

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -15,6 +15,7 @@ export interface I18nNuxtContext {
   distDir: string
   runtimeDir: string
   fullStatic: boolean
+  i18nModules: { langDir: string; locales: string[] | LocaleObject[] }[]
 }
 
 const resolver = createResolver(import.meta.url)
@@ -34,6 +35,7 @@ export function createContext(userOptions: NuxtI18nOptions): I18nNuxtContext {
     localeCodes: undefined!,
     normalizedLocales: undefined!,
     vueI18nConfigPaths: undefined!,
-    fullStatic: undefined!
+    fullStatic: undefined!,
+    i18nModules: []
   }
 }

--- a/src/prepare/runtime-config.ts
+++ b/src/prepare/runtime-config.ts
@@ -4,20 +4,19 @@ import type { I18nPublicRuntimeConfig } from '../types'
 import { DEFAULT_OPTIONS } from '../constants'
 import { defu } from 'defu'
 import { simplifyLocaleOptions } from '../gen'
-import { assign } from '@intlify/shared'
 
-export function prepareRuntimeConfig({ options }: I18nNuxtContext, nuxt: Nuxt) {
+export function prepareRuntimeConfig(ctx: I18nNuxtContext, nuxt: Nuxt) {
   // @ts-expect-error generated type
   nuxt.options.runtimeConfig.public.i18n = defu(nuxt.options.runtimeConfig.public.i18n, {
-    baseUrl: options.baseUrl,
-    defaultLocale: options.defaultLocale,
-    rootRedirect: options.rootRedirect,
-    skipSettingLocaleOnNavigate: options.skipSettingLocaleOnNavigate,
-    locales: options.locales,
-    detectBrowserLanguage: options.detectBrowserLanguage ?? DEFAULT_OPTIONS.detectBrowserLanguage,
-    experimental: options.experimental,
+    baseUrl: ctx.options.baseUrl,
+    defaultLocale: ctx.options.defaultLocale,
+    rootRedirect: ctx.options.rootRedirect,
+    skipSettingLocaleOnNavigate: ctx.options.skipSettingLocaleOnNavigate,
+    locales: ctx.options.locales,
+    detectBrowserLanguage: ctx.options.detectBrowserLanguage ?? DEFAULT_OPTIONS.detectBrowserLanguage,
+    experimental: ctx.options.experimental,
     domainLocales: {} as I18nPublicRuntimeConfig['domainLocales']
   })
 
-  nuxt.options.runtimeConfig.public.i18n.locales = simplifyLocaleOptions(nuxt, assign({}, options))
+  nuxt.options.runtimeConfig.public.i18n.locales = simplifyLocaleOptions(ctx, nuxt)
 }

--- a/src/transform/heist.ts
+++ b/src/transform/heist.ts
@@ -13,7 +13,7 @@ import { useNuxt } from '@nuxt/kit'
  */
 export const HeistPlugin = (options: BundlerPluginOptions, ctx: I18nNuxtContext, nuxt = useNuxt()) => {
   // transform `runtime/shared` to be nuxt/nitro context agnostic
-  const shared = ctx.resolver.resolve(ctx.distDir, 'runtime/shared') + '/*'
+  const shared = ctx.resolver.resolve(ctx.distDir, 'runtime/shared/*')
 
   const replacementName = `__nuxtMock`
   const replacementMock = `const ${replacementName} = { runWithContext: async (fn) => await fn() };`

--- a/src/types.ts
+++ b/src/types.ts
@@ -169,11 +169,6 @@ export type NuxtI18nOptions<
    * @internal
    */
   overrides?: Omit<NuxtI18nOptions<Context>, 'overrides'>
-  /**
-   * Do not use in projects - this is used internally for e2e tests to override default option merging.
-   * @internal
-   */
-  i18nModules?: { langDir?: string | null; locales?: NuxtI18nOptions<Context>['locales'] }[]
   rootRedirect?: string | RootRedirectOptions
   skipSettingLocaleOnNavigate?: boolean
   /**


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined function signatures to use a unified context object for locale and configuration handling.
  - Improved internal locale merging logic for better efficiency and consistency.

- **Chores**
  - Removed unused internal properties and imports to clean up codebase.

No user-facing features or visible changes have been introduced in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->