### PR TITLE
docs: improve migration page

### DIFF
--- a/docs/content/docs/02.guide/90.migrating.md
+++ b/docs/content/docs/02.guide/90.migrating.md
@@ -7,7 +7,7 @@ toc:
 
 ## Upgraded to Vue I18n v11
 
-We have upgraded from Vue I18n v10 to v11, this major version bump deprecates the Legacy API mode and custom `v-t` directive and drops `tc()`{lang="ts"} and `$tc()`{lang="ts"} from Legacy API mode.
+We have upgraded from Vue I18n v10 to v11, this major version bump deprecates the Legacy API mode and custom `v-t` directive, and removes `tc()`{lang="ts"} and `$tc()`{lang="ts"} from Legacy API mode.
 
 Check the documentation detailing the breaking changes [here](https://vue-i18n.intlify.dev/guide/migration/breaking11.html).
 
@@ -31,7 +31,7 @@ The following [Configuration options](/docs/api/options) have been changed, depr
 
 ## I18n functions
 
-The following [I18n functions](/docs/api/i18n) which are extensions on Vue I18n have been changed, deprecated, or removed.
+The following composables and [I18n functions](/docs/api/vue-i18n) have been changed, deprecated, or removed.
 
 | Status | Function | Notes |
 |---|---|---|

--- a/docs/content/docs/02.guide/90.migrating.md
+++ b/docs/content/docs/02.guide/90.migrating.md
@@ -6,82 +6,72 @@ toc:
 ---
 
 ## Upgraded to Vue I18n v11
-We have upgraded from Vue I18n v10 to v11, this major version bump deprecates the Legacy API mode and custom `v-t` directive and drops `tc` and `$tc` from Legacy API mode.
+
+We have upgraded from Vue I18n v10 to v11, this major version bump deprecates the Legacy API mode and custom `v-t` directive and drops `tc()`{lang="ts"} and `$tc()`{lang="ts"} from Legacy API mode.
 
 Check the documentation detailing the breaking changes [here](https://vue-i18n.intlify.dev/guide/migration/breaking11.html).
 
-## General changes
-These options and functions have undergone a minor change, they are still available but have been limited in functionality or changed in some other way.
-
-| Option/Function | Reasoning |
-|------------------|---------|
- | `restructureDir`{lang="yml"} | It is no longer possible to disable the new directory structure by setting `restructureDir: false`{lang="ts"}.<br><br>We recommend leaving this unset to use the default value of `'i18n'`{lang="ts"}. |
-| `baseUrl`{lang="yaml"} | The `baseUrl`{lang="yaml"} option will no longer support function configuration in v11, which will only support string values.<br><br>Use runtime config or rely on multi domain locales to set the base URL for complex setups. |
- | `useLocaleHead()`{lang="ts"} | The `key` property has been removed and can no longer be configured, this is necessary for predictable and consistent localized head tag management. |
- |`$localeHead()`{lang="ts"} | Same as `useLocaleHead()`{lang="ts"}. |
-
 ## Configuration options
 
-### Removals
-The following options have been removed:
+The following [Configuration options](/docs/api/options) have been changed, deprecated, or removed.
 
-| Option | Reasoning |
-|--------|--------|
-| `lazy`{lang="yml"} | Lazy loading of locale messages is now the default behavior. |
-| `bundle.optimizeTranslationDirective`{lang="yml"} | This feature has been disabled and fully removed, see [the discussion in this issue](https://github.com/nuxt-modules/i18n/issues/3238#issuecomment-2672492536) for context on this change. |
-| `experimental.generatedLocaleFilePathFormat`{lang="yml"} | File paths (e.g. locale files, vue-i18n configs) configured for this module are now removed from the build entirely making this option obsolete. |
-
-
-### Deprecations
-The following options have been deprecated and will be removed in v11:
-
-| Option | Reasoning |
-|---|---|
-| `types`{lang="yml"} | Only `'composition'`{lang="yml"} types will be supported in v11, in line with Vue I18n v12. |
-| `routesNameSeparator`{lang="yml"} | This was documented as internal, use cases for end-users are unclear. |
-| `defaultLocaleRouteNameSuffix`{lang="yml"} | This was documented as internal, use cases for end-users are unclear. |
-
-### Promotions
-These options are stable and are now enabled by default, some have been renamed to better reflect their purpose. 
-
-| Option | Replacement |
-|---|---|
-| `experimental.hmr`{lang="yml"} | `hmr`{lang="yml"} |
-| `experimental.switchLocalePathLinkSSR`{lang="yml"} | This is stable and the option to enable/disable it has been removed. |
-| `experimental.autoImportTranslationFunctions`{lang="yml"} | `autoDeclare`{lang="yml"} |
+| Status | Option | Notes |
+|---|---|---|
+| :badge{label="promoted" color="success"} | `experimental.hmr`{lang="yml"} | Enabled by default and renamed to [`hmr`{lang="yml"}](/docs/api/options#hmr) |
+| :badge{label="promoted" color="success"} | `experimental.switchLocalePathLinkSSR`{lang="yml"} | Enabled by default and the option to disable it has been removed. |
+| :badge{label="promoted" color="success"} | `experimental.autoImportTranslationFunctions`{lang="yml"} | Enabled by default and renamed to [`autoDeclare`{lang="yml"}](/docs/api/options#autodeclare) |
+| :badge{label="changed" color="info"} | [`restructureDir`{lang="yml"}](/docs/api/options#restructuredir) | This can no longer be disabled.<br><br>We recommend leaving this unset to use the default value of `'i18n'`{lang="ts"}. |
+| :badge{label="deprecated" color="warning"} | [`types`{lang="yml"}](/docs/api/options#types) | Only `'composition'`{lang="yml"} types will be supported in v11, in line with Vue I18n v12. |
+| :badge{label="deprecated" color="warning"} | [`baseUrl`{lang="yaml"}](/docs/api/options#baseurl) | Will only allow string values and will no longer support function configuration in v11.<br><br>Use runtime config or rely on multi domain locales to set the base URL for complex setups. |  
+| :badge{label="deprecated" color="warning"} | [`routesNameSeparator`{lang="yml"}](/docs/api/options#routesnameseparator) | This was documented as internal, use cases for end-users are unclear. |
+| :badge{label="deprecated" color="warning"} | [`defaultLocaleRouteNameSuffix`{lang="yml"}](/docs/api/options#defaultlocaleroutenamesuffix) | This was documented as internal, use cases for end-users are unclear. |
+| :badge{label="removed" color="error"} | `lazy`{lang="yml"} | Lazy loading of locale messages is now enabled for all locale files. |
+| :badge{label="removed" color="error"} | `bundle.optimizeTranslationDirective`{lang="yml"} | This feature has been disabled and fully removed, see [the discussion in this issue](https://github.com/nuxt-modules/i18n/issues/3238#issuecomment-2672492536) for context on this change. |
+| :badge{label="removed" color="error"} | `experimental.generatedLocaleFilePathFormat`{lang="yml"} | File paths (e.g. locale files, vue-i18n configs) configured for this module are now removed from the build entirely making this option obsolete. |
 
 ## I18n functions
 
-### Removals
-The following i18n functions have been removed from the module, they were deprecated in v9.
+The following [I18n functions](/docs/api/i18n) which are extensions on Vue I18n have been changed, deprecated, or removed.
 
-| Function | Reasoning |
-|---|---|
-| `onLanguageSwitched()`{lang="ts"} | This function actually called the hook instead of subscribing to it, leading to unpredictable behavior.<br><br>Use the [`'i18n:languageSwitched'`{lang="ts"}](/docs/guide/runtime-hooks) hook instead. |
-| `onBeforeLanguageSwitch()`{lang="ts"} | This function actually called the hook instead of subscribing to it, leading to unpredictable behavior.<br><br>Use the [`'i18n:beforeLanguageSwitch'`{lang="ts"}](/docs/guide/runtime-hooks) hook instead. |
+| Status | Function | Notes |
+|---|---|---|
+| :badge{label="changed" color="info"}| [`useLocaleHead()`{lang="ts"}](/docs/composables/use-locale-head) | The `key`{lang="yml"} property on the options parameter has been removed and can no longer be configured, this is necessary for predictable and consistent localized head tag management. |
+| :badge{label="removed" color="error"} | `onLanguageSwitched()`{lang="ts"} | Use the [`'i18n:languageSwitched'`{lang="ts"}](/docs/guide/runtime-hooks) hook instead.<br><br>This function actually called the hook instead of subscribing to it, leading to unpredictable behavior.|
+| :badge{label="removed" color="error"} | `onBeforeLanguageSwitch()`{lang="ts"} | Use the [`'i18n:beforeLanguageSwitch'`{lang="ts"}](/docs/guide/runtime-hooks) hook instead.<br><br>This function actually called the hook instead of subscribing to it, leading to unpredictable behavior. |
 
 
 ## Context functions
 
-### Removals
-The following functions have been removed from the Nuxt context.
+The following [context functions](/docs/api/nuxt) have been changed, deprecated, or removed.
 
-| Function | Replacement |
-|---|---|
-| `$resolveRoute()`{lang="ts"} | Use `$localeRoute()`{lang="ts"} instead |
-| `$localeLocation()`{lang="ts"} | Use `$localeRoute()`{lang="ts"} instead |
+| Status | Function | Notes |
+|---|---|---|
+| :badge{label="changed" color="info"}| [`$localeHead()`{lang="ts"}](/docs/api/nuxt#localehead) | The `key`{lang="yml"} property on the options parameter has been removed and can no longer be configured, this is necessary for predictable and consistent localized head tag management. |
+| :badge{label="deprecated" color="warning"} | [`$localeHead()`{lang="ts"}](/docs/api/nuxt#localehead) | Use the `useLocaleHead()`{lang="ts"} composable instead.<br><br>Deprecated due to limited use cases, the [`useLocaleHead()`{lang="ts"}](/docs/composables/use-locale-head) composable offers the same functionality and is easier to use in combination with `useHead()`{lang="ts"}. |
+| :badge{label="deprecated" color="warning"} | `$getRouteBaseName()`{lang="ts"} | Use [`$routeBaseName()`{lang="ts"}](/docs/api/nuxt#routebasename) instead.<br><br>Deprecated in favor of the same function under a new name: [`$routeBaseName()`{lang="ts"}](/docs/api/nuxt#routebasename), to be consistent with the other context functions and their composable counterparts. |
+| :badge{label="removed" color="error"} | `$resolveRoute()`{lang="ts"} | Use [`$localeRoute()`{lang="ts"}](/docs/api/nuxt#localeroute) instead |
+| :badge{label="removed" color="error"} | `$localeLocation()`{lang="ts"} | Use [`$localeRoute()`{lang="ts"}](/docs/api/nuxt#localeroute) instead |
 
+## Runtime config
 
-### Deprecations
-These Nuxt context functions have been deprecated and will be removed in v11. 
+Several options set in the runtime config were only used to transfer build-time configuration to runtime and changing these at runtime could cause issues.
 
-| Function | Reason for Deprecation / Replacement |
-|---|---|
-| `$localeHead()`{lang="ts"} | Deprecated due to limited use cases, the `useLocaleHead()`{lang="ts"} composable offers the same functionality and is easier to use in combination with `useHead()`{lang="ts"}. |
-| `$getRouteBaseName()`{lang="ts"} | Deprecated in favor of the same function under a new name: `$routeBaseName()`{lang="ts"}, to be consistent with the other context functions and their composable counterparts. |
+Instead of setting these on runtime config we now treat them as compiler constants, this way we can tree-shake any unused logic from a project build.
 
+The following options have been removed from runtime config:
+| Removed runtime config option |
+|---|
+| `lazy`{lang="yml"} |
+| `strategy`{lang="yml"} |
+| `trailingSlash`{lang="yml"} |
+| `differentDomains`{lang="yml"} | 
+| `defaultDirection`{lang="yml"} |
+| `multiDomainLocales`{lang="yml"} |
+| `routeNameSeparator`{lang="yml"} |
+| `defaultLocaleRouteNameSuffix`{lang="yml"} |
 
 ## Generated options
+
 The generated options files in your projects are meant for internal use by this module at runtime and should never be used, more properties may be removed in the future.
 
 The following exports have been removed from the generated options files (`#build/i18n.options.mjs` and `#internal/i18n/options.mjs`):
@@ -99,23 +89,6 @@ The following exports have been removed from the generated options files (`#buil
 Reasons for removal: 
 * These are no longer used by the module and might expose vulnerable information in the final build
 * Some options are now used as static values for better tree-shaking resulting in a smaller project build.
-
-## Runtime config
-Several options set in the runtime config were only used to transfer build-time configuration to runtime and changing these at runtime could cause issues.
-
-Instead of setting these on runtime config we now treat them as compiler constants, this way we can tree-shake any unused logic from a project build.
-
-The following options have been removed from runtime config:
-| Removed runtime config option |
-|---|
-| `lazy`{lang="yml"} |
-| `strategy`{lang="yml"} |
-| `trailingSlash`{lang="yml"} |
-| `differentDomains`{lang="yml"} | 
-| `defaultDirection`{lang="yml"} |
-| `multiDomainLocales`{lang="yml"} |
-| `routeNameSeparator`{lang="yml"} |
-| `defaultLocaleRouteNameSuffix`{lang="yml"} |
 
 ## Legacy migration
 The migration guides for v7 and v8 can be found in the [legacy documentation](https://v9.i18n.nuxtjs.org/docs/guide/migrating)

--- a/docs/content/docs/04.api/05.vue.md
+++ b/docs/content/docs/04.api/05.vue.md
@@ -51,10 +51,6 @@ See also [Link localizing](/docs/getting-started/usage)
 
 ### `localeHead()`{lang="ts"}
 
-::callout{icon="i-heroicons-light-bulb"}
-`localeHead()`{lang="ts"} is renamed from `$nuxtI18nHead()`{lang="ts"} provided in `@nuxtjs/i18n` v7.x.
-::
-
 - **Arguments**:
   - options: (type: `I18nHeadOptions`{lang="ts-type"})
 - **Returns**: `I18nHeadMetaInfo`{lang="ts-type"}

--- a/docs/content/docs/06.composables/04.use-locale-head.md
+++ b/docs/content/docs/06.composables/04.use-locale-head.md
@@ -30,11 +30,6 @@ An object accepting the following optional fields:
   - type: `boolean | SeoAttributesOptions`{lang="ts"}
   - Adds various SEO attributes.
 
-- `key`
-  - type: `string`{lang="ts"}
-  - default: `'key'`{lang="ts"}
-  - Identifier attribute of `<meta>` tag.
-
 ## Usage
 
 ```vue


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Improved the migration guide for upgrading to Vue I18n v11 with clearer structure, updated tables, explicit deprecation/removal notices, and guidance on replacements.
	- Updated the API documentation for `localeHead()` by removing outdated renaming notes.
	- Revised the `useLocaleHead()` composable documentation to remove the description of the deprecated `key` option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->