### PR TITLE
refactor: layer locale and vue-i18n resolvers

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -15,7 +15,6 @@ export interface I18nNuxtContext {
   distDir: string
   runtimeDir: string
   fullStatic: boolean
-  i18nModules: { langDir: string; locales: string[] | LocaleObject[] }[]
 }
 
 const resolver = createResolver(import.meta.url)
@@ -35,7 +34,6 @@ export function createContext(userOptions: NuxtI18nOptions): I18nNuxtContext {
     localeCodes: undefined!,
     normalizedLocales: undefined!,
     vueI18nConfigPaths: undefined!,
-    fullStatic: undefined!,
-    i18nModules: []
+    fullStatic: undefined!
   }
 }

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -1,7 +1,6 @@
 import { isString } from '@intlify/shared'
 import { genDynamicImport, genSafeVariableName, genString } from 'knitwork'
 import { resolve, relative, join, basename } from 'pathe'
-import { getLayerI18n } from './utils'
 import { asI18nVirtual } from './transform/utils'
 import { resolveModule } from '@nuxt/kit'
 
@@ -16,13 +15,10 @@ function stripLocaleFiles(locale: LocaleObject) {
   return locale
 }
 
-export function simplifyLocaleOptions(ctx: I18nNuxtContext, nuxt: Nuxt) {
+export function simplifyLocaleOptions(ctx: I18nNuxtContext, _nuxt: Nuxt) {
   const isLocaleObjectsArray = (locales?: Locale[] | LocaleObject[]) => locales?.some(x => !isString(x))
 
-  const hasLocaleObjects =
-    nuxt.options._layers.some(layer => isLocaleObjectsArray(getLayerI18n(layer)?.locales)) ||
-    ctx.i18nModules.some(module => isLocaleObjectsArray(module?.locales))
-
+  const hasLocaleObjects = isLocaleObjectsArray(ctx.options.locales)
   const locales = (ctx.options.locales ?? []) as LocaleObject[]
   return locales.map(locale => (!hasLocaleObjects ? locale.code : stripLocaleFiles(locale)))
 }

--- a/src/layers.ts
+++ b/src/layers.ts
@@ -58,16 +58,13 @@ export function applyLayerOptions(ctx: I18nNuxtContext, nuxt: Nuxt) {
   const configs: LocaleConfig[] = []
 
   // collect `installModule` config, identified by absolute `langDir` and `locales` paths
-  const installModuleConfig: LocaleConfig<LocaleObject[]> = { langDir: ctx.options.langDir || '', locales: [] }
-  if (isAbsolute(installModuleConfig.langDir)) {
+  if (isAbsolute(ctx.options.langDir || '')) {
+    const config: LocaleConfig<LocaleObject[]> = { langDir: ctx.options.langDir!, locales: [] }
     for (const locale of ctx.options.locales) {
-      if (isString(locale)) continue
-      // absolute locale path starts with absolute path langDir
-      if (!getLocaleFiles(locale)?.[0]?.path?.startsWith(installModuleConfig.langDir)) continue
-      installModuleConfig.locales.push(locale)
+      if (isString(locale) || !getLocaleFiles(locale)?.[0]?.path?.startsWith(config.langDir)) continue
+      config.locales.push(locale)
     }
-
-    configs.push(installModuleConfig)
+    configs.push(config)
   }
 
   // collect layer configs

--- a/src/layers.ts
+++ b/src/layers.ts
@@ -6,7 +6,7 @@ import { assign, isString } from '@intlify/shared'
 
 import type { LocaleConfig } from './utils'
 import type { Nuxt, NuxtConfigLayer } from '@nuxt/schema'
-import type { FileMeta, LocaleObject, NuxtI18nOptions } from './types'
+import type { FileMeta, LocaleObject, LocaleType, NuxtI18nOptions } from './types'
 import type { I18nNuxtContext } from './context'
 
 export function checkLayerOptions(_options: NuxtI18nOptions, nuxt: Nuxt) {
@@ -46,12 +46,8 @@ export function checkLayerOptions(_options: NuxtI18nOptions, nuxt: Nuxt) {
   }
 }
 
-export function resolveI18nDir(layer: NuxtConfigLayer, i18n: NuxtI18nOptions) {
-  return resolve(layer.config.rootDir, i18n.restructureDir ?? 'i18n')
-}
-
-function resolveLayerLangDir(layer: NuxtConfigLayer, i18n: NuxtI18nOptions) {
-  return resolve(resolveI18nDir(layer, i18n), i18n.langDir ?? 'locales')
+export function resolveI18nDir(layer: NuxtConfigLayer, i18n: NuxtI18nOptions, i18nDir = i18n.restructureDir ?? 'i18n') {
+  return resolve(layer.config.rootDir, i18nDir)
 }
 
 /**
@@ -59,64 +55,60 @@ function resolveLayerLangDir(layer: NuxtConfigLayer, i18n: NuxtI18nOptions) {
  * This overwrites `options.locales`
  */
 export function applyLayerOptions(ctx: I18nNuxtContext, nuxt: Nuxt) {
-  ctx.options.locales ??= []
-
   const configs: LocaleConfig[] = []
+
+  // collect `installModule` config, identified by absolute `langDir` and `locales` paths
+  const installModuleConfig: LocaleConfig<LocaleObject[]> = { langDir: ctx.options.langDir || '', locales: [] }
+  if (isAbsolute(installModuleConfig.langDir)) {
+    for (const locale of ctx.options.locales) {
+      if (isString(locale)) continue
+      // absolute locale path starts with absolute path langDir
+      if (!getLocaleFiles(locale)?.[0]?.path?.startsWith(installModuleConfig.langDir)) continue
+      installModuleConfig.locales.push(locale)
+    }
+
+    configs.push(installModuleConfig)
+  }
+
+  // collect layer configs
   for (const layer of nuxt.options._layers) {
     const i18n = getLayerI18n(layer)
     if (i18n?.locales == null) continue
-    configs.push(assign({}, i18n, { langDir: resolveLayerLangDir(layer, i18n), locales: i18n.locales }))
+
+    configs.push(
+      assign({}, i18n, {
+        langDir: resolve(resolveI18nDir(layer, i18n), i18n.langDir ?? 'locales'),
+        locales: i18n.locales
+      })
+    )
   }
-
-  /**
-   * Collect any locale files that are not provided by layers these are added when
-   * installing through `installModule` and should have absolute paths.
-   */
-  const installModuleConfigMap = new Map<string, LocaleConfig>()
-  outer: for (const locale of ctx.options.locales) {
-    if (isString(locale)) continue
-
-    const files = getLocaleFiles(locale)
-    if (files.length === 0) continue
-
-    const langDir = parse(files[0].path).dir
-    const locales = (installModuleConfigMap.get(langDir)?.locales ?? []) as LocaleObject[]
-
-    // check if all files are absolute and not present in configs
-    for (const file of files) {
-      if (!isAbsolute(file.path)) continue outer
-      if (configs.find(config => config.langDir === parse(file.path).dir) != null) continue outer
-    }
-
-    locales.push(locale)
-    installModuleConfigMap.set(langDir, { langDir, locales })
-  }
-
-  configs.unshift(...installModuleConfigMap.values())
 
   ctx.options.locales = mergeConfigLocales(configs)
 }
 
 export async function resolveLayerVueI18nConfigInfo(options: NuxtI18nOptions, nuxt = useNuxt()) {
-  const resolved = await Promise.all(
-    nuxt.options._layers.map(async layer => {
-      const i18n = getLayerI18n(layer)
-      const i18nDirPath = resolveI18nDir(layer, i18n || {})
-      const res = await resolveVueI18nConfigInfo(i18nDirPath, i18n?.vueI18n)
+  const resolvers: Promise<{ path: string; hash: string; type: LocaleType } | undefined>[] = []
 
-      if (res == null && i18n?.vueI18n != null) {
-        logger.warn(`Vue I18n configuration file \`${i18n.vueI18n}\` not found in \`${i18nDirPath}\`. Skipping...`)
-        return undefined
-      }
-
-      return res
-    })
-  )
-
-  // use `vueI18n` passed by `installModule`
+  // collect `installModule` config
   if (options.vueI18n && isAbsolute(options.vueI18n)) {
-    resolved.unshift(await resolveVueI18nConfigInfo(parse(options.vueI18n).dir, options.vueI18n))
+    resolvers.push(resolveVueI18nConfigInfo(parse(options.vueI18n).dir, options.vueI18n))
   }
 
-  return resolved.filter((x): x is Required<FileMeta> => x != null)
+  for (const layer of nuxt.options._layers) {
+    resolvers.push(resolveLayerVueI18n(layer))
+  }
+
+  return (await Promise.all(resolvers)).filter((x): x is Required<FileMeta> => x != null)
+}
+
+async function resolveLayerVueI18n(layer: NuxtConfigLayer) {
+  const i18n = getLayerI18n(layer)
+  const i18nDir = resolveI18nDir(layer, i18n || {})
+  const resolved = await resolveVueI18nConfigInfo(i18nDir, i18n?.vueI18n)
+
+  if (import.meta.dev && resolved == null && i18n?.vueI18n) {
+    logger.warn(`Vue I18n configuration file \`${i18n.vueI18n}\` not found in \`${i18nDir}\`. Skipping...`)
+  }
+
+  return resolved
 }

--- a/src/layers.ts
+++ b/src/layers.ts
@@ -52,9 +52,8 @@ export function resolveI18nDir(layer: NuxtConfigLayer, i18n: NuxtI18nOptions, i1
 
 /**
  * Merges `locales` configured by each layer and resolves the locale `files` to absolute paths.
- * This overwrites `options.locales`
  */
-export function applyLayerOptions(ctx: I18nNuxtContext, nuxt: Nuxt) {
+export async function applyLayerOptions(ctx: I18nNuxtContext, nuxt: Nuxt) {
   const configs: LocaleConfig[] = []
 
   // collect `installModule` config, identified by absolute `langDir` and `locales` paths
@@ -76,7 +75,13 @@ export function applyLayerOptions(ctx: I18nNuxtContext, nuxt: Nuxt) {
     configs.push(assign({}, i18n, { langDir, locales: i18n.locales }))
   }
 
-  ctx.options.locales = mergeConfigLocales(configs)
+  // collect hook configs
+  await nuxt.callHook(
+    'i18n:registerModule',
+    ({ langDir, locales }) => langDir && locales && configs.push({ langDir, locales })
+  )
+
+  return mergeConfigLocales(configs)
 }
 
 export async function resolveLayerVueI18nConfigInfo(options: NuxtI18nOptions, nuxt = useNuxt()) {

--- a/src/layers.ts
+++ b/src/layers.ts
@@ -75,12 +75,8 @@ export function applyLayerOptions(ctx: I18nNuxtContext, nuxt: Nuxt) {
     const i18n = getLayerI18n(layer)
     if (i18n?.locales == null) continue
 
-    configs.push(
-      assign({}, i18n, {
-        langDir: resolve(resolveI18nDir(layer, i18n), i18n.langDir ?? 'locales'),
-        locales: i18n.locales
-      })
-    )
+    const langDir = resolve(resolveI18nDir(layer, i18n), i18n.langDir ?? 'locales')
+    configs.push(assign({}, i18n, { langDir, locales: i18n.locales }))
   }
 
   ctx.options.locales = mergeConfigLocales(configs)

--- a/src/prepare/locale-info.ts
+++ b/src/prepare/locale-info.ts
@@ -2,15 +2,14 @@ import type { I18nNuxtContext } from '../context'
 import type { Nuxt } from '@nuxt/schema'
 import { isString } from '@intlify/shared'
 import { applyLayerOptions, resolveLayerVueI18nConfigInfo } from '../layers'
-import { filterLocales, mergeI18nModules, resolveLocales } from '../utils'
+import { filterLocales, resolveLocales } from '../utils'
 
 export async function resolveLocaleInfo(ctx: I18nNuxtContext, nuxt: Nuxt) {
   /**
    * collect and merge locales from layers and module hooks
    */
-  applyLayerOptions(ctx, nuxt)
-  await mergeI18nModules(ctx, nuxt)
-  filterLocales(ctx, nuxt)
+  ctx.options.locales = await applyLayerOptions(ctx, nuxt)
+  ctx.options.locales = filterLocales(ctx, nuxt)
 
   /**
    * resolve locale info

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -141,7 +141,7 @@ export const getLocaleFiles = (locale: LocaleObject): LocaleFile[] => {
     .map(x => (isString(x) ? { path: x, cache: undefined } : x))
 }
 
-function resolveRelativeLocales(locale: LocaleObject, config: LocaleConfig) {
+export function resolveRelativeLocales(locale: LocaleObject, config: LocaleConfig) {
   return getLocaleFiles(locale).map(file => ({
     path: resolve(config.langDir, file.path),
     cache: file.cache

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -150,9 +150,9 @@ export function resolveRelativeLocales(locale: LocaleObject, config: LocaleConfi
   })) as LocaleFile[]
 }
 
-export type LocaleConfig = {
+export type LocaleConfig<T = string[] | LocaleObject[]> = {
   langDir: string
-  locales: string[] | LocaleObject[]
+  locales: T
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import { readFileSync, existsSync } from 'node:fs'
 import { createHash, type BinaryLike } from 'node:crypto'
 import { resolvePath, useLogger } from '@nuxt/kit'
 import { resolve } from 'pathe'
-import { isString, isArray, assign, isObject } from '@intlify/shared'
+import { isString, isArray, assign } from '@intlify/shared'
 import { NUXT_I18N_MODULE_ID, EXECUTABLE_EXTENSIONS, EXECUTABLE_EXT_RE } from './constants'
 import { parseSync } from 'oxc-parser'
 
@@ -14,15 +14,13 @@ import type { I18nNuxtContext } from './context'
 
 export function filterLocales(ctx: I18nNuxtContext, nuxt: Nuxt) {
   const project = getLayerI18n(nuxt.options._layers[0])
-  const includingLocales = toArray(project?.bundle?.onlyLocales ?? []).filter(isString)
+  const include = toArray(project?.bundle?.onlyLocales ?? []).filter(isString)
 
-  if (!includingLocales.length) {
-    return
+  if (!include.length) {
+    return ctx.options.locales
   }
 
-  ctx.options.locales = ctx.options.locales.filter(locale =>
-    includingLocales.includes(isString(locale) ? locale : locale.code)
-  ) as string[] | LocaleObject[]
+  return ctx.options.locales.filter(x => include.includes(isString(x) ? x : x.code)) as string[] | LocaleObject[]
 }
 
 export function resolveLocales(srcDir: string, locales: LocaleObject[]): LocaleInfo[] {
@@ -143,17 +141,14 @@ export const getLocaleFiles = (locale: LocaleObject): LocaleFile[] => {
     .map(x => (isString(x) ? { path: x, cache: undefined } : x))
 }
 
-export function resolveRelativeLocales(locale: LocaleObject, config: LocaleConfig) {
+function resolveRelativeLocales(locale: LocaleObject, config: LocaleConfig) {
   return getLocaleFiles(locale).map(file => ({
     path: resolve(config.langDir, file.path),
     cache: file.cache
   })) as LocaleFile[]
 }
 
-export type LocaleConfig<T = string[] | LocaleObject[]> = {
-  langDir: string
-  locales: T
-}
+export type LocaleConfig<T = string[] | LocaleObject[]> = { langDir: string; locales: T }
 
 /**
  * Generically merge LocaleObject locales
@@ -188,24 +183,6 @@ export const mergeConfigLocales = (configs: LocaleConfig[], mergedLocales: Map<s
   }
 
   return Array.from(mergedLocales.values())
-}
-
-/**
- * Merges project layer locales with registered i18n modules
- */
-export const mergeI18nModules = async (ctx: I18nNuxtContext, nuxt: Nuxt) => {
-  await nuxt.callHook(
-    'i18n:registerModule',
-    ({ langDir, locales }) => langDir && locales && ctx.i18nModules.push({ langDir, locales })
-  )
-
-  const mergedLocales = new Map<string, LocaleObject>()
-  for (const locale of ctx.options.locales) {
-    if (!isObject(locale)) continue
-    mergedLocales.set(locale.code, assign({}, locale, { file: undefined, files: getLocaleFiles(locale) }))
-  }
-
-  ctx.options.locales = mergeConfigLocales(ctx.i18nModules, mergedLocales)
 }
 
 function getHash(text: BinaryLike): string {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced clarity and modularity in managing language directories and locale configurations for internationalization.
  - Streamlined merging and resolution of locale and Vue I18n configuration files across multiple layers.
  - Improved locale filtering to return updated locale lists without side effects.

No user-facing features or bug fixes were introduced in this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->