### PR TITLE
refactor: simplify locale file and config logic

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -39,14 +39,13 @@ export async function extendBundler(ctx: I18nNuxtContext, nuxt: Nuxt) {
   /**
    * shared plugins (vite/webpack/rspack)
    */
-  const { options } = ctx
   const localePaths = [...new Set(ctx.localeInfo.flatMap(x => x.meta.map(m => m.path)))]
-  ctx.fullStatic = ctx.localeInfo.flatMap(x => x.meta).every(x => x.type === 'static' || x.file.cache !== false)
+  ctx.fullStatic = ctx.localeInfo.flatMap(x => x.meta).every(x => x.type === 'static' || x.cache !== false)
 
   const vueI18nPluginOptions: PluginOptions = {
-    ...options.bundle,
-    ...options.compilation,
-    ...options.customBlocks,
+    ...ctx.options.bundle,
+    ...ctx.options.compilation,
+    ...ctx.options.customBlocks,
     allowDynamic: true,
     optimizeTranslationDirective: false,
     include: localePaths.length ? localePaths : undefined
@@ -56,7 +55,7 @@ export async function extendBundler(ctx: I18nNuxtContext, nuxt: Nuxt) {
     webpack: () => VueI18nPlugin.webpack(vueI18nPluginOptions)
   })
   addBuildPlugin(TransformMacroPlugin(pluginOptions))
-  if (options.autoDeclare && nuxt.options.imports.autoImport !== false) {
+  if (ctx.options.autoDeclare && nuxt.options.imports.autoImport !== false) {
     addBuildPlugin(TransformI18nFunctionPlugin(pluginOptions))
   }
 

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -6,7 +6,6 @@ import { resolveModule } from '@nuxt/kit'
 
 import type { Nuxt } from '@nuxt/schema'
 import type { LocaleObject } from './types'
-import type { Locale } from 'vue-i18n'
 import type { I18nNuxtContext } from './context'
 
 function stripLocaleFiles(locale: LocaleObject) {
@@ -16,10 +15,8 @@ function stripLocaleFiles(locale: LocaleObject) {
 }
 
 export function simplifyLocaleOptions(ctx: I18nNuxtContext, _nuxt: Nuxt) {
-  const isLocaleObjectsArray = (locales?: Locale[] | LocaleObject[]) => locales?.some(x => !isString(x))
-
-  const hasLocaleObjects = isLocaleObjectsArray(ctx.options.locales)
   const locales = (ctx.options.locales ?? []) as LocaleObject[]
+  const hasLocaleObjects = locales?.some(x => !isString(x))
   return locales.map(locale => (!hasLocaleObjects ? locale.code : stripLocaleFiles(locale)))
 }
 
@@ -47,7 +44,7 @@ export function generateLoaderOptions(
         importMapper.set(meta.path, {
           key,
           relative: relative(nuxt.options.buildDir, meta.path),
-          cache: meta.file.cache ?? true,
+          cache: meta.cache ?? true,
           load: genDynamicImport(asI18nVirtual(meta.hash), { comment: `webpackChunkName: ${key}` })
         })
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,7 @@ export type LocaleFile = { path: string; cache?: boolean }
 
 export type LocaleInfo = Omit<LocaleObject, 'file' | 'files'> & {
   code: Locale
-  meta: (FileMeta & { file: LocaleFile })[]
+  meta: FileMeta[]
 }
 
 /**
@@ -47,6 +47,7 @@ export type LocaleInfo = Omit<LocaleObject, 'file' | 'files'> & {
 export type FileMeta = {
   path: string
   hash: string
+  cache: boolean
   type: LocaleType
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -160,7 +160,7 @@ export const mergeConfigLocales = (configs: LocaleConfig[]) => {
 
       existing.files = [...files, ...(existing.files as LocaleFile[])]
 
-      merged.set(current.code, assign(existing, current))
+      merged.set(current.code, assign({}, current, existing))
     }
   }
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -68,10 +68,7 @@ test('resolveLocales', async () => {
         "code": "en",
         "meta": [
           {
-            "file": {
-              "cache": true,
-              "path": "en.json",
-            },
+            "cache": true,
             "hash": "5c407b7f",
             "path": "/path/to/project/en.json",
             "type": "static",
@@ -82,10 +79,7 @@ test('resolveLocales', async () => {
         "code": "ja",
         "meta": [
           {
-            "file": {
-              "cache": true,
-              "path": "ja.json",
-            },
+            "cache": true,
             "hash": "0e1b8bd4",
             "path": "/path/to/project/ja.json",
             "type": "static",
@@ -96,10 +90,7 @@ test('resolveLocales', async () => {
         "code": "es",
         "meta": [
           {
-            "file": {
-              "cache": true,
-              "path": "es.json",
-            },
+            "cache": true,
             "hash": "c78280fb",
             "path": "/path/to/project/es.json",
             "type": "static",
@@ -110,19 +101,13 @@ test('resolveLocales', async () => {
         "code": "es-AR",
         "meta": [
           {
-            "file": {
-              "cache": true,
-              "path": "es.json",
-            },
+            "cache": true,
             "hash": "c78280fb",
             "path": "/path/to/project/es.json",
             "type": "static",
           },
           {
-            "file": {
-              "cache": true,
-              "path": "es-AR.json",
-            },
+            "cache": true,
             "hash": "65220c0a",
             "path": "/path/to/project/es-AR.json",
             "type": "static",
@@ -133,10 +118,7 @@ test('resolveLocales', async () => {
         "code": "nl",
         "meta": [
           {
-            "file": {
-              "cache": false,
-              "path": "nl.js",
-            },
+            "cache": false,
             "hash": "b7971e5b",
             "path": "/path/to/project/nl.js",
             "type": "dynamic",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified and streamlined how locale metadata is structured and merged, removing nested file objects and making the cache property more accessible.
  - Improved internal logic for detecting and merging locale configurations.

- **Bug Fixes**
  - Corrected how cache flags are read and handled in locale metadata.

- **Tests**
  - Updated test snapshots to reflect the new, simplified metadata structure for locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->