### PR TITLE
refactor: move runtime dev logic to plugin

### DIFF
--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -28,7 +28,7 @@ export const useLocaleConfigs = () =>
 /**
  * @internal
  */
-export type NuxtI18nContext = {
+export interface NuxtI18nContext {
   vueI18n: I18n
   config: I18nPublicRuntimeConfig
   detection: DetectBrowserLanguageOptions & { enabled: boolean }

--- a/src/runtime/plugins/dev.ts
+++ b/src/runtime/plugins/dev.ts
@@ -1,0 +1,111 @@
+import { vueI18nConfigs } from '#build/i18n.options.mjs'
+import { defineNuxtPlugin, useNuxtApp } from '#imports'
+import { getComposer } from '../compatibility'
+import { useNuxtI18nContext } from '../context'
+import { loadVueI18nOptions } from '../shared/messages'
+
+import type { I18nOptions } from 'vue-i18n'
+
+declare module '../context' {
+  interface NuxtI18nContext {
+    dev?: {
+      resetI18nProperties: (locale?: string) => Promise<void>
+      deepEqual: typeof deepEqual
+    }
+  }
+}
+
+export default defineNuxtPlugin({
+  name: 'i18n:dev',
+  dependsOn: ['i18n:plugin'],
+  setup() {
+    if (!import.meta.dev) return
+    const nuxt = useNuxtApp()
+    const ctx = useNuxtI18nContext(nuxt)
+    const composer = getComposer(ctx.vueI18n)
+
+    /**
+     * Reload vue-i18n configs and locale message files in the correct order
+     *
+     * @param locale only passed when a locale file has been changed, if `undefined` indicates a vue-i18n config change
+     */
+    async function resetI18nProperties(locale?: string) {
+      const opts: I18nOptions = await loadVueI18nOptions(vueI18nConfigs)
+
+      const messageLocales = uniqueKeys(opts.messages!, composer.messages.value)
+      for (const k of messageLocales) {
+        if (locale && k !== locale) continue
+
+        // set to vue-i18n messages or reset to account for removed messages
+        composer.setLocaleMessage(k, opts?.messages?.[k] ?? {})
+        await ctx.loadMessages(k)
+      }
+
+      // skip vue-i18n config properties if locale is passed (locale file HMR)
+      if (locale != null) return
+
+      const numberFormatLocales = uniqueKeys(opts.numberFormats || {}, composer.numberFormats.value)
+      for (const k of numberFormatLocales) {
+        composer.setNumberFormat(k, opts.numberFormats?.[k] || {})
+      }
+
+      const datetimeFormatsLocales = uniqueKeys(opts.datetimeFormats || {}, composer.datetimeFormats.value)
+      for (const k of datetimeFormatsLocales) {
+        composer.setDateTimeFormat(k, opts.datetimeFormats?.[k] || {})
+      }
+    }
+
+    nuxt._nuxtI18nCtx.dev = {
+      resetI18nProperties,
+      deepEqual
+    }
+  }
+})
+
+// collect unique keys of passed objects
+function uniqueKeys(...objects: Array<Record<string, unknown>>): string[] {
+  const keySet = new Set<string>()
+
+  for (const obj of objects) {
+    for (const key of Object.keys(obj)) {
+      keySet.add(key)
+    }
+  }
+
+  return Array.from(keySet)
+}
+
+// helper function to compare old and new vue-i18n configs
+function deepEqual<T extends Record<string, unknown>, K extends keyof T>(a: T, b: T, ignoreKeys: K[] = []) {
+  if (a === b) return true
+  if (a == null || b == null || typeof a !== 'object' || typeof b !== 'object') return false
+
+  // top-level keys excluding ignoreKeys
+  const keysA = Object.keys(a).filter(k => !ignoreKeys.includes(k as K))
+  const keysB = Object.keys(b).filter(k => !ignoreKeys.includes(k as K))
+
+  if (keysA.length !== keysB.length) return false
+
+  for (const key of keysA) {
+    if (!keysB.includes(key)) return false
+    const valA = a[key]
+    const valB = b[key]
+    // compare functions stringified
+    if (typeof valA === 'function' && typeof valB === 'function') {
+      if (valA.toString() !== valB.toString()) {
+        return false
+      }
+    }
+    // nested recursive check (no ignoring at deeper levels)
+    else if (typeof valA === 'object' && typeof valB === 'object') {
+      if (!deepEqual(valA as unknown as T, valB as unknown as T)) {
+        return false
+      }
+    }
+    // primitive value check
+    else if (valA !== valB) {
+      return false
+    }
+  }
+  return true
+}

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -2,7 +2,7 @@ import { computed, ref, watch } from 'vue'
 import { createI18n } from 'vue-i18n'
 import { defineNuxtPlugin, prerenderRoutes, useNuxtApp } from '#imports'
 import { localeCodes, normalizedLocales } from '#build/i18n.options.mjs'
-import { loadAndSetLocale, navigate, createNuxtI18nDev, createComposableContext } from '../utils'
+import { loadAndSetLocale, navigate, createComposableContext } from '../utils'
 import { extendI18n } from '../routing/i18n'
 import { getI18nTarget } from '../compatibility'
 import { localeHead, _useLocaleHead } from '../routing/head'
@@ -52,11 +52,6 @@ export default defineNuxtPlugin({
 
     if (__I18N_STRIP_UNUSED__ && import.meta.server && nuxt.ssrContext?.event.context.nuxtI18n) {
       wrapTranslationFunctions(ctx, nuxt.ssrContext?.event.context.nuxtI18n)
-    }
-
-    // HMR helper functionality
-    if (import.meta.dev) {
-      nuxt._nuxtI18nDev = createNuxtI18nDev()
     }
 
     // extend i18n instance

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -1,10 +1,7 @@
 import { isEqual, joinURL, withoutTrailingSlash, withTrailingSlash } from 'ufo'
 import { isFunction, isString } from '@intlify/shared'
 import { navigateTo, useHead, useNuxtApp, useRouter } from '#imports'
-import { vueI18nConfigs } from '#build/i18n.options.mjs'
-import { getComposer } from './compatibility'
 import { getDefaultLocaleForDomain } from './domain'
-import { loadVueI18nOptions } from './shared/messages'
 import { createLocaleRouteNameGetter, createLocalizedRouteByPathResolver } from './routing/utils'
 import { getRouteBaseName } from '#i18n-kit/routing'
 import {
@@ -16,7 +13,7 @@ import {
 } from './routing/routing'
 import { useNuxtI18nContext } from './context'
 
-import type { Locale, I18nOptions } from 'vue-i18n'
+import type { Locale } from 'vue-i18n'
 import type { NuxtApp } from '#app'
 import type { RouteLocationPathRaw, Router, RouteRecordNameGeneric } from 'vue-router'
 import type {
@@ -316,93 +313,4 @@ export function createBaseUrlGetter(
 
     return baseUrl ?? ''
   }
-}
-
-// collect unique keys of passed objects
-function uniqueKeys(...objects: Array<Record<string, unknown>>): string[] {
-  const keySet = new Set<string>()
-
-  for (const obj of objects) {
-    for (const key of Object.keys(obj)) {
-      keySet.add(key)
-    }
-  }
-
-  return Array.from(keySet)
-}
-
-// HMR helper functionality
-export function createNuxtI18nDev() {
-  const ctx = useNuxtI18nContext()
-  const composer = getComposer(ctx.vueI18n)
-
-  // helper function to compare old and new vue-i18n configs
-  function deepEqual<T extends Record<string, unknown>, K extends keyof T>(a: T, b: T, ignoreKeys: K[] = []) {
-    if (a === b) return true
-    if (a == null || b == null || typeof a !== 'object' || typeof b !== 'object') return false
-
-    // top-level keys excluding ignoreKeys
-    const keysA = Object.keys(a).filter(k => !ignoreKeys.includes(k as K))
-    const keysB = Object.keys(b).filter(k => !ignoreKeys.includes(k as K))
-
-    if (keysA.length !== keysB.length) return false
-
-    for (const key of keysA) {
-      if (!keysB.includes(key)) return false
-      const valA = a[key]
-      const valB = b[key]
-      // compare functions stringified
-      if (typeof valA === 'function' && typeof valB === 'function') {
-        if (valA.toString() !== valB.toString()) {
-          return false
-        }
-      }
-      // nested recursive check (no ignoring at deeper levels)
-      else if (typeof valA === 'object' && typeof valB === 'object') {
-        if (!deepEqual(valA as unknown as T, valB as unknown as T)) {
-          return false
-        }
-      }
-      // primitive value check
-      else if (valA !== valB) {
-        return false
-      }
-    }
-    return true
-  }
-
-  /**
-   * Triggers a reload of vue-i18n configs (if needed) and locale message files in the correct order
-   *
-   * @param locale only passed when a locale file has been changed, if `undefined` indicates a vue-i18n config change
-   */
-  async function resetI18nProperties(locale?: string) {
-    const opts: I18nOptions = await loadVueI18nOptions(vueI18nConfigs)
-
-    const messageLocales = uniqueKeys(opts.messages!, composer.messages.value)
-    for (const k of messageLocales) {
-      if (locale && k !== locale) continue
-
-      if (opts?.messages && k in opts.messages) {
-        composer.setLocaleMessage(k, opts?.messages[k] ?? {})
-      }
-
-      await ctx.loadMessages(k)
-    }
-
-    // skip vue-i18n config properties if locale is passed (locale file HMR)
-    if (locale != null) return
-
-    const numberFormatLocales = uniqueKeys(opts.numberFormats || {}, composer.numberFormats.value)
-    for (const k of numberFormatLocales) {
-      composer.setNumberFormat(k, opts.numberFormats?.[k] || {})
-    }
-
-    const datetimeFormatsLocales = uniqueKeys(opts.datetimeFormats || {}, composer.datetimeFormats.value)
-    for (const k of datetimeFormatsLocales) {
-      composer.setDateTimeFormat(k, opts.datetimeFormats?.[k] || {})
-    }
-  }
-
-  return { resetI18nProperties, deepEqual }
 }

--- a/src/template.ts
+++ b/src/template.ts
@@ -23,7 +23,7 @@ function genLocaleLoaderHMR(localeLoaders: TemplateNuxtI18nOptions['localeLoader
           //   replace locale loader
           `    localeLoaders["${locale}"][${i}].load = () => Promise.resolve(mod.default)`,
           //   trigger locale messages reload for locale
-          `    await useNuxtApp()._nuxtI18nDev.resetI18nProperties("${locale}")`,
+          `    await useNuxtApp()._nuxtI18nCtx.dev.resetI18nProperties("${locale}")`,
           `  })`
         ].join('\n')
       )
@@ -45,8 +45,8 @@ function genVueI18nConfigHMR(configs: TemplateNuxtI18nOptions['vueI18nConfigs'])
         //   replace config loader
         `    vueI18nConfigs[${i}] = () => Promise.resolve(mod)`,
         //   compare data - reload configs if _only_ replaceable properties have changed
-        `    if(useNuxtApp()._nuxtI18nDev.deepEqual(oldData, newData, ['messages', 'numberFormats', 'datetimeFormats'])) {`,
-        `      return await useNuxtApp()._nuxtI18nDev.resetI18nProperties()`,
+        `    if(useNuxtApp()._nuxtI18nCtx.dev.deepEqual(oldData, newData, ['messages', 'numberFormats', 'datetimeFormats'])) {`,
+        `      return await useNuxtApp()._nuxtI18nCtx.dev.resetI18nProperties()`,
         `    }`,
         //   communicate to vite plugin to trigger a page load
         `    import.meta.hot.send('i18n:options-complex-invalidation', {})`,


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced development-only utilities for internationalization, including tools to reload locale messages and compare configuration objects during development.

- **Refactor**
  - Updated internal references to development utilities, improving integration with the app’s context for smoother hot module replacement and development workflows.
  - Changed the Nuxt i18n context declaration to an interface for improved type management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->