### PR TITLE
refactor: cleanup runtime logic

### DIFF
--- a/src/runtime/components/SwitchLocalePathLink.ts
+++ b/src/runtime/components/SwitchLocalePathLink.ts
@@ -18,10 +18,10 @@ const SlpComponent = defineComponent({
   setup(props, { slots, attrs }) {
     const nuxtApp = useNuxtApp()
     const switchLocalePath = useSwitchLocalePath()
-    const slp = nuxtApp._nuxtI18n.getSLP()
+    const payload = nuxtApp._nuxtI18n.localePathPayload
 
     const resolved = computed(() => {
-      if (__I18N_STRICT_SEO__ && nuxtApp.isHydrating && Object.keys(slp ?? {}).length && !slp?.[props.locale]) {
+      if (__I18N_STRICT_SEO__ && nuxtApp.isHydrating && Object.keys(payload ?? {}).length && !payload?.[props.locale]) {
         return '#'
       }
       return encodeURI(switchLocalePath(props.locale)) || (__I18N_STRICT_SEO__ && '#') || ''

--- a/src/runtime/plugins/route-locale-detect.ts
+++ b/src/runtime/plugins/route-locale-detect.ts
@@ -19,7 +19,7 @@ export default defineNuxtPlugin({
       defineNuxtRouteMiddleware(async to => {
         const locale = await nuxt.runWithContext(() => loadAndSetLocale(detectLocale(to)))
 
-        ctx.firstAccess = false
+        ctx.initial = false
 
         return nuxt.runWithContext(() => navigate(to, locale))
       }),

--- a/src/runtime/plugins/ssg-detect.ts
+++ b/src/runtime/plugins/ssg-detect.ts
@@ -17,7 +17,7 @@ export default defineNuxtPlugin({
     nuxt.hook('app:mounted', async () => {
       const detected = detectLocale(nuxt.$router.currentRoute.value)
       await nuxt.runWithContext(() => nuxt.$i18n.setLocale(detected))
-      ctx.firstAccess = false
+      ctx.initial = false
     })
   }
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Unified the naming of an internal state flag from "firstAccess" to "initial" across the locale detection logic.
  - Improved locale detection by separating header-based and browser-based locale retrieval.
  - Updated internal logic for handling locale path payloads to enhance hydration and strict SEO mode compatibility.

- **Bug Fixes**
  - Enhanced reliability of locale path link disabling/fallback during hydration under strict SEO mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->