### PR TITLE
fix: clear message cache on server startup

### DIFF
--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -20,8 +20,11 @@ import type {
   RootRedirectOptions
 } from '#internal-i18n-types'
 
-const useLocaleConfigs = () =>
-  useState<Record<string, { cacheable: boolean; fallbacks: string[] }>>('i18n:cached-locale-configs', () => ({}))
+export const useLocaleConfigs = () =>
+  useState<Record<string, { cacheable: boolean; fallbacks: string[] }> | undefined>(
+    'i18n:cached-locale-configs',
+    () => undefined
+  )
 
 /**
  * @internal
@@ -84,7 +87,7 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
   const localeCookie = useI18nCookie(detectConfig)
 
   /** Get computed config for locale */
-  const getLocaleConfig = (locale: string) => serverLocaleConfigs.value[locale]
+  const getLocaleConfig = (locale: string) => serverLocaleConfigs.value![locale]
   const getDomainFromLocale = (locale: string) =>
     domainFromLocale(runtimeI18n.domainLocales, useRequestURL({ xForwardedHost: true }), locale)
   const baseUrl = createBaseUrlGetter(nuxt, runtimeI18n.baseUrl, defaultLocale, getDomainFromLocale)

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -7,9 +7,9 @@ import { extendI18n } from '../routing/i18n'
 import { getI18nTarget } from '../compatibility'
 import { localeHead, _useLocaleHead } from '../routing/head'
 import { useLocalePath, useLocaleRoute, useRouteBaseName, useSwitchLocalePath } from '../composables'
-import { getDefaultLocaleForDomain } from '../shared/locales'
+import { createLocaleConfigs, getDefaultLocaleForDomain } from '../shared/locales'
 import { setupVueI18nOptions } from '../shared/vue-i18n'
-import { createNuxtI18nContext, useNuxtI18nContext, type NuxtI18nContext } from '../context'
+import { createNuxtI18nContext, useLocaleConfigs, useNuxtI18nContext, type NuxtI18nContext } from '../context'
 import { useI18nDetection, useRuntimeI18n } from '../shared/utils'
 import { useDetectors } from '../shared/detection'
 import { resolveSupportedLocale } from '../shared/locales'
@@ -30,6 +30,14 @@ export default defineNuxtPlugin({
     const _defaultLocale =
       getDefaultLocaleForDomain(useRequestURL({ xForwardedHost: true }).host) || runtimeI18n.defaultLocale || ''
     const optionsI18n = preloadedOptions || (await setupVueI18nOptions(_defaultLocale))
+
+    const localeConfigs = useLocaleConfigs()
+    if (import.meta.server) {
+      localeConfigs.value = useRequestEvent()!.context.nuxtI18n?.localeConfigs || {}
+    } else {
+      // fallback when server is disabled
+      localeConfigs.value ??= createLocaleConfigs(optionsI18n.fallbackLocale)
+    }
 
     if (__MULTI_DOMAIN_LOCALES__) {
       setupMultiDomainLocales(optionsI18n.defaultLocale)

--- a/src/runtime/server/routes/messages.ts
+++ b/src/runtime/server/routes/messages.ts
@@ -33,6 +33,8 @@ const _messagesHandler = defineEventHandler(async (event: H3Event) => {
 const _messagesHandlerCached = defineCachedEventHandler(_messagesHandler, {
   name: 'i18n:messages',
   maxAge: !__I18N_CACHE__ ? -1 : 60 * 60 * 24,
+  staleMaxAge: !__I18N_CACHE__ ? -1 : 60,
+  swr: __I18N_CACHE__,
   getKey: event => getRouterParam(event, 'locale') ?? 'null',
   shouldBypassCache(event) {
     const locale = getRouterParam(event, 'locale')

--- a/src/runtime/server/routes/messages.ts
+++ b/src/runtime/server/routes/messages.ts
@@ -12,8 +12,6 @@ import type { H3Event } from 'h3'
 const _messagesHandler = defineEventHandler(async (event: H3Event) => {
   const locale = getRouterParam(event, 'locale')
 
-  console.log(`Loading messages for locale: ${locale}`)
-
   if (!locale) {
     throw createError({ status: 400, message: 'Locale not specified.' })
   }
@@ -29,7 +27,7 @@ const _messagesHandler = defineEventHandler(async (event: H3Event) => {
   return ctx.messages
 })
 
-const _cached = defineCachedFunction(_messagesHandler, {
+const _cachedMessageLoader = defineCachedFunction(_messagesHandler, {
   name: 'i18n:messages-internal',
   maxAge: !__I18N_CACHE__ ? -1 : 60 * 60 * 24,
   getKey: event => getRouterParam(event, 'locale') ?? 'null',
@@ -43,7 +41,7 @@ const _cached = defineCachedFunction(_messagesHandler, {
 /**
  * Load messages for the specified locale event parameter (cached)
  */
-const _messagesHandlerCached = defineCachedEventHandler(_cached, {
+const _messagesHandlerCached = defineCachedEventHandler(_cachedMessageLoader, {
   name: 'i18n:messages',
   maxAge: !__I18N_CACHE__ ? -1 : 10,
   swr: false,

--- a/src/runtime/server/routes/messages.ts
+++ b/src/runtime/server/routes/messages.ts
@@ -1,5 +1,5 @@
 import { deepCopy } from '@intlify/shared'
-import { defineCachedEventHandler } from 'nitropack/runtime'
+import { defineCachedEventHandler, defineCachedFunction } from 'nitropack/runtime'
 import { getRouterParam, createError, defineEventHandler } from 'h3'
 import { useI18nContext } from '../context'
 import { getMergedMessages } from '../utils/messages'
@@ -11,6 +11,8 @@ import type { H3Event } from 'h3'
  */
 const _messagesHandler = defineEventHandler(async (event: H3Event) => {
   const locale = getRouterParam(event, 'locale')
+
+  console.log(`Loading messages for locale: ${locale}`)
 
   if (!locale) {
     throw createError({ status: 400, message: 'Locale not specified.' })
@@ -27,20 +29,25 @@ const _messagesHandler = defineEventHandler(async (event: H3Event) => {
   return ctx.messages
 })
 
-/**
- * Load messages for the specified locale event parameter (cached)
- */
-const _messagesHandlerCached = defineCachedEventHandler(_messagesHandler, {
-  name: 'i18n:messages',
+const _cached = defineCachedFunction(_messagesHandler, {
+  name: 'i18n:messages-internal',
   maxAge: !__I18N_CACHE__ ? -1 : 60 * 60 * 24,
-  staleMaxAge: !__I18N_CACHE__ ? -1 : 60,
-  swr: __I18N_CACHE__,
   getKey: event => getRouterParam(event, 'locale') ?? 'null',
   shouldBypassCache(event) {
     const locale = getRouterParam(event, 'locale')
     if (locale == null) return false
     return !useI18nContext(event).localeConfigs?.[locale]?.cacheable
   }
+})
+
+/**
+ * Load messages for the specified locale event parameter (cached)
+ */
+const _messagesHandlerCached = defineCachedEventHandler(_cached, {
+  name: 'i18n:messages',
+  maxAge: !__I18N_CACHE__ ? -1 : 10,
+  swr: false,
+  getKey: event => getRouterParam(event, 'locale') ?? 'null'
 })
 
 /**


### PR DESCRIPTION
### 🔗 Linked issue
* #3681 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Resolves #3681 

This wraps the cached message loading logic inside the cached message loading route, this way the browser won't cache responses for too long (even across builds) while message loading are cached server-side. 
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced caching for locale message loading with layered cache durations and improved cache bypass logic.
- **Chores**
  - Cache for i18n handlers is now cleared on server startup to ensure fresh data.
- **Refactor**
  - Locale configuration initialization improved for better handling across server and client environments.
  - Locale configuration state management updated to support undefined initial states for improved flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->