### PR TITLE
fix: reuse server-side locale detection

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,6 +312,96 @@ importers:
         specifier: latest
         version: 3.17.5(@netlify/blobs@8.2.0)(@parcel/watcher@2.5.1)(@types/node@22.15.3)(better-sqlite3@11.9.1)(db0@0.3.2(better-sqlite3@11.9.1))(eslint@9.28.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.2)(terser@5.39.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(yaml@2.8.0))(yaml@2.8.0)
 
+  specs/fixtures/issues/1888:
+    devDependencies:
+      '@nuxtjs/i18n':
+        specifier: workspace:*
+        version: link:../../../..
+      nuxt:
+        specifier: latest
+        version: 3.17.5(@netlify/blobs@8.2.0)(@parcel/watcher@2.5.1)(@types/node@22.15.3)(better-sqlite3@11.9.1)(db0@0.3.2(better-sqlite3@11.9.1))(eslint@9.28.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.2)(terser@5.39.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(yaml@2.8.0))(yaml@2.8.0)
+
+  specs/fixtures/issues/2151:
+    devDependencies:
+      '@nuxtjs/i18n':
+        specifier: workspace:*
+        version: link:../../../..
+      nuxt:
+        specifier: latest
+        version: 3.17.5(@netlify/blobs@8.2.0)(@parcel/watcher@2.5.1)(@types/node@22.15.3)(better-sqlite3@11.9.1)(db0@0.3.2(better-sqlite3@11.9.1))(eslint@9.28.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.2)(terser@5.39.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(yaml@2.8.0))(yaml@2.8.0)
+
+  specs/fixtures/issues/2220:
+    devDependencies:
+      '@nuxtjs/i18n':
+        specifier: workspace:*
+        version: link:../../../..
+      nuxt:
+        specifier: latest
+        version: 3.17.5(@netlify/blobs@8.2.0)(@parcel/watcher@2.5.1)(@types/node@22.15.3)(better-sqlite3@11.9.1)(db0@0.3.2(better-sqlite3@11.9.1))(eslint@9.28.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.2)(terser@5.39.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(yaml@2.8.0))(yaml@2.8.0)
+
+  specs/fixtures/issues/2247:
+    devDependencies:
+      '@nuxtjs/i18n':
+        specifier: workspace:*
+        version: link:../../../..
+      nuxt:
+        specifier: latest
+        version: 3.17.5(@netlify/blobs@8.2.0)(@parcel/watcher@2.5.1)(@types/node@22.15.3)(better-sqlite3@11.9.1)(db0@0.3.2(better-sqlite3@11.9.1))(eslint@9.28.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.2)(terser@5.39.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(yaml@2.8.0))(yaml@2.8.0)
+
+  specs/fixtures/issues/2288:
+    devDependencies:
+      '@nuxtjs/i18n':
+        specifier: workspace:*
+        version: link:../../../..
+      nuxt:
+        specifier: latest
+        version: 3.17.5(@netlify/blobs@8.2.0)(@parcel/watcher@2.5.1)(@types/node@22.15.3)(better-sqlite3@11.9.1)(db0@0.3.2(better-sqlite3@11.9.1))(eslint@9.28.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.2)(terser@5.39.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(yaml@2.8.0))(yaml@2.8.0)
+
+  specs/fixtures/issues/2315:
+    devDependencies:
+      '@nuxtjs/i18n':
+        specifier: workspace:*
+        version: link:../../../..
+      nuxt:
+        specifier: latest
+        version: 3.17.5(@netlify/blobs@8.2.0)(@parcel/watcher@2.5.1)(@types/node@22.15.3)(better-sqlite3@11.9.1)(db0@0.3.2(better-sqlite3@11.9.1))(eslint@9.28.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.2)(terser@5.39.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(yaml@2.8.0))(yaml@2.8.0)
+
+  specs/fixtures/issues/2590:
+    devDependencies:
+      '@nuxtjs/i18n':
+        specifier: workspace:*
+        version: link:../../../..
+      nuxt:
+        specifier: latest
+        version: 3.17.5(@netlify/blobs@8.2.0)(@parcel/watcher@2.5.1)(@types/node@22.15.3)(better-sqlite3@11.9.1)(db0@0.3.2(better-sqlite3@11.9.1))(eslint@9.28.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.2)(terser@5.39.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(yaml@2.8.0))(yaml@2.8.0)
+
+  specs/fixtures/issues/3039:
+    devDependencies:
+      '@nuxtjs/i18n':
+        specifier: workspace:*
+        version: link:../../../..
+      nuxt:
+        specifier: latest
+        version: 3.17.5(@netlify/blobs@8.2.0)(@parcel/watcher@2.5.1)(@types/node@22.15.3)(better-sqlite3@11.9.1)(db0@0.3.2(better-sqlite3@11.9.1))(eslint@9.28.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.2)(terser@5.39.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(yaml@2.8.0))(yaml@2.8.0)
+
+  specs/fixtures/issues/3404:
+    devDependencies:
+      '@nuxtjs/i18n':
+        specifier: workspace:*
+        version: link:../../../..
+      nuxt:
+        specifier: latest
+        version: 3.17.5(@netlify/blobs@8.2.0)(@parcel/watcher@2.5.1)(@types/node@22.15.3)(better-sqlite3@11.9.1)(db0@0.3.2(better-sqlite3@11.9.1))(eslint@9.28.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.2)(terser@5.39.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(yaml@2.8.0))(yaml@2.8.0)
+
+  specs/fixtures/issues/3407:
+    devDependencies:
+      '@nuxtjs/i18n':
+        specifier: workspace:*
+        version: link:../../../..
+      nuxt:
+        specifier: latest
+        version: 3.17.5(@netlify/blobs@8.2.0)(@parcel/watcher@2.5.1)(@types/node@22.15.3)(better-sqlite3@11.9.1)(db0@0.3.2(better-sqlite3@11.9.1))(eslint@9.28.0(jiti@2.4.2))(ioredis@5.6.1)(lightningcss@1.30.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.40.2)(terser@5.39.0)(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(yaml@2.8.0))(yaml@2.8.0)
+
   specs/fixtures/lazy:
     devDependencies:
       '@nuxtjs/i18n':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - docs
   - playground
   - specs/fixtures/*
+  - specs/fixtures/issues/*
 onlyBuiltDependencies:
   - '@parcel/watcher'
   - '@tailwindcss/oxide'

--- a/specs/fixtures/issues/3039/app.vue
+++ b/specs/fixtures/issues/3039/app.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    <NuxtRouteAnnouncer />
+    <NuxtPage />
+  </div>
+</template>

--- a/specs/fixtures/issues/3039/i18n/locales/en.json
+++ b/specs/fixtures/issues/3039/i18n/locales/en.json
@@ -1,0 +1,3 @@
+{
+  "welcome": "Welcome"
+}

--- a/specs/fixtures/issues/3039/i18n/locales/fr.json
+++ b/specs/fixtures/issues/3039/i18n/locales/fr.json
@@ -1,0 +1,3 @@
+{
+  "welcome": "Bienvenue"
+}

--- a/specs/fixtures/issues/3039/nuxt.config.ts
+++ b/specs/fixtures/issues/3039/nuxt.config.ts
@@ -1,0 +1,16 @@
+import { defineNuxtConfig } from 'nuxt/config'
+
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/i18n'],
+  i18n: {
+    strategy: 'no_prefix',
+    // When using prefix_except_default strategy
+    detectBrowserLanguage: false,
+    defaultLocale: 'fr',
+    locales: [
+      { code: 'fr', file: 'fr.json', name: 'Français' },
+      { code: 'en', file: 'en.json', name: 'English' }
+    ]
+  },
+  compatibilityDate: '2024-07-23'
+})

--- a/specs/fixtures/issues/3039/package.json
+++ b/specs/fixtures/issues/3039/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "fixture-3039",
+  "private": true,
+  "scripts": {
+    "build": "nuxt build",
+    "dev": "nuxt dev",
+    "generate": "nuxt generate",
+    "preview": "nuxt preview"
+  },
+  "devDependencies": {
+    "@nuxtjs/i18n": "latest",
+    "nuxt": "latest"
+  }
+}

--- a/specs/fixtures/issues/3039/pages/index.vue
+++ b/specs/fixtures/issues/3039/pages/index.vue
@@ -1,0 +1,12 @@
+<script lang="ts" setup>
+const { locale, setLocale } = useI18n()
+
+if (import.meta.server) {
+  await setLocale('en')
+}
+</script>
+
+<template>
+  <div data-testid="locale">{{ locale }}</div>
+  <p data-testid="welcome">{{ $t('welcome') }}</p>
+</template>

--- a/specs/issues/3039.spec.ts
+++ b/specs/issues/3039.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect, describe } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { createPage, setup } from '../utils'
+
+describe('#3039', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL(`../fixtures/issues/3039`, import.meta.url)),
+    browser: true
+  })
+
+  test('does not detect and set locale client-side if locale has been detected and set server-side', async () => {
+    // localized routing is disabled (no_prefix or defineI18nRoute(false))
+    const page = await createPage('/')
+
+    // default locale is `fr` but has been set to `en` server-side
+    expect(await page.getByTestId('locale').textContent()).toEqual('en')
+    expect(await page.getByTestId('welcome').textContent()).toEqual('Welcome')
+  })
+})

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -26,6 +26,8 @@ export const useLocaleConfigs = () =>
     () => undefined
   )
 
+export const useResolvedLocale = () => useState<string>('i18n:resolved-locale', () => '')
+
 /**
  * @internal
  */
@@ -91,6 +93,7 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
   const getDomainFromLocale = (locale: string) =>
     domainFromLocale(runtimeI18n.domainLocales, useRequestURL({ xForwardedHost: true }), locale)
   const baseUrl = createBaseUrlGetter(nuxt, runtimeI18n.baseUrl, defaultLocale, getDomainFromLocale)
+  const resolvedLocale = useResolvedLocale()
 
   const ctx: NuxtI18nContext = {
     vueI18n,
@@ -112,6 +115,8 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
       }
 
       await nuxt.callHook('i18n:localeSwitched', { newLocale: locale, oldLocale })
+
+      resolvedLocale.value = locale
     },
     setLocaleSuspend: async (locale: string) => {
       if (!isSupportedLocale(locale)) return

--- a/src/runtime/plugins/route-locale-detect.ts
+++ b/src/runtime/plugins/route-locale-detect.ts
@@ -1,4 +1,4 @@
-import { useNuxtI18nContext } from '../context'
+import { useNuxtI18nContext, useResolvedLocale } from '../context'
 import { detectLocale, loadAndSetLocale, navigate } from '../utils'
 import { addRouteMiddleware, defineNuxtPlugin, defineNuxtRouteMiddleware, useNuxtApp } from '#imports'
 
@@ -9,7 +9,10 @@ export default defineNuxtPlugin({
     const nuxt = useNuxtApp()
     const ctx = useNuxtI18nContext(nuxt)
 
-    await nuxt.runWithContext(() => loadAndSetLocale(detectLocale(nuxt.$router.currentRoute.value)))
+    const resolvedLocale = useResolvedLocale()
+    await nuxt.runWithContext(() =>
+      loadAndSetLocale((ctx.initial && resolvedLocale.value) || detectLocale(nuxt.$router.currentRoute.value))
+    )
 
     // no pages or no prefixes - do not register route middleware
     if (!__I18N_ROUTING__) return


### PR DESCRIPTION
### 🔗 Linked issue
* #3039 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Resolves #3039 

This ensures that, if a locale has been detected or set server-side, the module will not attempt to detect and set the locale on initial load. I am surprised this does not break any existing tests 🤔🤷
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for tracking and using the resolved locale across the app, ensuring consistent locale handling between server and client.
  - Introduced new localization resources for English and French, including translation files and configuration for internationalization.
- **Bug Fixes**
  - Improved locale detection to respect the server-set locale and prevent client-side overrides when localized routing is disabled.
- **Tests**
  - Added a new test suite to verify correct locale detection behavior in specific scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->