### PR TITLE
fix: fail safe on redefine property nuxt.$i18n

### DIFF
--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -127,11 +127,14 @@ export default defineNuxtPlugin({
 
     nuxt.vueApp.use(i18n)
 
-    /**
-     * We inject `i18n.global` to **nuxt app instance only** as vue-i18n has already been injected into vue
-     * from https://github.com/nuxt/nuxt/blob/a995f724eadaa06d5443b188879ac18dfe73de2e/packages/nuxt/src/app/nuxt.ts#L295-L299
-     */
-    Object.defineProperty(nuxt, '$i18n', { get: () => getI18nTarget(i18n) })
+    // Use the existing instance or create a new one of `nuxt.$i18n`
+    if (!nuxt.$i18n) {
+      /**
+       * We inject `i18n.global` to **nuxt app instance only** as vue-i18n has already been injected into vue
+       * from https://github.com/nuxt/nuxt/blob/a995f724eadaa06d5443b188879ac18dfe73de2e/packages/nuxt/src/app/nuxt.ts#L295-L299
+       */
+      Object.defineProperty(nuxt, '$i18n', { get: () => getI18nTarget(i18n) })
+    }
 
     nuxt.provide('localeHead', (options: I18nHeadOptions) => localeHead(nuxt._nuxtI18n, options))
     nuxt.provide('localePath', useLocalePath())


### PR DESCRIPTION
### 📚 Description

In an environment using Nuxt with `@nuxtjs/i18n` and Storybook, we came across this issue while rendering the components. The first story of a component loads perfectly fine in Storybook, but the following ones are not and return the following error:

```
Error: Cannot redefine property: $i18n
  at setup (/node_modules/@nuxtjs/i18n/dist/runtime/plugins/i18n.js?v=c4d0cc47:162:12))
  at async applyPlugin (/node_modules/nuxt/dist/app/nuxt.js?v=c4d0cc47:139:25))
  at async executePlugin (/node_modules/nuxt/dist/app/nuxt.js?v=c4d0cc47:175:9))
  at async applyPlugins (/node_modules/nuxt/dist/app/nuxt.js?v=c4d0cc47:189:5))
  at async (/node_modules/@storybook-vue/nuxt/dist/preview.mjs?v=c4d0cc47:39:3)
  at async Promise.all (index (1))
  at async runSetupFunctions (/node_modules/@storybook/vue3/dist/chunk-IBPFZ7LW.mjs?v=c4d0cc47:5:630))
  at async Dn2.renderToCanvas [as renderToScreen] (/node_modules/@storybook/vue3/dist/chunk-IBPFZ7LW.mjs?v=c4d0cc47:5:1589))
  at async Object.renderToCanvas (/node_modules/.cache/storybook/1c3385a5d25e538d10b518b310c74d3ca2690b6aaffeadccd74da79736171f86/sb-vite/deps/storybook_internal_preview_runtime.js?v=aea4bcc3:8388:19))
```

We are using Storybook 8 with Nuxt and Vite without a problem, but adding `@nuxtjs/i18n` in the project results in the error above. What happens in Storybook is that every story is generated in a sandbox using iframes, thus also reevaluating the JavaScript for each iframe it produces. The first component renders fine as the property `$i18n` does not exist yet on the `nuxt` object, but the stories thereafter are trying to redefine the property, although `Object.defineProperty` does modify if it is already present in the object.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of the `$i18n` property to prevent potential conflicts and ensure smoother multilingual support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->