### PR TITLE
docs: correct the name of the runtime locales property

### DIFF
--- a/docs/content/docs/02.guide/09.different-domains.md
+++ b/docs/content/docs/02.guide/09.different-domains.md
@@ -100,18 +100,18 @@ export default defineNuxtConfig({
 
 With the above config, a build would have to be run for staging and production with different .env files that specify `DOMAIN_UK` and `DOMAIN_FR`.
 
-Alternatively, to avoid the need for multiple builds, the locale domains can be overridden via runtime environment variables. The variable name should follow the format `NUXT_PUBLIC_I18N_LOCALES_{locale code}_DOMAIN`
+Alternatively, to avoid the need for multiple builds, the locale domains can be overridden via runtime environment variables. The variable name should follow the format `NUXT_PUBLIC_I18N_DOMAIN_LOCALES_{code}_DOMAIN`
 
 For example:
 
 ```shell [production.env]
-NUXT_PUBLIC_I18N_LOCALES_UK_DOMAIN=uk.example.test
-NUXT_PUBLIC_I18N_LOCALES_FR_DOMAIN=fr.example.test
+NUXT_PUBLIC_I18N_DOMAIN_LOCALES_UK_DOMAIN=uk.example.test
+NUXT_PUBLIC_I18N_DOMAIN_LOCALES_FR_DOMAIN=fr.example.test
 ```
 
 ```shell [staging.env]
-NUXT_PUBLIC_I18N_LOCALES_UK_DOMAIN=uk.staging.example.test
-NUXT_PUBLIC_I18N_LOCALES_FR_DOMAIN=fr.staging.example.test
+NUXT_PUBLIC_I18N_DOMAIN_LOCALES_UK_DOMAIN=uk.staging.example.test
+NUXT_PUBLIC_I18N_DOMAIN_LOCALES_FR_DOMAIN=fr.staging.example.test
 ```
 
 ## Using different domains for only some of the languages

--- a/docs/content/docs/04.api/07.runtime-config.md
+++ b/docs/content/docs/04.api/07.runtime-config.md
@@ -54,9 +54,9 @@ This runtime config option is the same as the [`baseUrl`](/docs/api/options#base
 Note that the `baseUrl` module option allows you to set the function, but the runtime config does not due to limitations.
 ::
 
-### `locales`
+### `domainLocales`
 
-- property: `locales[code].domain`
+- property: `domainLocales[code].domain`
 - key: `NUXT_PUBLIC_I18N_DOMAIN_LOCALES_{code}_DOMAIN`
 
 This runtime config option allows overriding the domain set in the [`locales`](/docs/api/options#locales) module option.


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

Resolves #3691

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

This change updates the different domain docs to use the new naming of the runtime configuration. 

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->
