### PR TITLE
fix: getDefaultLocaleForDomain should respect runtime config

### DIFF
--- a/specs/different_domains/different_domains.spec.ts
+++ b/specs/different_domains/different_domains.spec.ts
@@ -151,6 +151,16 @@ test.each([
   expect(dom.querySelector('#welcome-text').textContent).toEqual(header)
 })
 
+test.only('(#2931) detect using runtimeConfig domain', async () => {
+  const res = await undiciRequest('/', {
+    headers: {
+      host: 'kr.staging.nuxt-app.localhost'
+    }
+  })
+  const dom = getDom(await res.body.text())
+  expect(dom.querySelector('#welcome-text').textContent).toEqual('환영하다')
+})
+
 test('(#2374) detect with x-forwarded-host on server', async () => {
   const html = await $fetch('/', {
     headers: {

--- a/specs/different_domains/different_domains.spec.ts
+++ b/specs/different_domains/different_domains.spec.ts
@@ -151,7 +151,7 @@ test.each([
   expect(dom.querySelector('#welcome-text').textContent).toEqual(header)
 })
 
-test.only('(#2931) detect using runtimeConfig domain', async () => {
+test('(#2931) detect using runtimeConfig domain', async () => {
   const res = await undiciRequest('/', {
     headers: {
       host: 'kr.staging.nuxt-app.localhost'

--- a/specs/fixtures/different_domains/i18n.config.ts
+++ b/specs/fixtures/different_domains/i18n.config.ts
@@ -40,6 +40,19 @@ export default {
           article: 'Dette er bloggartikkelsiden'
         }
       }
+    },
+    kr: {
+      welcome: '환영하다',
+      home: '홈페이지',
+      profile: '프로필',
+      about: '회사 소개',
+      posts: '게시물',
+      dynamic: '동적',
+      pages: {
+        blog: {
+          article: '여기는 블로그 게시물 페이지입니다'
+        }
+      }
     }
   },
   fallbackLocale: 'en'

--- a/src/runtime/domain.ts
+++ b/src/runtime/domain.ts
@@ -138,12 +138,21 @@ export function setupMultiDomainLocales(runtimeI18n: I18nPublicRuntimeConfig, de
  * Returns default locale for the current domain, returns `defaultLocale` by default
  */
 export function getDefaultLocaleForDomain(runtimeI18n: I18nPublicRuntimeConfig) {
-  const { locales, defaultLocale, multiDomainLocales } = runtimeI18n
+  const { locales, domainLocales, defaultLocale, multiDomainLocales } = runtimeI18n
+  const host = getHost()
+
   if (!multiDomainLocales) {
-    return defaultLocale || ''
+    const foundLocale = normalizedLocales.find(l => {
+      const localeCode = isString(l) ? l : l.code
+      const lang = normalizedLocales.find(locale => locale.code === localeCode)
+      const domain = domainLocales?.[localeCode]?.domain ?? lang?.domain
+
+      return domain === host
+    })
+
+    return foundLocale?.code ?? defaultLocale ?? ''
   }
 
-  const host = getHost()
   if (locales.some(l => !isString(l) && l.defaultForDomains != null)) {
     const findDefaultLocale = locales.find(
       (l): l is LocaleObject => !isString(l) && !!l.defaultForDomains?.includes(host)


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2931 

### 📚 Description

`domainLocales` was being checked in `getDomainFromLocale` which ensured the URLs for switching locales are correct, but when resolving the current locale `domainLocales` was ignored which resulted in the fallback locale being used for translations.

This changes adds similar logic to `getDefaultLocaleForDomain` to respect `domainLocales` and runtime-configured domains.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->
