### PR TITLE
fix: populate domainLocales based on module config (#3694)

### DIFF
--- a/src/prepare/runtime-config.ts
+++ b/src/prepare/runtime-config.ts
@@ -20,7 +20,15 @@ export function prepareRuntimeConfig({ options }: I18nNuxtContext, nuxt: Nuxt) {
     locales: options.locales,
     detectBrowserLanguage: options.detectBrowserLanguage ?? DEFAULT_OPTIONS.detectBrowserLanguage,
     experimental: options.experimental,
-    multiDomainLocales: options.multiDomainLocales
+    multiDomainLocales: options.multiDomainLocales,
+    domainLocales: Object.fromEntries(
+      options.locales.map(l => {
+        if (typeof l === 'string') {
+          return [l, { domain: '' }]
+        }
+        return [l.code, { domain: l.domain ?? '' }]
+      })
+    )
     // TODO: we should support more i18n module options. welcome PRs :-)
   })
 }


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #3694 

### 📚 Description

This change pre-populates `domainLocales` based on the values from the module config. This makes it possible to adjust the values at runtime through env variables, without requiring an additional change to the nuxt.config. The idea is to make the process simpler and less prone to error.



<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->
