### PR TITLE
fix: populate domainLocales based on module config (#3694)

### DIFF
--- a/src/prepare/runtime-config.ts
+++ b/src/prepare/runtime-config.ts
@@ -15,7 +15,14 @@ export function prepareRuntimeConfig(ctx: I18nNuxtContext, nuxt: Nuxt) {
     locales: ctx.options.locales,
     detectBrowserLanguage: ctx.options.detectBrowserLanguage ?? DEFAULT_OPTIONS.detectBrowserLanguage,
     experimental: ctx.options.experimental,
-    domainLocales: {} as I18nPublicRuntimeConfig['domainLocales']
+    domainLocales: Object.fromEntries(
+      ctx.options.locales.map(l => {
+        if (typeof l === 'string') {
+          return [l, { domain: '' }]
+        }
+        return [l.code, { domain: l.domain ?? '' }]
+      })
+    ) as I18nPublicRuntimeConfig['domainLocales']
   })
 
   nuxt.options.runtimeConfig.public.i18n.locales = simplifyLocaleOptions(ctx, nuxt)


### PR DESCRIPTION
### 🔗 Linked issue

#3694 

### 📚 Description

This ports the change from #3695 to v10.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the way locale and domain information is initialized, ensuring the configuration accurately reflects available locales and their associated domains. No changes to public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->