### PR TITLE
refactor: virtuals and constants naming consistency

### DIFF
--- a/internals.d.ts
+++ b/internals.d.ts
@@ -1,4 +1,4 @@
-declare module '#build/i18n.options.mjs' {
+declare module '#build/i18n-options.mjs' {
   import type { LocaleObject, VueI18nConfig } from '@nuxtjs/i18n'
 
   export type { LocaleObject }
@@ -10,7 +10,7 @@ declare module '#build/i18n.options.mjs' {
   export const normalizedLocales: LocaleObject[]
 }
 
-declare module '#internal/i18n/options.mjs' {
+declare module '#internal/i18n-options.mjs' {
   import type { LocaleObject, VueI18nConfig } from '@nuxtjs/i18n'
 
   type LocaleLoader = { key: string; cache: boolean; load: () => Promise<never> }
@@ -20,18 +20,12 @@ declare module '#internal/i18n/options.mjs' {
   export const normalizedLocales: LocaleObject[]
 }
 
-declare module '#internal/i18n/locale.detector.mjs' {
+declare module '#internal/i18n-locale-detector.mjs' {
   export const localeDetector: ((event: H3Event, config: LocaleConfig) => string) | undefined
 }
 
 declare module '#internal/i18n-type-generation-options' {
   export const dtsFile: string
-}
-
-declare module '#nuxt-i18n/logger' {
-  import type { ConsolaInstance } from 'consola'
-
-  export function createLogger(label: string): ConsolaInstance
 }
 
 declare module '#build/i18n-route-resources.mjs' {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -86,11 +86,10 @@ export const DEFAULT_OPTIONS = {
   autoDeclare: true
 } as const
 
-export const NUXT_I18N_TEMPLATE_OPTIONS_KEY = 'i18n.options.mjs'
-export const NUXT_I18N_COMPOSABLE_DEFINE_ROUTE = 'defineI18nRoute'
-export const NUXT_I18N_COMPOSABLE_DEFINE_LOCALE = 'defineI18nLocale'
-export const NUXT_I18N_COMPOSABLE_DEFINE_CONFIG = 'defineI18nConfig'
-export const NUXT_I18N_COMPOSABLE_DEFINE_LOCALE_DETECTOR = 'defineI18nLocaleDetector'
+export const DEFINE_I18N_ROUTE_FN = 'defineI18nRoute'
+export const DEFINE_I18N_LOCALE_FN = 'defineI18nLocale'
+export const DEFINE_I18N_CONFIG_FN = 'defineI18nConfig'
+export const DEFINE_LOCALE_DETECTOR_FN = 'defineI18nLocaleDetector'
 export const NUXT_I18N_VIRTUAL_PREFIX = '#nuxt-i18n'
 
 const TS_EXTENSIONS = ['.ts', '.cts', '.mts']

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -11,9 +11,9 @@ import {
   H3_PKG,
   UTILS_H3_PKG,
   EXECUTABLE_EXTENSIONS,
-  NUXT_I18N_COMPOSABLE_DEFINE_LOCALE,
-  NUXT_I18N_COMPOSABLE_DEFINE_CONFIG,
-  NUXT_I18N_COMPOSABLE_DEFINE_LOCALE_DETECTOR
+  DEFINE_I18N_LOCALE_FN,
+  DEFINE_I18N_CONFIG_FN,
+  DEFINE_LOCALE_DETECTOR_FN
 } from './constants'
 import { resolveI18nDir } from './layers'
 
@@ -25,9 +25,9 @@ export async function setupNitro(ctx: I18nNuxtContext, nuxt: Nuxt) {
   const [enableServerIntegration, localeDetectionPath] = await resolveLocaleDetectorPath(nuxt)
 
   addServerTemplate({
-    filename: '#internal/i18n/options.mjs',
+    filename: '#internal/i18n-options.mjs',
     getContents: () =>
-      nuxt.vfs['#build/i18n.options.mjs']?.replace(/\/\*\* client \*\*\/[\s\S]*\/\*\* client-end \*\*\//, '')
+      nuxt.vfs['#build/i18n-options.mjs']?.replace(/\/\*\* client \*\*\/[\s\S]*\/\*\* client-end \*\*\//, '')
   })
 
   addServerTemplate({
@@ -36,7 +36,7 @@ export async function setupNitro(ctx: I18nNuxtContext, nuxt: Nuxt) {
   })
 
   addServerTemplate({
-    filename: '#internal/i18n/locale.detector.mjs',
+    filename: '#internal/i18n-locale-detector.mjs',
     getContents: () =>
       enableServerIntegration
         ? `import localeDetector from ${JSON.stringify(localeDetectionPath)}
@@ -75,7 +75,7 @@ export { localeDetector }`
 
   // `defineI18nLocale`, `defineI18nConfig`
   addServerImports(
-    [NUXT_I18N_COMPOSABLE_DEFINE_LOCALE, NUXT_I18N_COMPOSABLE_DEFINE_CONFIG].map(key => ({
+    [DEFINE_I18N_LOCALE_FN, DEFINE_I18N_CONFIG_FN].map(key => ({
       name: key,
       as: key,
       from: ctx.resolver.resolve('runtime/composables/shared')
@@ -85,8 +85,8 @@ export { localeDetector }`
   // `defineLocaleDetector`
   addServerImports([
     {
-      name: NUXT_I18N_COMPOSABLE_DEFINE_LOCALE_DETECTOR,
-      as: NUXT_I18N_COMPOSABLE_DEFINE_LOCALE_DETECTOR,
+      name: DEFINE_LOCALE_DETECTOR_FN,
+      as: DEFINE_LOCALE_DETECTOR_FN,
       from: ctx.resolver.resolve('runtime/composables/server')
     }
   ])

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -7,7 +7,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { getRoutePath, parseSegment } from './utils/route-parsing'
 import { localizeRoutes } from './routing'
 import { resolve, parse as parsePath, dirname } from 'pathe'
-import { NUXT_I18N_COMPOSABLE_DEFINE_ROUTE } from './constants'
+import { DEFINE_I18N_ROUTE_FN } from './constants'
 import { createRoutesContext } from 'unplugin-vue-router'
 import { resolveOptions } from 'unplugin-vue-router/options'
 
@@ -386,7 +386,7 @@ function readComponent(target: string) {
     const content = readFileSync(target, 'utf-8')
     const { descriptor } = parseSFC(content)
 
-    if (!content.includes(NUXT_I18N_COMPOSABLE_DEFINE_ROUTE)) {
+    if (!content.includes(DEFINE_I18N_ROUTE_FN)) {
       return undefined
     }
 
@@ -399,7 +399,7 @@ function readComponent(target: string) {
       walk(ast, {
         enter(node: Node) {
           if (node.type !== 'CallExpression') return
-          if (node.callee.type === 'Identifier' && node.callee.name === NUXT_I18N_COMPOSABLE_DEFINE_ROUTE) {
+          if (node.callee.type === 'Identifier' && node.callee.name === DEFINE_I18N_ROUTE_FN) {
             const arg = node.arguments[0]
             if (
               arg.type === 'BooleanLiteral' ||

--- a/src/prepare/auto-imports.ts
+++ b/src/prepare/auto-imports.ts
@@ -1,9 +1,4 @@
-import {
-  NUXT_I18N_COMPOSABLE_DEFINE_CONFIG,
-  NUXT_I18N_COMPOSABLE_DEFINE_LOCALE,
-  NUXT_I18N_COMPOSABLE_DEFINE_ROUTE,
-  VUE_I18N_PKG
-} from '../constants'
+import { DEFINE_I18N_CONFIG_FN, DEFINE_I18N_LOCALE_FN, DEFINE_I18N_ROUTE_FN, VUE_I18N_PKG } from '../constants'
 import { addComponent, addImports, resolveModule, useNuxt } from '@nuxt/kit'
 import type { I18nNuxtContext } from '../context'
 
@@ -32,9 +27,9 @@ export function prepareAutoImports({ resolver, userOptions: options, runtimeDir 
       'useCookieLocale',
       'useSetI18nParams',
       'useI18nPreloadKeys',
-      NUXT_I18N_COMPOSABLE_DEFINE_ROUTE,
-      NUXT_I18N_COMPOSABLE_DEFINE_LOCALE,
-      NUXT_I18N_COMPOSABLE_DEFINE_CONFIG
+      DEFINE_I18N_ROUTE_FN,
+      DEFINE_I18N_LOCALE_FN,
+      DEFINE_I18N_CONFIG_FN
     ].map(key => ({ name: key, as: key, from: composablesIndex }))
   ])
 }

--- a/src/prepare/runtime.ts
+++ b/src/prepare/runtime.ts
@@ -3,7 +3,6 @@ import type { I18nNuxtContext } from '../context'
 import { addPlugin, addTemplate, addTypeTemplate, addVitePlugin, useNitro } from '@nuxt/kit'
 import { generateTemplateNuxtI18nOptions } from '../template'
 import { generateI18nTypes, generateLoaderOptions } from '../gen'
-import { NUXT_I18N_TEMPLATE_OPTIONS_KEY } from '../constants'
 
 export function prepareRuntime(ctx: I18nNuxtContext, nuxt: Nuxt) {
   const { options, resolver } = ctx
@@ -45,7 +44,7 @@ export function prepareRuntime(ctx: I18nNuxtContext, nuxt: Nuxt) {
   }
 
   addTemplate({
-    filename: NUXT_I18N_TEMPLATE_OPTIONS_KEY,
+    filename: 'i18n-options.mjs',
     getContents: () => generateTemplateNuxtI18nOptions(ctx, generateLoaderOptions(ctx, nuxt))
   })
 

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -1,7 +1,7 @@
 import { isRef, unref } from 'vue'
 
 import { useState, useCookie, useRequestURL } from '#imports'
-import { localeLoaders } from '#build/i18n.options.mjs'
+import { localeLoaders } from '#build/i18n-options.mjs'
 import { getLocaleMessagesMergedCached } from './shared/messages'
 import { createBaseUrlGetter, createComposableContext } from './utils'
 import { getI18nTarget } from './compatibility'

--- a/src/runtime/plugins/dev.ts
+++ b/src/runtime/plugins/dev.ts
@@ -1,4 +1,4 @@
-import { vueI18nConfigs } from '#build/i18n.options.mjs'
+import { vueI18nConfigs } from '#build/i18n-options.mjs'
 import { defineNuxtPlugin, useNuxtApp } from '#imports'
 import { getComposer } from '../compatibility'
 import { useNuxtI18nContext } from '../context'

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -1,7 +1,7 @@
 import { computed, ref, watch } from 'vue'
 import { createI18n } from 'vue-i18n'
 import { defineNuxtPlugin, prerenderRoutes, useNuxtApp, useRequestEvent, useRequestURL } from '#imports'
-import { localeCodes, normalizedLocales } from '#build/i18n.options.mjs'
+import { localeCodes, normalizedLocales } from '#build/i18n-options.mjs'
 import { loadAndSetLocale, navigate } from '../utils'
 import { extendI18n } from '../routing/i18n'
 import { getI18nTarget } from '../compatibility'

--- a/src/runtime/plugins/preload.ts
+++ b/src/runtime/plugins/preload.ts
@@ -1,7 +1,7 @@
 import { parse } from 'devalue'
 import { unref } from 'vue'
 import { useNuxtApp, defineNuxtPlugin } from '#app'
-import { localeCodes, localeLoaders } from '#build/i18n.options.mjs'
+import { localeCodes, localeLoaders } from '#build/i18n-options.mjs'
 import { getLocaleMessagesMergedCached } from '../shared/messages'
 import { useNuxtI18nContext, type NuxtI18nContext } from '../context'
 

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -9,7 +9,7 @@ import { setupVueI18nOptions } from '../shared/vue-i18n'
 import { joinURL } from 'ufo'
 // @ts-expect-error virtual file
 import { appId } from '#internal/nuxt.config.mjs'
-import { localeDetector } from '#internal/i18n/locale.detector.mjs'
+import { localeDetector } from '#internal/i18n-locale-detector.mjs'
 import { resolveRootRedirect, useI18nDetection, useRuntimeI18n } from '../shared/utils'
 import { isFunction } from '@intlify/shared'
 

--- a/src/runtime/server/type-generation.ts
+++ b/src/runtime/server/type-generation.ts
@@ -1,5 +1,5 @@
 import { deepCopy, isArray, isFunction, isObject } from '@intlify/shared'
-import { vueI18nConfigs, localeLoaders, normalizedLocales } from '#internal/i18n/options.mjs'
+import { vueI18nConfigs, localeLoaders, normalizedLocales } from '#internal/i18n-options.mjs'
 import { dtsFile } from '#internal/i18n-type-generation-options'
 import { loadVueI18nOptions } from '../shared/messages'
 import { getMergedMessages } from './utils/messages'

--- a/src/runtime/server/utils/locale-detector.ts
+++ b/src/runtime/server/utils/locale-detector.ts
@@ -1,10 +1,10 @@
 import { fetchMessages } from '../context'
 import { deepCopy } from '@intlify/shared'
-import { localeDetector } from '#internal/i18n/locale.detector.mjs'
+import { localeDetector } from '#internal/i18n-locale-detector.mjs'
 import { tryCookieLocale, tryHeaderLocale, tryQueryLocale } from '@intlify/h3'
 import { findBrowserLocale } from '#i18n-kit/browser'
 import { parseAcceptLanguage } from '@intlify/utils'
-import { normalizedLocales } from '#internal/i18n/options.mjs'
+import { normalizedLocales } from '#internal/i18n-options.mjs'
 
 import type { H3Event } from 'h3'
 import type { CoreOptions, FallbackLocale, Locale } from '@intlify/core'

--- a/src/runtime/server/utils/messages.ts
+++ b/src/runtime/server/utils/messages.ts
@@ -1,5 +1,5 @@
 import { deepCopy } from '@intlify/shared'
-import { localeLoaders } from '#internal/i18n/options.mjs'
+import { localeLoaders } from '#internal/i18n-options.mjs'
 import { getLocaleMessagesMerged } from '../../shared/messages'
 import { cachedFunctionI18n } from './cache'
 import { isLocaleCacheable, isLocaleWithFallbacksCacheable } from '../../shared/locales'

--- a/src/runtime/shared/detection.ts
+++ b/src/runtime/shared/detection.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { getRequestURL, getRequestHeader } from 'h3'
-import { normalizedLocales } from '#build/i18n.options.mjs'
+import { normalizedLocales } from '#build/i18n-options.mjs'
 import { getLocaleFromRoute, getLocaleFromRoutePath } from '#i18n-kit/routing'
 import { findBrowserLocale } from '#i18n-kit/browser'
 import { parseAcceptLanguage } from '@intlify/utils'

--- a/src/runtime/shared/domain.ts
+++ b/src/runtime/shared/domain.ts
@@ -1,5 +1,5 @@
 import { hasProtocol } from 'ufo'
-import { normalizedLocales } from '#build/i18n.options.mjs'
+import { normalizedLocales } from '#build/i18n-options.mjs'
 import { toArray } from './utils'
 
 import type { LocaleObject } from '#internal-i18n-types'

--- a/src/runtime/shared/locales.ts
+++ b/src/runtime/shared/locales.ts
@@ -1,4 +1,4 @@
-import { localeCodes, localeLoaders, normalizedLocales } from '#build/i18n.options.mjs'
+import { localeCodes, localeLoaders, normalizedLocales } from '#build/i18n-options.mjs'
 import { isArray, isString } from '@intlify/shared'
 import type { FallbackLocale } from 'vue-i18n'
 

--- a/src/runtime/shared/vue-i18n.ts
+++ b/src/runtime/shared/vue-i18n.ts
@@ -1,5 +1,5 @@
 import { loadVueI18nOptions } from './messages'
-import { vueI18nConfigs, localeCodes as _localeCodes } from '#build/i18n.options.mjs'
+import { vueI18nConfigs, localeCodes as _localeCodes } from '#build/i18n-options.mjs'
 
 import type { I18nOptions } from 'vue-i18n'
 

--- a/src/transform/heist.ts
+++ b/src/transform/heist.ts
@@ -17,6 +17,7 @@ export const HeistPlugin = (options: BundlerPluginOptions, ctx: I18nNuxtContext,
 
   const replacementName = `__nuxtMock`
   const replacementMock = `const ${replacementName} = { runWithContext: async (fn) => await fn() };`
+  const resources = ['i18n-route-resources.mjs', 'i18n-options.mjs']
 
   return createUnplugin(() => ({
     name: 'nuxtjs:i18n-heist',
@@ -39,9 +40,9 @@ export const HeistPlugin = (options: BundlerPluginOptions, ctx: I18nNuxtContext,
         // replace `#app` with `__nuxtMock`
         s.replaceAll(/useNuxtApp\(\)/g, replacementName)
 
-        s.replaceAll(/#build\/i18n-route-resources\.mjs/g, '#internal/i18n-route-resources.mjs')
-        // replace `#build/i18n.options.mjs` with `#internal/i18n/options.mjs`
-        s.replaceAll(/#build\/i18n\.options\.mjs/g, '#internal/i18n/options.mjs')
+        for (const resource of resources) {
+          s.replaceAll(new RegExp(`#build/${resource}`, 'g'), `#internal/${resource}`)
+        }
 
         return {
           code: s.toString(),

--- a/src/transform/macros.ts
+++ b/src/transform/macros.ts
@@ -10,11 +10,11 @@ import MagicString from 'magic-string'
 import { createUnplugin } from 'unplugin'
 import { parse as parseSFC } from '@vue/compiler-sfc'
 import { VIRTUAL_PREFIX_HEX, isVue } from './utils'
-import { NUXT_I18N_COMPOSABLE_DEFINE_ROUTE } from '../constants'
+import { DEFINE_I18N_ROUTE_FN } from '../constants'
 
 import type { BundlerPluginOptions } from './utils'
 
-const I18N_MACRO_FN_RE = new RegExp(`\\b${NUXT_I18N_COMPOSABLE_DEFINE_ROUTE}\\s*\\(\\s*`)
+const I18N_MACRO_FN_RE = new RegExp(`\\b${DEFINE_I18N_ROUTE_FN}\\s*\\(\\s*`)
 
 /**
  * TODO:

--- a/src/transform/resource.ts
+++ b/src/transform/resource.ts
@@ -1,11 +1,7 @@
 import MagicString from 'magic-string'
 import { createUnplugin } from 'unplugin'
 import { asI18nVirtual, VIRTUAL_PREFIX_HEX } from './utils'
-import {
-  NUXT_I18N_COMPOSABLE_DEFINE_LOCALE,
-  NUXT_I18N_COMPOSABLE_DEFINE_CONFIG,
-  NUXT_I18N_VIRTUAL_PREFIX
-} from '../constants'
+import { DEFINE_I18N_LOCALE_FN, DEFINE_I18N_CONFIG_FN, NUXT_I18N_VIRTUAL_PREFIX } from '../constants'
 import { resolve, dirname } from 'pathe'
 import { findStaticImports } from 'mlly'
 import { resolvePath, tryUseNuxt } from '@nuxt/kit'
@@ -22,7 +18,7 @@ async function transform<T extends TransformOptions>(
   return await esbuildTransform(input, { ...tryUseNuxt()?.options.esbuild?.options, ...options })
 }
 
-const pattern = [NUXT_I18N_COMPOSABLE_DEFINE_LOCALE, NUXT_I18N_COMPOSABLE_DEFINE_CONFIG].join('|')
+const pattern = [DEFINE_I18N_LOCALE_FN, DEFINE_I18N_CONFIG_FN].join('|')
 const DEFINE_I18N_FN_RE = new RegExp(`\\b(${pattern})\\s*\\((.+)\\s*\\)`, 'gms')
 
 export const ResourcePlugin = (options: BundlerPluginOptions, ctx: I18nNuxtContext) =>

--- a/vitest.config.test.ts
+++ b/vitest.config.test.ts
@@ -9,8 +9,7 @@ export default defineConfig({
     setupFiles: [...(vitestConfig.test?.setupFiles ?? []), resolve('./test/setup.ts')].filter(Boolean),
     alias: {
       ...vitestConfig.test?.alias,
-      '#build/i18n.options.mjs': resolve('./test/mocks/i18n.options.ts'),
-      '#nuxt-i18n/logger': resolve('./test/mocks/i18n-logger.ts'),
+      '#build/i18n-options.mjs': resolve('./test/mocks/i18n.options.ts'),
       '#app': 'nuxt'
     }
   }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal naming conventions for i18n-related modules and constants, leading to more consistent and streamlined identifiers throughout the codebase.
  * Removed outdated or redundant constants and module references.
  * Adjusted import paths to match new naming conventions for improved maintainability.
* **Chores**
  * Updated test configuration to reflect new module naming and removed obsolete aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->