### PR TITLE
docs: fix main menu styling for small screens

### DIFF
--- a/docs/components/Header.vue
+++ b/docs/components/Header.vue
@@ -33,7 +33,7 @@ const processed = computed<DropdownMenuItem[]>(() => {
     <template #left>
       <NuxtLink
         to="/"
-        class="flex items-end gap-2 font-bold text-xl text-(--ui-text-highlighted) min-w-0 focus-visible:outline-(--ui-primary) shrink-0"
+        class="flex items-end gap-2 font-bold text-lg text-(--ui-text-highlighted) min-w-0 focus-visible:outline-(--ui-primary) shrink-0"
       >
         <Logo class="w-auto h-8 shrink-0" />
       </NuxtLink>
@@ -43,6 +43,7 @@ const processed = computed<DropdownMenuItem[]>(() => {
         :items="processed"
         :ui="{ content: 'w-(--reka-dropdown-menu-trigger-width) min-w-0' }"
         size="xs"
+        class="hidden sm:flex"
       >
         <UButton
           :label="`v${config.public.version}`"
@@ -67,7 +68,7 @@ const processed = computed<DropdownMenuItem[]>(() => {
       <UContentSearchButton :label="null" />
       <!-- </UTooltip> -->
 
-      <UColorModeButton />
+      <UColorModeButton class="hidden sm:flex" />
 
       <template v-if="appConfig.header?.links">
         <UButton


### PR DESCRIPTION
### 🔗 Linked issue
* #3708 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Resolves #3708 

This does hide the version selector on mobile, but it takes up too much space in the header itself, we probably need to move it in the menu drawer on mobile.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->
