### PR TITLE
docs(migrating): correct hook names

### DIFF
--- a/docs/content/docs/02.guide/90.migrating.md
+++ b/docs/content/docs/02.guide/90.migrating.md
@@ -36,8 +36,8 @@ The following composables and [I18n functions](/docs/api/vue-i18n) have been cha
 | Status | Function | Notes |
 |---|---|---|
 | :badge{label="changed" color="info"}| [`useLocaleHead()`{lang="ts"}](/docs/composables/use-locale-head) | The `key`{lang="yml"} property on the options parameter has been removed and can no longer be configured, this is necessary for predictable and consistent localized head tag management. |
-| :badge{label="removed" color="error"} | `onLanguageSwitched()`{lang="ts"} | Use the [`'i18n:languageSwitched'`{lang="ts"}](/docs/guide/runtime-hooks) hook instead.<br><br>This function actually called the hook instead of subscribing to it, leading to unpredictable behavior.|
-| :badge{label="removed" color="error"} | `onBeforeLanguageSwitch()`{lang="ts"} | Use the [`'i18n:beforeLanguageSwitch'`{lang="ts"}](/docs/guide/runtime-hooks) hook instead.<br><br>This function actually called the hook instead of subscribing to it, leading to unpredictable behavior. |
+| :badge{label="removed" color="error"} | `onLanguageSwitched()`{lang="ts"} | Use the [`'i18n:localeSwitched'`{lang="ts"}](/docs/guide/runtime-hooks) hook instead.<br><br>This function actually called the hook instead of subscribing to it, leading to unpredictable behavior.|
+| :badge{label="removed" color="error"} | `onBeforeLanguageSwitch()`{lang="ts"} | Use the [`'i18n:beforeLocaleSwitch'`{lang="ts"}](/docs/guide/runtime-hooks) hook instead.<br><br>This function actually called the hook instead of subscribing to it, leading to unpredictable behavior. |
 
 
 ## Context functions


### PR DESCRIPTION
### 🔗 Linked issue

n/a

### 📚 Description

I think the hook names are called differently.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the migration guide to correct the recommended replacement hooks for removed I18n functions.
  * Improved wording in the "Generated options" section for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->