### PR TITLE
docs(options): list `strictSeo` under `experimental`

### DIFF
--- a/docs/content/docs/04.api/00.options.md
+++ b/docs/content/docs/04.api/00.options.md
@@ -452,6 +452,12 @@ Experimental configuration property is an object with the following properties:
 For more details on how to define the locale detector, see the [`defineI18nLocaleDetector()`{lang="ts"} API](/docs/composables/define-i18n-locale-detector)
 ::
 
+### `strictSeo`
+
+- type: `boolean | SeoAttributesOptions`{lang="ts-type"}
+- default: `false`{lang="ts"}
+- Enables strict SEO mode.
+
 ### `typedPages`
 
 - type: `boolean`{lang="ts-type"}
@@ -486,12 +492,6 @@ This feature relies on [Nuxt's `experimental.typedRoutes`](https://nuxt.com/docs
 ::callout{icon="i-heroicons-exclamation-triangle" color="warning"}
 This functionality is only supported for projects using vite.
 ::
-
-## `strictSeo`
-
-- type: `boolean | SeoAttributesOptions`{lang="ts-type"}
-- default: `false`{lang="ts"}
-- Enables strict SEO mode.
 
 ## customBlocks
 


### PR DESCRIPTION
### 🔗 Linked issue

n/a

### 📚 Description

Types say it's valid under `experimental` only.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved organization by moving the `strictSeo` option documentation under the `experimental` configuration section and removing redundant content. No changes to the actual option or its description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->