### PR TITLE
fix: remove conflicting `PageMeta` type workaround

### DIFF
--- a/src/gen.ts
+++ b/src/gen.ts
@@ -2,7 +2,6 @@ import { isString } from '@intlify/shared'
 import { genDynamicImport, genSafeVariableName, genString } from 'knitwork'
 import { resolve, relative, join, basename } from 'pathe'
 import { asI18nVirtual } from './transform/utils'
-import { resolveModule } from '@nuxt/kit'
 
 import type { Nuxt } from '@nuxt/schema'
 import type { LocaleObject } from './types'
@@ -214,11 +213,6 @@ declare module '#app' {
   interface PageMeta extends I18nMeta {}
 }
 
-
-// NOTE: this is a workaround for Nuxt <3.16.2
-declare module '${resolve(resolveModule('nuxt'), '../pages/runtime/composables')}' {
-  interface PageMeta extends I18nMeta {}
-}
 
 declare module 'vue-router' {
   interface RouteMeta extends I18nMeta {}


### PR DESCRIPTION
### 🔗 Linked issue
* #3713 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Resolves #3713


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed legacy workaround for extending page metadata related to older Nuxt versions. No changes to user-facing features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->