### PR TITLE
fix: message type generation

### DIFF
--- a/src/runtime/server/type-generation.ts
+++ b/src/runtime/server/type-generation.ts
@@ -34,7 +34,7 @@ export default async () => {
   const loaderPromises: Promise<unknown>[] = []
   for (const locale in localeLoaders) {
     if (!targetLocales.includes(locale)) continue
-    const loader = async () => deepCopy(await getMergedMessages(locale, []), merged.messages)
+    const loader = async () => deepCopy((await getMergedMessages(locale, []))?.[locale], merged.messages)
     loaderPromises.push(loader())
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Generated types should be a merged object of all locale messages (not keyed per locale)
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of locale-specific messages, ensuring only relevant messages for the current locale are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->