### PR TITLE
fix!: throw error on invalid config with `strictSeo` enabled

### DIFF
--- a/src/runtime/routing/head.ts
+++ b/src/runtime/routing/head.ts
@@ -18,6 +18,9 @@ function createHeadContext(
   const canonicalQueries = (typeof config.seo === 'object' && config.seo?.canonicalQueries) || []
 
   if (!baseUrl) {
+    if (__I18N_STRICT_SEO__) {
+      throw new Error('I18n `baseUrl` is required to generate valid SEO tag links.')
+    }
     console.warn('I18n `baseUrl` is required to generate valid SEO tag links.')
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
It only makes sense to throw an error if invalid configuration is used when `strictSeo` is enabled, we previously only printed warnings to preserve backwards compatibility.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to ensure a required setting is enforced under strict SEO mode, providing clearer feedback if configuration is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->