### PR TITLE
fix(types): allow partial public runtime config

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -120,7 +120,7 @@ type UserNuxtI18nOptions = Omit<NuxtI18nOptions, 'locales'> & { locales?: string
 export interface ModuleOptions extends UserNuxtI18nOptions {}
 
 export interface ModulePublicRuntimeConfig {
-  i18n: I18nPublicRuntimeConfig
+  i18n: Partial<I18nPublicRuntimeConfig>
 }
 export interface ModuleHooks {
   'i18n:registerModule': (


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/nuxt-modules/i18n/issues/3729

### 📚 Description

Marks `ModulePublicRuntimeConfig`'s `i18n` key type as `Partial` for compatibility with Nuxt 4's Typescript project references.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved flexibility of the runtime configuration by allowing partial i18n settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->