### PR TITLE
fix: correct root redirection with query params

### DIFF
--- a/specs/routing_strategies/prefix.spec.ts
+++ b/specs/routing_strategies/prefix.spec.ts
@@ -205,4 +205,19 @@ describe('strategy: prefix', async () => {
     expect(await page.locator('#issue-2020-existing').innerText()).toBe('/en/test-route?foo=bar')
     expect(await page.locator('#issue-2020-nonexistent').innerText()).toBe('/i-dont-exist?foo=bar')
   })
+  test('should keep query params when redirecting', async () => {
+    await startServerWithRuntimeConfig(
+      {
+        public: {
+          i18n: {
+            detectBrowserLanguage: false
+          }
+        }
+      },
+      true
+    )
+
+    const res = await fetch('/?foo=bar')
+    expect(res.url).toBe(url('/en?foo=bar'))
+  })
 })

--- a/specs/routing_strategies/prefix_legacy_detect.spec.ts
+++ b/specs/routing_strategies/prefix_legacy_detect.spec.ts
@@ -35,7 +35,8 @@ describe('strategy: prefix (legacy detect)', async () => {
     const redirectUrls = [
       ['/', '/en'],
       ['/about', '/en/about'],
-      ['/category/foo', '/en/category/foo']
+      ['/category/foo', '/en/category/foo'],
+      ['/?foo=bar', '/en?foo=bar']
     ]
     for (const [pathUrl, destination] of redirectUrls) {
       const res = await fetch(pathUrl, { redirect: 'manual' })

--- a/specs/routing_strategies/root_redirect.spec.ts
+++ b/specs/routing_strategies/root_redirect.spec.ts
@@ -34,6 +34,20 @@ describe('rootRedirect', async () => {
     const res = await fetch('/')
     expect(res.url).toBe(url('/fr'))
   })
+  test('keeps query params when redirecting', async () => {
+    await startServerWithRuntimeConfig(
+      {
+        public: {
+          i18n: {
+            rootRedirect: 'fr'
+          }
+        }
+      },
+      true
+    )
+    const res = await fetch('/?foo=bar')
+    expect(res.url).toBe(url('/fr?foo=bar'))
+  })
 
   test('(#2758) `statusCode` in `rootRedirect` should work with strategy "prefix"', async () => {
     await startServerWithRuntimeConfig(

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -109,7 +109,7 @@ export default defineNitroPlugin(async nitro => {
 
     let resolvedPath = undefined
     let redirectCode = 302
-    const requestURL = new URL(getRequestURL(event))
+    const requestURL = getRequestURL(event)
 
     if (rootRedirect && requestURL.pathname === '/') {
       locale = (detection.enabled && locale) || defaultLocale

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -109,11 +109,13 @@ export default defineNitroPlugin(async nitro => {
 
     let resolvedPath = undefined
     let redirectCode = 302
-    if (rootRedirect && event.path === '/') {
+    const requestURL = new URL(getRequestURL(event))
+
+    if (rootRedirect && requestURL.pathname === '/') {
       locale = (detection.enabled && locale) || defaultLocale
       resolvedPath =
-        (isSupportedLocale(detector.route(rootRedirect.path)) && rootRedirect.path) ||
-        matchLocalized(rootRedirect.path, locale, defaultLocale)
+        ((isSupportedLocale(detector.route(rootRedirect.path)) && rootRedirect.path) ||
+          matchLocalized(rootRedirect.path, locale, defaultLocale)) + requestURL.search
       redirectCode = rootRedirect.code
     } else if (runtimeI18n.redirectStatusCode) {
       redirectCode = runtimeI18n.redirectStatusCode
@@ -121,7 +123,7 @@ export default defineNitroPlugin(async nitro => {
 
     switch (detection.redirectOn) {
       case 'root':
-        if (event.path !== '/') break
+        if (requestURL.pathname !== '/') break
       // fallthrough (root has no prefix)
       case 'no prefix':
         if (pathLocale) break
@@ -131,10 +133,9 @@ export default defineNitroPlugin(async nitro => {
         break
     }
 
-    if (event.path === '/' && __I18N_STRATEGY__ === 'prefix') {
+    if (requestURL.pathname === '/' && __I18N_STRATEGY__ === 'prefix') {
       resolvedPath ??= getLocalizedMatch(defaultLocale)
     }
-
     return { path: resolvedPath, code: redirectCode, locale }
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #3733

### 📚 Description

The redirect middleware compared `event.path` to `/` to check if the prefix is missing. However, `event.path` does include the query string. Therefore, the redirects did not work properly when there was no prefix but a query string

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured query parameters are preserved during locale and root redirects.

* **Tests**
  * Added and expanded test cases verifying query parameter retention in locale-prefixed and root redirect URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->