### PR TITLE
docs: clarify redirectOn behavior change in v10 migration guide

### DIFF
--- a/docs/content/docs/02.guide/90.migrating.md
+++ b/docs/content/docs/02.guide/90.migrating.md
@@ -33,7 +33,7 @@ The following [Configuration options](/docs/api/options) have been changed, depr
 
 ### Browser Language Detection
 
-Language detection and redirection have been improved to strictly follow documented behavior. In v9, some combinations of `strategy` and `redirectOn` options worked unexpectedly, which has been corrected in v10.
+Language detection and redirection have been improved to follow documented behavior strictly. In v9, some combinations of `strategy` and `redirectOn` options worked unexpectedly, which has been corrected in v10.
 
 **Key Change**: When using `strategy: 'prefix'` with `redirectOn: 'root'`, non-root paths (e.g., `/search`) will no longer automatically redirect to their localized versions (e.g., `/zh/search`).
 
@@ -41,14 +41,24 @@ Language detection and redirection have been improved to strictly follow documen
 
 ```ts
 // v9 configuration (worked unexpectedly)
-detectBrowserLanguage: {
-  redirectOn: 'root',  // ⚠️ In v10 this will only redirect the root path
-}
+export default defineNuxtConfig({
+  i18n: {
+    strategy: 'prefix',
+    detectBrowserLanguage: {
+      redirectOn: 'root', // ⚠️ In v10 this will only redirect the root path
+    }
+  }
+})
 
 // v10 configuration (correct behavior)
-detectBrowserLanguage: {
-  redirectOn: 'all',   // Redirects all paths as documented
-}
+export default defineNuxtConfig({
+  i18n: {
+    strategy: 'prefix',
+    detectBrowserLanguage: {
+      redirectOn: 'all',  // Redirects all paths as documented
+    }
+  }
+})
 ```
 
 **Impact**: This affects projects using `strategy: 'prefix'` that relied on the previous unintended behavior where `redirectOn: 'root'` also handled non-root paths.

--- a/docs/content/docs/02.guide/90.migrating.md
+++ b/docs/content/docs/02.guide/90.migrating.md
@@ -102,8 +102,7 @@ The following options have been removed from runtime config:
 
 The generated options files in your projects are meant for internal use by this module at runtime and should never be used, more properties may be removed in the future.
 
--Future changes to these internal options will not be documented in the migration guide. If you have use cases for these options, please open an issue describing your use case so we can evaluate if we can support it in a different way.
-+Future changes to these internal options will not be documented in the migration guide. If you have use cases for these options, please open an issue describing your use case so we can evaluate if we can support it differently.
+Future changes to these internal options will not be documented in the migration guide. If you have use cases for these options, please open an issue describing your use case so we can evaluate if we can support it differently.
 
 The generated option files have been renamed:
 

--- a/docs/content/docs/02.guide/90.migrating.md
+++ b/docs/content/docs/02.guide/90.migrating.md
@@ -29,6 +29,40 @@ The following [Configuration options](/docs/api/options) have been changed, depr
 | :badge{label="removed" color="error"} | `bundle.optimizeTranslationDirective`{lang="yml"} | This feature has been disabled and fully removed, see [the discussion in this issue](https://github.com/nuxt-modules/i18n/issues/3238#issuecomment-2672492536) for context on this change. |
 | :badge{label="removed" color="error"} | `experimental.generatedLocaleFilePathFormat`{lang="yml"} | File paths (e.g. locale files, vue-i18n configs) configured for this module are now removed from the build entirely making this option obsolete. |
 
+## Language detection behavior
+
+Language detection and redirection has been improved in v10 to more accurately follow the documented behavior. This may affect existing configurations.
+
+### redirectOn with prefix strategy
+
+In v9, the combination of `strategy: 'prefix'` and `detectBrowserLanguage.redirectOn: 'root'` could redirect non-root paths (e.g., `/search`) to their localized versions. This behavior was inconsistent with the documented specification.
+
+In v10, `redirectOn: 'root'` now strictly only handles redirects for the root path (`/`) as documented. If you need redirection for all paths with a prefix strategy, use `redirectOn: 'all'`.
+
+**Migration required if you used:**
+```typescript
+// v9 configuration that worked but was inconsistent with docs
+i18n: {
+  strategy: 'prefix',
+  detectBrowserLanguage: {
+    redirectOn: 'root' // This only redirected root path in v10
+  }
+}
+```
+
+**Update to:**
+```typescript
+// v10 configuration for consistent behavior
+i18n: {
+  strategy: 'prefix',
+  detectBrowserLanguage: {
+    redirectOn: 'all' // Required for non-root path redirection
+  }
+}
+```
+
+See the [`redirectOn` documentation](/docs/api/options#redirecton) for more details about the available options.
+
 ## I18n functions
 
 The following composables and [I18n functions](/docs/api/vue-i18n) have been changed, deprecated, or removed.
@@ -39,6 +73,30 @@ The following composables and [I18n functions](/docs/api/vue-i18n) have been cha
 | :badge{label="removed" color="error"} | `onLanguageSwitched()`{lang="ts"} | Use the [`'i18n:localeSwitched'`{lang="ts"}](/docs/guide/runtime-hooks) hook instead.<br><br>This function actually called the hook instead of subscribing to it, leading to unpredictable behavior.|
 | :badge{label="removed" color="error"} | `onBeforeLanguageSwitch()`{lang="ts"} | Use the [`'i18n:beforeLocaleSwitch'`{lang="ts"}](/docs/guide/runtime-hooks) hook instead.<br><br>This function actually called the hook instead of subscribing to it, leading to unpredictable behavior. |
 
+
+## Behavior Changes
+
+### Browser Language Detection
+
+The `redirectOn` option now strictly follows its documented behavior. In v9, some combinations of `strategy` and `redirectOn` options worked unexpectedly, which has been corrected in v10.
+
+**Key Change**: When using `strategy: 'prefix'` with `redirectOn: 'root'`, non-root paths (e.g., `/search`) will no longer automatically redirect to their localized versions (e.g., `/zh/search`).
+
+**Migration Required**: If you need redirection for all paths, update your configuration:
+
+```ts
+// v9 (worked unexpectedly)
+detectBrowserLanguage: {
+  redirectOn: 'root',  // Only redirects root path in v10
+}
+
+// v10 (correct configuration)
+detectBrowserLanguage: {
+  redirectOn: 'all',   // Redirects all paths as expected
+}
+```
+
+**Impact**: This affects projects using `strategy: 'prefix'` that relied on the previous unintended behavior where `redirectOn: 'root'` also handled non-root paths.
 
 ## Context functions
 

--- a/docs/content/docs/02.guide/90.migrating.md
+++ b/docs/content/docs/02.guide/90.migrating.md
@@ -29,37 +29,29 @@ The following [Configuration options](/docs/api/options) have been changed, depr
 | :badge{label="removed" color="error"} | `bundle.optimizeTranslationDirective`{lang="yml"} | This feature has been disabled and fully removed, see [the discussion in this issue](https://github.com/nuxt-modules/i18n/issues/3238#issuecomment-2672492536) for context on this change. |
 | :badge{label="removed" color="error"} | `experimental.generatedLocaleFilePathFormat`{lang="yml"} | File paths (e.g. locale files, vue-i18n configs) configured for this module are now removed from the build entirely making this option obsolete. |
 
-## Language detection behavior
+## Behavior Changes
 
-Language detection and redirection has been improved in v10 to more accurately follow the documented behavior. This may affect existing configurations.
+### Browser Language Detection
 
-### redirectOn with prefix strategy
+Language detection and redirection have been improved to strictly follow documented behavior. In v9, some combinations of `strategy` and `redirectOn` options worked unexpectedly, which has been corrected in v10.
 
-In v9, the combination of `strategy: 'prefix'` and `detectBrowserLanguage.redirectOn: 'root'` could redirect non-root paths (e.g., `/search`) to their localized versions. This behavior was inconsistent with the documented specification.
+**Key Change**: When using `strategy: 'prefix'` with `redirectOn: 'root'`, non-root paths (e.g., `/search`) will no longer automatically redirect to their localized versions (e.g., `/zh/search`).
 
-In v10, `redirectOn: 'root'` now strictly only handles redirects for the root path (`/`) as documented. If you need redirection for all paths with a prefix strategy, use `redirectOn: 'all'`.
+**Migration Required**: If you need redirection for all paths with a prefix strategy, update your configuration:
 
-**Migration required if you used:**
-```typescript
-// v9 configuration that worked but was inconsistent with docs
-i18n: {
-  strategy: 'prefix',
-  detectBrowserLanguage: {
-    redirectOn: 'root' // This only redirected root path in v10
-  }
+```ts
+// v9 configuration (worked unexpectedly)
+detectBrowserLanguage: {
+  redirectOn: 'root',  // ⚠️ In v10 this will only redirect the root path
+}
+
+// v10 configuration (correct behavior)
+detectBrowserLanguage: {
+  redirectOn: 'all',   // Redirects all paths as documented
 }
 ```
 
-**Update to:**
-```typescript
-// v10 configuration for consistent behavior
-i18n: {
-  strategy: 'prefix',
-  detectBrowserLanguage: {
-    redirectOn: 'all' // Required for non-root path redirection
-  }
-}
-```
+**Impact**: This affects projects using `strategy: 'prefix'` that relied on the previous unintended behavior where `redirectOn: 'root'` also handled non-root paths.
 
 See the [`redirectOn` documentation](/docs/api/options#redirecton) for more details about the available options.
 
@@ -74,29 +66,7 @@ The following composables and [I18n functions](/docs/api/vue-i18n) have been cha
 | :badge{label="removed" color="error"} | `onBeforeLanguageSwitch()`{lang="ts"} | Use the [`'i18n:beforeLocaleSwitch'`{lang="ts"}](/docs/guide/runtime-hooks) hook instead.<br><br>This function actually called the hook instead of subscribing to it, leading to unpredictable behavior. |
 
 
-## Behavior Changes
 
-### Browser Language Detection
-
-The `redirectOn` option now strictly follows its documented behavior. In v9, some combinations of `strategy` and `redirectOn` options worked unexpectedly, which has been corrected in v10.
-
-**Key Change**: When using `strategy: 'prefix'` with `redirectOn: 'root'`, non-root paths (e.g., `/search`) will no longer automatically redirect to their localized versions (e.g., `/zh/search`).
-
-**Migration Required**: If you need redirection for all paths, update your configuration:
-
-```ts
-// v9 (worked unexpectedly)
-detectBrowserLanguage: {
-  redirectOn: 'root',  // Only redirects root path in v10
-}
-
-// v10 (correct configuration)
-detectBrowserLanguage: {
-  redirectOn: 'all',   // Redirects all paths as expected
-}
-```
-
-**Impact**: This affects projects using `strategy: 'prefix'` that relied on the previous unintended behavior where `redirectOn: 'root'` also handled non-root paths.
 
 ## Context functions
 

--- a/docs/content/docs/02.guide/90.migrating.md
+++ b/docs/content/docs/02.guide/90.migrating.md
@@ -33,37 +33,27 @@ The following [Configuration options](/docs/api/options) have been changed, depr
 
 ### Browser Language Detection
 
-Language detection and redirection have been improved to follow documented behavior strictly. In v9, some combinations of `strategy` and `redirectOn` options worked unexpectedly, which has been corrected in v10.
+Language detection and redirection have been improved to follow documented behavior strictly. In v9, some combinations of `strategy`{lang="yml"}  and `redirectOn`{lang="yml"} options worked unexpectedly, which has been corrected in v10.
 
-**Key Change**: When using `strategy: 'prefix'` with `redirectOn: 'root'`, non-root paths (e.g., `/search`) will no longer automatically redirect to their localized versions (e.g., `/zh/search`).
+**Key Change**: When using `strategy: 'prefix'`{lang="ts"}  with `redirectOn: 'root'`{lang="ts"} , non-root paths (e.g., `'/search'`{lang="ts"}) will no longer automatically redirect to their localized versions (e.g., `'/zh/search'`{lang="ts"}).
 
-**Migration Required**: If you need redirection for all paths with a prefix strategy, update your configuration:
+**Migration**: If you need redirection for all paths with a prefix strategy, update your configuration:
 
-```ts
-// v9 configuration (worked unexpectedly)
+```diff
 export default defineNuxtConfig({
   i18n: {
     strategy: 'prefix',
     detectBrowserLanguage: {
-      redirectOn: 'root', // ⚠️ In v10 this will only redirect the root path
-    }
-  }
-})
-
-// v10 configuration (correct behavior)
-export default defineNuxtConfig({
-  i18n: {
-    strategy: 'prefix',
-    detectBrowserLanguage: {
-      redirectOn: 'all',  // Redirects all paths as documented
+-      // redirectOn: 'root', // ⚠️ In v10 this will only redirect the root path
++      redirectOn: 'all',  // Redirects all paths as documented
     }
   }
 })
 ```
 
-**Impact**: This affects projects using `strategy: 'prefix'` that relied on the previous unintended behavior where `redirectOn: 'root'` also handled non-root paths.
+**Impact**: This affects projects using `strategy: 'prefix'`{lang="ts"}  that relied on the previous unintended behavior where `redirectOn: 'root'`{lang="ts"}  also handled non-root paths.
 
-See the [`redirectOn` documentation](/docs/api/options#redirecton) for more details about the available options.
+See the [`redirectOn`{lang="yml"} documentation](/docs/api/options#redirecton) for more details about the available options.
 
 ## I18n functions
 


### PR DESCRIPTION
## Summary

This PR clarifies the `redirectOn` behavior change in the v10 migration guide to help developers understand and properly configure their language detection settings.

## Background

In v9, some combinations of `strategy` and `redirectOn` options worked unexpectedly. Specifically, when using `strategy: 'prefix'` with `redirectOn: 'root'`, non-root paths (e.g., `/search`) would automatically redirect to their localized versions (e.g., `/zh/search`), even though this contradicted the documented behavior.

v10 corrected this behavior to strictly follow the documentation, but this change wasn't explicitly documented in the migration guide, leading to confusion for developers upgrading from v9.

## Changes

- Added a new "Behavior Changes" section to the migration guide
- Documented the `redirectOn` behavior correction 
- Provided clear migration instructions for affected configurations
- Explained the impact on existing projects

## Migration Path

For users who relied on the previous unintended behavior:

**Before (v9 - worked unexpectedly):**
```typescript
detectBrowserLanguage: {
  redirectOn: 'root',  // Only should redirect root path
}
```

**After (v10 - correct configuration):**
```typescript
detectBrowserLanguage: {
  redirectOn: 'all',   // Redirects all paths as intended
}
```

## Related Issues

Fixes #3735

## Testing

- [x] Documentation builds successfully
- [x] Migration guide section is clear and actionable
- [x] Examples demonstrate the correct configuration

## Impact

This documentation update will help developers:
1. Understand why their v9 configuration no longer works in v10
2. Know exactly how to fix their configuration
3. Avoid confusion about the intended behavior of `redirectOn` options

The change affects projects using `strategy: 'prefix'` that relied on the previous unintended behavior where `redirectOn: 'root'` also handled non-root paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the migration guide to clarify changes in language detection and redirection behavior for v10, including stricter handling of root path redirection and explicit migration instructions for configuration updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->