### PR TITLE
fix: root redirection with query parameters

### DIFF
--- a/specs/browser_language_detection/prefix_except_default.spec.ts
+++ b/specs/browser_language_detection/prefix_except_default.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe, beforeEach } from 'vitest'
 import { fileURLToPath } from 'node:url'
-import { setup, url } from '../utils'
+import { fetch, setup, url } from '../utils'
 import { renderPage, setServerRuntimeConfig } from '../helper'
 
 await setup({
@@ -78,6 +78,14 @@ describe('`detectBrowserLanguage` using strategy `prefix_except_default`', async
       const { page } = await renderPage('/', { extraHTTPHeaders: { 'Accept-Language': 'fr' } })
 
       expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+    })
+
+    test('should keep query params when redirecting', async () => {
+      const { url: url1 } = await fetch('/?foo=bar')
+      expect(url1).toBe(url('/?foo=bar'))
+
+      const { url: url2 } = await fetch('/?foo=bar', { headers: { 'Accept-Language': 'fr' } })
+      expect(url2).toBe(url('/fr?foo=bar'))
     })
   })
 })

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -109,13 +109,13 @@ export default defineNitroPlugin(async nitro => {
 
     let resolvedPath = undefined
     let redirectCode = 302
-    const requestURL = getRequestURL(event)
 
+    const requestURL = getRequestURL(event)
     if (rootRedirect && requestURL.pathname === '/') {
       locale = (detection.enabled && locale) || defaultLocale
       resolvedPath =
-        ((isSupportedLocale(detector.route(rootRedirect.path)) && rootRedirect.path) ||
-          matchLocalized(rootRedirect.path, locale, defaultLocale)) + requestURL.search
+        (isSupportedLocale(detector.route(rootRedirect.path)) && rootRedirect.path) ||
+        matchLocalized(rootRedirect.path, locale, defaultLocale)
       redirectCode = rootRedirect.code
     } else if (runtimeI18n.redirectStatusCode) {
       redirectCode = runtimeI18n.redirectStatusCode
@@ -142,6 +142,7 @@ export default defineNitroPlugin(async nitro => {
   const baseUrlGetter = createBaseUrlGetter()
   nitro.hooks.hook('request', async (event: H3Event) => {
     const options = await setupVueI18nOptions(getDefaultLocaleForDomain(getHost(event)) || _defaultLocale)
+    const url = getRequestURL(event)
     const ctx = createI18nContext()
     event.context.nuxtI18n = ctx
 
@@ -149,18 +150,22 @@ export default defineNitroPlugin(async nitro => {
       const detector = useDetectors(event, detection)
       const localeSegment = detector.route(event.path)
       const pathLocale = (isSupportedLocale(localeSegment) && localeSegment) || undefined
-      const path = (pathLocale && event.path.slice(pathLocale.length + 1)) || event.path
+      const path = (pathLocale && url.pathname.slice(pathLocale.length + 1)) || url.pathname
 
       // attempt to only run i18n detection for nuxt pages and i18n server routes
-      if (!event.path.includes('/_i18n/') && !isExistingNuxtRoute(path)) {
+      if (!url.pathname.includes('/_i18n/') && !isExistingNuxtRoute(path)) {
         return
       }
 
       const resolved = resolveRedirectPath(event, path, pathLocale, options.defaultLocale, detector)
-      if (resolved.path) {
+      if (resolved.path && resolved.path !== url.pathname) {
         ctx.detectLocale = resolved.locale
         detection.useCookie && setCookie(event, detection.cookieKey, resolved.locale, cookieOptions)
-        await sendRedirect(event, joinURL(baseUrlGetter(event, options.defaultLocale), resolved.path), resolved.code)
+        await sendRedirect(
+          event,
+          joinURL(baseUrlGetter(event, options.defaultLocale), resolved.path + url.search),
+          resolved.code
+        )
         return
       }
     }


### PR DESCRIPTION
### 🔗 Linked issue
* #3734
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
While #3734 does correct redirection on the root path with strategy prefix when query parameters are involved, this was still broken using other strategies resulting in a redirection loop.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Query parameters are now preserved during language-based redirection, ensuring smoother navigation and consistent user experience when switching languages.
* **Tests**
  * Added new test cases to verify that query parameters remain intact when redirecting based on browser language preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->