### PR TITLE
fix: prevent vite resolve dependency failure warnings

### DIFF
--- a/src/alias.ts
+++ b/src/alias.ts
@@ -37,18 +37,17 @@ export function setupAlias({ userOptions: options }: I18nNuxtContext, nuxt: Nuxt
     })
     .filter((x): x is string => !!x)
 
+  const moduleIds = Object.keys(modules)
   nuxt.options.typescript = defu(nuxt.options.typescript, {
-    hoist: Object.keys(modules),
+    hoist: moduleIds,
     tsConfig: {
       include: layerI18nDirs
     }
   })
 
-  const optimize = Object.keys(modules)
-  optimize.push(UTILS_PKG, 'cookie-es')
   nuxt.options.vite = defu(nuxt.options.vite, {
     optimizeDeps: {
-      include: optimize
+      include: moduleIds
     }
   })
 


### PR DESCRIPTION
### 🔗 Linked issue
* #3731
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Resolves #3731

Optimizing the additional dependencies are the source of the warnings in #3731. Omitting these dep optimizations will cause reloads in the playground within this repo, but seems to work as expected in projects outside of this repo.

Perhaps this is related to the monorepo structure or something else, this fix will resolve the warnings downstream, the reloads in the playground will need to be investigated some other time.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of module keys for more consistent configuration.
  * Streamlined dependency optimization by only including module keys in Vite optimization settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->