### PR TITLE
fix: prevent unset `baseUrl` warning when using domain configuration

### DIFF
--- a/specs/different_domains/different_domains.spec.ts
+++ b/specs/different_domains/different_domains.spec.ts
@@ -41,7 +41,6 @@ await setup({
           domain: 'kr.nuxt-app.localhost'
         }
       ],
-      differentDomains: true,
       strategy: 'no_prefix',
       detectBrowserLanguage: {
         useCookie: true

--- a/specs/different_domains/different_domains_base_path.spec.ts
+++ b/specs/different_domains/different_domains_base_path.spec.ts
@@ -33,7 +33,6 @@ await setup({
           domain: 'kr.nuxt-app.localhost'
         }
       ],
-      differentDomains: true,
       strategy: 'no_prefix',
       detectBrowserLanguage: {
         useCookie: true

--- a/specs/different_domains/different_domains_multi_locales_prefix.spec.ts
+++ b/specs/different_domains/different_domains_multi_locales_prefix.spec.ts
@@ -30,7 +30,6 @@ await setup({
           domain: 'fr.nuxt-app.localhost'
         }
       ],
-      differentDomains: true,
       strategy: 'prefix',
       detectBrowserLanguage: {
         useCookie: true

--- a/specs/different_domains/different_domains_multi_locales_prefix_except_default.spec.ts
+++ b/specs/different_domains/different_domains_multi_locales_prefix_except_default.spec.ts
@@ -38,7 +38,6 @@ await setup({
           domainDefault: true
         }
       ],
-      differentDomains: true,
       strategy: 'prefix_except_default',
       detectBrowserLanguage: {
         useCookie: true

--- a/specs/different_domains/no_ssr.spec.ts
+++ b/specs/different_domains/no_ssr.spec.ts
@@ -7,7 +7,6 @@ await setup({
   nuxtConfig: {
     i18n: {
       defaultLocale: 'fr',
-      differentDomains: true,
       locales: [
         {
           code: 'en',

--- a/specs/fixtures/different_domains/nuxt.config.ts
+++ b/specs/fixtures/different_domains/nuxt.config.ts
@@ -24,6 +24,7 @@ export default defineNuxtConfig({
         domain: 'fr.nuxt-app.localhost'
       }
     ],
+    differentDomains: true,
     defaultLocale: 'ja'
   }
 })

--- a/src/runtime/routing/head.ts
+++ b/src/runtime/routing/head.ts
@@ -17,7 +17,7 @@ function createHeadContext(
   const currentLocale = locales.find(l => l.code === locale) || { code: locale }
   const canonicalQueries = (typeof config.seo === 'object' && config.seo?.canonicalQueries) || []
 
-  if (!baseUrl) {
+  if (!baseUrl && !__DIFFERENT_DOMAINS__ && !__MULTI_DOMAIN_LOCALES__) {
     if (__I18N_STRICT_SEO__) {
       throw new Error('I18n `baseUrl` is required to generate valid SEO tag links.')
     }


### PR DESCRIPTION
### 🔗 Linked issue
* #3727
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Resolves #3727

The `baseUrl` check can be ignored when using domain configuration since those implicitly configure the `baseUrl`.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configurations by removing the `differentDomains` option from various test setups.
  * Added the `differentDomains` property to the i18n configuration in the Nuxt config fixture.

* **Bug Fixes**
  * Relaxed the requirement for `baseUrl` in certain routing scenarios, preventing errors or warnings when specific domain-related flags are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->