### PR TITLE
#3721 remove redundant routes for the current domain

### DIFF
--- a/specs/different_domains/different_domains_custom_routes.spec.ts
+++ b/specs/different_domains/different_domains_custom_routes.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect, describe } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, $fetch, undiciRequest } from '../utils'
+// import { getDom } from '../helper'
+
+await setup({
+  rootDir: fileURLToPath(new URL(`../fixtures/different_domains`, import.meta.url)),
+  // overrides
+  nuxtConfig: {
+    extends: [fileURLToPath(new URL(`../fixtures/layers/layer-domain`, import.meta.url))],
+    i18n: {
+      baseUrl: 'http://localhost:3000',
+      locales: [
+        {
+          code: 'en',
+          language: 'en',
+          name: 'English',
+          domain: 'en.nuxt-app.localhost'
+        },
+        {
+          code: 'fr',
+          language: 'fr-FR',
+          name: 'Français',
+          domain: 'fr.nuxt-app.localhost'
+        },
+        {
+          code: 'kr',
+          language: 'ko-KR',
+          name: '한국어',
+          domain: 'kr.nuxt-app.localhost'
+        }
+      ],
+      differentDomains: true,
+      strategy: 'no_prefix',
+      detectBrowserLanguage: false,
+      customRoutes: 'page'
+    }
+  }
+})
+
+test('domain includes only routes for its locale', async () => {
+  const resFr = await undiciRequest('/localized-route', {
+    headers: {
+      host: 'fr.nuxt-app.localhost'
+    }
+  })
+  expect(resFr.statusCode).toBe(200)
+
+  const resEn = await undiciRequest('/localized-route', {
+    headers: {
+      host: 'en.nuxt-app.localhost'
+    }
+  })
+  expect(resEn.statusCode).toBe(200)
+
+  const resKr = await undiciRequest('/localized-route', {
+    headers: {
+      host: 'kr.nuxt-app.localhost'
+    }
+  })
+  expect(resKr.statusCode).toBe(404)
+})

--- a/specs/fixtures/different_domains/pages/localized-route.vue
+++ b/specs/fixtures/different_domains/pages/localized-route.vue
@@ -1,6 +1,12 @@
 <script setup>
 import BasicUsage from '../components/BasicUsage.vue'
 import LangSwitcher from '../components/LangSwitcher.vue'
+
+// for customRoutes: 'page' option
+// see /specs/different_domains/different_domains_custom_routes.spec.ts
+defineI18nRoute({
+  locales: ['en', 'fr']
+})
 </script>
 
 <template>

--- a/src/runtime/plugins/route-locale-detect.ts
+++ b/src/runtime/plugins/route-locale-detect.ts
@@ -3,7 +3,7 @@ import { hasPages } from '#build/i18n.options.mjs'
 import { addRouteMiddleware, defineNuxtPlugin, defineNuxtRouteMiddleware, useNuxtApp } from '#imports'
 import { createLogger } from '#nuxt-i18n/logger'
 import { makeFallbackLocaleCodes } from '../messages'
-import { detectLocale, detectRedirect, loadAndSetLocale, navigate } from '../utils'
+import { clearDomainRoutes, detectLocale, detectRedirect, loadAndSetLocale, navigate } from '../utils'
 
 import type { CompatRoute } from '../types'
 
@@ -27,6 +27,12 @@ export default defineNuxtPlugin({
 
       if (nuxt._vueI18n.__firstAccess) {
         nuxt._vueI18n.__setLocale(detected)
+
+        if (nuxt.$i18n.differentDomains) {
+          // remove routes that do not belong to the current domain/locale
+          clearDomainRoutes(nuxt, detected)
+        }
+
         const fallbackLocales = makeFallbackLocaleCodes(unref(nuxt._vueI18n.global.fallbackLocale), [detected])
         await Promise.all(fallbackLocales.map(x => nuxt.$i18n.loadLocaleMessages(x)))
         await nuxt.$i18n.loadLocaleMessages(detected)

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -404,3 +404,19 @@ export function createNuxtI18nDev() {
 export function toArray<T>(value: T | T[]): T[] {
   return isArray(value) ? value : [value]
 }
+
+/**
+ * Remove routes that do not belong to the current locale/domain in `differentDomains` mode
+ *
+ * @param nuxtApp Nuxt app instance
+ * @param locale current locale to keep routes for
+ */
+export function clearDomainRoutes(nuxtApp: NuxtApp, locale: Locale) {
+  const i18nSuffix = nuxtApp.$config.public.i18n.routesNameSeparator + locale
+
+  for (const route of nuxtApp.$router.getRoutes() as CompatRoute[]) {
+    if (typeof route.name === 'string' && !route.name.endsWith(i18nSuffix)) {
+      nuxtApp.$router.removeRoute(route.name)
+    }
+  }
+}


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #3721 

### 📚 Description

This change removes all redundant routes for the current domain/locale in `differentDomains` mode when `defineI18nRoute` is used.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [ ] I have updated the documentation accordingly.
