### PR TITLE
fix: always set locale during hydration

### DIFF
--- a/specs/basic_usage.spec.ts
+++ b/specs/basic_usage.spec.ts
@@ -700,6 +700,12 @@ describe('basic usage', async () => {
       expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
     })
 
+    test('(#3766) persists locale after hydration', async () => {
+      const { page } = await renderPage('/fr')
+      await page.waitForFunction(() => !window.useNuxtApp?.().isHydrating)
+      expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+    })
+
     test('retains query parameters', async () => {
       const { page } = await renderPage('/?foo=123')
       await page.waitForURL(url('/?foo=123'))

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -142,7 +142,7 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
         }
       })
 
-      if (import.meta.server || !ctx.config.skipSettingLocaleOnNavigate) {
+      if (import.meta.server || nuxt.isHydrating || !ctx.config.skipSettingLocaleOnNavigate) {
         await ctx.vueI18n.__resolvePendingLocalePromise?.()
       }
     },


### PR DESCRIPTION
### 🔗 Linked issue
* #3766
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Resolves #3766

Looks like this regression happened since it was not covered by tests.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new test to verify that the selected locale persists correctly after client-side hydration.

* **Bug Fixes**
  * Improved locale handling to ensure the correct language is maintained during and after hydration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->