### PR TITLE
fix: auto declare typescript regression

### DIFF
--- a/src/transform/i18n-function-injection.ts
+++ b/src/transform/i18n-function-injection.ts
@@ -22,6 +22,12 @@ const TRANSLATION_FUNCTIONS_MAP: Record<(typeof TRANSLATION_FUNCTIONS)[number], 
   $te: 'te: $te'
 }
 
+const QUERY_RE = /\?.*$/
+
+function withoutQuery(id: string) {
+  return id.replace(QUERY_RE, '')
+}
+
 export const TransformI18nFunctionPlugin = (options: BundlerPluginOptions) =>
   createUnplugin(() => {
     return {
@@ -41,7 +47,8 @@ export const TransformI18nFunctionPlugin = (options: BundlerPluginOptions) =>
           if (!script) return
 
           // replace .vue extension with .ts or .tsx
-          const missing = collectMissingI18nFunctions(script.code, id.replace(/\.\w+$/, '.' + script.loader))
+          const filepath = withoutQuery(id).replace(/\.\w+$/, '.' + script.loader)
+          const missing = collectMissingI18nFunctions(script.code, filepath)
           if (!missing.size) return
 
           // only add variables when used without having been declared

--- a/test/fn-injection.test.ts
+++ b/test/fn-injection.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { collectMissingI18nFunctions } from '../src/transform/i18n-function-injection'
 
 describe('collectMissingI18nFunctions', () => {
-  const id = 'test.vue'
+  const id = 'test.ts'
 
   it('collects undeclared i18n function calls', () => {
     const script = `
@@ -27,5 +27,16 @@ describe('collectMissingI18nFunctions', () => {
         })
       `
     expect(collectMissingI18nFunctions(script, id)).toEqual(new Set(['$d']))
+  })
+
+  it('collects i18n function calls from typescript', () => {
+    const script = `
+        const helloText = $t('hello')
+
+        function myFn(val: string) {
+          return val
+        }
+      `
+    expect(collectMissingI18nFunctions(script, id)).toEqual(new Set(['$t']))
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue
* #3775
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Resolves #3775

Ensures parser uses `ts` or `tsx` during auto declare transformation.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Better support for TypeScript/TSX script blocks and more robust detection/injection of i18n functions across .ts/.tsx variants.
  * Improved handling of script boundaries and insertion points to ensure injected i18n destructuring appears in the correct location.

* **Tests**
  * Expanded tests to cover TypeScript scenarios and verify i18n function collection in .ts/.tsx contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->