### PR TITLE
fix: prevent localizing undefined route names

### DIFF
--- a/src/kit/gen.ts
+++ b/src/kit/gen.ts
@@ -143,7 +143,7 @@ export type RouteContext = {
     locale: string,
     opts: LocalizeRouteParams
   ) => LocalizableRoute[]
-  localizeRouteName: (name: LocalizableRoute, locale: string, isDefault: boolean) => string
+  localizeRouteName: (name: LocalizableRoute, locale: string, isDefault: boolean) => string | undefined
   handleTrailingSlash: (localizedPath: string, hasParent: boolean) => string
   localizers: { enabled: (data: LocalizerData) => boolean; localizer: LocalizerFn }[]
 }
@@ -167,6 +167,7 @@ function createLocalizeRouteName(opts: {
   const separator = opts.routesNameSeparator || '___'
   const defaultSuffix = opts.defaultLocaleRouteNameSuffix || 'default'
   return (route, locale, isDefault) => {
+    if (route.name == null) return
     // prettier-ignore
     return !isDefault
       ? route.name + separator + locale

--- a/src/kit/gen.ts
+++ b/src/kit/gen.ts
@@ -43,12 +43,20 @@ export type LocalizeRouteParams = {
 
 function handlePathNesting(localizedPath: string, parentLocalizedPath: string = '') {
   if (!parentLocalizedPath) return localizedPath
-  // handle parent/index
-  const path = localizedPath.replace(parentLocalizedPath + '/', '')
-  if (path === parentLocalizedPath) {
-    return localizedPath === parentLocalizedPath ? '' : localizedPath
+
+  if (localizedPath[0] !== '/') {
+    return localizedPath
   }
-  return path
+
+  const index = localizedPath.indexOf(parentLocalizedPath)
+  if (index >= 0) {
+    // parent path is found, slice from index + parent length + slash, for example:
+    // * parent='/foo', child='/foo/bar'       => 'bar'
+    // * parent='bar',  child='/foo/bar/:id()' => ':id()'
+    return localizedPath.slice(localizedPath.indexOf(parentLocalizedPath) + parentLocalizedPath.length + 1)
+  }
+
+  return localizedPath
 }
 
 function createHandleTrailingSlash(ctx: RouteContext): RouteContext['handleTrailingSlash'] {

--- a/test/pages/custom_route.test.ts
+++ b/test/pages/custom_route.test.ts
@@ -299,6 +299,102 @@ test('#1649', () => {
   expect(localizedPages).toMatchSnapshot()
 })
 
+test('#3781', () => {
+  const pages = [
+    {
+      name: 'index',
+      path: '/',
+      file: '/path/to/3781/pages/index.vue',
+      children: []
+    },
+    {
+      path: '/customer',
+      file: '/path/to/3781/pages/customer.vue',
+      children: [
+        {
+          path: 'my-orders',
+          file: '/path/to/3781/pages/customer/my-orders.vue',
+          children: [
+            {
+              name: 'customer-my-orders',
+              path: 'index',
+              file: '/path/to/3781/pages/customer/my-orders/index.vue',
+              children: []
+            },
+            {
+              name: 'customer-my-orders-id',
+              path: ':id()',
+              file: '/path/to/3781/pages/customer/my-orders/[id].vue',
+              children: []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+
+  const options = getNuxtOptions({
+    customer: {
+      en: '/customer-account'
+    },
+    'customer-my-orders': {
+      en: '/customer-account/my-orders'
+    },
+    'customer-my-orders-id': {
+      en: '/customer-account/my-orders/[id]'
+    }
+  })
+
+  options.locales = [{ code: 'en' }]
+  options.defaultLocale = 'en'
+  options.customRoutes = 'config'
+
+  vi.spyOn(fs, 'readFileSync').mockReturnValue('')
+
+  const ctx = new NuxtPageAnalyzeContext(options.pages)
+  analyzeNuxtPages(ctx, 'pages', pages)
+  const localizedPages = localizeRoutes(pages, {
+    ...options,
+    includeUnprefixedFallback: false,
+    optionsResolver: getRouteOptionsResolver(ctx, options.defaultLocale!, options.customRoutes!)
+  } as Parameters<typeof localizeRoutes>[1])
+
+  expect(localizedPages).toMatchInlineSnapshot(`
+    [
+      {
+        "children": [],
+        "file": "/path/to/3781/pages/index.vue",
+        "name": "index___en",
+        "path": "/",
+      },
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "children": [],
+                "file": "/path/to/3781/pages/customer/my-orders/index.vue",
+                "name": "customer-my-orders___en",
+                "path": "",
+              },
+              {
+                "children": [],
+                "file": "/path/to/3781/pages/customer/my-orders/[id].vue",
+                "name": "customer-my-orders-id___en",
+                "path": ":id()",
+              },
+            ],
+            "file": "/path/to/3781/pages/customer/my-orders.vue",
+            "path": "my-orders",
+          },
+        ],
+        "file": "/path/to/3781/pages/customer.vue",
+        "path": "/customer-account",
+      },
+    ]
+  `)
+})
+
 test('pages config using route name', () => {
   const pages = [
     {


### PR DESCRIPTION
### 🔗 Linked issue
* #3781 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Resolves #3781 
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route localization to safely skip unnamed routes and more robustly handle nested paths, preventing errors and improving stability.

* **Chores**
  * Public API: route-name localization may now yield no value in some cases (calling code should handle undefined).

* **Tests**
  * Added an integration test covering nested custom routes and locale-aware naming/path mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->