### PR TITLE
fix: use script `lang` to parse and extract macro argument

### DIFF
--- a/test/fixtures/custom_route/simple/pages/about.vue
+++ b/test/fixtures/custom_route/simple/pages/about.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+// macro parsing should work when importing types (#3785)
+import type { AsyncData } from 'nuxt/app'
 import { defineI18nRoute } from '#i18n'
 
 defineI18nRoute({


### PR DESCRIPTION
### 🔗 Linked issue
* Resolves #3784

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Still need to add tests.

The regressions around `defineI18nRoute` is due to pages always having `.vue` as extension, by replacing the extension with `ts` or `tsx` based on the lang attribute in script (e.g. `<script lang="XX">`) the parser will not silently fail when parsing typescript code. 
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Per-page i18n route configuration is now reliably detected for TypeScript, TSX and Single-File Components.
  - Improved compatibility when pages are provided via virtual file systems.
  - Reduced parsing errors and clearer error messages showing full file paths.

- Refactor
  - Extraction logic redesigned for greater resilience and correctness when deriving per-page i18n route configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->