### PR TITLE
fix: preserve `RegExp` values when loading `vue-i18n` options

### DIFF
--- a/specs/basic_usage.spec.ts
+++ b/specs/basic_usage.spec.ts
@@ -651,6 +651,14 @@ describe('basic usage', async () => {
       await page.waitForURL(url('/nl/products/rode-mok'))
       expect(await page.locator('#switch-locale-path-link-en').getAttribute('href')).toEqual('/products/red-mug')
     })
+
+    test('(#3790) RegExp missingWarn', async () => {
+      const { page } = await renderPage('/')
+
+      // @ts-expect-error runtime types
+      expect(await page.evaluate(() => window.useNuxtApp?.().$i18n.missingWarn)).toMatchInlineSnapshot(`/\\^foo/`)
+    })
+
     ctx = useTestContext()
   })
 

--- a/specs/fixtures/basic_usage/i18n/config/i18n.config.ts
+++ b/specs/fixtures/basic_usage/i18n/config/i18n.config.ts
@@ -38,6 +38,8 @@ export default defineI18nConfig(() => {
         pascalCaseText: "@.pascalCase:{'aboutSite'}"
       }
     },
+    // #3790
+    missingWarn: /^foo/,
     modifiers: {
       // @ts-ignore
       snakeCase: (str: string) => str.split(' ').join('-')


### PR DESCRIPTION
### 🔗 Linked issue
* Resolves #3790
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
The `deepCopy` function tries to only merge plain object properties (except for arrays which are overwritten), this is fine for messages and similar configs but will skip other object values like `[object RegExp]`.

With this change we only `deepCopy` some keys such as messages (for perf since these objects tend to be large) while merging the rest with `defu`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support using a regular expression for i18n missing translation warnings (missingWarn).
- Bug Fixes
  - Improved merging of i18n configuration to reliably preserve locale messages and date/number formats, preventing unintended overrides or data loss during aggregation.
- Tests
  - Added tests validating RegExp handling for i18n missingWarn.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->