### PR TITLE
docs: add info about caching pages with different domains

### DIFF
--- a/docs/content/docs/02.guide/09.different-domains.md
+++ b/docs/content/docs/02.guide/09.different-domains.md
@@ -170,3 +170,26 @@ The same requests when using the `'prefix_except_default'`{lang="ts-type"} strat
 - https://mydomain.com/ua -> https://mydomain.com/ua (ua language)
 - https://es.mydomain.com -> https://es.mydomain.com (es language)
 - https://fr.mydomain.com -> https://fr.mydomain.com (fr language)
+
+## Caching considerations with different domains
+
+When using different domains, make sure to configure caching properly so that
+responses are correctly separated per domain.  
+
+Because the same route may be served under multiple domains (e.g. `en.mydomain.com`
+and `fr.mydomain.com`), caches need to vary by the request host. Otherwise,
+a response generated for one domain could be reused on another, causing the wrong language to render,
+leading to hydration mismatches and visible flashes on the client.
+
+The recommended setup is to use `cache.varies: ['host']` in your route rules,
+so that the `host` header is included in the cache key:
+
+```diff [nuxt.config.ts]
+export default defineNuxtConfig({
+  routeRules: {
+-    '/': { swr: 60 },
++    '/': { swr: 60, cache: { varies: ['host'] } },
+  },
+  // ...
+})
+```


### PR DESCRIPTION
### 🔗 Linked issue
* Resolves https://github.com/nuxt-modules/i18n/issues/2928
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This adds some information about how to configure route caching for projects using `differentDomains`.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Caching considerations with different domains” section explaining host-based cache variation to prevent cross-domain data leaks, hydration mismatches, and flashes.
  * Updated examples to show using cache.varies: ['host'] so the Host header is included in the cache key.
  * Refreshed Nuxt config snippet to demonstrate host-aware caching with SWR plus varies: ['host'].
  * Clarifies best practices for multi-domain deployments and caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->