### PR TITLE
Fix variable name in runtime hooks documentation

### DIFF
--- a/docs/content/docs/02.guide/02.runtime-hooks.md
+++ b/docs/content/docs/02.guide/02.runtime-hooks.md
@@ -52,8 +52,8 @@ A typical usage would be to define those callbacks via a plugin where you can ac
 ```ts [/plugins/i18n.ts]
 export default defineNuxtPlugin(nuxtApp => {
   // called right before setting a new locale
-  nuxtApp.hook('i18n:beforeLocaleSwitch', (switch) => {
-    console.log('onBeforeLanguageSwitch', switch.oldLocale, switch.newLocale, switch.initialSetup)
+  nuxtApp.hook('i18n:beforeLocaleSwitch', (switched) => {
+    console.log('onBeforeLanguageSwitch', switched.oldLocale, switched.newLocale, switched.initialSetup)
 
     // You can override the new locale by setting it to a different value
     if(switch.newLocale === 'fr') {
@@ -62,8 +62,8 @@ export default defineNuxtPlugin(nuxtApp => {
   })
 
   // called right after a new locale has been set
-  nuxtApp.hook('i18n:localeSwitched', (switch) => {
-    console.log('onLanguageSwitched', switch.oldLocale, switch.newLocale)
+  nuxtApp.hook('i18n:localeSwitched', (switched) => {
+    console.log('onLanguageSwitched', switched.oldLocale, switched.newLocale)
   })
 })
 ```


### PR DESCRIPTION
If use 'switch' TS crashes app.
Expression expected.ts(1109)

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated runtime hooks guide for Nuxt i18n.
  * In code examples for i18n:beforeLocaleSwitch and i18n:localeSwitched, the callback parameter is renamed from "switch" to "switched".
  * All references within the examples (conditions and console outputs) are aligned with the new parameter name.
  * No changes to behavior or API; examples are clearer and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->