### PR TITLE
fix: improved defaultLocale check for i18n strategy

### DIFF
--- a/src/prepare/options.ts
+++ b/src/prepare/options.ts
@@ -23,7 +23,8 @@ export function prepareOptions({ options }: I18nNuxtContext, nuxt: Nuxt) {
   }
 
   const strategy = nuxt.options.i18n?.strategy || options.strategy
-  if (strategy.endsWith('_default') && !nuxt.options.i18n?.defaultLocale) {
+  const defaultLocale = nuxt.options.i18n?.defaultLocale || options.defaultLocale
+  if (strategy.endsWith('_default') && !defaultLocale) {
     logger.warn(
       `The \`${strategy}\` i18n strategy${nuxt.options.i18n?.strategy == null ? ' (used by default)' : ''} needs \`defaultLocale\` to be set.`
     )


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt-modules/i18n/issues/3798
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Improved defaultLocale check for i18n strategy. In addition to the general nuxt config, I check the options with the settings for i18n
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “_default” strategy now correctly respects a default locale provided via configuration options, not just the framework’s i18n settings. This prevents unnecessary warnings when a default locale is set through options and ensures consistent locale resolution. Users relying on options-based configuration will see fewer false-positive warnings and more predictable behavior when selecting the default language, especially in setups where the strategy ends with “_default”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->