### PR TITLE
perf: lazy head initialization

### DIFF
--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -44,6 +44,7 @@ export type ComposableContext = {
     hreflangLinks: boolean
   }
   head: ReturnType<typeof useHead>
+  _head: ReturnType<typeof useHead> | undefined
   metaState: Required<I18nHeadMetaInfo>
   seoSettings: I18nHeadOptions
   localePathPayload: Record<string, Record<string, string> | false>
@@ -112,7 +113,11 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
 
   const composableCtx: ComposableContext = {
     router,
-    head: useHead({}),
+    _head: undefined,
+    get head() {
+      this._head ??= useHead({})
+      return this._head
+    },
     metaState: { htmlAttrs: {}, meta: [], link: [] },
     seoSettings: {
       dir: __I18N_STRICT_SEO__,


### PR DESCRIPTION
### 🔗 Linked issue
* https://github.com/nuxt-modules/i18n/issues/3800
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This partially resolves https://github.com/nuxt-modules/i18n/issues/3800 and https://github.com/nuxt-modules/ionic/issues/815, but experimental strictSeo will not work when using nuxt-ionic, that will require changes to their implementation of `useHead`.


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Defers initialization of document head management until first use, reducing initial overhead and memory usage. Users may see slightly faster startup in scenarios where head features aren’t immediately needed.

- **Refactor**
  - Internal shift to lazy initialization with caching for head handling. No changes to user-facing behavior or configuration are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->