### PR TITLE
docs: add link to multiple files lazy loading to `files` option docs

### DIFF
--- a/docs/content/docs/04.api/00.options.md
+++ b/docs/content/docs/04.api/00.options.md
@@ -121,6 +121,8 @@ When using an object form, the properties can be:
 - type: `null | string[] | { path: string; cache: string; }[]`{lang="ts-type"}
 - The name of the file in which multiple locale messages are defined. Will be resolved relative to `langDir` path when loading locale messages from file.
 
+See also [Multiple files lazy loading](/docs/guide/lazy-load-translations#multiple-files-lazy-loading) to learn more.
+
 ### `dir`
 
 - type: `null | 'rtl' | 'ltr' | 'auto'`{lang="ts-type"}


### PR DESCRIPTION


<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This adds a link to a page with more info about locale file merging to the `files` option.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->
