### PR TITLE
docs: fix link label rendering in mobile menu

### DIFF
--- a/docs/components/Header.vue
+++ b/docs/components/Header.vue
@@ -91,7 +91,7 @@ const processed = computed<DropdownMenuItem[]>(() => {
       >
         <template #link-title="{ link }">
           <span class="inline-flex items-center gap-0.5">
-            {{ link.title }}
+            {{ link.label }}
           </span>
         </template>
       </UContentNavigation>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

Similar to https://github.com/nuxt-modules/i18n/commit/840fe615a3b9b5df2493e09c5c2b5f6d2f258a9a

Before: 

<img width="331" height="293" alt="image" src="https://github.com/user-attachments/assets/d18683dc-50ab-45e5-a667-2f933483d270" />

After:

<img width="330" height="291" alt="image" src="https://github.com/user-attachments/assets/67f96573-6bf1-4edb-a53a-4818b089c0d3" />



<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated header navigation to display link labels instead of titles, providing clearer, consistent link names across the docs navigation. This aligns visible text with how links are referred to elsewhere.
* Style
  * Adjusts the link-title rendering in the navigation to use labels, improving readability without altering navigation behavior. Applies across all links in the header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->