### PR TITLE
fix: handle nested root page localization

### DIFF
--- a/specs/custom_route_paths/component.spec.ts
+++ b/specs/custom_route_paths/component.spec.ts
@@ -82,3 +82,11 @@ test('can not access to disable route path', async () => {
   // 404
   expect(res!.status()).toBe(404) // eslint-disable-line @typescript-eslint/no-non-null-assertion
 })
+
+test('(#3831) nested index root custom routes', async () => {
+  const { page } = await renderPage('/')
+
+  expect(await page.locator('#issue-3831-nested-root').getAttribute('href')).toBe('/my-localized-nested-root-page')
+  await page.locator('#issue-3831-nested-root').clickNavigate()
+  await page.waitForURL(url('/my-localized-nested-root-page'))
+})

--- a/specs/fixtures/basic/pages/index.vue
+++ b/specs/fixtures/basic/pages/index.vue
@@ -66,5 +66,6 @@ useHead(() => ({
       <span id="issue-2020-existing">{{ localePath('/test-route?foo=bar') }}</span>
       <span id="issue-2020-nonexistent">{{ localePath('/i-dont-exist?foo=bar') }}</span>
     </section>
+    <NuxtLink id="issue-3831-nested-root" :to="localePath('index-nested-root-page')">Nested index page</NuxtLink>
   </div>
 </template>

--- a/specs/fixtures/basic/pages/index/nested-root-page.vue
+++ b/specs/fixtures/basic/pages/index/nested-root-page.vue
@@ -1,0 +1,14 @@
+<script lang="ts" setup>
+defineI18nRoute({
+  paths: {
+    en: '/my-localized-nested-root-page',
+    fr: '/my-localized-nested-root-page-french'
+  }
+})
+</script>
+
+<template>
+  <div>
+    <h1>Welcome</h1>
+  </div>
+</template>

--- a/src/kit/gen.ts
+++ b/src/kit/gen.ts
@@ -42,7 +42,7 @@ export type LocalizeRouteParams = {
 }
 
 function handlePathNesting(localizedPath: string, parentLocalizedPath: string = '') {
-  if (!parentLocalizedPath) return localizedPath
+  if (!parentLocalizedPath || parentLocalizedPath === '/') return localizedPath
 
   if (localizedPath[0] !== '/') {
     return localizedPath


### PR DESCRIPTION
### 🔗 Linked issue
* Resolves #3831
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
I did not know it was possible to use an index folder to for root routes.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected handling of nested localized routes when the parent path is “/”, preventing incorrect path nesting. Links from index pages now resolve and navigate to the expected localized URLs for nested root pages.

- Tests
  - Added coverage for nested index root custom routes, verifying link hrefs and navigation to the correct localized URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->