### PR TITLE
fix: configure fallback locales before server-side redirection

### DIFF
--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -146,6 +146,11 @@ export default defineNitroPlugin(async nitro => {
     const options = await setupVueI18nOptions(getDefaultLocaleForDomain(getHost(event)) || _defaultLocale)
     const url = getRequestURL(event)
     const ctx = createI18nContext()
+
+    const localeConfigs = createLocaleConfigs(options.fallbackLocale)
+    ctx.vueI18nOptions = options
+    ctx.localeConfigs = localeConfigs
+
     event.context.nuxtI18n = ctx
 
     if (__I18N_SERVER_REDIRECT__) {
@@ -171,10 +176,6 @@ export default defineNitroPlugin(async nitro => {
         return
       }
     }
-
-    const localeConfigs = createLocaleConfigs(options.fallbackLocale)
-    ctx.vueI18nOptions = options
-    ctx.localeConfigs = localeConfigs
   })
 
   nitro.hooks.hook('render:html', (htmlContext, { event }) => {


### PR DESCRIPTION
### 🔗 Linked issue
* #3824
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Resolves #3824 (no reproduction to confirm)
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures consistent locale detection after server-side redirects by initializing locale settings once per request, reducing wrong-language content and flicker.

* **Performance**
  * Removes redundant initialization of locale settings, lowering processing overhead and slightly improving response times and stability for internationalized routing and redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->