### PR TITLE
fix: detect and redirect only on rendered routes

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,6 +358,15 @@ importers:
         specifier: latest
         version: 4.2.0(@parcel/watcher@2.5.1)(@types/node@24.9.1)(@vue/compiler-sfc@3.5.22)(better-sqlite3@12.4.1)(db0@0.3.4(better-sqlite3@12.4.1))(eslint@9.38.0(jiti@2.6.1))(ioredis@5.8.2)(lightningcss@1.30.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.5)(terser@5.44.0)(typescript@5.9.3)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)
 
+  specs/fixtures/issues/3842:
+    devDependencies:
+      '@nuxtjs/i18n':
+        specifier: workspace:*
+        version: link:../../../..
+      nuxt:
+        specifier: latest
+        version: 4.2.0(@parcel/watcher@2.5.1)(@types/node@24.9.1)(@vue/compiler-sfc@3.5.22)(better-sqlite3@12.4.1)(db0@0.3.4(better-sqlite3@12.4.1))(eslint@9.38.0(jiti@2.6.1))(ioredis@5.8.2)(lightningcss@1.30.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.52.5)(terser@5.44.0)(typescript@5.9.3)(vite@7.1.12(@types/node@24.9.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.0)(yaml@2.8.1))(yaml@2.8.1)
+
   specs/fixtures/lazy:
     devDependencies:
       '@nuxtjs/i18n':

--- a/specs/fixtures/issues/3842/nuxt.config.ts
+++ b/specs/fixtures/issues/3842/nuxt.config.ts
@@ -1,0 +1,13 @@
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+  modules: ["@nuxtjs/i18n"],
+  i18n: {
+    locales: ["en", "fr"],
+    defaultLocale: "en",
+    strategy: "prefix",
+    detectBrowserLanguage: {
+      useCookie: true,
+      redirectOn: 'no prefix',
+    },
+  },
+});

--- a/specs/fixtures/issues/3842/package.json
+++ b/specs/fixtures/issues/3842/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "fixture-3842",
+  "private": true,
+  "scripts": {
+    "build": "nuxt build",
+    "dev": "nuxt dev",
+    "generate": "nuxt generate",
+    "preview": "nuxt preview"
+  },
+  "devDependencies": {
+    "@nuxtjs/i18n": "latest",
+    "nuxt": "latest"
+  }
+}

--- a/specs/fixtures/issues/3842/pages/[...catch].vue
+++ b/specs/fixtures/issues/3842/pages/[...catch].vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    Catch all
+  </div>
+</template>

--- a/specs/fixtures/issues/3842/pages/index.vue
+++ b/specs/fixtures/issues/3842/pages/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    Hello world!
+  </div>
+</template>

--- a/specs/fixtures/issues/3842/server/api/test.ts
+++ b/specs/fixtures/issues/3842/server/api/test.ts
@@ -1,0 +1,3 @@
+export default defineEventHandler(() => {
+  return { message: 'Hello from test endpoint!' }
+})

--- a/specs/issues/3842.spec.ts
+++ b/specs/issues/3842.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect, describe } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { fetch, setup, url } from '../utils'
+
+describe('#3842 - prefix strategy catch-all redirects on server route', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL(`../fixtures/issues/3842`, import.meta.url)),
+  })
+
+  test('should not redirect API calls', async () => {
+    const res = await fetch(url('/api/test'))
+    
+    expect(res.redirected).toBe(false)
+    expect(await res.json()).toMatchInlineSnapshot(`
+      {
+        "message": "Hello from test endpoint!",
+      }
+    `)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue
* Resolves #3842 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed locale prefix redirect handling for catch-all routes in server scenarios. Redirect logic now processes at the appropriate phase to correctly handle i18n route detection and locale resolution.

* **Tests**
  * Added comprehensive test suite validating prefix strategy behavior with catch-all routes and API endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->