### PR TITLE
refactor: replace `@vue/compiler-sfc` parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "@miyaneee/rollup-plugin-json5": "^1.2.0",
     "@nuxt/kit": "^4.1.2",
     "@rollup/plugin-yaml": "^4.1.2",
-    "@vue/compiler-sfc": "^3.5.22",
     "defu": "^6.1.4",
     "devalue": "^5.1.1",
     "h3": "^1.15.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       '@rollup/plugin-yaml':
         specifier: ^4.1.2
         version: 4.1.2(rollup@4.52.5)
-      '@vue/compiler-sfc':
-        specifier: ^3.5.22
-        version: 3.5.22
       defu:
         specifier: ^6.1.4
         version: 6.1.4

--- a/src/utils/extract-script.ts
+++ b/src/utils/extract-script.ts
@@ -1,0 +1,14 @@
+const SFC_SCRIPT_RE = /<script(?<attrs>[^>]*)>(?<content>[\s\S]*?)<\/script[^>]*>/gi
+export function extractScriptContent(sfc: string) {
+  const contents: Array<{ loader: 'ts' | 'tsx', code: string }> = []
+  for (const match of sfc.matchAll(SFC_SCRIPT_RE)) {
+    if (match?.groups?.content) {
+      contents.push({
+        loader: match.groups.attrs && /[tj]sx/.test(match.groups.attrs) ? 'tsx' : 'ts',
+        code: match.groups.content.trim(),
+      })
+    }
+  }
+
+  return contents
+}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
WIP

This is to remove vue compiler sfc as direct prod dependency
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized internal script processing with improved error handling for complex component structures.

* **Chores**
  * Removed unnecessary dependency to reduce package footprint and installation time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->