### PR TITLE
fix: support passing localized routes to `localePath`

### DIFF
--- a/specs/fixtures/routing/pages/index.vue
+++ b/specs/fixtures/routing/pages/index.vue
@@ -49,6 +49,10 @@ const localeRoute = useLocaleRoute()
       <span class="external-link">{{ localePath('https://github.com') }}</span>
       <span class="external-mail">{{ localePath('mailto:example@mail.com') }}</span>
       <span class="external-phone">{{ localePath('tel:+31612345678') }}</span>
+
+      <!-- #3840 -->
+      <span data-testid="current-localized-route-param">{{ localePath($route, 'ja') }}</span>
+      <span data-testid="object-localized-route-param">{{ localePath({ name: 'index___en'}, 'ja') }}</span>
     </section>
     <ClientOnly>
       <section id="locale-route">

--- a/specs/routing/routing-tests.ts
+++ b/specs/routing/routing-tests.ts
@@ -66,6 +66,10 @@ export async function localePathTests(strategy: Strategies) {
   expect(await page.locator('#locale-path .external-mail').innerText()).toEqual('mailto:example@mail.com')
   expect(await page.locator('#locale-path .external-phone').innerText()).toEqual('tel:+31612345678')
 
+  // (#3840) localized route as parameter
+  expect(await page.getByTestId('current-localized-route-param').innerText()).toEqual(prefixPath('/', 'ja'))
+  expect(await page.getByTestId('object-localized-route-param').innerText()).toEqual(prefixPath('/', 'ja'))
+
   // for vue-router deprecation
   // https://github.com/vuejs/router/blob/main/packages/router/CHANGELOG.md#414-2022-08-22
   expect(consoleLogs.find(log => log.text.includes('Discarded invalid param(s)'))).toBeFalsy()

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -82,7 +82,7 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
   const getLocalizedRouteName = createLocaleRouteNameGetter(defaultLocale)
 
   function resolveLocalizedRouteByName(route: RouteLikeWithName, locale: string) {
-    route.name ||= getRouteBaseName(router.currentRoute.value) // fallback to current route name
+    route.name = getRouteBaseName(route.name || router.currentRoute.value) // fallback to current route name
 
     // check if localized variant exists
     const localizedName = getLocalizedRouteName(route.name, locale)


### PR DESCRIPTION
### 🔗 Linked issue
* Resolve #3840 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Tests need to be added before this can be merged
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Route name normalization now consistently resolves to base names, improving predictable localized routing behavior.

* **New Features**
  * Example views now display localized route parameter outputs so you can see localized paths for different locales.

* **Tests**
  * Added validations to ensure localized route parameter rendering matches expected localized paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->