### PR TITLE
fix: prevent duplicate message requests on hydration

### DIFF
--- a/specs/lazy_load/basic_lazy_load.spec.ts
+++ b/specs/lazy_load/basic_lazy_load.spec.ts
@@ -29,6 +29,11 @@ describe('basic lazy loading', async () => {
     expect(await page.locator('#dynamic-time').innerText()).to.not.equal(dynamicTime)
   })
 
+  test('(#3773) messages are loaded once on page load', async () => {
+    const { requests } = await renderPage('/')
+    expect(requests.filter(x => x.includes('/en/messages.json'))).toHaveLength(1)
+  })
+
   test('locales are fetched on demand', async () => {
     const home = url('/')
     const { page } = await renderPage(home)


### PR DESCRIPTION
### 🔗 Linked issue
* Resolves #3773 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where messages could be loaded multiple times during page hydration, ensuring they load only once on initial page load for improved performance.

* **Tests**
  * Added test case to verify that messages load exactly once during page initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->