### PR TITLE
feat: configurable message server route prefix

### DIFF
--- a/docs/content/docs/04.api/00.options.md
+++ b/docs/content/docs/04.api/00.options.md
@@ -624,3 +624,10 @@ Used to configure the directory used to resolve i18n files.
 ::callout{icon="i-heroicons-exclamation-triangle" color="warning"}
 This feature relies on [Nuxt's Auto-imports](https://nuxt.com/docs/guide/concepts/auto-imports) and will not work if this has been disabled.
 ::
+
+## serverRoutePrefix
+
+- type `string`{lang="ts-type"}
+- default: `'/_i18n'`{lang="ts"}
+
+Sets the prefix for the server route used for loading locale messages.

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -103,8 +103,8 @@ export function getDefineConfig(
 
     __I18N_ROUTING__: JSON.stringify(nuxt.options.pages.toString() && options.strategy !== 'no_prefix'),
     __I18N_STRICT_SEO__: JSON.stringify(!!options.experimental.strictSeo),
+    __I18N_SERVER_ROUTE__: JSON.stringify([options.serverRoutePrefix, deploymentHash].join('/')),
     __I18N_SERVER_REDIRECT__: JSON.stringify(!!options.experimental.nitroContextDetection),
-    __I18N_HASH__: JSON.stringify(deploymentHash),
   }
 
   if (nuxt.options.ssr || !server) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -83,6 +83,7 @@ export const DEFAULT_OPTIONS = {
   multiDomainLocales: false,
   hmr: true,
   autoDeclare: true,
+  serverRoutePrefix: '/_i18n',
 } as const
 
 export const DEFINE_I18N_ROUTE_FN = 'defineI18nRoute'

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -29,5 +29,5 @@ declare let __I18N_PRELOAD__: boolean
 declare let __I18N_ROUTING__: boolean
 declare let __I18N_STRICT_SEO__: boolean
 declare let __I18N_SERVER_REDIRECT__: boolean
-/** Hashed deployment timestamp */
-declare let __I18N_HASH__: string
+/** Includes hashed deployment timestamp */
+declare let __I18N_SERVER_ROUTE__: string

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -105,7 +105,7 @@ export { localeDetector }`
   addServerPlugin(ctx.resolver.resolve('runtime/server/plugin'))
 
   addServerHandler({
-    route: `/_i18n/:hash/:locale/messages.json`,
+    route: `${ctx.options.serverRoutePrefix}/:hash/:locale/messages.json`,
     handler: ctx.resolver.resolve('./runtime/server/routes/messages'),
   })
 }

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -164,7 +164,7 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
       if (nuxt.isHydrating && loadMap.has(locale)) { return }
 
       try {
-        return ctx.dynamicResourcesSSG
+        return ctx.dynamicResourcesSSG || import.meta.dev
           ? await loadMessagesFromClient(locale)
           : await loadMessagesFromServer(locale)
       } catch (e) {

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -99,7 +99,7 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
   const loadMessagesFromServer = async (locale: string) => {
     if (locale in localeLoaders === false) { return }
     const headers: HeadersInit = getLocaleConfig(locale)?.cacheable ? {} : { 'Cache-Control': 'no-cache' }
-    const messages = await $fetch(`/_i18n/${__I18N_HASH__}/${locale}/messages.json`, { headers })
+    const messages = await $fetch(`${__I18N_SERVER_ROUTE__}/${locale}/messages.json`, { headers })
     for (const k of Object.keys(messages)) {
       i18n.mergeLocaleMessage(k, messages[k])
     }
@@ -164,7 +164,7 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
       if (nuxt.isHydrating && loadMap.has(locale)) { return }
 
       try {
-        return ctx.dynamicResourcesSSG || import.meta.dev
+        return ctx.dynamicResourcesSSG
           ? await loadMessagesFromClient(locale)
           : await loadMessagesFromServer(locale)
       } catch (e) {

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -43,7 +43,7 @@ export default defineNuxtPlugin({
       setupMultiDomainLocales(optionsI18n.defaultLocale)
     }
 
-    prerenderRoutes(localeCodes.map(locale => `/_i18n/${__I18N_HASH__}/${locale}/messages.json`))
+    prerenderRoutes(localeCodes.map(locale => `${__I18N_SERVER_ROUTE__}/${locale}/messages.json`))
 
     // create i18n instance
     const i18n = createI18n(optionsI18n)

--- a/src/runtime/plugins/preload.ts
+++ b/src/runtime/plugins/preload.ts
@@ -19,7 +19,7 @@ export default defineNuxtPlugin({
     if (import.meta.server) {
       for (const locale of localeCodes) {
         try {
-          const messages = await $fetch(`/_i18n/${__I18N_HASH__}/${locale}/messages.json`)
+          const messages = await $fetch(`${__I18N_SERVER_ROUTE__}/${locale}/messages.json`)
           for (const locale of Object.keys(messages)) {
             nuxt.$i18n.mergeLocaleMessage(locale, messages[locale])
           }

--- a/src/runtime/server/context.ts
+++ b/src/runtime/server/context.ts
@@ -23,7 +23,7 @@ if (import.meta.dev) {
  * @internal
  */
 export const fetchMessages = async (locale: string) =>
-  await $fetch<LocaleMessages<DefineLocaleMessage>>(`/_i18n/${__I18N_HASH__}/${locale}/messages.json`, {
+  await $fetch<LocaleMessages<DefineLocaleMessage>>(`${__I18N_SERVER_ROUTE__}/${locale}/messages.json`, {
     headers,
   })
 

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -172,7 +172,7 @@ export default defineNitroPlugin(async (nitro) => {
     const path = (pathLocale && url.pathname.slice(pathLocale.length + 1)) || url.pathname
 
     // attempt to only run i18n detection for nuxt pages and i18n server routes
-    if (!url.pathname.includes('/_i18n/') && !isExistingNuxtRoute(path)) {
+    if (!url.pathname.includes(__I18N_SERVER_ROUTE__) && !isExistingNuxtRoute(path)) {
       return
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -420,6 +420,11 @@ export type NuxtI18nOptions<
    * @default true
    */
   autoDeclare?: boolean
+  /**
+   * Prefix for the server route used for loading locale messages.
+   * @default '/_i18n'
+   */
+  serverRoutePrefix?: string
 }
 
 /**


### PR DESCRIPTION
### 🔗 Linked issue
* Resolves #3822
* Related https://github.com/nuxt-modules/i18n/issues/3806#issuecomment-3253191346
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added serverRoutePrefix option (default: /_i18n) to customize where locale messages are loaded from the server.
* **Behavior Changes**
  * Message loading and prerender routes now use the configurable server route prefix instead of the previous hardcoded path.
* **Documentation**
  * Added docs entry describing the new serverRoutePrefix option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->