### PR TITLE
feat: add httpCacheDuration option for messages API endpoint

### DIFF
--- a/docs/content/docs/04.api/00.options.md
+++ b/docs/content/docs/04.api/00.options.md
@@ -485,6 +485,12 @@ This feature relies on [Nuxt's `experimental.typedRoutes`](https://nuxt.com/docs
 - default: `true`{lang="ts"}
 - Remove non-canonical query parameters from alternate link meta tags
 
+### `httpCacheDuration`
+
+- type: `number`{lang="ts-type"}
+- default: `10`{lang="ts"}
+- HTTP cache duration for the messages API endpoint in seconds. This controls how long browsers cache the translation data. Set to a higher value (e.g., `86400` for 24 hours) to reduce redundant network requests for unchanged translations.
+
 ## `hmr`
 
 - type: `boolean`{lang="ts-type"}

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -97,6 +97,7 @@ export function getDefineConfig(
     __DEFAULT_DIRECTION__: JSON.stringify(options.defaultDirection),
     __I18N_CACHE__: String(isCacheEnabled),
     __I18N_CACHE_LIFETIME__: JSON.stringify(cacheLifetime),
+    __I18N_HTTP_CACHE_DURATION__: JSON.stringify(options.experimental.httpCacheDuration ?? 10),
     __I18N_FULL_STATIC__: String(fullStatic),
     __I18N_STRIP_UNUSED__: JSON.stringify(stripMessagesPayload),
     __I18N_PRELOAD__: JSON.stringify(!!options.experimental.preload),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,6 +36,7 @@ export const DEFAULT_OPTIONS = {
     preload: false,
     strictSeo: false,
     nitroContextDetection: true,
+    httpCacheDuration: 10,
   },
   bundle: {
     compositionOnly: true,

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -22,6 +22,7 @@ declare let __ROUTE_NAME_DEFAULT_SUFFIX__: string
 declare let __DEFAULT_DIRECTION__: string
 declare let __I18N_CACHE__: boolean
 declare let __I18N_CACHE_LIFETIME__: number
+declare let __I18N_HTTP_CACHE_DURATION__: number
 declare let __I18N_FULL_STATIC__: boolean
 declare let __I18N_STRIP_UNUSED__: boolean
 declare let __I18N_PRELOAD__: boolean

--- a/src/runtime/server/routes/messages.ts
+++ b/src/runtime/server/routes/messages.ts
@@ -43,7 +43,7 @@ const _cachedMessageLoader = defineCachedFunction(_messagesHandler, {
  */
 const _messagesHandlerCached = defineCachedEventHandler(_cachedMessageLoader, {
   name: 'i18n:messages',
-  maxAge: !__I18N_CACHE__ ? -1 : 10,
+  maxAge: !__I18N_CACHE__ ? -1 : __I18N_HTTP_CACHE_DURATION__,
   swr: false,
   getKey: event => [getRouterParam(event, 'locale') ?? 'null', getRouterParam(event, 'hash') ?? 'null'].join('-'),
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,6 +193,12 @@ export interface ExperimentalFeatures {
    * @default true
    */
   nitroContextDetection?: boolean
+  /**
+   * HTTP cache duration for the messages API endpoint in seconds.
+   * This controls how long browsers cache the translation data.
+   * @default 10
+   */
+  httpCacheDuration?: number
 }
 
 export interface BundleOptions

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -3,6 +3,7 @@ import { vi } from 'vitest'
 // setup global constants
 vi.stubGlobal('__I18N_CACHE__', false)
 vi.stubGlobal('__I18N_CACHE_LIFETIME__', -1)
+vi.stubGlobal('__I18N_HTTP_CACHE_DURATION__', 10)
 vi.stubGlobal('__I18N_STRICT_SEO__', false)
 vi.stubGlobal('__PARALLEL_PLUGIN__', false)
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #3855

### 📚 Description

This PR adds a new experimental configuration option httpCacheDuration that allows users to configure the HTTP cache duration for the /_i18n/{locale}/messages.json endpoint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable HTTP cache duration setting for the messages API endpoint (default: 10 seconds).

* **Documentation**
  * Added documentation for the new HTTP cache duration configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->