### PR TITLE
refactor: cleanup constants and module nitro setup

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,3 @@
-export const H3_PKG = '@intlify/h3'
-export const UTILS_H3_PKG = '@intlify/utils/h3'
 export const STRATEGY_PREFIX = 'prefix'
 export const STRATEGY_PREFIX_EXCEPT_DEFAULT = 'prefix_except_default'
 export const STRATEGY_PREFIX_AND_DEFAULT = 'prefix_and_default'
@@ -79,12 +77,6 @@ export const DEFAULT_OPTIONS = {
   autoDeclare: true,
   serverRoutePrefix: '/_i18n',
 } as const
-
-export const DEFINE_I18N_ROUTE_FN = 'defineI18nRoute'
-export const DEFINE_I18N_LOCALE_FN = 'defineI18nLocale'
-export const DEFINE_I18N_CONFIG_FN = 'defineI18nConfig'
-export const DEFINE_LOCALE_DETECTOR_FN = 'defineI18nLocaleDetector'
-export const NUXT_I18N_VIRTUAL_PREFIX = '#nuxt-i18n'
 
 const TS_EXTENSIONS = ['.ts', '.cts', '.mts']
 const JS_EXTENSIONS = ['.js', '.cjs', '.mjs']

--- a/src/context.ts
+++ b/src/context.ts
@@ -23,7 +23,7 @@ export interface I18nNuxtContext {
   i18nLayers: LayerWithI18n[]
 }
 
-type LayerWithI18n = { config: NuxtConfigLayer, i18n: Partial<NuxtI18nOptions>, i18nDir: string }
+type LayerWithI18n = { config: NuxtConfigLayer, i18n: Partial<NuxtI18nOptions>, i18nDir: string, i18nDetector?: string }
 const resolver = createResolver(import.meta.url)
 const distDir = dirname(fileURLToPath(import.meta.url))
 const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))
@@ -35,7 +35,9 @@ export function createContext(userOptions: NuxtI18nOptions, nuxt: Nuxt): I18nNux
   for (const l of nuxt.options._layers) {
     const i18n = getLayerI18n(l)
     if (!i18n) { continue }
-    i18nLayers.push({ config: l, i18n, i18nDir: resolveI18nDir(l, i18n) })
+    const i18nDir = resolveI18nDir(l, i18n)
+    const i18nDetector = i18n.experimental?.localeDetector ? resolver.resolve(i18nDir, i18n.experimental.localeDetector) : undefined
+    i18nLayers.push({ config: l, i18n, i18nDir, i18nDetector })
   }
 
   return {

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,7 +2,7 @@ import { addComponent, addImports, addImportsSources, defineNuxtModule, resolveM
 import { setupPages } from './pages'
 import { setupNitro } from './nitro'
 import { extendBundler } from './bundler'
-import { DEFAULT_OPTIONS, DEFINE_I18N_CONFIG_FN, DEFINE_I18N_LOCALE_FN, DEFINE_I18N_ROUTE_FN } from './constants'
+import { DEFAULT_OPTIONS } from './constants'
 import type { HookResult } from '@nuxt/schema'
 import type { I18nPublicRuntimeConfig, LocaleObject, NuxtI18nOptions } from './types'
 import type { Locale } from 'vue-i18n'
@@ -68,9 +68,9 @@ export default defineNuxtModule<NuxtI18nOptions>({
         'useCookieLocale',
         'useSetI18nParams',
         'useI18nPreloadKeys',
-        DEFINE_I18N_ROUTE_FN,
-        DEFINE_I18N_LOCALE_FN,
-        DEFINE_I18N_CONFIG_FN,
+        'defineI18nRoute',
+        'defineI18nLocale',
+        'defineI18nConfig',
       ],
     })
 

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -7,7 +7,6 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { getRoutePath, parseSegment } from './utils/route-parsing'
 import { localizeRoutes } from './routing'
 import { dirname, parse as parsePath, resolve } from 'pathe'
-import { DEFINE_I18N_ROUTE_FN } from './constants'
 import { createRoutesContext } from 'unplugin-vue-router'
 import { resolveOptions } from 'unplugin-vue-router/options'
 import { transform } from './transform/resource'
@@ -386,7 +385,7 @@ function getI18nRouteConfig(absolutePath: string, vfs: Record<string, string> = 
 
   try {
     const content = absolutePath in vfs ? vfs[absolutePath]! : readFileSync(absolutePath, 'utf-8')
-    if (!content.includes(DEFINE_I18N_ROUTE_FN)) { return undefined }
+    if (!content.includes('defineI18nRoute')) { return undefined }
 
     const { descriptor } = parseSFC(content)
 
@@ -402,7 +401,7 @@ function getI18nRouteConfig(absolutePath: string, vfs: Record<string, string> = 
       if (
         node.type !== 'CallExpression'
         || node.callee.type !== 'Identifier'
-        || node.callee.name !== DEFINE_I18N_ROUTE_FN
+        || node.callee.name !== 'defineI18nRoute'
       ) { return }
 
       let routeArgument = node.arguments[0]
@@ -414,7 +413,7 @@ function getI18nRouteConfig(absolutePath: string, vfs: Record<string, string> = 
 
         if (transformed.errors.length) {
           for (const error of transformed.errors) {
-            console.warn(`Error while transforming \`${DEFINE_I18N_ROUTE_FN}()\`` + error.codeframe)
+            console.warn(`Error while transforming \`defineI18nRoute()\`` + error.codeframe)
           }
           return
         }

--- a/src/transform/macros.ts
+++ b/src/transform/macros.ts
@@ -10,11 +10,10 @@ import MagicString from 'magic-string'
 import { createUnplugin } from 'unplugin'
 import { parse as parseSFC } from '@vue/compiler-sfc'
 import { VIRTUAL_PREFIX_HEX, isVue } from './utils'
-import { DEFINE_I18N_ROUTE_FN } from '../constants'
 
 import type { BundlerPluginOptions } from './utils'
 
-const I18N_MACRO_FN_RE = new RegExp(`\\b${DEFINE_I18N_ROUTE_FN}\\s*\\(\\s*`)
+const I18N_MACRO_FN_RE = /\bdefineI18nRoute\s*\(\s*/
 
 /**
  * TODO:

--- a/src/transform/resource.ts
+++ b/src/transform/resource.ts
@@ -1,7 +1,6 @@
 import MagicString from 'magic-string'
 import { createUnplugin } from 'unplugin'
-import { VIRTUAL_PREFIX_HEX, asI18nVirtual } from './utils'
-import { DEFINE_I18N_CONFIG_FN, DEFINE_I18N_LOCALE_FN, NUXT_I18N_VIRTUAL_PREFIX } from '../constants'
+import { NUXT_I18N_VIRTUAL_PREFIX, VIRTUAL_PREFIX_HEX, asI18nVirtual } from './utils'
 import { dirname, resolve } from 'pathe'
 import { findStaticImports } from 'mlly'
 import { resolvePath, tryUseNuxt } from '@nuxt/kit'
@@ -16,8 +15,7 @@ export function transform(id: string, input: string, options?: TransformOptions)
   return oxcTransform(id, input, { ...oxcOptions, ...options })
 }
 
-const pattern = [DEFINE_I18N_LOCALE_FN, DEFINE_I18N_CONFIG_FN].join('|')
-const DEFINE_I18N_FN_RE = new RegExp(`\\b(${pattern})\\s*\\((.+)\\s*\\)`, 'gms')
+const DEFINE_I18N_FN_RE = /\b(defineI18nLocale|defineI18nConfig)\s*\((.+)\)/gs
 
 export const ResourcePlugin = (options: BundlerPluginOptions, ctx: I18nNuxtContext) =>
   createUnplugin(() => {

--- a/src/transform/utils.ts
+++ b/src/transform/utils.ts
@@ -1,8 +1,8 @@
 import { pathToFileURL } from 'node:url'
 import { parseQuery, parseURL } from 'ufo'
-import { NUXT_I18N_VIRTUAL_PREFIX } from '../constants'
 
 export const VIRTUAL_PREFIX_HEX = '\x00'
+export const NUXT_I18N_VIRTUAL_PREFIX = '#nuxt-i18n'
 
 export function asI18nVirtual(val: string) {
   return NUXT_I18N_VIRTUAL_PREFIX + '/' + val


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced public API surface and consolidated internal i18n utilities for a slimmer integration.
  * Simplified client/server wiring for locale handling and added explicit server-side locale imports and routing.
  * Replaced dynamic macro detection with fixed-pattern detection for more predictable behavior.

* **Chores**
  * Reorganized constant definitions and imports; added optional per-layer locale detector info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->