### PR TITLE
fix: no i18n context during prerender

### DIFF
--- a/src/runtime/server/context.ts
+++ b/src/runtime/server/context.ts
@@ -41,7 +41,7 @@ export const fetchMessages = async (locale: string) => {
   if (import.meta.dev) {
     headers.set('Cache-Control', 'no-cache')
   }
-  await $fetch<LocaleMessages<DefineLocaleMessage>>(`${__I18N_SERVER_ROUTE__}/${locale}/messages.json`, {
+  return await $fetch<LocaleMessages<DefineLocaleMessage>>(`${__I18N_SERVER_ROUTE__}/${locale}/messages.json`, {
     headers,
   })
 }

--- a/src/runtime/shared/utils.ts
+++ b/src/runtime/shared/utils.ts
@@ -1,10 +1,12 @@
-import { type NuxtApp, useRuntimeConfig } from '#app'
+import type { NuxtApp } from '#app'
+import { useRuntimeConfig } from '#imports'
 import { isString } from '@intlify/shared'
 import type { DetectBrowserLanguageOptions, I18nPublicRuntimeConfig, RootRedirectOptions } from '#internal-i18n-types'
+import type { H3Event } from 'h3'
 
-export function useRuntimeI18n(nuxtApp?: NuxtApp) {
+export function useRuntimeI18n(nuxtApp?: NuxtApp, event?: H3Event) {
   if (!nuxtApp) {
-    return useRuntimeConfig().public.i18n as unknown as I18nPublicRuntimeConfig
+    return useRuntimeConfig(event).public.i18n as unknown as I18nPublicRuntimeConfig
   }
   return nuxtApp.$config.public.i18n as unknown as I18nPublicRuntimeConfig
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced internationalization (i18n) context initialization during server requests.
  * Improved locale resolution with enhanced domain-based logic.
  * Better support for prerendering scenarios with more resilient context handling.
  * Optimized cache management with conditional caching in development environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->