### PR TITLE
fix: `differentDomains` localized path missing domain

### DIFF
--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -152,11 +152,11 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
       if (__MULTI_DOMAIN_LOCALES__ && __I18N_STRATEGY__ === 'prefix_except_default') {
         const defaultLocale = getDefaultLocaleForDomain(useRequestURL({ xForwardedHost: true }).host)
         if (locale !== defaultLocale || detectors.route(path) !== defaultLocale) {
-          return path
+          return joinURL(ctx.getBaseUrl(locale), path)
         }
 
         // remove default locale prefix
-        return path.slice(locale.length + 1)
+        return joinURL(ctx.getBaseUrl(locale), path.slice(locale.length + 1))
       }
 
       if (__DIFFERENT_DOMAINS__) {


### PR DESCRIPTION
### 🔗 Linked issue
* Resolves #3226
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Still missing tests, may not exactly resolve the linked issue but should cover it when using switchLocalePath
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL handling for multi-domain locale scenarios, ensuring proper path composition when switching between languages with certain prefix configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->