### PR TITLE
fix(server): prevent double redirect with root-level dynamic routes

### DIFF
--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -155,7 +155,7 @@ export default defineNitroPlugin(async (nitro) => {
     const detector = useDetectors(event, detection)
     const localeSegment = detector.route(event.path)
     const pathLocale = (isSupportedLocale(localeSegment) && localeSegment) || undefined
-    const path = (pathLocale && url.pathname.slice(pathLocale.length + 1)) || url.pathname
+    const path = (pathLocale && url.pathname.slice(pathLocale.length + 1)) ?? url.pathname
 
     // attempt to only run i18n detection for nuxt pages and i18n server routes
     if (!url.pathname.includes(__I18N_SERVER_ROUTE__) && !isExistingNuxtRoute(path)) {


### PR DESCRIPTION
### 🔗 Linked issue
resolves #3865

### 📚 Description

Fixes double redirect (e.g., `/` → `/en` → `/en/en`) when using `strategy: 'prefix'` with root-level dynamic routes by replacing OR operator with nullish coalescing operator.

**Problem:**  
The OR operator treats empty strings as falsy, causing locale prefixes to be preserved instead of removed:

```typescript
// Before (buggy):
const path = pathLocale && url.pathname.slice(pathLocale.length + 1) || url.pathname;
// "" || "/en" → "/en" (wrong)

// After (fixed):
const path = (pathLocale && url.pathname.slice(pathLocale.length + 1)) ?? url.pathname;
// "" ?? "/en" → "" (correct)
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path handling after locale prefix removal so empty paths are preserved correctly, leading to more consistent routing and redirect behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->