### PR TITLE
Allow localization of query parameters via useSetI18nParams

### DIFF
--- a/specs/basic_usage.spec.ts
+++ b/specs/basic_usage.spec.ts
@@ -569,6 +569,13 @@ describe('basic usage', async () => {
         '/products/red-mug?test=123&canonical=123'
       )
 
+      // Translated query args
+      await page.locator('#params-translate-query').clickNavigate()
+      await page.waitForURL(url('/nl/products/rode-mok?foo=bar&test=123&canonical=123'))
+      expect(await page.locator('#switch-locale-path-link-en').getAttribute('href')).toEqual(
+        '/products/red-mug?foo=baz&test=123&canonical=123'
+      )
+
       await page.locator('#params-remove-query').clickNavigate()
       await page.waitForURL(url('/nl/products/rode-mok'))
       expect(await page.locator('#switch-locale-path-link-en').getAttribute('href')).toEqual('/products/red-mug')

--- a/specs/fixtures/basic_usage/app/pages/products.vue
+++ b/specs/fixtures/basic_usage/app/pages/products.vue
@@ -22,6 +22,11 @@ onMounted(async () => {
       <li>
         <NuxtLink id="params-remove-query" :to="localePath({ query: undefined })">Remove query</NuxtLink>
       </li>
+      <li>
+        <NuxtLink id="params-translate-query" :to="localePath({ query: { foo: 'bar', test: '123', canonical: '123' } })"
+        >Translate query</NuxtLink
+        >
+      </li>
     </ul>
     <ul>
       <li v-for="product in products" :key="product.id">

--- a/specs/fixtures/basic_usage/app/pages/products/[slug].vue
+++ b/specs/fixtures/basic_usage/app/pages/products/[slug].vue
@@ -10,7 +10,7 @@ const setI18nParams = useSetI18nParams({ canonicalQueries: ['canonical'] })
 product.value = await $fetch(`/api/products/${route.params.slug}`)
 if (product.value != null) {
   const availableLocales = Object.keys(product.value.slugs)
-  const slugs: Record<string, string> = {}
+  const slugs: Record<string, string> = { en: { foo: 'baz' } }
 
   for (const l of availableLocales) {
     slugs[l] = { slug: product.value.slugs[l] }

--- a/src/runtime/shared/domain.ts
+++ b/src/runtime/shared/domain.ts
@@ -29,7 +29,7 @@ export function domainFromLocale(
 ): string | undefined {
   const lang = normalizedLocales.find(x => x.code === locale)
   // lookup the `differentDomain` origin associated with given locale.
-  const domain = domainLocales?.[locale]?.domain || lang?.domain || lang?.domains?.find(v => v === url.host)
+  const domain = domainLocales?.[locale]?.domain || lang?.domain || lang?.domains?.find((v: string) => v === url.host)
 
   if (!domain) {
     import.meta.dev && console.warn('[nuxt-i18n] Could not find domain name for locale ' + locale)

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -45,6 +45,7 @@ export type ComposableContext = {
   }
   head: ReturnType<typeof useHead>
   _head: ReturnType<typeof useHead> | undefined
+  isHydratingSSR: () => boolean
   metaState: Required<I18nHeadMetaInfo>
   seoSettings: I18nHeadOptions
   localePathPayload: Record<string, Record<string, string> | false>
@@ -124,6 +125,7 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
       lang: __I18N_STRICT_SEO__,
       seo: __I18N_STRICT_SEO__,
     },
+    isHydratingSSR: () => !!(nuxtApp.isHydrating && nuxtApp.payload?.serverRendered),
     localePathPayload: getLocalePathPayload(),
     routingOptions: {
       defaultLocale,

--- a/test/kit.test.ts
+++ b/test/kit.test.ts
@@ -443,6 +443,7 @@ describe('testing', () => {
       ja: {
         param: 'japan_test',
         foo: 'baz',
+        non_existing: 'bar',
       }
     });
     await router.push('/en/path/test?foo=bar#hash')


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt-modules/i18n/issues/3377

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Since we know which params and query args are available on a route we are already on, we can split them correctly between params and query without additional changes to setI18nParams

Also prevents the hash being included in switchLocalePath if the app is being hydrated from SSR (because the hash is never sent to the server and would be missing from the SSR, causing hydration mismatch)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Locale-switch routing now merges localized dynamic params and query keys correctly.
  * URL hash handling during SSR hydration fixed so hashes aren’t incorrectly preserved.

* **New Features**
  * Added SSR-hydration state detection to refine locale-switch path generation.
  * UI: added a "Translate query" link on product pages to generate translated query parameters.

* **Tests**
  * Added tests validating translated query params, locale-switch behavior during hydration, and suppression of hydration warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->