### PR TITLE
fix: skip localized redirection on nuxt error routes

### DIFF
--- a/src/runtime/shared/matching.ts
+++ b/src/runtime/shared/matching.ts
@@ -1,6 +1,7 @@
 import { joinURL, parsePath, withLeadingSlash } from 'ufo'
 import { createRouterMatcher } from 'vue-router'
 import { i18nPathToPath, pathToI18nConfig } from '#build/i18n-route-resources.mjs'
+import { NUXT_ERROR_SIGNATURE } from '#app/composables/error'
 
 const matcher = createRouterMatcher([], {})
 for (const path of Object.keys(i18nPathToPath)) {
@@ -18,6 +19,9 @@ const getI18nPathToI18nPath = (path: string, locale: string) => {
 
 export function isExistingNuxtRoute(path: string) {
   if (path === '') { return }
+  // Skip if this is a Nuxt error page (even if it matches a dynamic route)
+  if (path === NUXT_ERROR_SIGNATURE) { return }
+
   const resolvedMatch = matcher.resolve({ path }, { path: '/', name: '', matched: [], params: {}, meta: {} })
 
   return resolvedMatch.matched.length > 0 ? resolvedMatch : undefined

--- a/src/runtime/shared/matching.ts
+++ b/src/runtime/shared/matching.ts
@@ -1,7 +1,6 @@
 import { joinURL, parsePath, withLeadingSlash } from 'ufo'
 import { createRouterMatcher } from 'vue-router'
 import { i18nPathToPath, pathToI18nConfig } from '#build/i18n-route-resources.mjs'
-import { NUXT_ERROR_SIGNATURE } from '#app/composables/error'
 
 const matcher = createRouterMatcher([], {})
 for (const path of Object.keys(i18nPathToPath)) {
@@ -19,8 +18,9 @@ const getI18nPathToI18nPath = (path: string, locale: string) => {
 
 export function isExistingNuxtRoute(path: string) {
   if (path === '') { return }
-  // Skip if this is a Nuxt error page (even if it matches a dynamic route)
-  if (path === NUXT_ERROR_SIGNATURE) { return }
+  // TODO: path should not have base url - check if base url is stripped earlier
+  // skip nuxt error route - this path is hardcoded within nitro context code in nuxt
+  if (path.endsWith('/__nuxt_error')) { return }
 
   const resolvedMatch = matcher.resolve({ path }, { path: '/', name: '', matched: [], params: {}, meta: {} })
 


### PR DESCRIPTION
### 🔗 Linked issue
resolves #3870

### 📚 Description

Fixes an issue where `__nuxt_error` is incorrectly matched as a dynamic route parameter when root-level dynamic routes exist (e.g., `pages/[param]/`), causing infinite redirects with `strategy: 'prefix'`.

**Problem:**
- When a project has root-level dynamic routes, the router matcher treats `__nuxt_error` as a valid parameter value
- `isExistingNuxtRoute('__nuxt_error')` returns `true`, triggering i18n redirect logic on error pages

**Solution:**
- Added explicit check for `NUXT_ERROR_SIGNATURE` in `isExistingNuxtRoute()` 
- Error pages are now excluded from route matching regardless of dynamic route patterns

**Changes:**
- `src/runtime/shared/matching.ts`: Added early return when path matches `NUXT_ERROR_SIGNATURE`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error pages that end with "/__nuxt_error" are now excluded from route resolution, preventing them from being treated as valid dynamic routes and improving navigation consistency when errors occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->