### PR TITLE
ci: add id-token permissions to ci workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 ---
 name: CI
 
+permissions: {}
+
 env:
   CI: true
 
@@ -130,6 +132,8 @@ jobs:
       - build
       - test
     runs-on: ${{ matrix.os }}
+    permissions:
+      id-token: write
     strategy:
       matrix:
         node-version: [lts/*]

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,4 +1,7 @@
 name: nightly release
+
+permissions: {}
+
 on:
   push:
     branches:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Release
 
+permissions:
+  id-token: write
+  contents: write
+
 # trigger by `git tag` push only via `yarn release`
 on:
   push:

--- a/.github/workflows/reproduire.yml
+++ b/.github/workflows/reproduire.yml
@@ -1,10 +1,12 @@
 name: Reproduire
+
+permissions:
+  issues: write
+
 on:
   issues:
     types: [labeled]
 
-permissions:
-  issues: write
 
 jobs:
   reproduire:


### PR DESCRIPTION
### 🔗 Linked issue
* Resolves #3872 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Not sure if additional steps/changes are needed 🤔
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added explicit permissions blocks to GitHub Actions workflows (CI, nightly release, release) to define token scopes at the workflow and job levels.
  * Consolidated permissions configuration in the reproduire workflow by establishing a single top-level permissions block and removing duplicate definitions for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->