### PR TITLE
test: bundle size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .nitro
 .output
 .eslintcache
+.tmp
 
 dist
 temp
@@ -29,4 +30,3 @@ node_modules
 package-lock.json
 test/setup/context.json
 eslint-typegen.d.ts
-.eslintcache

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -1,51 +1,67 @@
 // adapted from https://github.com/nuxt/image/blob/5415ba721e8cb1ec15205f9bf54ada2e3d5fe07d/test/unit/bundle.test.ts
-import { join } from "node:path";
 import process from "node:process";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { promises as fsp } from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, writeFile, rm, lstat, readFile } from "node:fs/promises";
 import { buildNuxt, loadNuxt } from "@nuxt/kit";
 import type { NuxtConfig } from "@nuxt/schema";
 import { describe, it, expect } from "vitest";
 import { glob } from "tinyglobby";
 import { isWindows } from "std-env";
+import { defu } from "defu";
 
 describe.skipIf(process.env.ECOSYSTEM_CI || isWindows)(
   "nuxt i18n bundle size",
   () => {
     it("should match snapshot", { timeout: 120_000 }, async () => {
       const rootDir = fileURLToPath(new URL("../.tmp", import.meta.url));
-      await fsp.rm(rootDir, { recursive: true, force: true });
 
-      const [withoutModule, withModule, withVueI18n] = await Promise.all([
-        build(join(rootDir, "without")),
-        build(join(rootDir, "with"), {
-          modules: ["@nuxtjs/i18n"],
-          // i18n: {
-          //   defaultLocale: "en",
-          //   locales: [
-          //     { code: "en", file: "en.json" },
-          //     { code: "fr", file: "fr.json" },
-          //   ],
-          // },
-        }),
-        build(join(rootDir, "vue-i18n"), {}, { vueI18n: true }),
-      ]);
+      await rm(rootDir, { recursive: true, force: true }).catch(() => null);
 
-      // total bundle size increase
-      expect(
-        roundToKilobytes(withModule.totalBytes - withoutModule.totalBytes),
-      ).toMatchInlineSnapshot(`"69.4k"`);
+      const [base, withModule, withVueI18n, withVueI18nDropCompiler] =
+        await Promise.all([
+          build(join(rootDir, "without")),
+          build(join(rootDir, "with"), {
+            modules: ["@nuxtjs/i18n"],
+            // i18n: {
+            //   defaultLocale: "en",
+            //   locales: [
+            //     { code: "en", file: "en.json" },
+            //     { code: "fr", file: "fr.json" },
+            //   ],
+            // },
+          }),
+          build(join(rootDir, "vue-i18n"), {}, { vueI18n: true }),
+          build(
+            join(rootDir, "vue-i18n-drop-compiler"),
+            {
+              vite: {
+                define: {
+                  __INTLIFY_JIT_COMPILATION__: true,
+                  __INTLIFY_DROP_MESSAGE_COMPILER__: true,
+                },
+              },
+            },
+            { vueI18n: true },
+          ),
+        ]);
 
-      // vue-i18n bundle size (without nuxt-i18n)
-      expect(
-        roundToKilobytes(withVueI18n.totalBytes - withoutModule.totalBytes),
-      ).toMatchInlineSnapshot(`"43.3k"`);
+      const data = {
+        // total bundle size increase
+        module: roundToKilobytes(withModule.totalBytes - base.totalBytes),
+        "module (without vue-i18n)": roundToKilobytes(withModule.totalBytes - withVueI18n.totalBytes),
+        "vue-i18n": roundToKilobytes(withVueI18n.totalBytes - base.totalBytes),
+        "vue-i18n (without message compiler)": roundToKilobytes(withVueI18nDropCompiler.totalBytes - base.totalBytes),
+      };
 
-      // nuxt-i18n overhead
-      expect(
-        roundToKilobytes(withModule.totalBytes - withVueI18n.totalBytes),
-      ).toMatchInlineSnapshot(`"26.0k"`);
+      expect(data).toMatchInlineSnapshot(`
+        {
+          "module": "69.4k",
+          "module (without vue-i18n)": "26.0k",
+          "vue-i18n": "43.3k",
+          "vue-i18n (without message compiler)": "26.8k",
+        }
+      `);
     });
   },
 );
@@ -56,53 +72,63 @@ async function build(
   options: { vueI18n?: boolean } = {},
 ) {
   await mkdir(rootDir, { recursive: true });
-  // await mkdir(join(rootDir, "/i18n/locales"), { recursive: true });
-  // await writeFile(
-  //   join(rootDir, "/i18n/locales/en.json"),
-  //   `{ "hello": "Hello" }`,
-  // );
-  // await writeFile(
-  //   join(rootDir, "/i18n/locales/fr.json"),
-  //   `{ "hello": "Bonjour" }`,
-  // );
-  // await mkdir(join(rootDir, "/pages"), { recursive: true });
-  // await writeFile(
-  //   join(rootDir, "/pages/index.vue"),
-  //   `<template>{{ $t('hello') }}</template>`,
-  // );
-  await writeFile(
-    join(rootDir, "app.vue"),
-    // `<template><NuxtPage /></template>`,
-    options.vueI18n
-      ? `<script setup lang="ts">
-      import { useI18n } from 'vue-i18n'
-      const { t } = useI18n()
-      </script>\n`
-      : `` + `<template><div>Hello world</div></template>`,
-  );
+
+  const tree: Record<string, string> = {
+    // "/i18n/locales/en.json": `{ "hello": "Hello" }`,
+    // "/i18n/locales/fr.json": `{ "hello": "Bonjour" }`,
+    // "/pages/index.vue": `<template>{{ $t('hello') }}</template>`,
+    "/app.vue": `<template><NuxtPage /></template>`,
+  };
+
+  if (options.vueI18n) {
+    const template = [
+      `<script setup lang="ts">`,
+      `import { useI18n } from 'vue-i18n'`,
+      `const { t } = useI18n()`,
+      `</script>`,
+      `<template><div>{{ t('hello') }}</div></template>`,
+    ].join("\n");
+
+    if (tree["/pages/index.vue"]) {
+      tree["/pages/index.vue"] = template;
+    } else {
+      tree["/app.vue"] = template;
+    }
+  }
+
+  for (const [path, content] of Object.entries(tree)) {
+    const fullPath = join(rootDir, path);
+    const dir = join(fullPath, "..");
+    if (dir !== rootDir) {
+      await mkdir(join(fullPath, ".."), { recursive: true });
+    }
+    await writeFile(fullPath, content);
+  }
+
   const nuxt = await loadNuxt({
     cwd: rootDir,
     ready: true,
     overrides: {
-      ssr: false,
-      ...config,
-      vite: {
-        define: {
-          __INTLIFY_PROD_DEVTOOLS__: false, // for vue-i18n build - disabled in nuxt-i18n bundler.ts
+      // ssr: false,
+      ...defu(config, {
+        vite: {
+          define: {
+            __INTLIFY_PROD_DEVTOOLS__: false, // for vue-i18n build - disabled in nuxt-i18n bundler.ts
+          },
+          // to disable minification for easier size analysis
+          // $client: {
+          //   build: {
+          //     minify: false,
+          //     rollupOptions: {
+          //       output: {
+          //         chunkFileNames: "_nuxt/[name].js",
+          //         entryFileNames: "_nuxt/[name].js",
+          //       },
+          //     },
+          //   },
+          // },
         },
-        // to disable minification for easier size analysis
-        // $client: {
-        //   build: {
-        //     minify: false,
-        //     rollupOptions: {
-        //       output: {
-        //         chunkFileNames: "_nuxt/[name].js",
-        //         entryFileNames: "_nuxt/[name].js",
-        //       },
-        //     },
-        //   },
-        // },
-      },
+      }),
     },
   });
   await buildNuxt(nuxt);
@@ -115,12 +141,10 @@ async function analyzeSizes(pattern: string[], rootDir: string) {
   let totalBytes = 0;
   for (const file of files) {
     const path = join(rootDir, file);
-    const isSymlink = (
-      await fsp.lstat(path).catch(() => null)
-    )?.isSymbolicLink();
+    const isSymlink = (await lstat(path).catch(() => null))?.isSymbolicLink();
 
     if (!isSymlink) {
-      const bytes = Buffer.byteLength(await fsp.readFile(path));
+      const bytes = Buffer.byteLength(await readFile(path));
       totalBytes += bytes;
     }
   }

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -40,12 +40,12 @@ describe.skipIf(process.env.ECOSYSTEM_CI || isWindows)(
       // vue-i18n bundle size (without nuxt-i18n)
       expect(
         roundToKilobytes(withVueI18n.totalBytes - withoutModule.totalBytes),
-      ).toMatchInlineSnapshot(`"44.2k"`);
+      ).toMatchInlineSnapshot(`"43.3k"`);
 
       // nuxt-i18n overhead
       expect(
         roundToKilobytes(withModule.totalBytes - withVueI18n.totalBytes),
-      ).toMatchInlineSnapshot(`"25.2k"`);
+      ).toMatchInlineSnapshot(`"26.0k"`);
     });
   },
 );
@@ -75,9 +75,9 @@ async function build(
     // `<template><NuxtPage /></template>`,
     options.vueI18n
       ? `<script setup lang="ts">
-import { useI18n } from 'vue-i18n'
-const { t } = useI18n()
-</script>\n`
+      import { useI18n } from 'vue-i18n'
+      const { t } = useI18n()
+      </script>\n`
       : `` + `<template><div>Hello world</div></template>`,
   );
   const nuxt = await loadNuxt({
@@ -86,20 +86,23 @@ const { t } = useI18n()
     overrides: {
       ssr: false,
       ...config,
-      // to disable minification for easier size analysis
-      // vite: {
-      //   $client: {
-      //     build: {
-      //       minify: false,
-      //       rollupOptions: {
-      //         output: {
-      //           chunkFileNames: "_nuxt/[name].js",
-      //           entryFileNames: "_nuxt/[name].js",
-      //         },
-      //       },
-      //     },
-      //   },
-      // },
+      vite: {
+        define: {
+          __INTLIFY_PROD_DEVTOOLS__: false, // for vue-i18n build - disabled in nuxt-i18n bundler.ts
+        },
+        // to disable minification for easier size analysis
+        // $client: {
+        //   build: {
+        //     minify: false,
+        //     rollupOptions: {
+        //       output: {
+        //         chunkFileNames: "_nuxt/[name].js",
+        //         entryFileNames: "_nuxt/[name].js",
+        //       },
+        //     },
+        //   },
+        // },
+      },
     },
   });
   await buildNuxt(nuxt);
@@ -125,8 +128,5 @@ async function analyzeSizes(pattern: string[], rootDir: string) {
 }
 
 function roundToKilobytes(bytes: number) {
-  // const kb = bytes / 1024;
-  // const scale = 10000;
-  // return Math.trunc(kb * scale) / scale + "k";
   return (bytes / 1024).toFixed(bytes > 100 * 1024 ? 0 : 1) + "k";
 }

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -1,0 +1,110 @@
+// adapted from https://github.com/nuxt/image/blob/5415ba721e8cb1ec15205f9bf54ada2e3d5fe07d/test/unit/bundle.test.ts
+import { join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { promises as fsp } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { buildNuxt, loadNuxt } from "@nuxt/kit";
+import type { NuxtConfig } from "@nuxt/schema";
+import { describe, it, expect } from "vitest";
+import { glob } from "tinyglobby";
+import { isWindows } from "std-env";
+
+describe.skipIf(process.env.ECOSYSTEM_CI || isWindows)(
+  "nuxt i18n bundle size",
+  () => {
+    it("should match snapshot", { timeout: 120_000 }, async () => {
+      const rootDir = fileURLToPath(new URL("../.tmp", import.meta.url));
+      await fsp.rm(rootDir, { recursive: true, force: true });
+
+      const [withoutImage, withImage] = await Promise.all([
+        build(join(rootDir, "without")),
+        build(join(rootDir, "with"), {
+          modules: ["@nuxtjs/i18n"],
+          // i18n: {
+          //   defaultLocale: "en",
+          //   locales: [
+          //     { code: "en", file: "en.json" },
+          //     { code: "fr", file: "fr.json" },
+          //   ],
+          // },
+        }),
+      ]);
+
+      expect(
+        roundToKilobytes(withImage.totalBytes - withoutImage.totalBytes),
+      ).toMatchInlineSnapshot(`"69.4k"`);
+    });
+  },
+);
+
+async function build(rootDir: string, config: NuxtConfig = {}) {
+  await mkdir(rootDir, { recursive: true });
+  // await mkdir(join(rootDir, "/i18n/locales"), { recursive: true });
+  // await writeFile(
+  //   join(rootDir, "/i18n/locales/en.json"),
+  //   `{ "hello": "Hello" }`,
+  // );
+  // await writeFile(
+  //   join(rootDir, "/i18n/locales/fr.json"),
+  //   `{ "hello": "Bonjour" }`,
+  // );
+  // await mkdir(join(rootDir, "/pages"), { recursive: true });
+  // await writeFile(
+  //   join(rootDir, "/pages/index.vue"),
+  //   `<template>{{ $t('hello') }}</template>`,
+  // );
+  await writeFile(
+    join(rootDir, "app.vue"),
+    // `<template><NuxtPage /></template>`,
+    `<template><div>Hello world</div></template>`,
+  );
+  const nuxt = await loadNuxt({
+    cwd: rootDir,
+    ready: true,
+    overrides: {
+      ssr: false,
+      ...config,
+      // to disable minification for easier size analysis
+      // vite: {
+      //   $client: {
+      //     build: {
+      //       minify: false,
+      //       rollupOptions: {
+      //         output: {
+      //           chunkFileNames: "_nuxt/[name].js",
+      //           entryFileNames: "_nuxt/[name].js",
+      //         },
+      //       },
+      //     },
+      //   },
+      // },
+    },
+  });
+  await buildNuxt(nuxt);
+  await nuxt.close();
+  return await analyzeSizes(["**/*.js"], join(rootDir, ".output/public"));
+}
+async function analyzeSizes(pattern: string[], rootDir: string) {
+  const files: string[] = await glob(pattern, { cwd: rootDir });
+  let totalBytes = 0;
+  for (const file of files) {
+    const path = join(rootDir, file);
+    const isSymlink = (
+      await fsp.lstat(path).catch(() => null)
+    )?.isSymbolicLink();
+
+    if (!isSymlink) {
+      const bytes = Buffer.byteLength(await fsp.readFile(path));
+      totalBytes += bytes;
+    }
+  }
+  return { files, totalBytes };
+}
+
+function roundToKilobytes(bytes: number) {
+  // const kb = bytes / 1024;
+  // const scale = 10000;
+  // return Math.trunc(kb * scale) / scale + "k";
+  return (bytes / 1024).toFixed(bytes > 100 * 1024 ? 0 : 1) + "k";
+}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This adds tests to track the impact of this module on the client bundle size, reducing this is always a good idea, and we'll be able to catch unintended code bundling before merging a PR.

Besides checking the impact on a (near) empty project, I also added checks to compare the bundle size of vue-i18n alone and this module's impact without vue-i18n, this way we know how much can be optimized in this repository, or if doing so upstream would be more effective.

The size comparisons highlighted the size impact of the vue-i18n message compiler, if we can ensure all messages are precompiled (or compile messages at runtime from the server), we would be able to omit the message compiler from the client bundle, decreasing the module bundle size by `16.5kb` (about `~23%`).

I'm not sure how feasible it would be to detect/precompile all user messages (my concern is dynamic messages + `useI18n({ messages: ... })`), but documenting recommendations to have analyzable messages and to toggle bundling the compiler, could cover a lot of projects.

I also suspect there are smaller, less complicated size reductions we can make in this module's runtime code. It's surprising that this module (i18n routing, detection, message loading, composables) runtime code appears to be comparable in size to the vue-i18n (without compiler), suggesting further internal optimization is likely possible from this repo.




<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added bundle-size tests that build sample apps with and without i18n to detect size regressions; tests skip on CI and Windows environments.

* **Chores**
  * Updated repository ignore rules to add temporary file patterns and adjust eslint-related ignore entries.

Note: These are testing and repository-hygiene updates; no user-facing features were added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->