### PR TITLE
fix: route matcher warn

### DIFF
--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -155,7 +155,7 @@ export default defineNitroPlugin(async (nitro) => {
     const detector = useDetectors(event, detection)
     const localeSegment = detector.route(event.path)
     const pathLocale = (isSupportedLocale(localeSegment) && localeSegment) || undefined
-    const path = (pathLocale && url.pathname.slice(pathLocale.length + 1)) ?? url.pathname
+    const path = (pathLocale && event.path.slice(pathLocale.length + 1)) ?? event.path
 
     // attempt to only run i18n detection for nuxt pages and i18n server routes
     if (!url.pathname.includes(__I18N_SERVER_ROUTE__) && !isExistingNuxtRoute(path)) {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt-modules/i18n/issues/3887

### 📚 Description

Fix Warn when app.baseURL and strategy: "prefix" is set 

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path handling for localized routing to ensure more accurate detection and redirect logic based on request path information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->