### PR TITLE
fix: handle falsy `options.i18n` types

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -69,7 +69,7 @@ export function getDefineConfig(
 
   // `stripMessagesPayload` is enabled by default when `experimental.preload` is set to true
   let stripMessagesPayload = !!options.experimental.preload
-  if (nuxt.options.i18n?.experimental?.stripMessagesPayload != null) {
+  if (nuxt.options.i18n && nuxt.options.i18n.experimental?.stripMessagesPayload != null) {
     stripMessagesPayload = nuxt.options.i18n.experimental.stripMessagesPayload
   }
 

--- a/src/prepare/options.ts
+++ b/src/prepare/options.ts
@@ -16,17 +16,17 @@ export function prepareOptions({ options }: I18nNuxtContext, nuxt: Nuxt) {
     )
   }
 
-  if (nuxt.options.i18n?.autoDeclare && nuxt.options.imports.autoImport === false) {
+  if (nuxt.options.i18n && nuxt.options.i18n.autoDeclare && nuxt.options.imports.autoImport === false) {
     logger.warn(
       'Disabling `autoImports` in Nuxt is not compatible with `autoDeclare`, either enable `autoImports` or disable `autoDeclare`.',
     )
   }
 
-  const strategy = nuxt.options.i18n?.strategy || options.strategy
-  const defaultLocale = nuxt.options.i18n?.defaultLocale || options.defaultLocale
+  const strategy = (nuxt.options.i18n && nuxt.options.i18n.strategy) || options.strategy
+  const defaultLocale = (nuxt.options.i18n && nuxt.options.i18n.defaultLocale) || options.defaultLocale
   if (strategy.endsWith('_default') && !defaultLocale) {
     logger.warn(
-      `The \`${strategy}\` i18n strategy${nuxt.options.i18n?.strategy == null ? ' (used by default)' : ''} needs \`defaultLocale\` to be set.`,
+      `The \`${strategy}\` i18n strategy${(nuxt.options.i18n && nuxt.options.i18n.strategy) == null ? ' (used by default)' : ''} needs \`defaultLocale\` to be set.`,
     )
   }
 

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -58,7 +58,7 @@ describe.skipIf(process.env.ECOSYSTEM_CI || isWindows)(
         {
           "module": "69.4k",
           "module (without vue-i18n)": "26.0k",
-          "vue-i18n": "43.4k",
+          "vue-i18n": "43.3k",
           "vue-i18n (without message compiler)": "26.8k",
         }
       `);

--- a/test/bundle.test.ts
+++ b/test/bundle.test.ts
@@ -58,7 +58,7 @@ describe.skipIf(process.env.ECOSYSTEM_CI || isWindows)(
         {
           "module": "69.4k",
           "module (without vue-i18n)": "26.0k",
-          "vue-i18n": "43.3k",
+          "vue-i18n": "43.4k",
           "vue-i18n (without message compiler)": "26.8k",
         }
       `);


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/nuxt/issues/32949

### 📚 Description

as `false` is now a valid type, this performs a `&&` check rather than using optional chaining.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved stability by adding defensive null/undefined checks around internationalization configuration access to prevent potential runtime issues.

* **Tests**
  * Updated a bundle size snapshot expectation to reflect a minor size delta.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->