### PR TITLE
docs: fix typo in SEO guide

### DIFF
--- a/docs/content/docs/02.guide/06.seo.md
+++ b/docs/content/docs/02.guide/06.seo.md
@@ -53,7 +53,7 @@ export default defineNuxtConfig({
 
 ## Setup
 
-The `useLocaleHead()`{lang="ts"} is a composable function, Calling that composable function returns a function that returns metadata that is handled by [Head management](https://nuxt.com/docs/getting-started/seo-meta) that is integrated within Nuxt. That metadata can be specified the `setup` function in various places within Nuxt:
+The `useLocaleHead()`{lang="ts"} is a composable function, Calling that composable function returns a function that returns metadata that is handled by [Head management](https://nuxt.com/docs/getting-started/seo-meta) that is integrated within Nuxt. That metadata can be specified by the `setup` function in various places within Nuxt:
 
 - [`app.vue`](https://nuxt.com/docs/guide/directory-structure/app)
 - Vue components of [`pages`](https://nuxt.com/docs/guide/directory-structure/pages) directory


### PR DESCRIPTION
Added a missing word to the SEO guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected grammatical errors in the SEO guide for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->