### PR TITLE
fix: server-side redirect for root path (/) with prefix strategy (#3913)

### DIFF
--- a/specs/routing_strategies/prefix.spec.ts
+++ b/specs/routing_strategies/prefix.spec.ts
@@ -49,6 +49,28 @@ describe('strategy: prefix', async () => {
     }
   })
 
+  test('(#3913) server-side redirect for root path (/) with detectBrowserLanguage and redirectOn: root', async () => {
+    await startServerWithRuntimeConfig(
+      {
+        public: {
+          i18n: {
+            defaultLocale: 'fr',
+            detectBrowserLanguage: {
+              useCookie: true,
+              redirectOn: 'root'
+            }
+          }
+        }
+      },
+      true
+    )
+
+    // Must return 302 redirect (not 200) for SEO - curl/ bots should get server-side redirect
+    const res = await fetch('/', { redirect: 'manual', headers: { 'Accept-Language': 'fr' } })
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe('/fr')
+  })
+
   test('can access to prefix locale: /en', async () => {
     const { page } = await renderPage('/en')
 

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -158,7 +158,10 @@ export default defineNitroPlugin(async (nitro) => {
     const path = (pathLocale && url.pathname.slice(pathLocale.length + 1)) ?? url.pathname
 
     // attempt to only run i18n detection for nuxt pages and i18n server routes
-    if (!url.pathname.includes(__I18N_SERVER_ROUTE__) && !isExistingNuxtRoute(path)) {
+    // Root path (/) with prefix strategy is not in i18nPathToPath (only /en, /fr etc. are),
+    // but we need to run redirect logic to redirect / to /locale for SEO (issue #3913)
+    const isRootPathWithPrefixStrategy = url.pathname === '/' && __I18N_STRATEGY__ === 'prefix'
+    if (!url.pathname.includes(__I18N_SERVER_ROUTE__) && !isExistingNuxtRoute(path) && !isRootPathWithPrefixStrategy) {
       return
     }
 

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -137,6 +137,9 @@ export default defineNitroPlugin(async (nitro) => {
 
     if (requestURL.pathname === '/' && __I18N_STRATEGY__ === 'prefix') {
       resolvedPath ??= getLocalizedMatch(defaultLocale)
+      // Fallback: when no route exists for / in i18nPathToPath (e.g. pages/index/index.vue creates /index),
+      // redirect to /{locale} directly for SEO (308 permanent redirect)
+      resolvedPath ??= `/${locale}`
     }
     return { path: resolvedPath, code: redirectCode, locale }
   }


### PR DESCRIPTION
### 🔗 Linked issue
Fixes #3913

### 📚 Description

**Problem**

After upgrading from @nuxtjs/i18n v9 to v10, the server-side redirect from the root path (`/`) to the default locale (e.g. `/pl`) stopped working when using `strategy: 'prefix'` and `detectBrowserLanguage: { redirectOn: 'root' }`.

Instead of returning HTTP 302, the root path returns 200 with full HTML. The redirect only happens client-side via JavaScript, which causes:
- Search engine bots to see duplicate content (`/` and `/pl` both return 200 with the same content)
- `curl` and non-JS clients not being redirected

**Root cause**

With `strategy: 'prefix'`, `i18nPathToPath` only contains prefixed paths (`/en`, `/fr`, etc.), not the root `/`. As a result, `isExistingNuxtRoute('/')` returns `false`, so the redirect logic in the `render:before` hook exits early and never runs.

**Solution**

Allow the root path (`/`) to always go through the redirect logic when using `strategy: 'prefix'`, even if it is not present in `i18nPathToPath`. This restores the previous server-side redirect behavior.

**Changes**

- `src/runtime/server/plugin.ts`: Add a special case for root path with prefix strategy so redirect logic is always executed
- `specs/routing_strategies/prefix.spec.ts`: Add a test for the scenario from #3913 (server-side redirect with `detectBrowserLanguage` and `redirectOn: 'root'`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed server-side redirect for the root path when using the prefix i18n strategy with browser language detection and root-redirect configured — root now correctly redirects to the locale-prefixed path.

* **Tests**
  * Added server-side tests verifying root redirect behavior with detect-browser-language and root redirect settings (duplicated across relevant test scopes for coverage).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->