### PR TITLE
fix: respect trailingSlash on root

### DIFF
--- a/src/runtime/shared/matching.ts
+++ b/src/runtime/shared/matching.ts
@@ -1,7 +1,8 @@
-import { joinURL, parsePath, withLeadingSlash } from 'ufo'
+import { joinURL, parsePath, withLeadingSlash, withTrailingSlash, withoutTrailingSlash } from 'ufo'
 import { createRouterMatcher } from 'vue-router'
 import { i18nPathToPath, pathToI18nConfig } from '#build/i18n-route-resources.mjs'
 
+const formatTrailingSlash = __TRAILING_SLASH__ ? withTrailingSlash : withoutTrailingSlash
 const matcher = createRouterMatcher([], {})
 for (const path of Object.keys(i18nPathToPath)) {
   matcher.addRoute({ path, component: () => '', meta: {} })
@@ -47,7 +48,7 @@ export function matchLocalized(path: string, locale: string, defaultLocale: stri
     )
 
     const isPrefixable = prefixable(locale, defaultLocale)
-    return withLeadingSlash(joinURL(isPrefixable ? locale : '', match.path))
+    return formatTrailingSlash(withLeadingSlash(joinURL(isPrefixable ? locale : '', match.path)), true)
   }
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->


### 📚 Description

Resolves an issue when visiting: `example.com` it redirects to `example.com/en` while it should redirect to `example.com/en/`

It doesn't respect the `trailingSlash` option which is breaking change from v9 to v10.

I don't know where to push the test file as `trailingSlash` option isn't a runtime config anymore.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable trailing slash formatting for localized paths. Localized URLs can now be automatically formatted with or without trailing slashes based on your application configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->