### PR TITLE
fix: reduce locale file server chunks

### DIFF
--- a/src/gen.ts
+++ b/src/gen.ts
@@ -36,7 +36,7 @@ export function generateLoaderOptions(
    */
   const importMapper = new Map<string, LocaleLoaderData>()
   const localeLoaders: Record<string, LocaleLoaderData[]> = {}
-  const importStatements: string[] = []
+  const importStatements = new Set<string>()
   for (const locale of ctx.localeInfo) {
     localeLoaders[locale.code] ??= []
     for (const meta of locale.meta) {
@@ -44,7 +44,7 @@ export function generateLoaderOptions(
         const identifier = `locale_${genSafeVariableName(basename(meta.path))}_${meta.hash}`
         const key = genString(identifier)
 
-        importStatements.push(genImport(asI18nVirtual(meta.hash), identifier))
+        importStatements.add(genImport(asI18nVirtual(meta.hash), identifier))
         importMapper.set(meta.path, {
           key,
           relative: relative(nuxt.options.buildDir, meta.path),
@@ -66,7 +66,7 @@ export function generateLoaderOptions(
     const identifier = `config_${genSafeVariableName(basename(config.path))}_${config.hash}`
     const key = genString(identifier)
 
-    importStatements.push(genImport(asI18nVirtual(config.hash), identifier))
+    importStatements.add(genImport(asI18nVirtual(config.hash), identifier))
     vueI18nConfigs.push({
       importer: genDynamicImport(asI18nVirtual(config.hash), { comment: `webpackChunkName: ${key}` }),
       importerServer: `() => Promise.resolve(${identifier})`,
@@ -79,7 +79,7 @@ export function generateLoaderOptions(
    */
   const normalizedLocales = ctx.normalizedLocales.map(x => stripLocaleFiles(x))
 
-  return { localeLoaders, vueI18nConfigs, normalizedLocales, importStatements }
+  return { localeLoaders, vueI18nConfigs, normalizedLocales, importStatements: Array.from(importStatements) }
 }
 
 /**

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -1,5 +1,5 @@
 import { isString } from '@intlify/shared'
-import { genDynamicImport, genSafeVariableName, genString } from 'knitwork'
+import { genDynamicImport, genImport, genSafeVariableName, genString } from 'knitwork'
 import { basename, join, relative, resolve } from 'pathe'
 import { asI18nVirtual } from './transform/utils'
 
@@ -22,6 +22,7 @@ export function simplifyLocaleOptions(ctx: I18nNuxtContext, _nuxt: Nuxt) {
 type LocaleLoaderData = {
   key: string
   load: string
+  loadServer: string
   relative: string
   cache: boolean
 }
@@ -35,16 +36,21 @@ export function generateLoaderOptions(
    */
   const importMapper = new Map<string, LocaleLoaderData>()
   const localeLoaders: Record<string, LocaleLoaderData[]> = {}
+  const importStatements: string[] = []
   for (const locale of ctx.localeInfo) {
     localeLoaders[locale.code] ??= []
     for (const meta of locale.meta) {
       if (!importMapper.has(meta.path)) {
-        const key = genString(`locale_${genSafeVariableName(basename(meta.path))}_${meta.hash}`)
+        const identifier = `locale_${genSafeVariableName(basename(meta.path))}_${meta.hash}`
+        const key = genString(identifier)
+
+        importStatements.push(genImport(asI18nVirtual(meta.hash), identifier))
         importMapper.set(meta.path, {
           key,
           relative: relative(nuxt.options.buildDir, meta.path),
           cache: meta.cache ?? true,
           load: genDynamicImport(asI18nVirtual(meta.hash), { comment: `webpackChunkName: ${key}` }),
+          loadServer: `() => Promise.resolve(${identifier})`,
         })
       }
       localeLoaders[locale.code]!.push(importMapper.get(meta.path)!)
@@ -57,9 +63,13 @@ export function generateLoaderOptions(
   const vueI18nConfigs = []
   for (let i = ctx.vueI18nConfigPaths.length - 1; i >= 0; i--) {
     const config = ctx.vueI18nConfigPaths[i]!
-    const key = genString(`config_${genSafeVariableName(basename(config.path))}_${config.hash}`)
+    const identifier = `config_${genSafeVariableName(basename(config.path))}_${config.hash}`
+    const key = genString(identifier)
+
+    importStatements.push(genImport(asI18nVirtual(config.hash), identifier))
     vueI18nConfigs.push({
       importer: genDynamicImport(asI18nVirtual(config.hash), { comment: `webpackChunkName: ${key}` }),
+      importerServer: `() => Promise.resolve(${identifier})`,
       relative: relative(nuxt.options.buildDir, config.path),
     })
   }
@@ -69,7 +79,7 @@ export function generateLoaderOptions(
    */
   const normalizedLocales = ctx.normalizedLocales.map(x => stripLocaleFiles(x))
 
-  return { localeLoaders, vueI18nConfigs, normalizedLocales }
+  return { localeLoaders, vueI18nConfigs, normalizedLocales, importStatements }
 }
 
 /**

--- a/src/runtime/shared/messages.ts
+++ b/src/runtime/shared/messages.ts
@@ -30,7 +30,7 @@ export async function loadVueI18nOptions(vueI18nConfigs: VueI18nConfig[]): Promi
   let vueI18nOptions: I18nOptions = { messages: create(null) as LocaleMessages<DefineLocaleMessage> }
 
   for (const configFile of vueI18nConfigs) {
-    const resolver = await configFile().then(x => x.default)
+    const resolver = await configFile().then(x => (isModule(x) ? x.default : x))
     const resolved = isFunction(resolver) ? await nuxtApp.runWithContext(() => resolver()) : resolver
     vueI18nOptions = merger(create(null), resolved, vueI18nOptions)
   }
@@ -45,17 +45,12 @@ export async function loadVueI18nOptions(vueI18nConfigs: VueI18nConfig[]): Promi
 const isModule = (val: unknown): val is { default: unknown } => toTypeString(val) === '[object Module]'
 
 /**
- * Check if the value is a module and handle edge case server-side
- */
-const isResolvedModule = (val: unknown): val is { default: unknown } => isModule(val) || import.meta.server
-
-/**
  * Get locale messages from loader
  */
 async function getLocaleMessages(locale: string, loader: LocaleLoader) {
   const nuxtApp = useNuxtApp()
   try {
-    const getter = await nuxtApp.runWithContext(loader.load).then(x => (isResolvedModule(x) ? x.default : x))
+    const getter = await nuxtApp.runWithContext(loader.load).then(x => (isModule(x) ? x.default : x))
     return isFunction(getter) ? await nuxtApp.runWithContext(() => getter(locale)) : getter
   } catch (e: unknown) {
     throw new Error(`Failed loading locale (${locale}): ` + (e as Error).message)

--- a/src/template.ts
+++ b/src/template.ts
@@ -61,6 +61,7 @@ function genVueI18nConfigHMR(configs: TemplateNuxtI18nOptions['vueI18nConfigs'])
 export function generateTemplateNuxtI18nOptions(
   ctx: I18nNuxtContext,
   opts: TemplateNuxtI18nOptions,
+  server: boolean = false,
   nuxt = useNuxt(),
 ): string {
   const codeHMR
@@ -76,15 +77,15 @@ export function generateTemplateNuxtI18nOptions(
 
   const localeLoaderEntries: Record<string, { key: string, load: string, cache: boolean }[]> = {}
   for (const locale in opts.localeLoaders) {
-    localeLoaderEntries[locale] = opts.localeLoaders[locale]!.map(({ key, load, cache }) => ({ key, load, cache }))
+    localeLoaderEntries[locale] = opts.localeLoaders[locale]!.map(({ key, load, loadServer, cache }) => ({ key, load: server ? loadServer : load, cache }))
   }
 
   return `// @ts-nocheck
+${server ? opts.importStatements.join('\n') : ''}
 export const localeCodes =  ${genArrayFromRaw(ctx.localeCodes.map(x => genString(x)))}
 export const localeLoaders = ${genObjectFromRaw(localeLoaderEntries)}
-export const vueI18nConfigs = ${genArrayFromRaw(opts.vueI18nConfigs.map(x => x.importer))}
+export const vueI18nConfigs = ${genArrayFromRaw(opts.vueI18nConfigs.map(x => server ? x.importerServer : x.importer))}
 export const normalizedLocales = ${genArrayFromRaw(opts.normalizedLocales.map(x => genObjectFromValues(x, '  ')))}
-/** client **/
-${codeHMR || ''}
-/** client-end **/`
+${server ? '' : codeHMR || ''}
+`
 }

--- a/test/__snapshots__/gen.test.ts.snap
+++ b/test/__snapshots__/gen.test.ts.snap
@@ -2,12 +2,19 @@
 
 exports[`basic 1`] = `
 {
+  "importStatements": [
+    "import locale_en_46json_f7535dc0 from "#nuxt-i18n/f7535dc0";",
+    "import locale_ja_46json_5843ecf1 from "#nuxt-i18n/5843ecf1";",
+    "import locale_fr_46json_3d83f3b3 from "#nuxt-i18n/3d83f3b3";",
+    "import config_to_c3216fe6 from "#nuxt-i18n/c3216fe6";",
+  ],
   "localeLoaders": {
     "en": [
       {
         "cache": true,
         "key": ""locale_en_46json_f7535dc0"",
         "load": "() => import("#nuxt-i18n/f7535dc0" /* webpackChunkName: "locale_en_46json_f7535dc0" */)",
+        "loadServer": "() => Promise.resolve(locale_en_46json_f7535dc0)",
         "relative": "../en.json",
       },
     ],
@@ -16,6 +23,7 @@ exports[`basic 1`] = `
         "cache": true,
         "key": ""locale_fr_46json_3d83f3b3"",
         "load": "() => import("#nuxt-i18n/3d83f3b3" /* webpackChunkName: "locale_fr_46json_3d83f3b3" */)",
+        "loadServer": "() => Promise.resolve(locale_fr_46json_3d83f3b3)",
         "relative": "../fr.json",
       },
     ],
@@ -24,6 +32,7 @@ exports[`basic 1`] = `
         "cache": true,
         "key": ""locale_ja_46json_5843ecf1"",
         "load": "() => import("#nuxt-i18n/5843ecf1" /* webpackChunkName: "locale_ja_46json_5843ecf1" */)",
+        "loadServer": "() => Promise.resolve(locale_ja_46json_5843ecf1)",
         "relative": "../ja.json",
       },
     ],
@@ -42,6 +51,7 @@ exports[`basic 1`] = `
   "vueI18nConfigs": [
     {
       "importer": "() => import("#nuxt-i18n/c3216fe6" /* webpackChunkName: "config_to_c3216fe6" */)",
+      "importerServer": "() => Promise.resolve(config_to_c3216fe6)",
       "relative": "../../path/to",
     },
   ],
@@ -50,12 +60,21 @@ exports[`basic 1`] = `
 
 exports[`files with cache configuration 1`] = `
 {
+  "importStatements": [
+    "import locale_en_46json_7973e345 from "#nuxt-i18n/7973e345";",
+    "import locale_ja_46json_4c459061 from "#nuxt-i18n/4c459061";",
+    "import locale_fr_46json_aa45ccf4 from "#nuxt-i18n/aa45ccf4";",
+    "import locale_es_46json_cffd8a40 from "#nuxt-i18n/cffd8a40";",
+    "import locale_es_45AR_46json_d3b7c72c from "#nuxt-i18n/d3b7c72c";",
+    "import config_to_c3216fe6 from "#nuxt-i18n/c3216fe6";",
+  ],
   "localeLoaders": {
     "en": [
       {
         "cache": true,
         "key": ""locale_en_46json_7973e345"",
         "load": "() => import("#nuxt-i18n/7973e345" /* webpackChunkName: "locale_en_46json_7973e345" */)",
+        "loadServer": "() => Promise.resolve(locale_en_46json_7973e345)",
         "relative": "../srcDir/locales/en.json",
       },
     ],
@@ -64,6 +83,7 @@ exports[`files with cache configuration 1`] = `
         "cache": false,
         "key": ""locale_es_46json_cffd8a40"",
         "load": "() => import("#nuxt-i18n/cffd8a40" /* webpackChunkName: "locale_es_46json_cffd8a40" */)",
+        "loadServer": "() => Promise.resolve(locale_es_46json_cffd8a40)",
         "relative": "../srcDir/locales/es.json",
       },
     ],
@@ -72,12 +92,14 @@ exports[`files with cache configuration 1`] = `
         "cache": false,
         "key": ""locale_es_46json_cffd8a40"",
         "load": "() => import("#nuxt-i18n/cffd8a40" /* webpackChunkName: "locale_es_46json_cffd8a40" */)",
+        "loadServer": "() => Promise.resolve(locale_es_46json_cffd8a40)",
         "relative": "../srcDir/locales/es.json",
       },
       {
         "cache": true,
         "key": ""locale_es_45AR_46json_d3b7c72c"",
         "load": "() => import("#nuxt-i18n/d3b7c72c" /* webpackChunkName: "locale_es_45AR_46json_d3b7c72c" */)",
+        "loadServer": "() => Promise.resolve(locale_es_45AR_46json_d3b7c72c)",
         "relative": "../srcDir/locales/es-AR.json",
       },
     ],
@@ -86,6 +108,7 @@ exports[`files with cache configuration 1`] = `
         "cache": true,
         "key": ""locale_fr_46json_aa45ccf4"",
         "load": "() => import("#nuxt-i18n/aa45ccf4" /* webpackChunkName: "locale_fr_46json_aa45ccf4" */)",
+        "loadServer": "() => Promise.resolve(locale_fr_46json_aa45ccf4)",
         "relative": "../srcDir/locales/fr.json",
       },
     ],
@@ -94,6 +117,7 @@ exports[`files with cache configuration 1`] = `
         "cache": true,
         "key": ""locale_ja_46json_4c459061"",
         "load": "() => import("#nuxt-i18n/4c459061" /* webpackChunkName: "locale_ja_46json_4c459061" */)",
+        "loadServer": "() => Promise.resolve(locale_ja_46json_4c459061)",
         "relative": "../srcDir/locales/ja.json",
       },
     ],
@@ -118,6 +142,7 @@ exports[`files with cache configuration 1`] = `
   "vueI18nConfigs": [
     {
       "importer": "() => import("#nuxt-i18n/c3216fe6" /* webpackChunkName: "config_to_c3216fe6" */)",
+      "importerServer": "() => Promise.resolve(config_to_c3216fe6)",
       "relative": "../../path/to",
     },
   ],
@@ -126,12 +151,19 @@ exports[`files with cache configuration 1`] = `
 
 exports[`lazy 1`] = `
 {
+  "importStatements": [
+    "import locale_en_46json_f7535dc0 from "#nuxt-i18n/f7535dc0";",
+    "import locale_ja_46json_5843ecf1 from "#nuxt-i18n/5843ecf1";",
+    "import locale_fr_46json_3d83f3b3 from "#nuxt-i18n/3d83f3b3";",
+    "import config_to_c3216fe6 from "#nuxt-i18n/c3216fe6";",
+  ],
   "localeLoaders": {
     "en": [
       {
         "cache": true,
         "key": ""locale_en_46json_f7535dc0"",
         "load": "() => import("#nuxt-i18n/f7535dc0" /* webpackChunkName: "locale_en_46json_f7535dc0" */)",
+        "loadServer": "() => Promise.resolve(locale_en_46json_f7535dc0)",
         "relative": "../en.json",
       },
     ],
@@ -140,6 +172,7 @@ exports[`lazy 1`] = `
         "cache": true,
         "key": ""locale_fr_46json_3d83f3b3"",
         "load": "() => import("#nuxt-i18n/3d83f3b3" /* webpackChunkName: "locale_fr_46json_3d83f3b3" */)",
+        "loadServer": "() => Promise.resolve(locale_fr_46json_3d83f3b3)",
         "relative": "../fr.json",
       },
     ],
@@ -148,6 +181,7 @@ exports[`lazy 1`] = `
         "cache": true,
         "key": ""locale_ja_46json_5843ecf1"",
         "load": "() => import("#nuxt-i18n/5843ecf1" /* webpackChunkName: "locale_ja_46json_5843ecf1" */)",
+        "loadServer": "() => Promise.resolve(locale_ja_46json_5843ecf1)",
         "relative": "../ja.json",
       },
     ],
@@ -166,6 +200,7 @@ exports[`lazy 1`] = `
   "vueI18nConfigs": [
     {
       "importer": "() => import("#nuxt-i18n/c3216fe6" /* webpackChunkName: "config_to_c3216fe6" */)",
+      "importerServer": "() => Promise.resolve(config_to_c3216fe6)",
       "relative": "../../path/to",
     },
   ],
@@ -174,12 +209,19 @@ exports[`lazy 1`] = `
 
 exports[`locale file in nested 1`] = `
 {
+  "importStatements": [
+    "import locale_main_46json_291f935f from "#nuxt-i18n/291f935f";",
+    "import locale_main_46json_cfa671d1 from "#nuxt-i18n/cfa671d1";",
+    "import locale_main_46json_7ba1ed37 from "#nuxt-i18n/7ba1ed37";",
+    "import config_to_c3216fe6 from "#nuxt-i18n/c3216fe6";",
+  ],
   "localeLoaders": {
     "en": [
       {
         "cache": true,
         "key": ""locale_main_46json_291f935f"",
         "load": "() => import("#nuxt-i18n/291f935f" /* webpackChunkName: "locale_main_46json_291f935f" */)",
+        "loadServer": "() => Promise.resolve(locale_main_46json_291f935f)",
         "relative": "../en/main.json",
       },
     ],
@@ -188,6 +230,7 @@ exports[`locale file in nested 1`] = `
         "cache": true,
         "key": ""locale_main_46json_7ba1ed37"",
         "load": "() => import("#nuxt-i18n/7ba1ed37" /* webpackChunkName: "locale_main_46json_7ba1ed37" */)",
+        "loadServer": "() => Promise.resolve(locale_main_46json_7ba1ed37)",
         "relative": "../fr/main.json",
       },
     ],
@@ -196,6 +239,7 @@ exports[`locale file in nested 1`] = `
         "cache": true,
         "key": ""locale_main_46json_cfa671d1"",
         "load": "() => import("#nuxt-i18n/cfa671d1" /* webpackChunkName: "locale_main_46json_cfa671d1" */)",
+        "loadServer": "() => Promise.resolve(locale_main_46json_cfa671d1)",
         "relative": "../ja/main.json",
       },
     ],
@@ -214,6 +258,7 @@ exports[`locale file in nested 1`] = `
   "vueI18nConfigs": [
     {
       "importer": "() => import("#nuxt-i18n/c3216fe6" /* webpackChunkName: "config_to_c3216fe6" */)",
+      "importerServer": "() => Promise.resolve(config_to_c3216fe6)",
       "relative": "../../path/to",
     },
   ],
@@ -222,12 +267,21 @@ exports[`locale file in nested 1`] = `
 
 exports[`multiple files 1`] = `
 {
+  "importStatements": [
+    "import locale_en_46json_f7535dc0 from "#nuxt-i18n/f7535dc0";",
+    "import locale_ja_46json_5843ecf1 from "#nuxt-i18n/5843ecf1";",
+    "import locale_fr_46json_3d83f3b3 from "#nuxt-i18n/3d83f3b3";",
+    "import locale_es_46json_234aa7ad from "#nuxt-i18n/234aa7ad";",
+    "import locale_es_45AR_46json_dab30c5d from "#nuxt-i18n/dab30c5d";",
+    "import config_to_c3216fe6 from "#nuxt-i18n/c3216fe6";",
+  ],
   "localeLoaders": {
     "en": [
       {
         "cache": true,
         "key": ""locale_en_46json_f7535dc0"",
         "load": "() => import("#nuxt-i18n/f7535dc0" /* webpackChunkName: "locale_en_46json_f7535dc0" */)",
+        "loadServer": "() => Promise.resolve(locale_en_46json_f7535dc0)",
         "relative": "../en.json",
       },
     ],
@@ -236,6 +290,7 @@ exports[`multiple files 1`] = `
         "cache": true,
         "key": ""locale_es_46json_234aa7ad"",
         "load": "() => import("#nuxt-i18n/234aa7ad" /* webpackChunkName: "locale_es_46json_234aa7ad" */)",
+        "loadServer": "() => Promise.resolve(locale_es_46json_234aa7ad)",
         "relative": "../es.json",
       },
     ],
@@ -244,12 +299,14 @@ exports[`multiple files 1`] = `
         "cache": true,
         "key": ""locale_es_46json_234aa7ad"",
         "load": "() => import("#nuxt-i18n/234aa7ad" /* webpackChunkName: "locale_es_46json_234aa7ad" */)",
+        "loadServer": "() => Promise.resolve(locale_es_46json_234aa7ad)",
         "relative": "../es.json",
       },
       {
         "cache": true,
         "key": ""locale_es_45AR_46json_dab30c5d"",
         "load": "() => import("#nuxt-i18n/dab30c5d" /* webpackChunkName: "locale_es_45AR_46json_dab30c5d" */)",
+        "loadServer": "() => Promise.resolve(locale_es_45AR_46json_dab30c5d)",
         "relative": "../es-AR.json",
       },
     ],
@@ -258,6 +315,7 @@ exports[`multiple files 1`] = `
         "cache": true,
         "key": ""locale_fr_46json_3d83f3b3"",
         "load": "() => import("#nuxt-i18n/3d83f3b3" /* webpackChunkName: "locale_fr_46json_3d83f3b3" */)",
+        "loadServer": "() => Promise.resolve(locale_fr_46json_3d83f3b3)",
         "relative": "../fr.json",
       },
     ],
@@ -266,6 +324,7 @@ exports[`multiple files 1`] = `
         "cache": true,
         "key": ""locale_ja_46json_5843ecf1"",
         "load": "() => import("#nuxt-i18n/5843ecf1" /* webpackChunkName: "locale_ja_46json_5843ecf1" */)",
+        "loadServer": "() => Promise.resolve(locale_ja_46json_5843ecf1)",
         "relative": "../ja.json",
       },
     ],
@@ -290,6 +349,7 @@ exports[`multiple files 1`] = `
   "vueI18nConfigs": [
     {
       "importer": "() => import("#nuxt-i18n/c3216fe6" /* webpackChunkName: "config_to_c3216fe6" */)",
+      "importerServer": "() => Promise.resolve(config_to_c3216fe6)",
       "relative": "../../path/to",
     },
   ],
@@ -298,11 +358,15 @@ exports[`multiple files 1`] = `
 
 exports[`toCode: function (arrow) 1`] = `
 {
+  "importStatements": [
+    "import config_to_c3216fe6 from "#nuxt-i18n/c3216fe6";",
+  ],
   "localeLoaders": {},
   "normalizedLocales": [],
   "vueI18nConfigs": [
     {
       "importer": "() => import("#nuxt-i18n/c3216fe6" /* webpackChunkName: "config_to_c3216fe6" */)",
+      "importerServer": "() => Promise.resolve(config_to_c3216fe6)",
       "relative": "../../path/to",
     },
   ],
@@ -311,11 +375,15 @@ exports[`toCode: function (arrow) 1`] = `
 
 exports[`toCode: function (named) 1`] = `
 {
+  "importStatements": [
+    "import config_to_c3216fe6 from "#nuxt-i18n/c3216fe6";",
+  ],
   "localeLoaders": {},
   "normalizedLocales": [],
   "vueI18nConfigs": [
     {
       "importer": "() => import("#nuxt-i18n/c3216fe6" /* webpackChunkName: "config_to_c3216fe6" */)",
+      "importerServer": "() => Promise.resolve(config_to_c3216fe6)",
       "relative": "../../path/to",
     },
   ],
@@ -324,12 +392,19 @@ exports[`toCode: function (named) 1`] = `
 
 exports[`vueI18n option 1`] = `
 {
+  "importStatements": [
+    "import locale_en_46json_f7535dc0 from "#nuxt-i18n/f7535dc0";",
+    "import locale_ja_46json_5843ecf1 from "#nuxt-i18n/5843ecf1";",
+    "import locale_fr_46json_3d83f3b3 from "#nuxt-i18n/3d83f3b3";",
+    "import config_to_c3216fe6 from "#nuxt-i18n/c3216fe6";",
+  ],
   "localeLoaders": {
     "en": [
       {
         "cache": true,
         "key": ""locale_en_46json_f7535dc0"",
         "load": "() => import("#nuxt-i18n/f7535dc0" /* webpackChunkName: "locale_en_46json_f7535dc0" */)",
+        "loadServer": "() => Promise.resolve(locale_en_46json_f7535dc0)",
         "relative": "../en.json",
       },
     ],
@@ -338,6 +413,7 @@ exports[`vueI18n option 1`] = `
         "cache": true,
         "key": ""locale_fr_46json_3d83f3b3"",
         "load": "() => import("#nuxt-i18n/3d83f3b3" /* webpackChunkName: "locale_fr_46json_3d83f3b3" */)",
+        "loadServer": "() => Promise.resolve(locale_fr_46json_3d83f3b3)",
         "relative": "../fr.json",
       },
     ],
@@ -346,6 +422,7 @@ exports[`vueI18n option 1`] = `
         "cache": true,
         "key": ""locale_ja_46json_5843ecf1"",
         "load": "() => import("#nuxt-i18n/5843ecf1" /* webpackChunkName: "locale_ja_46json_5843ecf1" */)",
+        "loadServer": "() => Promise.resolve(locale_ja_46json_5843ecf1)",
         "relative": "../ja.json",
       },
     ],
@@ -364,14 +441,17 @@ exports[`vueI18n option 1`] = `
   "vueI18nConfigs": [
     {
       "importer": "() => import("#nuxt-i18n/c3216fe6" /* webpackChunkName: "config_to_c3216fe6" */)",
+      "importerServer": "() => Promise.resolve(config_to_c3216fe6)",
       "relative": "../../path/to",
     },
     {
       "importer": "() => import("#nuxt-i18n/c3216fe6" /* webpackChunkName: "config_to_c3216fe6" */)",
+      "importerServer": "() => Promise.resolve(config_to_c3216fe6)",
       "relative": "../../path/to",
     },
     {
       "importer": "() => import("#nuxt-i18n/c3216fe6" /* webpackChunkName: "config_to_c3216fe6" */)",
+      "importerServer": "() => Promise.resolve(config_to_c3216fe6)",
       "relative": "../../path/to",
     },
   ],


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
It's not entirely clear to me why the locale files for the server were built in both `.output/server/chunks/_` and `.output/server/chunks/build`, but this is resolved by using regular imports instead of dynamic imports. 
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Better server-side initialization for internationalization, allowing server-resolved locale and config loading and omitting client-only HMR when serving from the server.

* **Improvements**
  * More robust handling of locale/loading results to correctly support module and non-module loaders.
  * Exported template output now includes server-aware import entries and loader metadata to improve SSR consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->