### PR TITLE
fix(nitro): redirect without sending response in render hook

### DIFF
--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -13,7 +13,7 @@ import { localeDetector } from '#internal/i18n-locale-detector.mjs'
 import { resolveRootRedirect, useI18nDetection, useRuntimeI18n } from '../shared/utils'
 import { isFunction } from '@intlify/shared'
 
-import { type H3Event, getRequestURL, sendRedirect, setCookie } from 'h3'
+import { type H3Event, getRequestURL, sanitizeStatusCode, setCookie } from 'h3'
 import type { CoreOptions } from '@intlify/core'
 import { useDetectors } from '../shared/detection'
 import { domainFromLocale } from '../shared/domain'
@@ -38,6 +38,17 @@ function* detect(
   }
 
   yield { locale: detection.fallbackLocale, source: 'fallback' }
+}
+
+function createRedirectResponse(event: H3Event, dest: string, code: number) {
+  event.node.res.setHeader('location', dest)
+  event.node.res.statusCode = sanitizeStatusCode(code, event.node.res.statusCode)
+
+  return {
+    headers: event.node.res.getHeaders() as Record<string, string>,
+    statusCode: event.node.res.statusCode,
+    body: `<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=${dest.replace(/"/g, '%22')}"></head></html>`,
+  }
 }
 
 export default defineNitroPlugin(async (nitro) => {
@@ -147,8 +158,9 @@ export default defineNitroPlugin(async (nitro) => {
     await initializeI18nContext(event)
   })
 
-  nitro.hooks.hook('render:before', async ({ event }) => {
+  nitro.hooks.hook('render:before', async (context) => {
     if (!__I18N_SERVER_REDIRECT__) { return }
+    const { event } = context
 
     const ctx = import.meta.prerender && !event.context.nuxtI18n ? await initializeI18nContext(event) : useI18nContext(event)
     const url = getRequestURL(event)
@@ -166,7 +178,7 @@ export default defineNitroPlugin(async (nitro) => {
     if (resolved.path && resolved.path !== url.pathname) {
       ctx.detectLocale = resolved.locale
       detection.useCookie && setCookie(event, detection.cookieKey, resolved.locale, cookieOptions)
-      await sendRedirect(
+      context.response = createRedirectResponse(
         event,
         joinURL(baseUrlGetter(event, ctx.vueI18nOptions!.defaultLocale), resolved.path + url.search),
         resolved.code,

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -40,6 +40,8 @@ function* detect(
   yield { locale: detection.fallbackLocale, source: 'fallback' }
 }
 
+// Adapted from H3 v1
+// https://github.com/h3js/h3/blob/24231b9c448aa852b15b889c53253a783f67a126/src/utils/response.ts#L166-L179
 function createRedirectResponse(event: H3Event, dest: string, code: number) {
   event.node.res.setHeader('location', dest)
   event.node.res.statusCode = sanitizeStatusCode(code, event.node.res.statusCode)


### PR DESCRIPTION
### 🔗 Linked issue
* Resolves #3906
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This replaces the `sendRedirect` with an implementation that does the same without triggering a send, this will allow the render handler to continue without it trying to set headers while a response has already been sent out. 
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved redirect handling for more consistent and reliable redirects, including a fallback HTML refresh response.
  * Updated internal rendering hooks to use a generic request context for more flexible and robust request processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->