### PR TITLE
fix: type pollution through `shared-imports.d`

### DIFF
--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -43,8 +43,8 @@ export type ComposableContext = {
     /** Enable/disable hreflangLinks */
     hreflangLinks: boolean
   }
-  head: ReturnType<typeof useHead>
-  _head: ReturnType<typeof useHead> | undefined
+  head: ReturnType<typeof import('nuxt/app').useHead>
+  _head: ReturnType<typeof import('nuxt/app').useHead> | undefined
   metaState: Required<I18nHeadMetaInfo>
   seoSettings: I18nHeadOptions
   localePathPayload: Record<string, Record<string, string> | false>


### PR DESCRIPTION
### 🔗 Linked issue
* Resolves #3917
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
The types added to tsconfig need to be reworked in this module, and it would be good to rework the composable exports to prevent accidentally importing things that are not available in certain contexts (shared/nuxt/nitro).

Typecheck fails in Nuxt 4.3.0 due to the following (used as type only) `import { useHead } from '#imports';`, this was not an issue in previous releases. This might be something more modules will run into /cc @danielroe - related to https://github.com/nuxt/nuxt/issues/34142.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved type consistency for head-related properties across different Nuxt app versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->