### PR TITLE
fix: do not import from `nuxt/schema`

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -4,7 +4,7 @@ import { dirname } from 'pathe'
 import { hash } from 'ohash'
 import type { Resolver } from '@nuxt/kit'
 import type { FileMeta, LocaleInfo, LocaleObject, NuxtI18nOptions } from './types'
-import type { Nuxt, NuxtConfigLayer } from 'nuxt/schema'
+import type { Nuxt, NuxtConfigLayer } from '@nuxt/schema'
 import { getLayerI18n } from './utils'
 import { resolveI18nDir } from './layers'
 

--- a/test/kit.test.ts
+++ b/test/kit.test.ts
@@ -19,7 +19,7 @@ import { buildNuxt, loadNuxt } from '@nuxt/kit'
 import { resolve } from 'pathe'
 import { localizeRoutes } from '../src/routing'
 import { getNormalizedLocales } from './pages/utils'
-import type { NuxtPage } from 'nuxt/schema'
+import type { NuxtPage } from '@nuxt/schema'
 import type { Strategies } from '#internal-i18n-types'
 import { LocalizableRoute } from '../src/kit/gen'
 

--- a/test/pages/custom_route.test.ts
+++ b/test/pages/custom_route.test.ts
@@ -7,7 +7,7 @@ import { vi, afterAll, describe, test, expect } from 'vitest'
 
 import { deepCopy } from '@intlify/shared'
 import { loadNuxt, buildNuxt } from '@nuxt/kit'
-import { NuxtPage } from 'nuxt/schema'
+import { NuxtPage } from '@nuxt/schema'
 
 /**
  * NOTE:


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

related to https://github.com/nuxt/nuxt/commit/a6a044d8103705c2bd288b51e7b573a9763b65d4, https://github.com/nuxt/nuxt/pull/34255

this updates imports within the module so they are typed as expected (ie augmented)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal module references to improve build system compatibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->