### PR TITLE
fix(types): allow mixing strings and objects in locales

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -526,7 +526,7 @@ export interface LocaleObject<T = Locale> {
    *
    * Will be resolved relative to the langDir path when loading locale messages from file.
    */
-  files?: string[] | LocaleFile[]
+  files?: (string | LocaleFile)[]
 }
 
 /**


### PR DESCRIPTION
### 🔗 Linked issue

#3932 

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * File property now accepts mixed array types, enabling greater flexibility in how file references are specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->