### PR TITLE
refactor: i18n layer handling and config resolution

### DIFF
--- a/specs/utils/nuxt.ts
+++ b/specs/utils/nuxt.ts
@@ -1,6 +1,6 @@
 import { existsSync, promises as fsp } from 'node:fs'
 import { defu } from 'defu'
-import * as _kit from '@nuxt/kit'
+import { useNuxt, loadNuxt, logger, buildNuxt } from '@nuxt/kit'
 import { useTestContext } from './context'
 import { resolve } from 'node:path'
 import { relative } from 'pathe'
@@ -17,10 +17,6 @@ function getTestKey(ctx: VitestContext) {
 
   return testKey
 }
-
-// @ts-expect-error type cast
-// eslint-disable-next-line
-const kit: typeof _kit = _kit.default || _kit
 
 const isNuxtApp = (dir: string) => {
   return (
@@ -71,7 +67,7 @@ export async function loadFixture(testContext: VitestContext) {
            * Arrays are merged instead of overridden so we manually override the project layer with the test override config.
            */
           'modules:before'() {
-            const nuxt = _kit.useNuxt() as any // type is incomplete in this context
+            const nuxt = useNuxt() as any // type is incomplete in this context
             
             /**
              * Register nitro plugin for IPC communication to update runtime config
@@ -102,7 +98,7 @@ export async function loadFixture(testContext: VitestContext) {
     )
   }
 
-  ctx.nuxt = await kit.loadNuxt({
+  ctx.nuxt = await loadNuxt({
     cwd: ctx.options.rootDir,
     dev: ctx.options.dev,
     overrides: ctx.options.nuxtConfig,
@@ -126,8 +122,8 @@ async function clearDir(path: string) {
 export async function buildFixture() {
   const ctx = useTestContext()
   // Hide build info for test
-  const prevLevel = kit.logger.level
-  kit.logger.level = ctx.options.logLevel
-  await kit.buildNuxt(ctx.nuxt!)
-  kit.logger.level = prevLevel
+  const prevLevel = logger.level
+  logger.level = ctx.options.logLevel
+  await buildNuxt(ctx.nuxt!)
+  logger.level = prevLevel
 }

--- a/specs/utils/nuxt.ts
+++ b/specs/utils/nuxt.ts
@@ -124,6 +124,9 @@ export async function buildFixture() {
   // Hide build info for test
   const prevLevel = logger.level
   logger.level = ctx.options.logLevel
-  await buildNuxt(ctx.nuxt!)
-  logger.level = prevLevel
+  try {
+    await buildNuxt(ctx.nuxt!)
+  } finally {
+    logger.level = prevLevel
+  }
 }

--- a/specs/utils/nuxt.ts
+++ b/specs/utils/nuxt.ts
@@ -66,13 +66,19 @@ export async function loadFixture(testContext: VitestContext) {
       ctx.options.nuxtConfig,
       {
         buildDir,
-        modules: [
-          (_, nuxt) => {
+        hooks: {
+          /**
+           * Arrays are merged instead of overridden so we manually override the project layer with the test override config.
+           */
+          'modules:before'() {
+            const nuxt = _kit.useNuxt() as any // type is incomplete in this context
+            
             /**
              * Register nitro plugin for IPC communication to update runtime config
              */
             nuxt.options.nitro.plugins ||= []
             nuxt.options.nitro.plugins.push(fileURLToPath(new URL('./nitro-plugin', import.meta.url)))
+
             /**
              * The `overrides` option is only used for testing, it is used to option overrides to the project layer in a fixture.
              */
@@ -84,7 +90,7 @@ export async function loadFixture(testContext: VitestContext) {
               Object.assign(nuxt.options.i18n, defu(overrides, mergedOptions))
             }
           }
-        ],
+        },
         _generate: ctx.options.prerender,
         nitro: {
           output: {

--- a/src/context.ts
+++ b/src/context.ts
@@ -14,7 +14,7 @@ export interface I18nNuxtContext {
   normalizedLocales: LocaleObject<string>[]
   localeCodes: string[]
   localeInfo: LocaleInfo[]
-  vueI18nConfigPaths: FileMeta[]
+  vueI18nConfigPaths: Omit<FileMeta, 'cache'>[]
   distDir: string
   runtimeDir: string
   fullStatic: boolean

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,12 +1,11 @@
 import { createResolver } from '@nuxt/kit'
 import { fileURLToPath } from 'node:url'
-import { dirname } from 'pathe'
+import { dirname, resolve } from 'pathe'
 import { hash } from 'ohash'
 import type { Resolver } from '@nuxt/kit'
 import type { FileMeta, LocaleInfo, LocaleObject, NuxtI18nOptions } from './types'
 import type { Nuxt, NuxtConfigLayer } from '@nuxt/schema'
 import { getLayerI18n } from './utils'
-import { resolveI18nDir } from './layers'
 
 export interface I18nNuxtContext {
   resolver: Resolver
@@ -35,7 +34,7 @@ export function createContext(userOptions: NuxtI18nOptions, nuxt: Nuxt): I18nNux
   for (const l of nuxt.options._layers) {
     const i18n = getLayerI18n(l)
     if (!i18n) { continue }
-    const i18nDir = resolveI18nDir(l, i18n)
+    const i18nDir = resolve(l.config.rootDir, i18n.restructureDir ?? 'i18n')
     const i18nDetector = i18n.experimental?.localeDetector ? resolver.resolve(i18nDir, i18n.experimental.localeDetector) : undefined
     i18nLayers.push({ config: l, i18n, i18nDir, i18nDetector })
   }

--- a/src/layers.ts
+++ b/src/layers.ts
@@ -7,7 +7,7 @@ import { EXECUTABLE_EXTENSIONS } from './constants'
 
 import type { LocaleConfig } from './utils'
 import type { Nuxt } from '@nuxt/schema'
-import type { LocaleObject, LocaleType, NuxtI18nOptions } from './types'
+import type { FileMeta, LocaleObject, NuxtI18nOptions } from './types'
 import type { I18nNuxtContext } from './context'
 
 export function checkLayerOptions(_options: NuxtI18nOptions, nuxt: Nuxt) {
@@ -77,7 +77,7 @@ export async function applyLayerOptions(ctx: I18nNuxtContext, nuxt: Nuxt) {
 }
 
 export async function resolveLayerVueI18nConfigInfo({ options, i18nLayers }: I18nNuxtContext, nuxt = useNuxt()) {
-  const res: ({ path: string, hash: string, type: LocaleType })[] = []
+  const res: Omit<FileMeta, 'cache'>[] = []
 
   // collect `installModule` config
   if (options.vueI18n && isAbsolute(options.vueI18n)) {

--- a/src/layers.ts
+++ b/src/layers.ts
@@ -76,19 +76,19 @@ export async function applyLayerOptions(ctx: I18nNuxtContext, nuxt: Nuxt) {
   return mergeConfigLocales(configs)
 }
 
-export async function resolveLayerVueI18nConfigInfo({ options, i18nLayers }: I18nNuxtContext, nuxt = useNuxt()) {
+export async function resolveLayerVueI18nConfigInfo(ctx: I18nNuxtContext, nuxt = useNuxt()) {
   const res: Omit<FileMeta, 'cache'>[] = []
 
   // collect `installModule` config
-  if (options.vueI18n && isAbsolute(options.vueI18n)) {
-    const resolved = await findPath(options.vueI18n, { extensions: EXECUTABLE_EXTENSIONS })
+  if (ctx.options.vueI18n && isAbsolute(ctx.options.vueI18n)) {
+    const resolved = await findPath(ctx.options.vueI18n, { extensions: EXECUTABLE_EXTENSIONS })
 
     if (resolved) {
       res.push(resolveVueI18nConfigInfo(resolved, nuxt.vfs))
     }
   }
 
-  for (const layer of i18nLayers) {
+  for (const layer of ctx.i18nLayers) {
     const resolved = await findPath(layer.i18n.vueI18n || 'i18n.config', { cwd: layer.i18nDir, extensions: EXECUTABLE_EXTENSIONS })
 
     if (!resolved) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -173,7 +173,7 @@ export default defineNuxtModule<NuxtI18nOptions>({
       ctx.localeCodes = ctx.normalizedLocales.map(locale => locale.code)
       ctx.localeInfo = resolveLocales(nuxt.options.srcDir, ctx.normalizedLocales, nuxt.vfs)
 
-      ctx.vueI18nConfigPaths = await resolveLayerVueI18nConfigInfo(ctx.options)
+      ctx.vueI18nConfigPaths = await resolveLayerVueI18nConfigInfo(ctx)
 
       /**
        * expose i18n options via runtime config for use in app/server contexts

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 import { defu } from 'defu'
-import { existsSync, readFileSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { type BinaryLike, createHash } from 'node:crypto'
-import { resolvePath, useLogger } from '@nuxt/kit'
+import { findPath, useLogger } from '@nuxt/kit'
 import { resolve } from 'pathe'
 import { assign, isArray, isString } from '@intlify/shared'
 import { EXECUTABLE_EXTENSIONS, EXECUTABLE_EXT_RE } from './constants'
@@ -111,11 +111,11 @@ function scanProgram(program: Program) {
 }
 
 export async function resolveVueI18nConfigInfo(rootDir: string, configPath: string = 'i18n.config', vfs: Record<string, string>) {
-  const absolutePath = await resolvePath(configPath, { cwd: rootDir, extensions: EXECUTABLE_EXTENSIONS })
-  if (!existsSync(absolutePath)) { return undefined }
+  const absolutePath = await findPath(configPath, { cwd: rootDir, extensions: EXECUTABLE_EXTENSIONS })
+  if (!absolutePath) { return undefined }
 
   return {
-    path: absolutePath, // absolute
+    path: absolutePath,
     hash: getHash(absolutePath),
     type: getLocaleType(absolutePath, vfs),
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,10 @@
 import { defu } from 'defu'
 import { readFileSync } from 'node:fs'
 import { type BinaryLike, createHash } from 'node:crypto'
-import { findPath, useLogger } from '@nuxt/kit'
+import { useLogger } from '@nuxt/kit'
 import { resolve } from 'pathe'
 import { assign, isArray, isString } from '@intlify/shared'
-import { EXECUTABLE_EXTENSIONS, EXECUTABLE_EXT_RE } from './constants'
+import { EXECUTABLE_EXT_RE } from './constants'
 import { parseSync } from 'oxc-parser'
 
 import type { LocaleFile, LocaleInfo, LocaleObject, LocaleType, NuxtI18nOptions } from './types'
@@ -110,14 +110,11 @@ function scanProgram(program: Program) {
   return false
 }
 
-export async function resolveVueI18nConfigInfo(rootDir: string, configPath: string = 'i18n.config', vfs: Record<string, string>) {
-  const absolutePath = await findPath(configPath, { cwd: rootDir, extensions: EXECUTABLE_EXTENSIONS })
-  if (!absolutePath) { return undefined }
-
+export function resolveVueI18nConfigInfo(path: string, vfs: Record<string, string>) {
   return {
-    path: absolutePath,
-    hash: getHash(absolutePath),
-    type: getLocaleType(absolutePath, vfs),
+    path,
+    hash: getHash(path),
+    type: getLocaleType(path, vfs),
   }
 }
 

--- a/test/gen.test.ts
+++ b/test/gen.test.ts
@@ -81,8 +81,8 @@ const makeNuxtOptions = (localeInfo: LocaleInfo[]) => {
 
 test('basic', async () => {
   const locales = getMockLocales()
-  const localeInfo = await resolveLocales('/test', locales)
-  const vueI18nConfig = await resolveVueI18nConfigInfo('/test', parse(NUXT_I18N_VUE_I18N_CONFIG.path).dir)
+  const localeInfo = await resolveLocales('/test', locales, {})
+  const vueI18nConfig = resolveVueI18nConfigInfo(parse(NUXT_I18N_VUE_I18N_CONFIG.path).dir, {})
   const code = generateLoaderOptions(
     {
       vueI18nConfigPaths: [vueI18nConfig].filter((x): x is Required<FileMeta> => x != null),
@@ -98,8 +98,8 @@ test('basic', async () => {
 
 test('lazy', async () => {
   const locales = getMockLocales()
-  const localeInfo = await resolveLocales('/test', locales)
-  const vueI18nConfig = await resolveVueI18nConfigInfo('/test', parse(NUXT_I18N_VUE_I18N_CONFIG.path).dir)
+  const localeInfo = await resolveLocales('/test', locales, {})
+  const vueI18nConfig = resolveVueI18nConfigInfo(parse(NUXT_I18N_VUE_I18N_CONFIG.path).dir, {})
   const code = generateLoaderOptions(
     {
       vueI18nConfigPaths: [vueI18nConfig].filter((x): x is Required<FileMeta> => x != null),
@@ -130,8 +130,8 @@ test('multiple files', async () => {
     ])
   ]
 
-  const localeInfo = await resolveLocales('/test', locales)
-  const vueI18nConfig = await resolveVueI18nConfigInfo('/test', parse(NUXT_I18N_VUE_I18N_CONFIG.path).dir)
+  const localeInfo = await resolveLocales('/test', locales, {})
+  const vueI18nConfig = await resolveVueI18nConfigInfo(parse(NUXT_I18N_VUE_I18N_CONFIG.path).dir, {})
 
   const code = generateLoaderOptions(
     {
@@ -166,8 +166,8 @@ test('files with cache configuration', async () => {
     l.files = resolveRelativeLocales(l, { langDir: '/test/srcDir/locales' })
   }
 
-  const localeInfo = await resolveLocales('/test', locales)
-  const vueI18nConfig = await resolveVueI18nConfigInfo('/test', parse(NUXT_I18N_VUE_I18N_CONFIG.path).dir)
+  const localeInfo = await resolveLocales('/test', locales, {})
+  const vueI18nConfig = resolveVueI18nConfigInfo(parse(NUXT_I18N_VUE_I18N_CONFIG.path).dir, {})
 
   const code = generateLoaderOptions(
     {
@@ -197,9 +197,9 @@ test('locale file in nested', async () => {
       files: [{ path: 'fr/main.json', cache: true }]
     }
   ]
-  const localeInfo = await resolveLocales('/test', locales)
+  const localeInfo = await resolveLocales('/test', locales, {})
 
-  const vueI18nConfig = await resolveVueI18nConfigInfo('/test', parse(NUXT_I18N_VUE_I18N_CONFIG.path).dir)
+  const vueI18nConfig = await resolveVueI18nConfigInfo(parse(NUXT_I18N_VUE_I18N_CONFIG.path).dir, {})
   const code = generateLoaderOptions(
     {
       vueI18nConfigPaths: [vueI18nConfig].filter((x): x is Required<FileMeta> => x != null),
@@ -215,8 +215,8 @@ test('locale file in nested', async () => {
 
 test('vueI18n option', async () => {
   const locales = getMockLocales()
-  const localeInfo = await resolveLocales('/test', locales)
-  const vueI18nConfigs = await Promise.all(
+  const localeInfo = await resolveLocales('/test', locales, {})
+  const vueI18nConfigs = 
     [
       NUXT_I18N_VUE_I18N_CONFIG,
       {
@@ -231,7 +231,7 @@ test('vueI18n option', async () => {
           loadPath: 'vue-i18n.options.js'
         }
       }
-    ].map(x => resolveVueI18nConfigInfo('/test', parse(NUXT_I18N_VUE_I18N_CONFIG.path).dir))
+    ].map(x => resolveVueI18nConfigInfo(parse(NUXT_I18N_VUE_I18N_CONFIG.path).dir, {})
   )
   const code = generateLoaderOptions(
     {
@@ -249,7 +249,7 @@ test('vueI18n option', async () => {
 })
 
 test('toCode: function (arrow)', async () => {
-  const vueI18nConfig = await resolveVueI18nConfigInfo('/test', parse(NUXT_I18N_VUE_I18N_CONFIG.path).dir)
+  const vueI18nConfig = resolveVueI18nConfigInfo(parse(NUXT_I18N_VUE_I18N_CONFIG.path).dir, {})
   const localeInfo = getMockLocales().map(locale => ({
     ...locale,
     testFunc: (prop: string) => {
@@ -273,7 +273,7 @@ test('toCode: function (arrow)', async () => {
 })
 
 test('toCode: function (named)', async () => {
-  const vueI18nConfig = await resolveVueI18nConfigInfo('/test', parse(NUXT_I18N_VUE_I18N_CONFIG.path).dir)
+  const vueI18nConfig = resolveVueI18nConfigInfo(parse(NUXT_I18N_VUE_I18N_CONFIG.path).dir, {})
   const localeInfo = getMockLocales().map(locale => ({
     ...locale,
     testFunc(prop: string) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Per-layer i18n resolution now uses each layer’s root and optional restructure directory (default "i18n"), simplifying locale/config discovery.
  * Context now exposes config paths without internal cache metadata.
  * Module initialization moved to a hook-based lifecycle for clearer configuration merging and resolution.

* **Bug Fixes**
  * Missing per-layer i18n configs are skipped with a dev-time warning instead of failing.

* **Tests**
  * Test signatures updated to match the simplified config resolution and broadened call patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->