### PR TITLE
fix: add warning for missing domains when multiDomainLocales is enabled

### DIFF
--- a/src/prepare/options.ts
+++ b/src/prepare/options.ts
@@ -34,9 +34,9 @@ export function prepareOptions({ options }: I18nNuxtContext, nuxt: Nuxt) {
   }
 
   if (hasMultiDomainLocales) {
-    const hasDomainLocales = nuxt.options.i18n.locales?.some(
-      locale => !isString(locale) && locale.domains?.length,
-    )
+    const locales = (nuxt.options.i18n && nuxt.options.i18n.locales) || options.locales
+    const hasDomainLocales = locales.some(locale => !isString(locale) && locale.domains?.length)
+
     if (!hasDomainLocales) {
       logger.warn(
         `The \`domains\` needs to be set when \`multiDomainLocales\` is enabled.`,

--- a/src/prepare/options.ts
+++ b/src/prepare/options.ts
@@ -39,7 +39,7 @@ export function prepareOptions({ options }: I18nNuxtContext, nuxt: Nuxt) {
 
     if (!hasDomainLocales) {
       logger.warn(
-        `The \`domains\` needs to be set when \`multiDomainLocales\` is enabled.`,
+        `Locale \`domains\` must be configured when \`multiDomainLocales\` is enabled.`,
       )
     }
   }

--- a/src/prepare/options.ts
+++ b/src/prepare/options.ts
@@ -34,7 +34,7 @@ export function prepareOptions({ options }: I18nNuxtContext, nuxt: Nuxt) {
   }
 
   if (hasMultiDomainLocales) {
-    const locales = (nuxt.options.i18n && nuxt.options.i18n.locales) || options.locales
+    const locales = (nuxt.options.i18n && nuxt.options.i18n.locales) || options.locales || []
     const hasDomainLocales = locales.some(locale => !isString(locale) && locale.domains?.length)
 
     if (!hasDomainLocales) {

--- a/src/prepare/options.ts
+++ b/src/prepare/options.ts
@@ -2,6 +2,7 @@ import type { I18nNuxtContext } from '../context'
 import type { Nuxt } from '@nuxt/schema'
 import { logger } from '../utils'
 import { checkLayerOptions } from '../layers'
+import { isString } from '@intlify/shared'
 
 export function prepareOptions({ options }: I18nNuxtContext, nuxt: Nuxt) {
   checkLayerOptions(options, nuxt)
@@ -24,10 +25,23 @@ export function prepareOptions({ options }: I18nNuxtContext, nuxt: Nuxt) {
 
   const strategy = (nuxt.options.i18n && nuxt.options.i18n.strategy) || options.strategy
   const defaultLocale = (nuxt.options.i18n && nuxt.options.i18n.defaultLocale) || options.defaultLocale
-  if (strategy.endsWith('_default') && !defaultLocale) {
+  const hasMultiDomainLocales = (nuxt.options.i18n && nuxt.options.i18n.multiDomainLocales) || options.multiDomainLocales
+
+  if (strategy.endsWith('_default') && !defaultLocale && !hasMultiDomainLocales) {
     logger.warn(
       `The \`${strategy}\` i18n strategy${(nuxt.options.i18n && nuxt.options.i18n.strategy) == null ? ' (used by default)' : ''} needs \`defaultLocale\` to be set.`,
     )
+  }
+
+  if (hasMultiDomainLocales) {
+    const hasDomainLocales = nuxt.options.i18n.locales?.some(
+      locale => !isString(locale) && locale.domains?.length,
+    )
+    if (!hasDomainLocales) {
+      logger.warn(
+        `The \`domains\` needs to be set when \`multiDomainLocales\` is enabled.`,
+      )
+    }
   }
 
   if (nuxt.options.experimental.scanPageMeta === false) {


### PR DESCRIPTION
### 📚 Description
If you have multiDomainLocales enabled now, you’ll get a warning about the defaultLocale, but it’s not required when using multiDomainLocales.

### 🗒️ Note
Developed by: Social Deal (@socialdeal)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation that warns when multi-domain locale mode is enabled but no locale has domains configured, helping catch configuration issues early.
  * Improved warning behavior for default-strategy detection: clearer guidance when a default strategy is present but no default locale is set and multi-domain mode is not active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->