### PR TITLE
feat: experimental regex routes

### DIFF
--- a/docs/content/docs/02.guide/91.new-features.md
+++ b/docs/content/docs/02.guide/91.new-features.md
@@ -42,3 +42,56 @@ With strict SEO mode enabled, the i18n head tags are managed internally, this al
 * The `useSetI18nParams()`{lang="ts"} inherits the global canonical query parameter config which can be overridden through its options parameter.
 
 If this mode proves stable it will become the default in v11, please try it out and report any issues you encounter.
+
+### Compact routes
+
+We have added a new experimental option `compactRoutes`{lang="yml"} that changes how locale-prefixed routes are generated. Instead of creating a separate route for every locale, eligible routes are compacted into a single route using a regex parameter for the locale segment.
+
+For example, with three locales (`en`, `fr`, `ja`) and the `prefix` strategy, the `/about` page would normally produce three routes:
+```
+/en/about
+/fr/about
+/ja/about
+```
+
+With `compactRoutes` enabled, these are compacted into a single route:
+```
+/:locale(en|fr|ja)/about
+```
+
+This can be enabled in `nuxt.config.ts`:
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  i18n: {
+    experimental: {
+      compactRoutes: true
+    }
+  }
+})
+```
+
+**Why this is an improvement:**
+* **Fewer routes** — Applications with many pages and locales can generate a large number of routes (pages × locales). Compact routes significantly reduces this, resulting in a smaller route table and faster route matching.
+* **Smaller bundle size** — The router configuration shipped to the client is more compact, which reduces the JavaScript payload.
+* **Better scalability** — The number of routes stays proportional to the number of pages rather than growing multiplicatively with the number of locales.
+
+**How it works with different strategies:**
+* `prefix` — All locales are compacted into a single route.
+* `prefix_except_default` — The default locale keeps its unprefixed route, while all other locales are compacted into a single route.
+* `prefix_and_default` — The default locale keeps its unprefixed route, and all locales (including the default) are compacted into a single route.
+
+**When routes cannot be compacted:**
+
+Not all routes are eligible for compaction. A route will still be generated per locale when:
+* It has custom per-locale paths defined (e.g., `/about` in English but `/a-propos` in French).
+* It is not available for all configured locales (e.g., a route is disabled for certain locales).
+
+In these cases, the module automatically falls back to the standard per-locale route generation for that specific route, while still compacting all eligible routes.
+
+::callout{icon="i-heroicons-light-bulb"}
+This option is opt-in for now but is expected to become the default in v11. Please try it out and report any issues you encounter.
+::
+
+::callout{icon="i-heroicons-exclamation-triangle" color="warning"}
+This option is not compatible with `no_prefix` strategy, `differentDomains`, or `multiDomainLocales`.
+::

--- a/docs/content/docs/02.guide/91.new-features.md
+++ b/docs/content/docs/02.guide/91.new-features.md
@@ -48,14 +48,14 @@ If this mode proves stable it will become the default in v11, please try it out 
 We have added a new experimental option `compactRoutes`{lang="yml"} that changes how locale-prefixed routes are generated. Instead of creating a separate route for every locale, eligible routes are compacted into a single route using a regex parameter for the locale segment.
 
 For example, with three locales (`en`, `fr`, `ja`) and the `prefix` strategy, the `/about` page would normally produce three routes:
-```
+```text
 /en/about
 /fr/about
 /ja/about
 ```
 
 With `compactRoutes` enabled, these are compacted into a single route:
-```
+```text
 /:locale(en|fr|ja)/about
 ```
 

--- a/docs/content/docs/04.api/00.options.md
+++ b/docs/content/docs/04.api/00.options.md
@@ -491,6 +491,16 @@ This feature relies on [Nuxt's `experimental.typedPages`](https://nuxt.com/docs/
 - default: `10`{lang="ts"}
 - HTTP cache duration for the messages API endpoint in seconds. This controls how long browsers cache the translation data. Set to a higher value (e.g., `86400` for 24 hours) to reduce redundant network requests for unchanged translations.
 
+### `compactRoutes`
+
+- type: `boolean`{lang="ts-type"}
+- default: `false`{lang="ts"}
+- Consolidates locale-prefixed routes into a single regex route instead of generating separate routes for each locale.
+
+::callout{icon="i-heroicons-light-bulb"}
+This option is opt-in for now but is expected to become the default in v11. See [Compact routes](/docs/guide/new-features#compact-routes) for more details.
+::
+
 ## `hmr`
 
 - type: `boolean`{lang="ts-type"}

--- a/docs/content/docs/04.api/00.options.md
+++ b/docs/content/docs/04.api/00.options.md
@@ -495,7 +495,7 @@ This feature relies on [Nuxt's `experimental.typedPages`](https://nuxt.com/docs/
 
 - type: `boolean`{lang="ts-type"}
 - default: `false`{lang="ts"}
-- Consolidates locale-prefixed routes into a single regex route instead of generating separate routes for each locale.
+- Consolidates locale-prefixed routes into a single regex route instead of generating separate routes for each locale. This option is not compatible with `no_prefix` strategy, `differentDomains`, or `multiDomainLocales`.
 
 ::callout{icon="i-heroicons-light-bulb"}
 This option is opt-in for now but is expected to become the default in v11. See [Compact routes](/docs/guide/new-features#compact-routes) for more details.

--- a/specs/routing/routing-tests.ts
+++ b/specs/routing/routing-tests.ts
@@ -142,10 +142,10 @@ export async function switchLocalePathTests() {
 export async function localeRouteTests() {
   const { page } = await renderPage('/en')
 
-  // Detect consolidation: consolidated routes use the base name (no ___locale suffix)
+  // Detect compact routes: compact routes use the base name (no ___locale suffix)
   const indexRoute = JSON.parse(await page.locator('#locale-route .index').innerText())
-  const consolidated = !indexRoute.name.includes('___')
-  const routeName = (base: string, locale: string) => (consolidated ? base : `${base}___${locale}`)
+  const compacted = !indexRoute.name.includes('___')
+  const routeName = (base: string, locale: string) => (compacted ? base : `${base}___${locale}`)
 
   expect(indexRoute).include({
     fullPath: '/en',

--- a/specs/routing/routing-tests.ts
+++ b/specs/routing/routing-tests.ts
@@ -142,45 +142,50 @@ export async function switchLocalePathTests() {
 export async function localeRouteTests() {
   const { page } = await renderPage('/en')
 
-  expect(JSON.parse(await page.locator('#locale-route .index').innerText())).include({
+  // Detect consolidation: consolidated routes use the base name (no ___locale suffix)
+  const indexRoute = JSON.parse(await page.locator('#locale-route .index').innerText())
+  const consolidated = !indexRoute.name.includes('___')
+  const routeName = (base: string, locale: string) => (consolidated ? base : `${base}___${locale}`)
+
+  expect(indexRoute).include({
     fullPath: '/en',
     path: '/en',
-    name: 'index___en',
+    name: routeName('index', 'en'),
     href: '/en'
   })
 
   expect(JSON.parse(await page.locator('#locale-route .index-name-ja').innerText())).include({
     fullPath: '/ja',
     path: '/ja',
-    name: 'index___ja',
+    name: routeName('index', 'ja'),
     href: '/ja'
   })
 
   expect(JSON.parse(await page.locator('#locale-route .about-name').innerText())).include({
     fullPath: '/en/about',
     path: '/en/about',
-    name: 'about___en',
+    name: routeName('about', 'en'),
     href: '/en/about'
   })
 
   expect(JSON.parse(await page.locator('#locale-route .about-ja').innerText())).include({
     fullPath: '/ja/about',
     path: '/ja/about',
-    name: 'about___ja',
+    name: routeName('about', 'ja'),
     href: '/ja/about'
   })
 
   expect(JSON.parse(await page.locator('#locale-route .about-name-ja').innerText())).include({
     fullPath: '/ja/about',
     path: '/ja/about',
-    name: 'about___ja',
+    name: routeName('about', 'ja'),
     href: '/ja/about'
   })
 
   expect(JSON.parse(await page.locator('#locale-route .path-match-ja').innerText())).include({
     fullPath: '/ja/:pathMatch(.*)*',
     path: '/ja/:pathMatch(.*)*',
-    name: 'pathMatch___ja',
+    name: routeName('pathMatch', 'ja'),
     href: '/ja/:pathMatch(.*)*'
   })
 
@@ -188,14 +193,14 @@ export async function localeRouteTests() {
   expect(JSON.parse(await page.locator('#locale-route .path-match-name').innerText())).include({
     fullPath: '/en',
     path: '/en',
-    name: 'pathMatch___en',
+    name: routeName('pathMatch', 'en'),
     href: '/en'
   })
 
   expect(JSON.parse(await page.locator('#locale-route .path-match-name-ja').innerText())).include({
     fullPath: '/ja',
     path: '/ja',
-    name: 'pathMatch___ja',
+    name: routeName('pathMatch', 'ja'),
     href: '/ja'
   })
 
@@ -203,7 +208,7 @@ export async function localeRouteTests() {
   expect(JSON.parse(await page.locator('#locale-route .about-object-ja').innerText())).include({
     fullPath: '/ja/about',
     path: '/ja/about',
-    name: 'about___ja',
+    name: routeName('about', 'ja'),
     href: '/ja/about'
   })
 
@@ -211,7 +216,7 @@ export async function localeRouteTests() {
   expect(JSON.parse(await page.locator('#locale-route .undefined-path-ja').innerText())).include({
     fullPath: '/ja/vue-i18n',
     path: '/ja/vue-i18n',
-    name: 'pathMatch___ja',
+    name: routeName('pathMatch', 'ja'),
     href: '/ja/vue-i18n'
   })
 

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -96,6 +96,7 @@ export function getDefineConfig(
     __I18N_PRELOAD__: JSON.stringify(!!options.experimental.preload),
 
     __I18N_ROUTING__: JSON.stringify(nuxt.options.pages.toString() && options.strategy !== 'no_prefix'),
+    __I18N_CONSOLIDATED_ROUTES__: String(!!options.experimental?.regexConsolidation),
     __I18N_STRICT_SEO__: JSON.stringify(!!options.experimental.strictSeo),
     __I18N_SERVER_ROUTE__: JSON.stringify([options.serverRoutePrefix, deploymentHash].join('/')),
     __I18N_SERVER_REDIRECT__: JSON.stringify(!!options.experimental.nitroContextDetection),

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -96,7 +96,7 @@ export function getDefineConfig(
     __I18N_PRELOAD__: JSON.stringify(!!options.experimental.preload),
 
     __I18N_ROUTING__: JSON.stringify(nuxt.options.pages.toString() && options.strategy !== 'no_prefix'),
-    __I18N_CONSOLIDATED_ROUTES__: String(!!options.experimental?.regexConsolidation),
+    __I18N_COMPACT_ROUTES__: String(!!options.experimental?.compactRoutes),
     __I18N_STRICT_SEO__: JSON.stringify(!!options.experimental.strictSeo),
     __I18N_SERVER_ROUTE__: JSON.stringify([options.serverRoutePrefix, deploymentHash].join('/')),
     __I18N_SERVER_REDIRECT__: JSON.stringify(!!options.experimental.nitroContextDetection),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,7 +28,7 @@ export const DEFAULT_OPTIONS = {
     strictSeo: false,
     nitroContextDetection: true,
     httpCacheDuration: 10,
-    compactRoutes: false,
+    compactRoutes: true,
   },
   bundle: {
     compositionOnly: true,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,8 +28,7 @@ export const DEFAULT_OPTIONS = {
     strictSeo: false,
     nitroContextDetection: true,
     httpCacheDuration: 10,
-    // TODO: REVERT before merging
-    regexConsolidation: true,
+    compactRoutes: false,
   },
   bundle: {
     compositionOnly: true,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,6 +28,8 @@ export const DEFAULT_OPTIONS = {
     strictSeo: false,
     nitroContextDetection: true,
     httpCacheDuration: 10,
+    // TODO: REVERT before merging
+    regexConsolidation: true,
   },
   bundle: {
     compositionOnly: true,

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -31,5 +31,5 @@ declare let __I18N_STRICT_SEO__: boolean
 declare let __I18N_SERVER_REDIRECT__: boolean
 /** Includes hashed deployment timestamp */
 declare let __I18N_SERVER_ROUTE__: string
-/** Whether regex route consolidation is enabled */
-declare let __I18N_CONSOLIDATED_ROUTES__: boolean
+/** Whether compact routes are enabled */
+declare let __I18N_COMPACT_ROUTES__: boolean

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -31,3 +31,5 @@ declare let __I18N_STRICT_SEO__: boolean
 declare let __I18N_SERVER_REDIRECT__: boolean
 /** Includes hashed deployment timestamp */
 declare let __I18N_SERVER_ROUTE__: string
+/** Whether regex route consolidation is enabled */
+declare let __I18N_CONSOLIDATED_ROUTES__: boolean

--- a/src/kit/gen.ts
+++ b/src/kit/gen.ts
@@ -112,12 +112,12 @@ export function localizeSingleRoute(
     return [route]
   }
 
-  // Consolidate eligible top-level routes into a single regex-prefixed route.
+  // Compact eligible top-level routes into a single regex-prefixed route.
   // Guards: only at the top level (no parent), not inside a default-tree pass.
-  if (ctx.consolidateRoute && !options.defaultTree && options.parent == null
-    && canConsolidateRoute(routeOptions, options.locales)
-    && canConsolidateChildren(route.children, options.locales, ctx)) {
-    return ctx.consolidateRoute(route, routeOptions, options)
+  if (ctx.compactRoute && !options.defaultTree && options.parent == null
+    && canCompactRoute(routeOptions, options.locales)
+    && canCompactChildren(route.children, options.locales, ctx)) {
+    return ctx.compactRoute(route, routeOptions, options)
   }
 
   const resultRoutes: LocalizableRoute[] = []
@@ -162,8 +162,8 @@ export type RouteContext = {
   localizeRouteName: (name: LocalizableRoute, locale: string, isDefault: boolean) => string | undefined
   handleTrailingSlash: (localizedPath: string, hasParent: boolean) => string
   localizers: { enabled: (data: LocalizerData) => boolean, localizer: LocalizerFn }[]
-  /** When set, eligible routes are consolidated into a single regex-prefixed route instead of per-locale duplicates. */
-  consolidateRoute?: (
+  /** When set, eligible routes are compacted into a single regex-prefixed route instead of per-locale duplicates. */
+  compactRoute?: (
     route: LocalizableRoute,
     routeOptions: ComputedRouteOptions,
     params: LocalizeRouteParams,
@@ -229,10 +229,10 @@ export function createRouteContext(opts: {
 }
 
 /**
- * Check whether a route can be consolidated into a single regex route.
+ * Check whether a route can be compacted into a single regex route.
  * A route is eligible when all provided locales are enabled and no per-locale custom paths are defined.
  */
-export function canConsolidateRoute(
+export function canCompactRoute(
   routeOptions: ComputedRouteOptions | undefined,
   allLocales: readonly string[],
 ): boolean {
@@ -242,11 +242,11 @@ export function canConsolidateRoute(
 }
 
 /**
- * Recursively check that all child routes are also eligible for consolidation.
- * A parent with consolidation-eligible options but a child with per-locale custom paths
- * cannot be consolidated since children of the consolidated route would miss the custom paths.
+ * Recursively check that all child routes are also eligible for compaction.
+ * A parent with compact-eligible options but a child with per-locale custom paths
+ * cannot be compacted since children of the compact route would miss the custom paths.
  */
-function canConsolidateChildren(
+function canCompactChildren(
   children: LocalizableRoute[] | undefined,
   allLocales: readonly string[],
   ctx: RouteContext,
@@ -254,8 +254,8 @@ function canConsolidateChildren(
   if (!children?.length) { return true }
   for (const child of children) {
     const childOptions = ctx.optionsResolver(child, allLocales as string[])
-    if (!canConsolidateRoute(childOptions, allLocales)) { return false }
-    if (!canConsolidateChildren(child.children, allLocales, ctx)) { return false }
+    if (!canCompactRoute(childOptions, allLocales)) { return false }
+    if (!canCompactChildren(child.children, allLocales, ctx)) { return false }
   }
   return true
 }

--- a/src/kit/gen.ts
+++ b/src/kit/gen.ts
@@ -112,6 +112,12 @@ export function localizeSingleRoute(
     return [route]
   }
 
+  // Consolidate eligible top-level routes into a single regex-prefixed route.
+  // Guards: only at the top level (no parent), not inside a default-tree pass.
+  if (ctx.consolidateRoute && !options.defaultTree && options.parent == null && canConsolidateRoute(routeOptions, options.locales)) {
+    return ctx.consolidateRoute(route, routeOptions, options)
+  }
+
   const resultRoutes: LocalizableRoute[] = []
   for (const locale of routeOptions.locales) {
     // use custom path if found
@@ -154,6 +160,12 @@ export type RouteContext = {
   localizeRouteName: (name: LocalizableRoute, locale: string, isDefault: boolean) => string | undefined
   handleTrailingSlash: (localizedPath: string, hasParent: boolean) => string
   localizers: { enabled: (data: LocalizerData) => boolean, localizer: LocalizerFn }[]
+  /** When set, eligible routes are consolidated into a single regex-prefixed route instead of per-locale duplicates. */
+  consolidateRoute?: (
+    route: LocalizableRoute,
+    routeOptions: ComputedRouteOptions,
+    params: LocalizeRouteParams,
+  ) => LocalizableRoute[]
 }
 
 type LocalizerFn = (data: LocalizerData) => LocalizableRoute[]

--- a/src/kit/gen.ts
+++ b/src/kit/gen.ts
@@ -213,3 +213,16 @@ export function createRouteContext(opts: {
 
   return ctx
 }
+
+/**
+ * Check whether a route can be consolidated into a single regex route.
+ * A route is eligible when all provided locales are enabled and no per-locale custom paths are defined.
+ */
+export function canConsolidateRoute(
+  routeOptions: ComputedRouteOptions | undefined,
+  allLocales: readonly string[],
+): boolean {
+  if (!routeOptions) { return false }
+  if (routeOptions.locales.length !== allLocales.length) { return false }
+  return Object.keys(routeOptions.paths).length === 0
+}

--- a/src/kit/gen.ts
+++ b/src/kit/gen.ts
@@ -114,7 +114,9 @@ export function localizeSingleRoute(
 
   // Consolidate eligible top-level routes into a single regex-prefixed route.
   // Guards: only at the top level (no parent), not inside a default-tree pass.
-  if (ctx.consolidateRoute && !options.defaultTree && options.parent == null && canConsolidateRoute(routeOptions, options.locales)) {
+  if (ctx.consolidateRoute && !options.defaultTree && options.parent == null
+    && canConsolidateRoute(routeOptions, options.locales)
+    && canConsolidateChildren(route.children, options.locales, ctx)) {
     return ctx.consolidateRoute(route, routeOptions, options)
   }
 
@@ -237,4 +239,23 @@ export function canConsolidateRoute(
   if (!routeOptions) { return false }
   if (routeOptions.locales.length !== allLocales.length) { return false }
   return Object.keys(routeOptions.paths).length === 0
+}
+
+/**
+ * Recursively check that all child routes are also eligible for consolidation.
+ * A parent with consolidation-eligible options but a child with per-locale custom paths
+ * cannot be consolidated since children of the consolidated route would miss the custom paths.
+ */
+function canConsolidateChildren(
+  children: LocalizableRoute[] | undefined,
+  allLocales: readonly string[],
+  ctx: RouteContext,
+): boolean {
+  if (!children?.length) { return true }
+  for (const child of children) {
+    const childOptions = ctx.optionsResolver(child, allLocales as string[])
+    if (!canConsolidateRoute(childOptions, allLocales)) { return false }
+    if (!canConsolidateChildren(child.children, allLocales, ctx)) { return false }
+  }
+  return true
 }

--- a/src/kit/gen.ts
+++ b/src/kit/gen.ts
@@ -117,7 +117,8 @@ export function localizeSingleRoute(
   if (ctx.compactRoute && !options.defaultTree && options.parent == null
     && canCompactRoute(routeOptions, options.locales)
     && canCompactChildren(route.children, options.locales, ctx)) {
-    return ctx.compactRoute(route, routeOptions, options)
+    const compacted = ctx.compactRoute(route, routeOptions, options)
+    if (compacted) { return compacted }
   }
 
   const resultRoutes: LocalizableRoute[] = []
@@ -167,7 +168,7 @@ export type RouteContext = {
     route: LocalizableRoute,
     routeOptions: ComputedRouteOptions,
     params: LocalizeRouteParams,
-  ) => LocalizableRoute[]
+  ) => LocalizableRoute[] | undefined
 }
 
 type LocalizerFn = (data: LocalizerData) => LocalizableRoute[]

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -89,6 +89,7 @@ export const i18nPathToPath = ${JSON.stringify(routeResources.i18nPathToPath, nu
         includeUnprefixedFallback,
         locales: normalizedLocales,
         optionsResolver: resolver,
+        regexConsolidation: !!options.experimental?.regexConsolidation,
       })
 
       // Build path config from original pages (not localized copies)

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -14,7 +14,7 @@ import type { Nuxt, NuxtPage, ResolvedNuxtTemplate } from '@nuxt/schema'
 import type { EditableTreeNode, Options as TypedRouterOptions } from 'vue-router/unplugin'
 import type { NuxtI18nOptions } from './types'
 import type { I18nNuxtContext } from './context'
-import type { ComputedRouteOptions, RouteOptionsResolver } from './kit/gen'
+import type { ComputedRouteOptions, LocalizableRoute, RouteOptionsResolver } from './kit/gen'
 import type { I18nRoute } from './runtime/composables'
 import { type CallExpression, type ExpressionStatement, type ObjectExpression, parseSync } from 'oxc-parser'
 
@@ -82,12 +82,17 @@ export const i18nPathToPath = ${JSON.stringify(routeResources.i18nPathToPath, nu
         await typedRouter.createContext(pages).scanPages(false)
       }
 
+      const resolver = createPureOptionsResolver(ctx, options.defaultLocale, options.customRoutes)
+
       const localizedPages = localizeRoutes(pages as NarrowedNuxtPage[], {
         ...options,
         includeUnprefixedFallback,
         locales: normalizedLocales,
-        optionsResolver: getRouteOptionsResolver(ctx, options.defaultLocale, options.customRoutes),
+        optionsResolver: resolver,
       })
+
+      // Build path config from original pages (not localized copies)
+      buildPathToConfig(ctx, localeCodes, resolver, pages as LocalizableRoute[])
 
       // keep root when using prefixed routing without prerendering
       const indexPage = pages.find(x => x.path === '/')
@@ -264,32 +269,57 @@ export function analyzeNuxtPages(ctx: NuxtPageAnalyzeContext, pagesDir: string, 
 }
 
 /**
- * Function factory, returns a function based on the `customRoutes` option property
+ * Returns a pure RouteOptionsResolver with no side effects.
+ */
+export function createPureOptionsResolver(
+  ctx: NuxtPageAnalyzeContext,
+  defaultLocale: string,
+  customRoutes: NuxtI18nOptions['customRoutes'],
+): RouteOptionsResolver {
+  return (route, localeCodes) => getRouteOptions(route, localeCodes, ctx, defaultLocale, customRoutes)
+}
+
+/**
+ * Post-processing step: builds ctx.pathToConfig from the original (pre-localized) routes.
+ * Call this after localizeRoutes() with the same resolver used for localization.
+ */
+export function buildPathToConfig(
+  ctx: NuxtPageAnalyzeContext,
+  localeCodes: string[],
+  resolver: RouteOptionsResolver,
+  routes: LocalizableRoute[],
+): void {
+  for (const route of routes) {
+    if (route.file) {
+      const res = resolver(route, localeCodes)
+      const localeCfg = res?.srcPaths
+      const mappedPath = ctx.fileToPath[route.file]
+      if (mappedPath) {
+        ctx.pathToConfig[mappedPath] ??= {} as Record<string, string | boolean>
+        for (const l of localeCodes) {
+          ctx.pathToConfig[mappedPath][l] ??= localeCfg?.[l] ?? false
+        }
+        for (const l of res?.locales ?? []) {
+          ctx.pathToConfig[mappedPath][l] ||= true
+        }
+      }
+    }
+    if (route.children?.length) {
+      buildPathToConfig(ctx, localeCodes, resolver, route.children)
+    }
+  }
+}
+
+/**
+ * Function factory, returns a function based on the `customRoutes` option property.
+ * @deprecated Use createPureOptionsResolver + buildPathToConfig instead.
  */
 export function getRouteOptionsResolver(
   ctx: NuxtPageAnalyzeContext,
   defaultLocale: string,
   customRoutes: NuxtI18nOptions['customRoutes'],
 ): RouteOptionsResolver {
-  return (route, localeCodes) => {
-    const res = getRouteOptions(route, localeCodes, ctx, defaultLocale, customRoutes)
-    if (route.file) {
-      const localeCfg = res?.srcPaths
-      const mappedPath = ctx.fileToPath[route.file]!
-      ctx.pathToConfig[mappedPath] ??= {} as Record<string, string | boolean>
-
-      // set paths for all locales, assume no custom path is a disabled locale
-      for (const l of localeCodes) {
-        ctx.pathToConfig[mappedPath][l] ??= localeCfg?.[l] ?? false
-      }
-
-      for (const l of res?.locales ?? []) {
-        ctx.pathToConfig[mappedPath][l] ||= true
-      }
-    }
-
-    return res
-  }
+  return createPureOptionsResolver(ctx, defaultLocale, customRoutes)
 }
 
 function resolveRoutePath(path: string): string {

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -89,7 +89,7 @@ export const i18nPathToPath = ${JSON.stringify(routeResources.i18nPathToPath, nu
         includeUnprefixedFallback,
         locales: normalizedLocales,
         optionsResolver: resolver,
-        regexConsolidation: !!options.experimental?.regexConsolidation,
+        compactRoutes: !!options.experimental?.compactRoutes,
       })
 
       // Build path config from original pages (not localized copies)

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -277,7 +277,14 @@ export function createPureOptionsResolver(
   defaultLocale: string,
   customRoutes: NuxtI18nOptions['customRoutes'],
 ): RouteOptionsResolver {
-  return (route, localeCodes) => getRouteOptions(route, localeCodes, ctx, defaultLocale, customRoutes)
+  const cache = new Map<string, ComputedRouteOptions | undefined>()
+  return (route, localeCodes) => {
+    const key = `${route.file ?? route.name ?? route.path}::${localeCodes.join(',')}`
+    if (cache.has(key)) { return cache.get(key) }
+    const resolved = getRouteOptions(route, localeCodes, ctx, defaultLocale, customRoutes)
+    cache.set(key, resolved)
+    return resolved
+  }
 }
 
 /**

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -62,7 +62,7 @@ type SetupLocalizeRoutesOptions = {
   defaultLocaleRouteNameSuffix: string
   defaultLocale?: string
   optionsResolver?: RouteOptionsResolver
-  regexConsolidation?: boolean
+  compactRoutes?: boolean
 }
 
 /**
@@ -82,29 +82,29 @@ export function localizeRoutes(routes: LocalizableRoute[], config: SetupLocalize
   const strategy = config.strategy ?? 'prefix_and_default'
 
   /**
-   * Regex consolidation: merge all per-locale routes into a single `/:locale(en|fr)/path` route
+   * Compact routes: merge all per-locale routes into a single `/:locale(en|fr)/path` route
    * for routes where all locales share the same path.
    */
-  if (config.regexConsolidation && strategy !== 'no_prefix' && !config.differentDomains && !config.multiDomainLocales) {
+  if (config.compactRoutes && strategy !== 'no_prefix' && !config.differentDomains && !config.multiDomainLocales) {
     const defaultLocale = config.defaultLocale ?? ''
-    ctx.consolidateRoute = (route, routeOptions, params) => {
+    ctx.compactRoute = (route, routeOptions, params) => {
       const makeRegexRoute = (locales: readonly string[]): LocalizableRoute => {
         const localePattern = locales.join('|')
         const regexPrefix = `/:locale(${localePattern})`
         const regexPath = route.path === '/'
           ? regexPrefix
           : regexPrefix + route.path
-        const consolidated: LocalizableRoute = {
+        const compacted: LocalizableRoute = {
           ...route,
           path: ctx.handleTrailingSlash(regexPath, !!params.parent),
-          meta: { ...(route.meta as Record<string, unknown> ?? {}), __i18nConsolidated: true },
+          meta: { ...(route.meta as Record<string, unknown> ?? {}), __i18nCompact: true },
         }
         // Prefix aliases with the locale regex pattern so params match the parent route
-        if (consolidated.alias) {
-          const aliases = Array.isArray(consolidated.alias) ? consolidated.alias : [consolidated.alias]
-          consolidated.alias = aliases.map(a => regexPrefix + (a.startsWith('/') ? a : '/' + a))
+        if (compacted.alias) {
+          const aliases = Array.isArray(compacted.alias) ? compacted.alias : [compacted.alias]
+          compacted.alias = aliases.map(a => regexPrefix + (a.startsWith('/') ? a : '/' + a))
         }
-        return consolidated
+        return compacted
       }
 
       if (strategy === 'prefix_except_default' && defaultLocale) {

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -85,9 +85,20 @@ export function localizeRoutes(routes: LocalizableRoute[], config: SetupLocalize
    * Compact routes: merge all per-locale routes into a single `/:locale(en|fr)/path` route
    * for routes where all locales share the same path.
    */
-  if (config.compactRoutes && strategy !== 'no_prefix' && !config.differentDomains && !config.multiDomainLocales) {
+  if (
+    config.compactRoutes
+    && strategy !== 'no_prefix'
+    && !config.differentDomains
+    && !config.multiDomainLocales
+    && !config.includeUnprefixedFallback
+  ) {
     const defaultLocale = config.defaultLocale ?? ''
     ctx.compactRoute = (route, routeOptions, params) => {
+      // Skip compaction if the route already defines a :locale param to avoid collisions
+      if (route.path.includes(':locale')) {
+        return undefined
+      }
+
       const makeRegexRoute = (locales: readonly string[]): LocalizableRoute => {
         const localePattern = locales.join('|')
         const regexPrefix = `/:locale(${localePattern})`
@@ -99,10 +110,13 @@ export function localizeRoutes(routes: LocalizableRoute[], config: SetupLocalize
           path: ctx.handleTrailingSlash(regexPath, !!params.parent),
           meta: { ...(route.meta as Record<string, unknown> ?? {}), __i18nCompact: true },
         }
-        // Prefix aliases with the locale regex pattern so params match the parent route
+        // Prefix aliases with the locale regex pattern and normalize trailing slashes
         if (compacted.alias) {
           const aliases = Array.isArray(compacted.alias) ? compacted.alias : [compacted.alias]
-          compacted.alias = aliases.map(a => regexPrefix + (a.startsWith('/') ? a : '/' + a))
+          compacted.alias = aliases.map((a) => {
+            const aliasPath = regexPrefix + (a.startsWith('/') ? a : '/' + a)
+            return ctx.handleTrailingSlash(aliasPath, !!params.parent)
+          })
         }
         return compacted
       }

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -85,7 +85,7 @@ export function localizeRoutes(routes: LocalizableRoute[], config: SetupLocalize
    * Regex consolidation: merge all per-locale routes into a single `/:locale(en|fr)/path` route
    * for routes where all locales share the same path.
    */
-  if (config.regexConsolidation) {
+  if (config.regexConsolidation && strategy !== 'no_prefix' && !config.differentDomains && !config.multiDomainLocales) {
     const defaultLocale = config.defaultLocale ?? ''
     ctx.consolidateRoute = (route, routeOptions, params) => {
       const makeRegexRoute = (locales: readonly string[]): LocalizableRoute => {
@@ -107,7 +107,7 @@ export function localizeRoutes(routes: LocalizableRoute[], config: SetupLocalize
         return consolidated
       }
 
-      if (strategy === 'prefix_except_default') {
+      if (strategy === 'prefix_except_default' && defaultLocale) {
         const result: LocalizableRoute[] = []
         // Unprefixed route for default locale (name: about___en)
         const unprefixed: LocalizableRoute = { ...route }
@@ -123,7 +123,7 @@ export function localizeRoutes(routes: LocalizableRoute[], config: SetupLocalize
         return result
       }
 
-      if (strategy === 'prefix_and_default') {
+      if (strategy === 'prefix_and_default' && defaultLocale) {
         // Default tree unprefixed route (name: about___en___default)
         const defaultTree: LocalizableRoute = { ...route }
         defaultTree.name &&= ctx.localizeRouteName(defaultTree, defaultLocale, true)

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -90,23 +90,30 @@ export function localizeRoutes(routes: LocalizableRoute[], config: SetupLocalize
     ctx.consolidateRoute = (route, routeOptions, params) => {
       const makeRegexRoute = (locales: readonly string[]): LocalizableRoute => {
         const localePattern = locales.join('|')
+        const regexPrefix = `/:locale(${localePattern})`
         const regexPath = route.path === '/'
-          ? `/:locale(${localePattern})`
-          : `/:locale(${localePattern})${route.path}`
-        return {
+          ? regexPrefix
+          : regexPrefix + route.path
+        const consolidated: LocalizableRoute = {
           ...route,
           path: ctx.handleTrailingSlash(regexPath, !!params.parent),
           meta: { ...(route.meta as Record<string, unknown> ?? {}), __i18nConsolidated: true },
         }
+        // Prefix aliases with the locale regex pattern so params match the parent route
+        if (consolidated.alias) {
+          const aliases = Array.isArray(consolidated.alias) ? consolidated.alias : [consolidated.alias]
+          consolidated.alias = aliases.map(a => regexPrefix + (a.startsWith('/') ? a : '/' + a))
+        }
+        return consolidated
       }
 
       if (strategy === 'prefix_except_default') {
         const result: LocalizableRoute[] = []
         // Unprefixed route for default locale (name: about___en)
         const unprefixed: LocalizableRoute = { ...route }
-        if (unprefixed.name) {
-          unprefixed.name = ctx.localizeRouteName(unprefixed, defaultLocale, false)
-        }
+        unprefixed.name &&= ctx.localizeRouteName(unprefixed, defaultLocale, false)
+        // Localize children for the default locale so they get ___en suffixes
+        unprefixed.children &&= ctx.localizeChildren(route, unprefixed, defaultLocale, params)
         result.push(unprefixed)
         // Regex route for non-default locales (keeps base name)
         const nonDefault = routeOptions.locales.filter(l => !ctx.isDefaultLocale(l))
@@ -119,9 +126,9 @@ export function localizeRoutes(routes: LocalizableRoute[], config: SetupLocalize
       if (strategy === 'prefix_and_default') {
         // Default tree unprefixed route (name: about___en___default)
         const defaultTree: LocalizableRoute = { ...route }
-        if (defaultTree.name) {
-          defaultTree.name = ctx.localizeRouteName(defaultTree, defaultLocale, true)
-        }
+        defaultTree.name &&= ctx.localizeRouteName(defaultTree, defaultLocale, true)
+        // Localize children for the default locale so they get proper suffixes
+        defaultTree.children &&= ctx.localizeChildren(route, defaultTree, defaultLocale, { ...params, defaultTree: true })
         // Regex route for all locales (keeps base name)
         return [defaultTree, makeRegexRoute(routeOptions.locales)]
       }

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -62,6 +62,7 @@ type SetupLocalizeRoutesOptions = {
   defaultLocaleRouteNameSuffix: string
   defaultLocale?: string
   optionsResolver?: RouteOptionsResolver
+  regexConsolidation?: boolean
 }
 
 /**
@@ -78,10 +79,61 @@ export function localizeRoutes(routes: LocalizableRoute[], config: SetupLocalize
     defaultLocaleRouteNameSuffix: config.defaultLocaleRouteNameSuffix,
   })
 
+  const strategy = config.strategy ?? 'prefix_and_default'
+
+  /**
+   * Regex consolidation: merge all per-locale routes into a single `/:locale(en|fr)/path` route
+   * for routes where all locales share the same path.
+   */
+  if (config.regexConsolidation) {
+    const defaultLocale = config.defaultLocale ?? ''
+    ctx.consolidateRoute = (route, routeOptions, params) => {
+      const makeRegexRoute = (locales: readonly string[]): LocalizableRoute => {
+        const localePattern = locales.join('|')
+        const regexPath = route.path === '/'
+          ? `/:locale(${localePattern})`
+          : `/:locale(${localePattern})${route.path}`
+        return {
+          ...route,
+          path: ctx.handleTrailingSlash(regexPath, !!params.parent),
+          meta: { ...(route.meta as Record<string, unknown> ?? {}), __i18nConsolidated: true },
+        }
+      }
+
+      if (strategy === 'prefix_except_default') {
+        const result: LocalizableRoute[] = []
+        // Unprefixed route for default locale (name: about___en)
+        const unprefixed: LocalizableRoute = { ...route }
+        if (unprefixed.name) {
+          unprefixed.name = ctx.localizeRouteName(unprefixed, defaultLocale, false)
+        }
+        result.push(unprefixed)
+        // Regex route for non-default locales (keeps base name)
+        const nonDefault = routeOptions.locales.filter(l => !ctx.isDefaultLocale(l))
+        if (nonDefault.length > 0) {
+          result.push(makeRegexRoute(nonDefault))
+        }
+        return result
+      }
+
+      if (strategy === 'prefix_and_default') {
+        // Default tree unprefixed route (name: about___en___default)
+        const defaultTree: LocalizableRoute = { ...route }
+        if (defaultTree.name) {
+          defaultTree.name = ctx.localizeRouteName(defaultTree, defaultLocale, true)
+        }
+        // Regex route for all locales (keeps base name)
+        return [defaultTree, makeRegexRoute(routeOptions.locales)]
+      }
+
+      // prefix strategy: single regex route for all locales (keeps base name)
+      return [makeRegexRoute(routeOptions.locales)]
+    }
+  }
+
   /**
    * Default tree for prefix_and_default strategy
    */
-  const strategy = config.strategy ?? 'prefix_and_default'
   if (strategy === 'prefix_and_default') {
     // unshift to preserve test snapshots
     ctx.localizers.unshift({

--- a/src/runtime/kit/routing.ts
+++ b/src/runtime/kit/routing.ts
@@ -49,7 +49,7 @@ export function getLocaleFromRoute(route: RouteName | RouteObject) {
   const fromName = getLocaleFromRouteName(input)
   if (fromName) { return fromName }
 
-  // Fallback: for consolidated routes the name has no locale suffix,
+  // Fallback: for compact routes the name has no locale suffix,
   // try path-based detection if the route object has a path.
   if (typeof route === 'object' && route?.path) {
     return getLocaleFromRoutePath(String(route.path))

--- a/src/runtime/kit/routing.ts
+++ b/src/runtime/kit/routing.ts
@@ -42,7 +42,18 @@ function normalizeInput(input: RouteName | RouteObject) {
  */
 export function getLocaleFromRoute(route: RouteName | RouteObject) {
   const input = normalizeInput(route)
-  return input[0] === '/'
-    ? getLocaleFromRoutePath(input)
-    : getLocaleFromRouteName(input)
+  if (input[0] === '/') {
+    return getLocaleFromRoutePath(input)
+  }
+
+  const fromName = getLocaleFromRouteName(input)
+  if (fromName) return fromName
+
+  // Fallback: for consolidated routes the name has no locale suffix,
+  // try path-based detection if the route object has a path.
+  if (typeof route === 'object' && route?.path) {
+    return getLocaleFromRoutePath(String(route.path))
+  }
+
+  return ''
 }

--- a/src/runtime/kit/routing.ts
+++ b/src/runtime/kit/routing.ts
@@ -47,7 +47,7 @@ export function getLocaleFromRoute(route: RouteName | RouteObject) {
   }
 
   const fromName = getLocaleFromRouteName(input)
-  if (fromName) return fromName
+  if (fromName) { return fromName }
 
   // Fallback: for consolidated routes the name has no locale suffix,
   // try path-based detection if the route object has a path.

--- a/src/runtime/plugins/route-locale-detect.ts
+++ b/src/runtime/plugins/route-locale-detect.ts
@@ -15,7 +15,7 @@ export default defineNuxtPlugin({
     if (__I18N_COMPACT_ROUTES__) {
       const router = useRouter()
       for (const route of router.getRoutes()) {
-        if (route.meta?.__i18nCompact) {
+        if (route.meta?.__i18nCompact && route.meta.key == null) {
           route.meta.key = (r: { path: string }) => r.path
         }
       }

--- a/src/runtime/plugins/route-locale-detect.ts
+++ b/src/runtime/plugins/route-locale-detect.ts
@@ -10,12 +10,12 @@ export default defineNuxtPlugin({
     const nuxt = useNuxtApp(_nuxt._id)
     const ctx = useNuxtI18nContext(nuxt)
 
-    // Set meta.key on consolidated routes so NuxtPage triggers transitions when the locale param changes.
+    // Set meta.key on compact routes so NuxtPage triggers transitions when the locale param changes.
     // This must be done at runtime because functions in route meta don't survive Nuxt's build-time serialization.
-    if (__I18N_CONSOLIDATED_ROUTES__) {
+    if (__I18N_COMPACT_ROUTES__) {
       const router = useRouter()
       for (const route of router.getRoutes()) {
-        if (route.meta?.__i18nConsolidated) {
+        if (route.meta?.__i18nCompact) {
           route.meta.key = (r: { path: string }) => r.path
         }
       }

--- a/src/runtime/plugins/route-locale-detect.ts
+++ b/src/runtime/plugins/route-locale-detect.ts
@@ -1,6 +1,6 @@
 import { useNuxtI18nContext, useResolvedLocale } from '../context'
 import { detectLocale, loadAndSetLocale, navigate } from '../utils'
-import { addRouteMiddleware, defineNuxtPlugin, defineNuxtRouteMiddleware, useNuxtApp } from '#imports'
+import { addRouteMiddleware, defineNuxtPlugin, defineNuxtRouteMiddleware, useNuxtApp, useRouter } from '#imports'
 
 export default defineNuxtPlugin({
   name: 'i18n:plugin:route-locale-detect',
@@ -9,6 +9,17 @@ export default defineNuxtPlugin({
     // @ts-expect-error untyped internal id parameter
     const nuxt = useNuxtApp(_nuxt._id)
     const ctx = useNuxtI18nContext(nuxt)
+
+    // Set meta.key on consolidated routes so NuxtPage triggers transitions when the locale param changes.
+    // This must be done at runtime because functions in route meta don't survive Nuxt's build-time serialization.
+    if (__I18N_CONSOLIDATED_ROUTES__) {
+      const router = useRouter()
+      for (const route of router.getRoutes()) {
+        if (route.meta?.__i18nConsolidated) {
+          route.meta.key = (r: { path: string }) => r.path
+        }
+      }
+    }
 
     const resolvedLocale = useResolvedLocale()
     await nuxt.runWithContext(() =>

--- a/src/runtime/routing/routing.ts
+++ b/src/runtime/routing/routing.ts
@@ -95,7 +95,6 @@ export function switchLocalePath(
       {},
       route.params,
       ctx.getLocalizedDynamicParams(locale),
-      __I18N_CONSOLIDATED_ROUTES__ ? { locale } : {},
     ),
     fullPath: route.fullPath,
     query: route.query,

--- a/src/runtime/routing/routing.ts
+++ b/src/runtime/routing/routing.ts
@@ -91,7 +91,12 @@ export function switchLocalePath(
    */
   const routeCopy = {
     name,
-    params: assign({}, route.params, ctx.getLocalizedDynamicParams(locale)),
+    params: assign(
+      {},
+      route.params,
+      ctx.getLocalizedDynamicParams(locale),
+      __I18N_CONSOLIDATED_ROUTES__ ? { locale } : {},
+    ),
     fullPath: route.fullPath,
     query: route.query,
     hash: route.hash,

--- a/src/runtime/routing/utils.ts
+++ b/src/runtime/routing/utils.ts
@@ -50,10 +50,10 @@ export function createLocalizedRouteByPathResolver(
         return router.resolve(assign({}, route, _route, { path: targetPath }))
       }
 
-      // For consolidated routes, the regex pattern (e.g. /:locale(en|ja)/path/:param)
+      // For compact routes, the regex pattern (e.g. /:locale(en|ja)/path/:param)
       // won't have an exact match above. Return the original route — downstream
       // resolveLocalizedRouteByPath will add the prefix and router.resolve will
-      // match the consolidated route using path-based resolution (preserving URL encoding).
+      // match the compact route using path-based resolution (preserving URL encoding).
       return route
     }
   }

--- a/src/runtime/routing/utils.ts
+++ b/src/runtime/routing/utils.ts
@@ -44,21 +44,17 @@ export function createLocalizedRouteByPathResolver(
     return (route, locale) => {
       const targetPath = '/' + locale + (route.path === '/' ? '' : route.path)
 
-      if (__I18N_CONSOLIDATED_ROUTES__) {
-        // router.resolve handles regex route matching (e.g. /:locale(en|fr)/about) natively
-        const resolved = router.resolve(assign({}, route, { path: targetPath }))
-        if (resolved.matched.length > 0) {
-          return resolved
-        }
-      }
-
-      // Fallback: exact path match for per-locale routes
+      // Exact path match for per-locale routes
       const _route = router.options.routes.find(r => r.path === targetPath)
-      if (_route == null) {
-        return route
+      if (_route != null) {
+        return router.resolve(assign({}, route, _route, { path: targetPath }))
       }
 
-      return router.resolve(assign({}, route, _route, { path: targetPath }))
+      // For consolidated routes, the regex pattern (e.g. /:locale(en|ja)/path/:param)
+      // won't have an exact match above. Return the original route — downstream
+      // resolveLocalizedRouteByPath will add the prefix and router.resolve will
+      // match the consolidated route using path-based resolution (preserving URL encoding).
+      return route
     }
   }
 

--- a/src/runtime/routing/utils.ts
+++ b/src/runtime/routing/utils.ts
@@ -43,8 +43,17 @@ export function createLocalizedRouteByPathResolver(
      */
     return (route, locale) => {
       const targetPath = '/' + locale + (route.path === '/' ? '' : route.path)
-      const _route = router.options.routes.find(r => r.path === targetPath)
 
+      if (__I18N_CONSOLIDATED_ROUTES__) {
+        // router.resolve handles regex route matching (e.g. /:locale(en|fr)/about) natively
+        const resolved = router.resolve(assign({}, route, { path: targetPath }))
+        if (resolved.matched.length > 0) {
+          return resolved
+        }
+      }
+
+      // Fallback: exact path match for per-locale routes
+      const _route = router.options.routes.find(r => r.path === targetPath)
       if (_route == null) {
         return route
       }

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -126,9 +126,10 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
         // Fallback: consolidated route — keep base name with locale param
         const record = router.getRoutes().find(r => r.name === baseName)
         if (record?.meta?.__i18nConsolidated) {
-          route.name = baseName
-          route.params = { ...(route.params || {}), locale }
-          return route
+          const consolidated = route as RouteLikeWithName
+          consolidated.name = baseName
+          consolidated.params = { ...(consolidated.params || {}), locale }
+          return consolidated
         }
       }
 

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -124,8 +124,8 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
 
       if (__I18N_COMPACT_ROUTES__) {
         // Fallback: compact route — keep base name with locale param
-        const record = router.getRoutes().find(r => r.name === baseName)
-        if (record?.meta?.__i18nCompact) {
+        const resolved = router.resolve({ name: baseName, params: {} })
+        if (resolved.matched.some(r => r.meta?.__i18nCompact)) {
           const compacted = route as RouteLikeWithName
           compacted.name = baseName
           compacted.params = { ...(compacted.params || {}), locale }

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -92,15 +92,19 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
       if (__I18N_CONSOLIDATED_ROUTES__ && route.params) {
         delete (route.params as Record<string, unknown>).locale
       }
-    } else if (__I18N_CONSOLIDATED_ROUTES__ && router.hasRoute(route.name!)) {
+    } else if (__I18N_CONSOLIDATED_ROUTES__ && isSupportedLocale(locale) && router.hasRoute(route.name!)) {
       // consolidated route: keep base name, inject locale as route param
       // spread existing params (e.g. slug) to satisfy all required route params
       const resolved = router.resolve({ name: route.name!, params: { ...(route.params as Record<string, unknown> || {}), locale } })
       if (resolved.meta?.__i18nConsolidated) {
         route.params = { ...(route.params || {}), locale }
+        return route
       }
     }
 
+    // No per-locale or consolidated match: set localized name so router.resolve
+    // fails for unsupported locales (e.g. 'undefined'), matching per-locale behavior.
+    route.name = localizedName
     return route
   }
 
@@ -110,17 +114,27 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
     const baseName = getRouteBaseName(route)
 
     if (baseName) {
+      // Try per-locale route first (e.g. about___en) — this handles the default locale
+      // in prefix_except_default where the unprefixed route exists alongside the consolidated one.
       const localizedName = getLocalizedRouteName(baseName, locale)
       if (router.hasRoute(localizedName)) {
         route.name = localizedName
-      } else if (__I18N_CONSOLIDATED_ROUTES__) {
-        // check if this is actually a consolidated route (not a disabled/unlocalized one)
+        return route
+      }
+
+      if (__I18N_CONSOLIDATED_ROUTES__) {
+        // Fallback: consolidated route — keep base name with locale param
         const record = router.getRoutes().find(r => r.name === baseName)
         if (record?.meta?.__i18nConsolidated) {
           route.name = baseName
           route.params = { ...(route.params || {}), locale }
+          return route
         }
       }
+
+      // Set the localized route name — if the route doesn't exist (e.g. disabled routes),
+      // router.resolve will fail and localePath correctly returns empty.
+      route.name = localizedName
       return route
     }
 

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -88,9 +88,14 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
     const localizedName = getLocalizedRouteName(route.name, locale)
     if (router.hasRoute(localizedName)) {
       route.name = localizedName
+      // Remove stale locale param inherited from a consolidated route — per-locale routes don't use it
+      if (__I18N_CONSOLIDATED_ROUTES__ && route.params) {
+        delete (route.params as Record<string, unknown>).locale
+      }
     } else if (__I18N_CONSOLIDATED_ROUTES__ && router.hasRoute(route.name!)) {
       // consolidated route: keep base name, inject locale as route param
-      const resolved = router.resolve({ name: route.name! })
+      // spread existing params (e.g. slug) to satisfy all required route params
+      const resolved = router.resolve({ name: route.name!, params: { ...(route.params as Record<string, unknown> || {}), locale } })
       if (resolved.meta?.__i18nConsolidated) {
         route.params = { ...(route.params || {}), locale }
       }
@@ -109,9 +114,12 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
       if (router.hasRoute(localizedName)) {
         route.name = localizedName
       } else if (__I18N_CONSOLIDATED_ROUTES__) {
-        // consolidated route: keep base name, inject locale as route param
-        route.name = baseName
-        route.params = { ...(route.params || {}), locale }
+        // check if this is actually a consolidated route (not a disabled/unlocalized one)
+        const record = router.getRoutes().find(r => r.name === baseName)
+        if (record?.meta?.__i18nConsolidated) {
+          route.name = baseName
+          route.params = { ...(route.params || {}), locale }
+        }
       }
       return route
     }
@@ -201,8 +209,8 @@ export async function loadAndSetLocale(nuxtApp: NuxtApp, locale: Locale): Promis
   const ctx = useNuxtI18nContext(nuxtApp)
   const oldLocale = ctx.getLocale()
 
-  // skip if locale is already set
-  if (locale === oldLocale && !ctx.initial) {
+  // skip if locale is already set and there is no pending locale change to a different locale
+  if (locale === oldLocale && !ctx.initial && (!ctx.vueI18n.__pendingLocale || ctx.vueI18n.__pendingLocale === locale)) {
     return locale
   }
 

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -88,21 +88,21 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
     const localizedName = getLocalizedRouteName(route.name, locale)
     if (router.hasRoute(localizedName)) {
       route.name = localizedName
-      // Remove stale locale param inherited from a consolidated route — per-locale routes don't use it
-      if (__I18N_CONSOLIDATED_ROUTES__ && route.params) {
+      // Remove stale locale param inherited from a compact route — per-locale routes don't use it
+      if (__I18N_COMPACT_ROUTES__ && route.params) {
         delete (route.params as Record<string, unknown>).locale
       }
-    } else if (__I18N_CONSOLIDATED_ROUTES__ && isSupportedLocale(locale) && router.hasRoute(route.name!)) {
-      // consolidated route: keep base name, inject locale as route param
+    } else if (__I18N_COMPACT_ROUTES__ && isSupportedLocale(locale) && router.hasRoute(route.name!)) {
+      // compact route: keep base name, inject locale as route param
       // spread existing params (e.g. slug) to satisfy all required route params
       const resolved = router.resolve({ name: route.name!, params: { ...(route.params as Record<string, unknown> || {}), locale } })
-      if (resolved.meta?.__i18nConsolidated) {
+      if (resolved.meta?.__i18nCompact) {
         route.params = { ...(route.params || {}), locale }
         return route
       }
     }
 
-    // No per-locale or consolidated match: set localized name so router.resolve
+    // No per-locale or compact match: set localized name so router.resolve
     // fails for unsupported locales (e.g. 'undefined'), matching per-locale behavior.
     route.name = localizedName
     return route
@@ -115,21 +115,21 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
 
     if (baseName) {
       // Try per-locale route first (e.g. about___en) — this handles the default locale
-      // in prefix_except_default where the unprefixed route exists alongside the consolidated one.
+      // in prefix_except_default where the unprefixed route exists alongside the compact one.
       const localizedName = getLocalizedRouteName(baseName, locale)
       if (router.hasRoute(localizedName)) {
         route.name = localizedName
         return route
       }
 
-      if (__I18N_CONSOLIDATED_ROUTES__) {
-        // Fallback: consolidated route — keep base name with locale param
+      if (__I18N_COMPACT_ROUTES__) {
+        // Fallback: compact route — keep base name with locale param
         const record = router.getRoutes().find(r => r.name === baseName)
-        if (record?.meta?.__i18nConsolidated) {
-          const consolidated = route as RouteLikeWithName
-          consolidated.name = baseName
-          consolidated.params = { ...(consolidated.params || {}), locale }
-          return consolidated
+        if (record?.meta?.__i18nCompact) {
+          const compacted = route as RouteLikeWithName
+          compacted.name = baseName
+          compacted.params = { ...(compacted.params || {}), locale }
+          return compacted
         }
       }
 

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -88,6 +88,12 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
     const localizedName = getLocalizedRouteName(route.name, locale)
     if (router.hasRoute(localizedName)) {
       route.name = localizedName
+    } else if (__I18N_CONSOLIDATED_ROUTES__ && router.hasRoute(route.name!)) {
+      // consolidated route: keep base name, inject locale as route param
+      const resolved = router.resolve({ name: route.name! })
+      if (resolved.meta?.__i18nConsolidated) {
+        route.params = { ...(route.params || {}), locale }
+      }
     }
 
     return route
@@ -99,7 +105,14 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
     const baseName = getRouteBaseName(route)
 
     if (baseName) {
-      route.name = getLocalizedRouteName(baseName, locale)
+      const localizedName = getLocalizedRouteName(baseName, locale)
+      if (router.hasRoute(localizedName)) {
+        route.name = localizedName
+      } else if (__I18N_CONSOLIDATED_ROUTES__) {
+        // consolidated route: keep base name, inject locale as route param
+        route.name = baseName
+        route.params = { ...(route.params || {}), locale }
+      }
       return route
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -199,6 +199,13 @@ export interface ExperimentalFeatures {
    * @default 10
    */
   httpCacheDuration?: number
+  /**
+   * Consolidates locale-prefixed routes into a single regex route (e.g. `/:locale(en|fr)/about`)
+   * instead of generating separate routes per locale. Only applies to routes where all locales
+   * share the same path and no locale is disabled.
+   * @default false
+   */
+  regexConsolidation?: boolean
 }
 
 export interface BundleOptions

--- a/src/types.ts
+++ b/src/types.ts
@@ -205,7 +205,7 @@ export interface ExperimentalFeatures {
    * share the same path and no locale is disabled.
    * @default false
    */
-  regexConsolidation?: boolean
+  compactRoutes?: boolean
 }
 
 export interface BundleOptions

--- a/test/pages/route_localization.test.ts
+++ b/test/pages/route_localization.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { localizeRoutes } from '../../src/routing'
-import { localizeSingleRoute, createRouteContext, canConsolidateRoute } from '../../src/kit/gen'
+import { localizeSingleRoute, createRouteContext, canCompactRoute } from '../../src/kit/gen'
 import { buildPathToConfig, NuxtPageAnalyzeContext } from '../../src/pages'
 import { createMockOptionsResolver, createTestConfig, getNormalizedLocales } from './utils'
 
@@ -611,42 +611,42 @@ describe('buildPathToConfig', () => {
 })
 
 // ---------------------------------------------------------------------------
-// e) canConsolidateRoute
+// e) canCompactRoute
 // ---------------------------------------------------------------------------
 
-describe('canConsolidateRoute', () => {
+describe('canCompactRoute', () => {
   const allLocales = ['en', 'fr', 'ja']
 
   it('returns true when all locales enabled and no custom paths', () => {
-    expect(canConsolidateRoute({ locales: ['en', 'fr', 'ja'], paths: {} }, allLocales)).toBe(true)
+    expect(canCompactRoute({ locales: ['en', 'fr', 'ja'], paths: {} }, allLocales)).toBe(true)
   })
 
   it('returns false when some locales have custom paths', () => {
-    expect(canConsolidateRoute({ locales: ['en', 'fr', 'ja'], paths: { fr: '/a-propos' } }, allLocales)).toBe(false)
+    expect(canCompactRoute({ locales: ['en', 'fr', 'ja'], paths: { fr: '/a-propos' } }, allLocales)).toBe(false)
   })
 
   it('returns false when only a subset of locales is enabled', () => {
-    expect(canConsolidateRoute({ locales: ['en', 'fr'], paths: {} }, allLocales)).toBe(false)
+    expect(canCompactRoute({ locales: ['en', 'fr'], paths: {} }, allLocales)).toBe(false)
   })
 
   it('returns false when routeOptions is undefined', () => {
-    expect(canConsolidateRoute(undefined, allLocales)).toBe(false)
+    expect(canCompactRoute(undefined, allLocales)).toBe(false)
   })
 
   it('returns true for single locale with no custom paths', () => {
-    expect(canConsolidateRoute({ locales: ['en'], paths: {} }, ['en'])).toBe(true)
+    expect(canCompactRoute({ locales: ['en'], paths: {} }, ['en'])).toBe(true)
   })
 
   it('returns false when paths is non-empty even if values match original', () => {
-    expect(canConsolidateRoute({ locales: ['en', 'fr'], paths: { en: '/about', fr: '/about' } }, ['en', 'fr'])).toBe(false)
+    expect(canCompactRoute({ locales: ['en', 'fr'], paths: { en: '/about', fr: '/about' } }, ['en', 'fr'])).toBe(false)
   })
 })
 
 // ---------------------------------------------------------------------------
-// f) regex consolidation via localizeRoutes
+// f) compact routes via localizeRoutes
 // ---------------------------------------------------------------------------
 
-describe('regex consolidation', () => {
+describe('compact routes', () => {
   const locales = ['en', 'fr', 'ja']
   const routes: LocalizableRoute[] = [
     { path: '/', name: 'home' },
@@ -654,8 +654,8 @@ describe('regex consolidation', () => {
   ]
 
   describe('eligible routes — prefix strategy', () => {
-    it('consolidates into a single regex route', () => {
-      const config = createTestConfig({ locales, strategy: 'prefix', defaultLocale: 'en', regexConsolidation: true })
+    it('compacts into a single regex route', () => {
+      const config = createTestConfig({ locales, strategy: 'prefix', defaultLocale: 'en', compactRoutes: true })
       const result = localizeRoutes(routes, config)
 
       // single route per page — no per-locale duplication
@@ -663,13 +663,13 @@ describe('regex consolidation', () => {
       const about = result.find(r => r.path === '/:locale(en|fr|ja)/about')
       expect(about).toBeDefined()
       expect(about?.name).toBe('about')
-      expect((about?.meta as Record<string, unknown>)?.__i18nConsolidated).toBe(true)
+      expect((about?.meta as Record<string, unknown>)?.__i18nCompact).toBe(true)
     })
   })
 
   describe('eligible routes — prefix_except_default strategy', () => {
     it('generates unprefixed default route + non-default regex route', () => {
-      const config = createTestConfig({ locales, strategy: 'prefix_except_default', defaultLocale: 'en', regexConsolidation: true })
+      const config = createTestConfig({ locales, strategy: 'prefix_except_default', defaultLocale: 'en', compactRoutes: true })
       const result = localizeRoutes(routes, config)
 
       const aboutEn = findRoute(result, 'about___en')
@@ -687,7 +687,7 @@ describe('regex consolidation', () => {
 
   describe('eligible routes — prefix_and_default strategy', () => {
     it('generates default-tree route + all-locale regex route', () => {
-      const config = createTestConfig({ locales, strategy: 'prefix_and_default', defaultLocale: 'en', regexConsolidation: true })
+      const config = createTestConfig({ locales, strategy: 'prefix_and_default', defaultLocale: 'en', compactRoutes: true })
       const result = localizeRoutes(routes, config)
 
       const aboutDefault = findRoute(result, 'about___en___default')
@@ -704,11 +704,11 @@ describe('regex consolidation', () => {
   })
 
   describe('ineligible routes — must stay per-locale', () => {
-    it('does NOT consolidate a route with custom per-locale paths', () => {
+    it('does NOT compact a route with custom per-locale paths', () => {
       const resolver = createMockOptionsResolver({
         about: { locales, paths: { fr: '/a-propos' } },
       })
-      const config = createTestConfig({ locales, strategy: 'prefix', defaultLocale: 'en', optionsResolver: resolver, regexConsolidation: true })
+      const config = createTestConfig({ locales, strategy: 'prefix', defaultLocale: 'en', optionsResolver: resolver, compactRoutes: true })
       const result = localizeRoutes([{ path: '/about', name: 'about' }], config)
 
       expect(findRoute(result, 'about___en')).toBeDefined()
@@ -717,11 +717,11 @@ describe('regex consolidation', () => {
       expect(result.find(r => r.path?.includes(':locale'))).toBeUndefined()
     })
 
-    it('does NOT consolidate a route available for a locale subset', () => {
+    it('does NOT compact a route available for a locale subset', () => {
       const resolver = createMockOptionsResolver({
         about: { locales: ['fr', 'ja'], paths: {} },
       })
-      const config = createTestConfig({ locales, strategy: 'prefix', defaultLocale: 'en', optionsResolver: resolver, regexConsolidation: true })
+      const config = createTestConfig({ locales, strategy: 'prefix', defaultLocale: 'en', optionsResolver: resolver, compactRoutes: true })
       const result = localizeRoutes([{ path: '/about', name: 'about' }], config)
 
       expect(findRoute(result, 'about___fr')).toBeDefined()
@@ -730,9 +730,9 @@ describe('regex consolidation', () => {
       expect(result.find(r => r.path?.includes(':locale'))).toBeUndefined()
     })
 
-    it('does NOT consolidate a disabled route (resolver returns undefined)', () => {
+    it('does NOT compact a disabled route (resolver returns undefined)', () => {
       const resolver = createMockOptionsResolver({ about: false })
-      const config = createTestConfig({ locales, strategy: 'prefix', defaultLocale: 'en', optionsResolver: resolver, regexConsolidation: true })
+      const config = createTestConfig({ locales, strategy: 'prefix', defaultLocale: 'en', optionsResolver: resolver, compactRoutes: true })
       const result = localizeRoutes([{ path: '/about', name: 'about' }], config)
 
       // route returned unchanged
@@ -742,22 +742,22 @@ describe('regex consolidation', () => {
     })
   })
 
-  describe('mixed app — some routes consolidated, some per-locale', () => {
-    it('handles consolidatable and non-consolidatable routes in the same call', () => {
+  describe('mixed app — some routes compacted, some per-locale', () => {
+    it('handles compactable and non-compactable routes in the same call', () => {
       const resolver = createMockOptionsResolver({
-        // contact has a custom fr path → not consolidatable
+        // contact has a custom fr path → not compactable
         contact: { locales, paths: { fr: '/nous-contacter' } },
-        // about has no custom paths → consolidatable
+        // about has no custom paths → compactable
         about: { locales, paths: {} },
       })
-      const config = createTestConfig({ locales, strategy: 'prefix', defaultLocale: 'en', optionsResolver: resolver, regexConsolidation: true })
+      const config = createTestConfig({ locales, strategy: 'prefix', defaultLocale: 'en', optionsResolver: resolver, compactRoutes: true })
       const input: LocalizableRoute[] = [
         { path: '/about', name: 'about' },
         { path: '/contact', name: 'contact' },
       ]
       const result = localizeRoutes(input, config)
 
-      // about → consolidated
+      // about → compacted
       expect(result.find(r => r.path === '/:locale(en|fr|ja)/about')).toBeDefined()
       expect(findRoute(result, 'about___en')).toBeUndefined()
 

--- a/test/pages/route_localization.test.ts
+++ b/test/pages/route_localization.test.ts
@@ -641,3 +641,130 @@ describe('canConsolidateRoute', () => {
     expect(canConsolidateRoute({ locales: ['en', 'fr'], paths: { en: '/about', fr: '/about' } }, ['en', 'fr'])).toBe(false)
   })
 })
+
+// ---------------------------------------------------------------------------
+// f) regex consolidation via localizeRoutes
+// ---------------------------------------------------------------------------
+
+describe('regex consolidation', () => {
+  const locales = ['en', 'fr', 'ja']
+  const routes: LocalizableRoute[] = [
+    { path: '/', name: 'home' },
+    { path: '/about', name: 'about' },
+  ]
+
+  describe('eligible routes — prefix strategy', () => {
+    it('consolidates into a single regex route', () => {
+      const config = createTestConfig({ locales, strategy: 'prefix', defaultLocale: 'en', regexConsolidation: true })
+      const result = localizeRoutes(routes, config)
+
+      // single route per page — no per-locale duplication
+      expect(result.filter(r => r.path?.includes('/about'))).toHaveLength(1)
+      const about = result.find(r => r.path === '/:locale(en|fr|ja)/about')
+      expect(about).toBeDefined()
+      expect(about?.name).toBe('about')
+      expect((about?.meta as Record<string, unknown>)?.__i18nConsolidated).toBe(true)
+    })
+  })
+
+  describe('eligible routes — prefix_except_default strategy', () => {
+    it('generates unprefixed default route + non-default regex route', () => {
+      const config = createTestConfig({ locales, strategy: 'prefix_except_default', defaultLocale: 'en', regexConsolidation: true })
+      const result = localizeRoutes(routes, config)
+
+      const aboutEn = findRoute(result, 'about___en')
+      expect(aboutEn?.path).toBe('/about')
+
+      const aboutRegex = result.find(r => r.path === '/:locale(fr|ja)/about')
+      expect(aboutRegex).toBeDefined()
+      expect(aboutRegex?.name).toBe('about')
+
+      // no per-locale duplication for non-default locales
+      expect(findRoute(result, 'about___fr')).toBeUndefined()
+      expect(findRoute(result, 'about___ja')).toBeUndefined()
+    })
+  })
+
+  describe('eligible routes — prefix_and_default strategy', () => {
+    it('generates default-tree route + all-locale regex route', () => {
+      const config = createTestConfig({ locales, strategy: 'prefix_and_default', defaultLocale: 'en', regexConsolidation: true })
+      const result = localizeRoutes(routes, config)
+
+      const aboutDefault = findRoute(result, 'about___en___default')
+      expect(aboutDefault?.path).toBe('/about')
+
+      const aboutRegex = result.find(r => r.path === '/:locale(en|fr|ja)/about')
+      expect(aboutRegex).toBeDefined()
+      expect(aboutRegex?.name).toBe('about')
+
+      // no per-locale routes
+      expect(findRoute(result, 'about___en')).toBeUndefined()
+      expect(findRoute(result, 'about___fr')).toBeUndefined()
+    })
+  })
+
+  describe('ineligible routes — must stay per-locale', () => {
+    it('does NOT consolidate a route with custom per-locale paths', () => {
+      const resolver = createMockOptionsResolver({
+        about: { locales, paths: { fr: '/a-propos' } },
+      })
+      const config = createTestConfig({ locales, strategy: 'prefix', defaultLocale: 'en', optionsResolver: resolver, regexConsolidation: true })
+      const result = localizeRoutes([{ path: '/about', name: 'about' }], config)
+
+      expect(findRoute(result, 'about___en')).toBeDefined()
+      expect(findRoute(result, 'about___fr')).toBeDefined()
+      expect(findRoute(result, 'about___ja')).toBeDefined()
+      expect(result.find(r => r.path?.includes(':locale'))).toBeUndefined()
+    })
+
+    it('does NOT consolidate a route available for a locale subset', () => {
+      const resolver = createMockOptionsResolver({
+        about: { locales: ['fr', 'ja'], paths: {} },
+      })
+      const config = createTestConfig({ locales, strategy: 'prefix', defaultLocale: 'en', optionsResolver: resolver, regexConsolidation: true })
+      const result = localizeRoutes([{ path: '/about', name: 'about' }], config)
+
+      expect(findRoute(result, 'about___fr')).toBeDefined()
+      expect(findRoute(result, 'about___ja')).toBeDefined()
+      expect(findRoute(result, 'about___en')).toBeUndefined()
+      expect(result.find(r => r.path?.includes(':locale'))).toBeUndefined()
+    })
+
+    it('does NOT consolidate a disabled route (resolver returns undefined)', () => {
+      const resolver = createMockOptionsResolver({ about: false })
+      const config = createTestConfig({ locales, strategy: 'prefix', defaultLocale: 'en', optionsResolver: resolver, regexConsolidation: true })
+      const result = localizeRoutes([{ path: '/about', name: 'about' }], config)
+
+      // route returned unchanged
+      expect(result).toHaveLength(1)
+      expect(result[0].path).toBe('/about')
+      expect(result[0].name).toBe('about')
+    })
+  })
+
+  describe('mixed app — some routes consolidated, some per-locale', () => {
+    it('handles consolidatable and non-consolidatable routes in the same call', () => {
+      const resolver = createMockOptionsResolver({
+        // contact has a custom fr path → not consolidatable
+        contact: { locales, paths: { fr: '/nous-contacter' } },
+        // about has no custom paths → consolidatable
+        about: { locales, paths: {} },
+      })
+      const config = createTestConfig({ locales, strategy: 'prefix', defaultLocale: 'en', optionsResolver: resolver, regexConsolidation: true })
+      const input: LocalizableRoute[] = [
+        { path: '/about', name: 'about' },
+        { path: '/contact', name: 'contact' },
+      ]
+      const result = localizeRoutes(input, config)
+
+      // about → consolidated
+      expect(result.find(r => r.path === '/:locale(en|fr|ja)/about')).toBeDefined()
+      expect(findRoute(result, 'about___en')).toBeUndefined()
+
+      // contact → per-locale
+      expect(findRoute(result, 'contact___en')).toBeDefined()
+      expect(findRoute(result, 'contact___fr')).toBeDefined()
+      expect(findRoute(result, 'contact___ja')).toBeDefined()
+    })
+  })
+})

--- a/test/pages/route_localization.test.ts
+++ b/test/pages/route_localization.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { localizeRoutes } from '../../src/routing'
 import { localizeSingleRoute, createRouteContext, canConsolidateRoute } from '../../src/kit/gen'
+import { buildPathToConfig, NuxtPageAnalyzeContext } from '../../src/pages'
 import { createMockOptionsResolver, createTestConfig, getNormalizedLocales } from './utils'
 
 import type { LocalizableRoute, LocalizeRouteParams } from '../../src/kit/gen'
@@ -515,7 +516,102 @@ describe('localizeRoutes options', () => {
 })
 
 // ---------------------------------------------------------------------------
-// d) canConsolidateRoute
+// d) buildPathToConfig
+// ---------------------------------------------------------------------------
+
+describe('buildPathToConfig', () => {
+  function makeCtx(fileToPath: Record<string, string> = {}): NuxtPageAnalyzeContext {
+    const ctx = new NuxtPageAnalyzeContext({})
+    ctx.fileToPath = fileToPath
+    return ctx
+  }
+
+  it('marks all locales as true for a route with no custom paths', () => {
+    const ctx = makeCtx({ '/pages/about.vue': '/about' })
+    const resolver = createMockOptionsResolver({
+      about: { locales: ['en', 'fr'], paths: {} },
+    })
+    buildPathToConfig(ctx, ['en', 'fr'], resolver, [
+      { path: '/about', name: 'about', file: '/pages/about.vue' },
+    ])
+    expect(ctx.pathToConfig['/about']).toEqual({ en: true, fr: true })
+  })
+
+  it('stores srcPath string for locale with a custom path', () => {
+    const ctx = makeCtx({ '/pages/about.vue': '/about' })
+    const resolver = createMockOptionsResolver({
+      about: { locales: ['en', 'fr'], paths: { fr: '/a-propos' }, srcPaths: { fr: '/a-propos' } },
+    })
+    buildPathToConfig(ctx, ['en', 'fr'], resolver, [
+      { path: '/about', name: 'about', file: '/pages/about.vue' },
+    ])
+    expect(ctx.pathToConfig['/about']).toEqual({ en: true, fr: '/a-propos' })
+  })
+
+  it('marks all locales as false when resolver returns undefined (disabled route)', () => {
+    const ctx = makeCtx({ '/pages/secret.vue': '/secret' })
+    const resolver = createMockOptionsResolver({ secret: false })
+    buildPathToConfig(ctx, ['en', 'fr'], resolver, [
+      { path: '/secret', name: 'secret', file: '/pages/secret.vue' },
+    ])
+    expect(ctx.pathToConfig['/secret']).toEqual({ en: false, fr: false })
+  })
+
+  it('skips routes without a file', () => {
+    const ctx = makeCtx({})
+    const resolver = createMockOptionsResolver()
+    buildPathToConfig(ctx, ['en', 'fr'], resolver, [
+      { path: '/about', name: 'about' },
+    ])
+    expect(Object.keys(ctx.pathToConfig)).toHaveLength(0)
+  })
+
+  it('skips routes whose file is not in fileToPath', () => {
+    const ctx = makeCtx({})
+    const resolver = createMockOptionsResolver()
+    buildPathToConfig(ctx, ['en', 'fr'], resolver, [
+      { path: '/about', name: 'about', file: '/pages/about.vue' },
+    ])
+    expect(Object.keys(ctx.pathToConfig)).toHaveLength(0)
+  })
+
+  it('recurses into children routes', () => {
+    const ctx = makeCtx({
+      '/pages/account.vue': '/account',
+      '/pages/account/profile.vue': '/account/profile',
+    })
+    const resolver = createMockOptionsResolver()
+    buildPathToConfig(ctx, ['en', 'fr'], resolver, [
+      {
+        path: '/account',
+        name: 'account',
+        file: '/pages/account.vue',
+        children: [
+          { path: 'profile', name: 'account-profile', file: '/pages/account/profile.vue' },
+        ],
+      },
+    ])
+    expect(ctx.pathToConfig['/account']).toEqual({ en: true, fr: true })
+    expect(ctx.pathToConfig['/account/profile']).toEqual({ en: true, fr: true })
+  })
+
+  it('processes multiple top-level routes', () => {
+    const ctx = makeCtx({
+      '/pages/home.vue': '/',
+      '/pages/about.vue': '/about',
+    })
+    const resolver = createMockOptionsResolver()
+    buildPathToConfig(ctx, ['en', 'fr'], resolver, [
+      { path: '/', name: 'home', file: '/pages/home.vue' },
+      { path: '/about', name: 'about', file: '/pages/about.vue' },
+    ])
+    expect(ctx.pathToConfig['/']).toEqual({ en: true, fr: true })
+    expect(ctx.pathToConfig['/about']).toEqual({ en: true, fr: true })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// e) canConsolidateRoute
 // ---------------------------------------------------------------------------
 
 describe('canConsolidateRoute', () => {

--- a/test/pages/route_localization.test.ts
+++ b/test/pages/route_localization.test.ts
@@ -1,0 +1,547 @@
+import { describe, it, expect } from 'vitest'
+import { localizeRoutes } from '../../src/routing'
+import { localizeSingleRoute, createRouteContext, canConsolidateRoute } from '../../src/kit/gen'
+import { createMockOptionsResolver, createTestConfig, getNormalizedLocales } from './utils'
+
+import type { LocalizableRoute, LocalizeRouteParams } from '../../src/kit/gen'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Find a route in a flat array by name */
+const findRoute = (routes: LocalizableRoute[], name: string) => routes.find(r => r.name === name)
+
+/** Collect all route names from a flat array */
+const routeNames = (routes: LocalizableRoute[]) => routes.map(r => r.name).filter(Boolean)
+
+/** Collect all route paths from a flat array */
+const routePaths = (routes: LocalizableRoute[]) => routes.map(r => r.path)
+
+/** Simple shouldPrefix that respects child relative paths */
+const defaultShouldPrefix = (path: string, _locale: string, options: LocalizeRouteParams) => {
+  if (options.parent != null && !path.startsWith('/')) return false
+  return true
+}
+
+// ---------------------------------------------------------------------------
+// a) localizeSingleRoute unit tests
+// ---------------------------------------------------------------------------
+
+describe('localizeSingleRoute', () => {
+  it('prefixes route for each locale', () => {
+    const ctx = createRouteContext({
+      trailingSlash: false,
+      defaultLocales: ['en'],
+      routesNameSeparator: '___',
+      defaultLocaleRouteNameSuffix: 'default',
+      optionsResolver: createMockOptionsResolver(),
+    })
+
+    const route: LocalizableRoute = { path: '/about', name: 'about' }
+    const params: LocalizeRouteParams = {
+      locales: ['en', 'fr'],
+      defaultTree: false,
+      shouldPrefix: () => true,
+    }
+
+    const result = localizeSingleRoute(route, params, ctx)
+
+    expect(result).toHaveLength(2)
+    expect(findRoute(result, 'about___en')?.path).toBe('/en/about')
+    expect(findRoute(result, 'about___fr')?.path).toBe('/fr/about')
+  })
+
+  it('does not prefix when shouldPrefix returns false', () => {
+    const ctx = createRouteContext({
+      trailingSlash: false,
+      defaultLocales: ['en'],
+      routesNameSeparator: '___',
+      defaultLocaleRouteNameSuffix: 'default',
+      optionsResolver: createMockOptionsResolver(),
+    })
+
+    const route: LocalizableRoute = { path: '/about', name: 'about' }
+    const params: LocalizeRouteParams = {
+      locales: ['en', 'fr'],
+      defaultTree: false,
+      shouldPrefix: () => false,
+    }
+
+    const result = localizeSingleRoute(route, params, ctx)
+
+    expect(result).toHaveLength(2)
+    expect(result.every(r => r.path === '/about')).toBe(true)
+  })
+
+  it('uses custom path from resolver for specific locale', () => {
+    const ctx = createRouteContext({
+      trailingSlash: false,
+      defaultLocales: ['en'],
+      routesNameSeparator: '___',
+      defaultLocaleRouteNameSuffix: 'default',
+      optionsResolver: createMockOptionsResolver({
+        about: { locales: ['en', 'fr'], paths: { fr: '/a-propos' } },
+      }),
+    })
+
+    const route: LocalizableRoute = { path: '/about', name: 'about' }
+    const params: LocalizeRouteParams = {
+      locales: ['en', 'fr'],
+      defaultTree: false,
+      shouldPrefix: () => true,
+    }
+
+    const result = localizeSingleRoute(route, params, ctx)
+
+    expect(findRoute(result, 'about___en')?.path).toBe('/en/about')
+    expect(findRoute(result, 'about___fr')?.path).toBe('/fr/a-propos')
+  })
+
+  it('returns route unchanged when resolver returns undefined', () => {
+    const ctx = createRouteContext({
+      trailingSlash: false,
+      defaultLocales: ['en'],
+      routesNameSeparator: '___',
+      defaultLocaleRouteNameSuffix: 'default',
+      optionsResolver: createMockOptionsResolver({ about: undefined }),
+    })
+
+    const route: LocalizableRoute = { path: '/about', name: 'about' }
+    const params: LocalizeRouteParams = {
+      locales: ['en', 'fr'],
+      defaultTree: false,
+      shouldPrefix: () => true,
+    }
+
+    const result = localizeSingleRoute(route, params, ctx)
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toBe(route)
+  })
+
+  it('only produces routes for locales in resolver result', () => {
+    const ctx = createRouteContext({
+      trailingSlash: false,
+      defaultLocales: ['en'],
+      routesNameSeparator: '___',
+      defaultLocaleRouteNameSuffix: 'default',
+      optionsResolver: createMockOptionsResolver({
+        about: { locales: ['en'], paths: {} },
+      }),
+    })
+
+    const route: LocalizableRoute = { path: '/about', name: 'about' }
+    const params: LocalizeRouteParams = {
+      locales: ['en', 'fr'],
+      defaultTree: false,
+      shouldPrefix: () => true,
+    }
+
+    const result = localizeSingleRoute(route, params, ctx)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('about___en')
+  })
+
+  it('localizes children with relative paths', () => {
+    const ctx = createRouteContext({
+      trailingSlash: false,
+      defaultLocales: ['en'],
+      routesNameSeparator: '___',
+      defaultLocaleRouteNameSuffix: 'default',
+      optionsResolver: createMockOptionsResolver(),
+    })
+
+    const route: LocalizableRoute = {
+      path: '/user/:id',
+      name: 'user',
+      children: [
+        { path: 'profile', name: 'user-profile' },
+        { path: 'posts', name: 'user-posts' },
+      ],
+    }
+
+    const params: LocalizeRouteParams = {
+      locales: ['en', 'fr'],
+      defaultTree: false,
+      shouldPrefix: defaultShouldPrefix,
+    }
+
+    const result = localizeSingleRoute(route, params, ctx)
+
+    expect(result).toHaveLength(2)
+    const enRoute = findRoute(result, 'user___en')!
+    expect(enRoute.path).toBe('/en/user/:id')
+    expect(enRoute.children).toHaveLength(2)
+    expect(enRoute.children![0].name).toBe('user-profile___en')
+    expect(enRoute.children![0].path).toBe('profile')
+
+    const frRoute = findRoute(result, 'user___fr')!
+    expect(frRoute.path).toBe('/fr/user/:id')
+    expect(frRoute.children).toHaveLength(2)
+    expect(frRoute.children![0].name).toBe('user-profile___fr')
+  })
+
+  it('localizes aliases', () => {
+    const ctx = createRouteContext({
+      trailingSlash: false,
+      defaultLocales: ['en'],
+      routesNameSeparator: '___',
+      defaultLocaleRouteNameSuffix: 'default',
+      optionsResolver: createMockOptionsResolver(),
+    })
+
+    const route: LocalizableRoute = { path: '/about', name: 'about', alias: '/about-us' }
+    const params: LocalizeRouteParams = {
+      locales: ['en'],
+      defaultTree: false,
+      shouldPrefix: () => true,
+    }
+
+    const result = localizeSingleRoute(route, params, ctx)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].alias).toEqual(['/en/about-us'])
+  })
+
+  it('uses default tree naming when defaultTree is true', () => {
+    const ctx = createRouteContext({
+      trailingSlash: false,
+      defaultLocales: ['en'],
+      routesNameSeparator: '___',
+      defaultLocaleRouteNameSuffix: 'default',
+      optionsResolver: createMockOptionsResolver(),
+    })
+
+    const route: LocalizableRoute = { path: '/about', name: 'about' }
+    const params: LocalizeRouteParams = {
+      locales: ['en'],
+      defaultTree: true,
+      shouldPrefix: () => false,
+    }
+
+    const result = localizeSingleRoute(route, params, ctx)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe('about___en___default')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// b) localizeRoutes strategy tests
+// ---------------------------------------------------------------------------
+
+describe('localizeRoutes strategies', () => {
+  const routes: LocalizableRoute[] = [
+    { path: '/', name: 'home' },
+    { path: '/about', name: 'about' },
+  ]
+
+  describe('prefix_except_default', () => {
+    it('default locale is unprefixed, non-default is prefixed', () => {
+      const config = createTestConfig({ locales: ['en', 'fr'], strategy: 'prefix_except_default', defaultLocale: 'en' })
+      const result = localizeRoutes(routes, config)
+
+      // en (default) - unprefixed
+      expect(findRoute(result, 'home___en')?.path).toBe('/')
+      expect(findRoute(result, 'about___en')?.path).toBe('/about')
+      // fr (non-default) - prefixed
+      expect(findRoute(result, 'home___fr')?.path).toBe('/fr')
+      expect(findRoute(result, 'about___fr')?.path).toBe('/fr/about')
+      // no default tree routes
+      expect(findRoute(result, 'home___en___default')).toBeUndefined()
+    })
+  })
+
+  describe('prefix_and_default', () => {
+    it('default locale gets both unprefixed (default tree) and prefixed routes', () => {
+      const config = createTestConfig({ locales: ['en', 'fr'], strategy: 'prefix_and_default', defaultLocale: 'en' })
+      const result = localizeRoutes(routes, config)
+
+      // en default tree (unprefixed)
+      expect(findRoute(result, 'home___en___default')?.path).toBe('/')
+      expect(findRoute(result, 'about___en___default')?.path).toBe('/about')
+      // en prefixed
+      expect(findRoute(result, 'home___en')?.path).toBe('/en')
+      expect(findRoute(result, 'about___en')?.path).toBe('/en/about')
+      // fr prefixed
+      expect(findRoute(result, 'home___fr')?.path).toBe('/fr')
+      expect(findRoute(result, 'about___fr')?.path).toBe('/fr/about')
+      // no default tree for non-default locale
+      expect(findRoute(result, 'home___fr___default')).toBeUndefined()
+    })
+  })
+
+  describe('prefix', () => {
+    it('all locales are prefixed', () => {
+      const config = createTestConfig({ locales: ['en', 'fr'], strategy: 'prefix', defaultLocale: 'en' })
+      const result = localizeRoutes(routes, config)
+
+      expect(findRoute(result, 'home___en')?.path).toBe('/en')
+      expect(findRoute(result, 'about___en')?.path).toBe('/en/about')
+      expect(findRoute(result, 'home___fr')?.path).toBe('/fr')
+      expect(findRoute(result, 'about___fr')?.path).toBe('/fr/about')
+    })
+
+    it('with includeUnprefixedFallback, default locale also gets unprefixed copy', () => {
+      const config = createTestConfig({
+        locales: ['en', 'fr'],
+        strategy: 'prefix',
+        defaultLocale: 'en',
+        includeUnprefixedFallback: true,
+      })
+      const result = localizeRoutes(routes, config)
+
+      // unprefixed fallback for default locale (original route without locale suffix)
+      const homeUnprefixed = result.find(r => r.name === 'home' && r.path === '/')
+      expect(homeUnprefixed).toBeDefined()
+      const aboutUnprefixed = result.find(r => r.name === 'about' && r.path === '/about')
+      expect(aboutUnprefixed).toBeDefined()
+
+      // prefixed routes still exist
+      expect(findRoute(result, 'home___en')?.path).toBe('/en')
+      expect(findRoute(result, 'home___fr')?.path).toBe('/fr')
+    })
+  })
+
+  describe('no_prefix', () => {
+    it('routes pass through unchanged without differentDomains', () => {
+      const config = createTestConfig({ locales: ['en', 'fr'], strategy: 'no_prefix', defaultLocale: 'en' })
+      const result = localizeRoutes(routes, config)
+
+      // routes are returned as-is
+      expect(result).toHaveLength(2)
+      expect(result[0].path).toBe('/')
+      expect(result[0].name).toBe('home')
+      expect(result[1].path).toBe('/about')
+      expect(result[1].name).toBe('about')
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// c) Custom paths via mock resolver
+// ---------------------------------------------------------------------------
+
+describe('localizeRoutes with custom paths', () => {
+  it('applies per-locale custom paths', () => {
+    const resolver = createMockOptionsResolver({
+      about: { locales: ['en', 'fr'], paths: { fr: '/a-propos' } },
+    })
+    const config = createTestConfig({
+      locales: ['en', 'fr'],
+      strategy: 'prefix_except_default',
+      defaultLocale: 'en',
+      optionsResolver: resolver,
+    })
+    const routes: LocalizableRoute[] = [
+      { path: '/', name: 'home' },
+      { path: '/about', name: 'about' },
+    ]
+
+    const result = localizeRoutes(routes, config)
+
+    // en default locale - unprefixed, uses original path
+    expect(findRoute(result, 'about___en')?.path).toBe('/about')
+    // fr non-default - prefixed, uses custom path
+    expect(findRoute(result, 'about___fr')?.path).toBe('/fr/a-propos')
+    // home routes are unaffected
+    expect(findRoute(result, 'home___en')?.path).toBe('/')
+    expect(findRoute(result, 'home___fr')?.path).toBe('/fr')
+  })
+
+  it('applies custom paths for all locales', () => {
+    const resolver = createMockOptionsResolver({
+      about: { locales: ['en', 'fr'], paths: { en: '/about-us', fr: '/a-propos' } },
+    })
+    const config = createTestConfig({
+      locales: ['en', 'fr'],
+      strategy: 'prefix_except_default',
+      defaultLocale: 'en',
+      optionsResolver: resolver,
+    })
+    const routes: LocalizableRoute[] = [{ path: '/about', name: 'about' }]
+    const result = localizeRoutes(routes, config)
+
+    expect(findRoute(result, 'about___en')?.path).toBe('/about-us')
+    expect(findRoute(result, 'about___fr')?.path).toBe('/fr/a-propos')
+  })
+
+  it('disables localization for a specific route', () => {
+    const resolver = createMockOptionsResolver({ secret: false })
+    const config = createTestConfig({
+      locales: ['en', 'fr'],
+      strategy: 'prefix_except_default',
+      defaultLocale: 'en',
+      optionsResolver: resolver,
+    })
+    const routes: LocalizableRoute[] = [
+      { path: '/', name: 'home' },
+      { path: '/secret', name: 'secret' },
+    ]
+    const result = localizeRoutes(routes, config)
+
+    // secret route is passed through unchanged
+    const secret = result.find(r => r.name === 'secret')
+    expect(secret).toBeDefined()
+    expect(secret!.path).toBe('/secret')
+    // only one secret route (not duplicated per locale)
+    expect(result.filter(r => r.name === 'secret')).toHaveLength(1)
+    // home is still localized
+    expect(findRoute(result, 'home___en')).toBeDefined()
+    expect(findRoute(result, 'home___fr')).toBeDefined()
+  })
+
+  it('restricts route to subset of locales', () => {
+    const resolver = createMockOptionsResolver({
+      about: { locales: ['en'], paths: {} },
+    })
+    const config = createTestConfig({
+      locales: ['en', 'fr'],
+      strategy: 'prefix_except_default',
+      defaultLocale: 'en',
+      optionsResolver: resolver,
+    })
+    const routes: LocalizableRoute[] = [{ path: '/about', name: 'about' }]
+    const result = localizeRoutes(routes, config)
+
+    expect(findRoute(result, 'about___en')).toBeDefined()
+    expect(findRoute(result, 'about___fr')).toBeUndefined()
+  })
+
+  it('handles nested routes with custom parent path', () => {
+    const resolver = createMockOptionsResolver({
+      account: { locales: ['en', 'fr'], paths: { fr: '/compte' } },
+    })
+    const config = createTestConfig({
+      locales: ['en', 'fr'],
+      strategy: 'prefix_except_default',
+      defaultLocale: 'en',
+      optionsResolver: resolver,
+    })
+    const routes: LocalizableRoute[] = [
+      {
+        path: '/account',
+        name: 'account',
+        children: [
+          { path: 'profile', name: 'account-profile' },
+        ],
+      },
+    ]
+    const result = localizeRoutes(routes, config)
+
+    const enAccount = findRoute(result, 'account___en')!
+    expect(enAccount.path).toBe('/account')
+    expect(enAccount.children![0].name).toBe('account-profile___en')
+    expect(enAccount.children![0].path).toBe('profile')
+
+    const frAccount = findRoute(result, 'account___fr')!
+    expect(frAccount.path).toBe('/fr/compte')
+    expect(frAccount.children![0].name).toBe('account-profile___fr')
+    expect(frAccount.children![0].path).toBe('profile')
+  })
+
+  it('handles dynamic route parameters', () => {
+    const resolver = createMockOptionsResolver({
+      'blog-slug': { locales: ['en', 'fr'], paths: { fr: '/article/:slug' } },
+    })
+    const config = createTestConfig({
+      locales: ['en', 'fr'],
+      strategy: 'prefix_except_default',
+      defaultLocale: 'en',
+      optionsResolver: resolver,
+    })
+    const routes: LocalizableRoute[] = [
+      { path: '/blog/:slug', name: 'blog-slug' },
+    ]
+    const result = localizeRoutes(routes, config)
+
+    expect(findRoute(result, 'blog-slug___en')?.path).toBe('/blog/:slug')
+    expect(findRoute(result, 'blog-slug___fr')?.path).toBe('/fr/article/:slug')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Trailing slash and route name separator
+// ---------------------------------------------------------------------------
+
+describe('localizeRoutes options', () => {
+  it('appends trailing slash when configured', () => {
+    const config = createTestConfig({
+      locales: ['en', 'fr'],
+      strategy: 'prefix_except_default',
+      defaultLocale: 'en',
+      trailingSlash: true,
+    })
+    const routes: LocalizableRoute[] = [
+      { path: '/', name: 'home' },
+      { path: '/about', name: 'about' },
+    ]
+    const result = localizeRoutes(routes, config)
+
+    expect(findRoute(result, 'home___en')?.path).toBe('/')
+    expect(findRoute(result, 'home___fr')?.path).toBe('/fr/')
+    expect(findRoute(result, 'about___en')?.path).toBe('/about/')
+    expect(findRoute(result, 'about___fr')?.path).toBe('/fr/about/')
+  })
+
+  it('uses custom route name separator', () => {
+    const config = createTestConfig({
+      locales: ['en', 'fr'],
+      strategy: 'prefix_except_default',
+      defaultLocale: 'en',
+      routesNameSeparator: '__',
+    })
+    const routes: LocalizableRoute[] = [{ path: '/about', name: 'about' }]
+    const result = localizeRoutes(routes, config)
+
+    expect(result.some(r => r.name === 'about__en')).toBe(true)
+    expect(result.some(r => r.name === 'about__fr')).toBe(true)
+  })
+
+  it('uses custom default locale route name suffix', () => {
+    const config = createTestConfig({
+      locales: ['en', 'fr'],
+      strategy: 'prefix_and_default',
+      defaultLocale: 'en',
+      defaultLocaleRouteNameSuffix: 'fallback',
+    })
+    const routes: LocalizableRoute[] = [{ path: '/about', name: 'about' }]
+    const result = localizeRoutes(routes, config)
+
+    expect(result.some(r => r.name === 'about___en___fallback')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// d) canConsolidateRoute
+// ---------------------------------------------------------------------------
+
+describe('canConsolidateRoute', () => {
+  const allLocales = ['en', 'fr', 'ja']
+
+  it('returns true when all locales enabled and no custom paths', () => {
+    expect(canConsolidateRoute({ locales: ['en', 'fr', 'ja'], paths: {} }, allLocales)).toBe(true)
+  })
+
+  it('returns false when some locales have custom paths', () => {
+    expect(canConsolidateRoute({ locales: ['en', 'fr', 'ja'], paths: { fr: '/a-propos' } }, allLocales)).toBe(false)
+  })
+
+  it('returns false when only a subset of locales is enabled', () => {
+    expect(canConsolidateRoute({ locales: ['en', 'fr'], paths: {} }, allLocales)).toBe(false)
+  })
+
+  it('returns false when routeOptions is undefined', () => {
+    expect(canConsolidateRoute(undefined, allLocales)).toBe(false)
+  })
+
+  it('returns true for single locale with no custom paths', () => {
+    expect(canConsolidateRoute({ locales: ['en'], paths: {} }, ['en'])).toBe(true)
+  })
+
+  it('returns false when paths is non-empty even if values match original', () => {
+    expect(canConsolidateRoute({ locales: ['en', 'fr'], paths: { en: '/about', fr: '/about' } }, ['en', 'fr'])).toBe(false)
+  })
+})

--- a/test/pages/utils.ts
+++ b/test/pages/utils.ts
@@ -1,7 +1,7 @@
-import type { NuxtI18nOptions } from '../../src/types'
+import type { NuxtI18nOptions, LocaleObject, Strategies } from '../../src/types'
 import type { NuxtPage } from '@nuxt/schema'
+import type { ComputedRouteOptions, LocalizableRoute, RouteOptionsResolver } from '../../src/kit/gen'
 
-import type { LocaleObject } from '../../src/types'
 import { isString } from '@intlify/shared'
 
 export const getNormalizedLocales = (locales: string[] | LocaleObject[] = []): LocaleObject[] =>
@@ -40,4 +40,66 @@ export function stripFilePropertyFromPages(pages: NuxtPage[]) {
     }
     return page
   })
+}
+
+/**
+ * Creates a mock `RouteOptionsResolver` from a simple map, bypassing `NuxtPageAnalyzeContext`.
+ *
+ * @param optionsMap - keyed by route name or path
+ *   - `ComputedRouteOptions`: custom locales/paths for the route
+ *   - `false`: route localization disabled (resolver returns `undefined`)
+ *   - `undefined` entry or missing key with no file: pass-through (resolver returns `undefined`)
+ * @param fallbackLocales - locales returned for routes not in the map (defaults to resolver's localeCodes)
+ */
+export function createMockOptionsResolver(
+  optionsMap: Record<string, ComputedRouteOptions | false | undefined> = {},
+  fallbackLocales?: string[]
+): RouteOptionsResolver {
+  return (route: LocalizableRoute, localeCodes: string[]) => {
+    const key = route.name || route.path
+    if (key && key in optionsMap) {
+      const value = optionsMap[key]
+      // false = disabled
+      if (value === false) return undefined
+      // explicit options
+      if (value != null) return value
+      // undefined = pass-through
+      return undefined
+    }
+
+    // redirect-only routes without a file are not localizable
+    if (route.redirect && !route.file) return undefined
+
+    // default: all locales, no custom paths
+    return { locales: fallbackLocales ?? localeCodes, paths: {} }
+  }
+}
+
+/**
+ * Creates a config object compatible with `localizeRoutes()` from minimal inputs.
+ */
+export function createTestConfig(opts: {
+  locales?: string[] | LocaleObject[]
+  strategy?: Strategies
+  defaultLocale?: string
+  trailingSlash?: boolean
+  optionsResolver?: RouteOptionsResolver
+  includeUnprefixedFallback?: boolean
+  differentDomains?: boolean
+  multiDomainLocales?: boolean
+  routesNameSeparator?: string
+  defaultLocaleRouteNameSuffix?: string
+}) {
+  return {
+    locales: getNormalizedLocales(opts.locales ?? ['en', 'fr']),
+    strategy: opts.strategy ?? 'prefix_except_default' as Strategies,
+    defaultLocale: opts.defaultLocale ?? 'en',
+    trailingSlash: opts.trailingSlash ?? false,
+    routesNameSeparator: opts.routesNameSeparator ?? '___',
+    defaultLocaleRouteNameSuffix: opts.defaultLocaleRouteNameSuffix ?? 'default',
+    optionsResolver: opts.optionsResolver,
+    includeUnprefixedFallback: opts.includeUnprefixedFallback ?? false,
+    differentDomains: opts.differentDomains,
+    multiDomainLocales: opts.multiDomainLocales,
+  }
 }

--- a/test/pages/utils.ts
+++ b/test/pages/utils.ts
@@ -89,7 +89,7 @@ export function createTestConfig(opts: {
   multiDomainLocales?: boolean
   routesNameSeparator?: string
   defaultLocaleRouteNameSuffix?: string
-  regexConsolidation?: boolean
+  compactRoutes?: boolean
 }) {
   return {
     locales: getNormalizedLocales(opts.locales ?? ['en', 'fr']),
@@ -102,6 +102,6 @@ export function createTestConfig(opts: {
     includeUnprefixedFallback: opts.includeUnprefixedFallback ?? false,
     differentDomains: opts.differentDomains,
     multiDomainLocales: opts.multiDomainLocales,
-    regexConsolidation: opts.regexConsolidation,
+    compactRoutes: opts.compactRoutes,
   }
 }

--- a/test/pages/utils.ts
+++ b/test/pages/utils.ts
@@ -89,6 +89,7 @@ export function createTestConfig(opts: {
   multiDomainLocales?: boolean
   routesNameSeparator?: string
   defaultLocaleRouteNameSuffix?: string
+  regexConsolidation?: boolean
 }) {
   return {
     locales: getNormalizedLocales(opts.locales ?? ['en', 'fr']),
@@ -101,5 +102,6 @@ export function createTestConfig(opts: {
     includeUnprefixedFallback: opts.includeUnprefixedFallback ?? false,
     differentDomains: opts.differentDomains,
     multiDomainLocales: opts.multiDomainLocales,
+    regexConsolidation: opts.regexConsolidation,
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental "compactRoutes" option to consolidate per-locale routes into single locale-regex routes, reducing duplication and supporting multiple routing strategies.
* **Bug Fixes**
  * Improved locale detection and route resolution to handle both compacted regex routes and per-locale routes; ensured route transitions react to locale param changes.
* **Tests**
  * Added comprehensive tests for localization, compaction eligibility, resolver behavior, and multiple routing strategies.
* **Documentation**
  * Documented the new experimental option, usage, behavior, and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->