### PR TITLE
fix: inline `@intlify/h3` to avoid dupes

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -76,6 +76,7 @@ export default defineNuxtModule<NuxtI18nOptions>({
       '@intlify/core-base',
       '@intlify/utils',
       '@intlify/utils/h3',
+      '@intlify/h3',
       '@intlify/message-compiler',
     ]
 

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -41,11 +41,8 @@ export async function setupNitro(ctx: I18nNuxtContext, nuxt: Nuxt) {
     { name: 'defineI18nLocaleDetector', from: ctx.resolver.resolve('runtime/composables/server') },
   ])
 
-  const h3UtilsExports = await resolveModuleExportNames(resolveModule('@intlify/utils/h3'))
-  addServerImports([
-    { name: 'useTranslation', from: '@intlify/h3' },
-    ...h3UtilsExports.map(name => ({ name, from: '@intlify/utils/h3' })),
-  ])
+  const h3Exports = await resolveModuleExportNames(resolveModule('@intlify/h3'))
+  addServerImports(h3Exports.map(name => ({ name, from: '@intlify/h3' })))
 
   // add nitro plugin
   addServerPlugin(ctx.resolver.resolve('runtime/server/plugin'))

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -41,8 +41,11 @@ export async function setupNitro(ctx: I18nNuxtContext, nuxt: Nuxt) {
     { name: 'defineI18nLocaleDetector', from: ctx.resolver.resolve('runtime/composables/server') },
   ])
 
-  const h3Exports = await resolveModuleExportNames(resolveModule('@intlify/h3'))
-  addServerImports(h3Exports.map(name => ({ name, from: '@intlify/h3' })))
+  const h3UtilsExports = await resolveModuleExportNames(resolveModule('@intlify/utils/h3'))
+  addServerImports([
+    { name: 'useTranslation', from: '@intlify/h3' },
+    ...h3UtilsExports.map(name => ({ name, from: '@intlify/h3' })),
+  ])
 
   // add nitro plugin
   addServerPlugin(ctx.resolver.resolve('runtime/server/plugin'))

--- a/src/runtime/server/routes/messages.ts
+++ b/src/runtime/server/routes/messages.ts
@@ -1,6 +1,7 @@
 import { deepCopy } from '@intlify/shared'
 import { defineCachedEventHandler, defineCachedFunction } from 'nitropack/runtime'
 import { createError, defineEventHandler, getRouterParam } from 'h3'
+import type {} from '@intlify/h3'
 import { initializeI18nContext, tryUseI18nContext, useI18nContext } from '../context'
 import { getMergedMessages } from '../utils/messages'
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

otherwise we can end up with different versions of `@intlify/utils/h3` and `@intlify/h3`

https://github.com/nuxt/ecosystem-ci/actions/runs/23833781405/job/69473060451

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to include an additional dependency so it’s picked up by transpilation, optimization, and TypeScript hoisting.
  * Added a type-only import to server routing code; no runtime behavior, API surface, or handler logic changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->