### PR TITLE
fix: incorrect route group server redirection during ssg

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,6 +353,15 @@ importers:
         specifier: latest
         version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.2))(yaml@2.8.2)
 
+  specs/fixtures/issues/3929:
+    devDependencies:
+      '@nuxtjs/i18n':
+        specifier: workspace:*
+        version: link:../../../..
+      nuxt:
+        specifier: latest
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.9.0))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.0)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(rollup-plugin-visualizer@6.0.11(rollup@4.59.0))(rollup@4.59.0)(terser@5.46.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.2))(yaml@2.8.2)
+
   specs/fixtures/lazy:
     devDependencies:
       '@nuxtjs/i18n':

--- a/specs/fixtures/issues/3929/nuxt.config.ts
+++ b/specs/fixtures/issues/3929/nuxt.config.ts
@@ -1,0 +1,11 @@
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/i18n'],
+  i18n: {
+    locales: ['en', 'fr'],
+    defaultLocale: 'en',
+    detectBrowserLanguage: {
+      redirectOn: 'no prefix'
+    }
+  }
+})

--- a/specs/fixtures/issues/3929/package.json
+++ b/specs/fixtures/issues/3929/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "fixture-3929",
+  "private": true,
+  "scripts": {
+    "build": "nuxt build",
+    "dev": "nuxt dev",
+    "generate": "nuxt generate",
+    "preview": "nuxt preview"
+  },
+  "devDependencies": {
+    "@nuxtjs/i18n": "latest",
+    "nuxt": "latest"
+  }
+}

--- a/specs/fixtures/issues/3929/pages/(group)/(nested)/bar.vue
+++ b/specs/fixtures/issues/3929/pages/(group)/(nested)/bar.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Bar (group/nested)</div>
+</template>

--- a/specs/fixtures/issues/3929/pages/(group)/foo.vue
+++ b/specs/fixtures/issues/3929/pages/(group)/foo.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Foo (group)</div>
+</template>

--- a/specs/fixtures/issues/3929/pages/index.vue
+++ b/specs/fixtures/issues/3929/pages/index.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Home</div>
+</template>

--- a/specs/issues/3929.spec.ts
+++ b/specs/issues/3929.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect, describe } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { $fetch, setup } from '../utils'
+
+describe('#3929 - route groups with `detectBrowserLanguage.redirectOn: "no prefix"` during prerender', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL(`../fixtures/issues/3929`, import.meta.url)),
+    // exercises `nuxt generate` — the original bug caused prerender to fail
+    prerender: true
+  })
+
+  test('prerenders pages inside a route group', async () => {
+    const html = await $fetch('/foo')
+    expect(html).toContain('Foo (group)')
+  })
+
+  test('prerenders pages inside nested route groups', async () => {
+    const html = await $fetch('/bar')
+    expect(html).toContain('Bar (group/nested)')
+  })
+
+  test('prerenders localized pages inside route groups', async () => {
+    const fooFr = await $fetch('/fr/foo')
+    expect(fooFr).toContain('Foo (group)')
+
+    const barFr = await $fetch('/fr/bar')
+    expect(barFr).toContain('Bar (group/nested)')
+  })
+})

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -242,11 +242,19 @@ export {}`
 function analyzePagePath(pagePath: string, parents = 0) {
   const { dir, name } = parsePath(pagePath)
 
-  if (parents > 0 || dir !== '/') {
-    return `${dir.slice(1, dir.length)}/${name}`
-  }
+  const analyzed = (parents > 0 || dir !== '/')
+    ? `${dir.slice(1, dir.length)}/${name}`
+    : name
 
-  return name
+  return stripRouteGroups(analyzed)
+}
+
+/**
+ * Strip Nuxt route-group segments (`(name)`) from a path. Route groups are
+ * directory names used to organize files without contributing to the URL.
+ */
+function stripRouteGroups(path: string): string {
+  return path.split('/').filter(s => !/^\([^)]+\)$/.test(s)).join('/')
 }
 
 /**


### PR DESCRIPTION
### 🔗 Linked issue
* Resolves #3929
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of route group directories during page path analysis to ensure grouped routes are processed correctly during prerendering.

* **Tests**
  * Added test coverage for route group prerendering with internationalization support, verifying correct HTML generation for grouped and nested route pages across multiple locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->