### PR TITLE
fix: stable locale message endpoint hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "magic-string": "^0.30.21",
     "mlly": "^1.7.4",
     "nuxt-define": "^1.0.0",
-    "ohash": "^2.0.11",
     "oxc-parser": "^0.112.0",
     "oxc-transform": "^0.112.0",
     "oxc-walker": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,9 +59,6 @@ importers:
       nuxt-define:
         specifier: ^1.0.0
         version: 1.0.0
-      ohash:
-        specifier: ^2.0.11
-        version: 2.0.11
       oxc-parser:
         specifier: ^0.112.0
         version: 0.112.0

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -60,7 +60,7 @@ export async function extendBundler(ctx: I18nNuxtContext, nuxt: Nuxt) {
 }
 
 export function getDefineConfig(
-  { options, fullStatic, deploymentHash }: I18nNuxtContext,
+  { options, fullStatic, localeHashes }: I18nNuxtContext,
   server = false,
   nuxt = useNuxt(),
 ) {
@@ -98,7 +98,8 @@ export function getDefineConfig(
     __I18N_ROUTING__: JSON.stringify(nuxt.options.pages.toString() && options.strategy !== 'no_prefix'),
     __I18N_COMPACT_ROUTES__: String(!!options.experimental?.compactRoutes),
     __I18N_STRICT_SEO__: JSON.stringify(!!options.experimental.strictSeo),
-    __I18N_SERVER_ROUTE__: JSON.stringify([options.serverRoutePrefix, deploymentHash].join('/')),
+    __I18N_SERVER_ROUTE__: JSON.stringify(options.serverRoutePrefix),
+    __I18N_LOCALE_HASHES__: JSON.stringify(localeHashes),
     __I18N_SERVER_REDIRECT__: JSON.stringify(!!options.experimental.nitroContextDetection),
   }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,7 +1,6 @@
 import { createResolver } from '@nuxt/kit'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'pathe'
-import { hash } from 'ohash'
 import type { Resolver } from '@nuxt/kit'
 import type { FileMeta, LocaleInfo, LocaleObject, NuxtI18nOptions } from './types'
 import type { Nuxt, NuxtConfigLayer } from '@nuxt/schema'
@@ -18,7 +17,7 @@ export interface I18nNuxtContext {
   distDir: string
   runtimeDir: string
   fullStatic: boolean
-  deploymentHash: string
+  localeHashes: Record<string, string>
   i18nLayers: LayerWithI18n[]
 }
 
@@ -51,6 +50,6 @@ export function createContext(userOptions: NuxtI18nOptions, nuxt: Nuxt): I18nNux
     normalizedLocales: undefined!,
     vueI18nConfigPaths: undefined!,
     fullStatic: undefined!,
-    deploymentHash: hash(Date.now()).slice(0, 8),
+    localeHashes: undefined!,
   }
 }

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -29,7 +29,9 @@ declare let __I18N_PRELOAD__: boolean
 declare let __I18N_ROUTING__: boolean
 declare let __I18N_STRICT_SEO__: boolean
 declare let __I18N_SERVER_REDIRECT__: boolean
-/** Includes hashed deployment timestamp */
+/** Server route prefix for i18n message endpoints */
 declare let __I18N_SERVER_ROUTE__: string
+/** Per-locale content hash, used as the `:hash` segment of message routes */
+declare let __I18N_LOCALE_HASHES__: Record<string, string>
 /** Whether compact routes are enabled */
 declare let __I18N_COMPACT_ROUTES__: boolean

--- a/src/module.ts
+++ b/src/module.ts
@@ -14,7 +14,7 @@ import { relative } from 'pathe'
 import { generateTemplateNuxtI18nOptions } from './template'
 import { generateI18nTypes, generateLoaderOptions, simplifyLocaleOptions } from './gen'
 import { applyLayerOptions, resolveLayerVueI18nConfigInfo } from './layers'
-import { filterLocales, resolveLocales } from './utils'
+import { computeLocaleHashes, filterLocales, resolveLocales } from './utils'
 import { isString } from '@intlify/shared'
 
 export * from './types'
@@ -174,6 +174,13 @@ export default defineNuxtModule<NuxtI18nOptions>({
       ctx.localeInfo = resolveLocales(nuxt.options.srcDir, ctx.normalizedLocales, nuxt.vfs)
 
       ctx.vueI18nConfigPaths = await resolveLayerVueI18nConfigInfo(ctx)
+
+      /**
+       * content-hash locale files now that all locales and configs are known,
+       * used to cache-bust per-locale message server routes without churning
+       * on every build
+       */
+      ctx.localeHashes = computeLocaleHashes(ctx.localeInfo, ctx.vueI18nConfigPaths)
 
       /**
        * expose i18n options via runtime config for use in app/server contexts

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -99,7 +99,7 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
   const loadMessagesFromServer = async (locale: string) => {
     if (locale in localeLoaders === false) { return }
     const headers: HeadersInit = getLocaleConfig(locale)?.cacheable ? {} : { 'Cache-Control': 'no-cache' }
-    const messages = await $fetch(`${__I18N_SERVER_ROUTE__}/${locale}/messages.json`, { headers })
+    const messages = await $fetch(`${__I18N_SERVER_ROUTE__}/${__I18N_LOCALE_HASHES__[locale]}/${locale}/messages.json`, { headers })
     for (const k of Object.keys(messages)) {
       i18n.mergeLocaleMessage(k, messages[k])
     }

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -43,7 +43,7 @@ export default defineNuxtPlugin({
       setupMultiDomainLocales(optionsI18n.defaultLocale)
     }
 
-    prerenderRoutes(localeCodes.map(locale => `${__I18N_SERVER_ROUTE__}/${locale}/messages.json`))
+    prerenderRoutes(localeCodes.map(locale => `${__I18N_SERVER_ROUTE__}/${__I18N_LOCALE_HASHES__[locale]}/${locale}/messages.json`))
 
     // create i18n instance
     const i18n = createI18n(optionsI18n)

--- a/src/runtime/plugins/preload.ts
+++ b/src/runtime/plugins/preload.ts
@@ -19,7 +19,7 @@ export default defineNuxtPlugin({
     if (import.meta.server) {
       for (const locale of localeCodes) {
         try {
-          const messages = await $fetch(`${__I18N_SERVER_ROUTE__}/${locale}/messages.json`)
+          const messages = await $fetch(`${__I18N_SERVER_ROUTE__}/${__I18N_LOCALE_HASHES__[locale]}/${locale}/messages.json`)
           for (const locale of Object.keys(messages)) {
             nuxt.$i18n.mergeLocaleMessage(locale, messages[locale])
           }

--- a/src/runtime/server/context.ts
+++ b/src/runtime/server/context.ts
@@ -41,7 +41,7 @@ export const fetchMessages = async (locale: string) => {
   if (import.meta.dev) {
     headers.set('Cache-Control', 'no-cache')
   }
-  return await $fetch<LocaleMessages<DefineLocaleMessage>>(`${__I18N_SERVER_ROUTE__}/${locale}/messages.json`, {
+  return await $fetch<LocaleMessages<DefineLocaleMessage>>(`${__I18N_SERVER_ROUTE__}/${__I18N_LOCALE_HASHES__[locale]}/${locale}/messages.json`, {
     headers,
   })
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,7 @@ import { assign, isArray, isString } from '@intlify/shared'
 import { EXECUTABLE_EXT_RE } from './constants'
 import { parseSync } from 'oxc-parser'
 
-import type { LocaleFile, LocaleInfo, LocaleObject, LocaleType, NuxtI18nOptions } from './types'
+import type { FileMeta, LocaleFile, LocaleInfo, LocaleObject, LocaleType, NuxtI18nOptions } from './types'
 import type { Nuxt, NuxtConfigLayer } from '@nuxt/schema'
 import type { IdentifierName, Program, VariableDeclarator } from 'oxc-parser'
 import type { I18nNuxtContext } from './context'
@@ -165,6 +165,33 @@ export const mergeConfigLocales = (configs: LocaleConfig[]) => {
 
 function getHash(text: BinaryLike): string {
   return createHash('sha256').update(text).digest('hex').substring(0, 8)
+}
+
+/**
+ * Compute a content-based hash for cache-busting message server routes.
+ * Why: vue-i18n config files run at runtime and may declare `fallbackLocale`,
+ * so we can't statically resolve fallback chains. To stay correct under
+ * fallbacks, every locale shares one hash covering all locale + config
+ * files — any content change busts every endpoint.
+ */
+export function computeLocaleHashes(localeInfo: LocaleInfo[], vueI18nConfigPaths: Omit<FileMeta, 'cache'>[]): Record<string, string> {
+  const hasher = createHash('sha256')
+  const paths = [
+    ...localeInfo.flatMap(l => l.meta.map(m => m.path)),
+    ...vueI18nConfigPaths.map(c => c.path),
+  ].sort()
+
+  for (const p of paths) {
+    hasher.update(readFileSync(p))
+  }
+
+  const digest = hasher.digest('hex').substring(0, 8)
+  const hashes: Record<string, string> = {}
+  for (const locale of localeInfo) {
+    hashes[locale.code] = digest
+  }
+
+  return hashes
 }
 
 export function getLayerI18n(configLayer: NuxtConfigLayer) {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Instead of having a hash based on the build time, we now use all locale files and their contents to create a hash that is stable if no changes were made to the locale files across builds.

Unfortunately we can't use a per-locale hash, since it's possible to define fallback locales in vue-i18n configuration which we can only reliably load at runtime.


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated internationalization message caching to use content-based hashing for better cache management across locales
* **Chores**
  * Removed unused dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->