### PR TITLE
test: improve ssg fixture process handling to reduce flakiness

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "ofetch": "^1.4.1",
     "playwright-core": "^1.54.1",
     "scule": "^1.3.0",
+    "sirv": "^3.0.2",
     "tinyexec": "^1.0.1",
     "typescript": "^5.9.3",
     "unbuild": "^3.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       scule:
         specifier: ^1.3.0
         version: 1.3.0
+      sirv:
+        specifier: ^3.0.2
+        version: 3.0.2
       tinyexec:
         specifier: ^1.0.1
         version: 1.0.2

--- a/specs/utils/server.ts
+++ b/specs/utils/server.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { createServer } from 'node:http'
+import sirv from 'sirv'
 import { x } from 'tinyexec'
 import { getRandomPort, waitForPort } from 'get-port-please'
 import type { FetchOptions } from 'ofetch'
@@ -50,24 +52,25 @@ export async function startServer(env: Record<string, unknown> = {}) {
     ctx.serverProcess.kill()
     throw lastError || new Error('Timeout waiting for dev server!')
   } else if (ctx.options.prerender) {
-    const listenTo = ports.map(port => `-l tcp://${host}:${port}`).join(' ')
-    const command = `pnpx serve ${ctx.nuxt!.options.nitro!.output?.publicDir} ${listenTo} --no-port-switching`
-    // ;(await import('consola')).consola.restoreConsole()
-    const [_command, ...commandArgs] = command.split(' ')
-
-    ctx.serverProcess = x(_command, commandArgs, {
-      throwOnError: true,
-      nodeOptions: {
-        env: {
-          ...process.env,
-          PORT: String(ports[0]),
-          HOST: host,
-          ...env
-        }
-      }
+    const handler = sirv(ctx.nuxt!.options.nitro!.output!.publicDir!, {
+      dev: false,
+      etag: true,
+      single: false
     })
 
-    await waitForPort(ports[0], { retries: 50, host, delay: process.env.CI ? 1000 : 500 })
+    ctx.staticServers = await Promise.all(
+      ports.map(
+        port =>
+          new Promise<import('node:http').Server>((resolveListen, rejectListen) => {
+            const server = createServer((req, res) => handler(req, res))
+            server.once('error', rejectListen)
+            server.listen(port, host, () => {
+              server.off('error', rejectListen)
+              resolveListen(server)
+            })
+          })
+      )
+    )
   } else {
     ctx.serverProcess = x('node', [resolve(ctx.nuxt!.options.nitro.output!.dir!, 'server/index.mjs')], {
       throwOnError: true,
@@ -96,6 +99,14 @@ export async function startServer(env: Record<string, unknown> = {}) {
 export function stopServer() {
   const ctx = useTestContext()
   ctx.serverProcess?.kill()
+  ctx.serverProcess = undefined
+  if (ctx.staticServers) {
+    for (const server of ctx.staticServers) {
+      server.closeAllConnections?.()
+      server.close()
+    }
+    ctx.staticServers = undefined
+  }
 }
 
 export function fetch(path: string, options?: any) {
@@ -122,7 +133,7 @@ export function url(path: string, port?: number) {
 
   // replace port in url
   if (port != null) {
-    return ctx.url.slice(0, ctx.url.lastIndexOf(':')) + `:${port}/` + path
+    return ctx.url.slice(0, ctx.url.lastIndexOf(':')) + `:${port}` + path
   }
 
   return ctx.url + path

--- a/specs/utils/setup/index.ts
+++ b/specs/utils/setup/index.ts
@@ -5,10 +5,42 @@ import { createBrowser } from '../browser'
 import setupVitest from './vitest'
 import consola from 'consola'
 
-import type { TestHooks, TestOptions, VitestContext } from '../types'
+import type { TestContext, TestHooks, TestOptions, VitestContext } from '../types'
+
+const activeContexts = new Set<TestContext>()
+let processCleanupRegistered = false
+
+function registerProcessCleanup() {
+  if (processCleanupRegistered) return
+  processCleanupRegistered = true
+
+  const cleanup = () => {
+    for (const ctx of activeContexts) {
+      try {
+        setTestContext(ctx)
+        stopServer()
+      } catch {
+        // best-effort: cleanup must not throw on exit
+      } finally {
+        setTestContext(undefined)
+      }
+    }
+    activeContexts.clear()
+  }
+
+  process.once('exit', cleanup)
+  for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP'] as const) {
+    process.once(signal, () => {
+      cleanup()
+      process.exit(signal === 'SIGINT' ? 130 : 1)
+    })
+  }
+}
 
 function createTest(options: Partial<TestOptions>): TestHooks {
   const ctx = createTestContext(options)
+  registerProcessCleanup()
+  activeContexts.add(ctx)
 
   const beforeEach = () => {
     setTestContext(ctx)
@@ -22,11 +54,13 @@ function createTest(options: Partial<TestOptions>): TestHooks {
   }
 
   const afterAll = async () => {
-    if (ctx.serverProcess) {
+    if (ctx.serverProcess || ctx.staticServers) {
       setTestContext(ctx)
       stopServer()
       setTestContext(undefined)
     }
+
+    activeContexts.delete(ctx)
 
     if (ctx.nuxt && ctx.nuxt.options.dev) {
       await ctx.nuxt.close()

--- a/specs/utils/types.ts
+++ b/specs/utils/types.ts
@@ -1,4 +1,5 @@
 import type { Nuxt, NuxtConfig } from '@nuxt/schema'
+import type { Server } from 'node:http'
 import type { exec } from 'tinyexec'
 import type { Browser, LaunchOptions } from 'playwright-core'
 import type { NuxtI18nOptions } from '../../src/types'
@@ -33,6 +34,7 @@ export interface TestContext {
   browser?: Browser
   url?: string
   serverProcess?: ReturnType<typeof exec>
+  staticServers?: Server[]
   // eslint-disable-next-line @typescript-eslint/ban-types
   mockFn?: Function
   /**


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This should reduce flakiness caused by improper cleanup and `pnpx serve` install/startup race conditions.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced an in-process static server option for prerendered content.
  * Improved test server lifecycle and global process-level cleanup (handles exit/signals).
  * Ensured test servers are fully closed (including active connections) during shutdown.
  * Fixed URL port substitution to avoid an extra slash after the port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->