### PR TITLE
fix: prevent silently disabling `experimental.compactRoutes`

### DIFF
--- a/src/prepare/options.ts
+++ b/src/prepare/options.ts
@@ -49,4 +49,16 @@ export function prepareOptions({ options }: I18nNuxtContext, nuxt: Nuxt) {
       'Route localization features (e.g. custom name, prefixed aliases) require Nuxt\'s `experimental.scanPageMeta` to be enabled.\nThis feature will be enabled in future Nuxt versions (https://github.com/nuxt/nuxt/pull/27134), check out the docs for more details: https://nuxt.com/docs/guide/going-further/experimental-features#scanpagemeta',
     )
   }
+
+  if (options.experimental?.compactRoutes) {
+    const conflicts: string[] = []
+    if (strategy === 'no_prefix') { conflicts.push('`strategy: "no_prefix"`') }
+    if (options.differentDomains) { conflicts.push('`differentDomains`') }
+    if (hasMultiDomainLocales) { conflicts.push('`multiDomainLocales`') }
+    if (conflicts.length) {
+      logger.warn(
+        `\`experimental.compactRoutes\` is enabled but has no effect due to incompatible option(s): ${conflicts.join(', ')}. Routes will fall back to per-locale duplication.`,
+      )
+    }
+  }
 }

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -90,7 +90,7 @@ export function localizeRoutes(routes: LocalizableRoute[], config: SetupLocalize
     && strategy !== 'no_prefix'
     && !config.differentDomains
     && !config.multiDomainLocales
-    && !config.includeUnprefixedFallback
+    && !(strategy === 'prefix' && config.includeUnprefixedFallback)
   ) {
     const defaultLocale = config.defaultLocale ?? ''
     ctx.compactRoute = (route, routeOptions, params) => {

--- a/test/pages/route_localization.test.ts
+++ b/test/pages/route_localization.test.ts
@@ -703,6 +703,55 @@ describe('compact routes', () => {
     })
   })
 
+  // The Nuxt module wrapper passes `includeUnprefixedFallback: true` for any
+  // strategy other than `prefix`, even though the flag is only consulted when
+  // strategy === 'prefix'. The compactRoutes gate must not treat that as a
+  // disable signal — see issue #3971.
+  describe('compactRoutes is not blocked by includeUnprefixedFallback for non-prefix strategies', () => {
+    it('compacts under prefix_except_default + includeUnprefixedFallback: true', () => {
+      const config = createTestConfig({
+        locales,
+        strategy: 'prefix_except_default',
+        defaultLocale: 'en',
+        compactRoutes: true,
+        includeUnprefixedFallback: true,
+      })
+      const result = localizeRoutes(routes, config)
+
+      expect(result.find(r => r.path === '/:locale(fr|ja)/about')).toBeDefined()
+      expect(findRoute(result, 'about___fr')).toBeUndefined()
+      expect(findRoute(result, 'about___ja')).toBeUndefined()
+    })
+
+    it('compacts under prefix_and_default + includeUnprefixedFallback: true', () => {
+      const config = createTestConfig({
+        locales,
+        strategy: 'prefix_and_default',
+        defaultLocale: 'en',
+        compactRoutes: true,
+        includeUnprefixedFallback: true,
+      })
+      const result = localizeRoutes(routes, config)
+
+      expect(result.find(r => r.path === '/:locale(en|fr|ja)/about')).toBeDefined()
+      expect(findRoute(result, 'about___fr')).toBeUndefined()
+      expect(findRoute(result, 'about___ja')).toBeUndefined()
+    })
+
+    it('still blocks compaction under prefix + includeUnprefixedFallback: true', () => {
+      const config = createTestConfig({
+        locales,
+        strategy: 'prefix',
+        defaultLocale: 'en',
+        compactRoutes: true,
+        includeUnprefixedFallback: true,
+      })
+      const result = localizeRoutes(routes, config)
+
+      expect(result.find(r => r.path?.includes(':locale'))).toBeUndefined()
+    })
+  })
+
   describe('ineligible routes — must stay per-locale', () => {
     it('does NOT compact a route with custom per-locale paths', () => {
       const resolver = createMockOptionsResolver({


### PR DESCRIPTION
### 🔗 Linked issue
* Resolves #3971
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added validation warnings when using `compactRoutes` with incompatible configurations, informing users that the feature will be ignored in those specific scenarios.
  * Expanded route compaction eligibility to support additional routing strategy and configuration option combinations.

* **Tests**
  * Added comprehensive test coverage for route compaction behavior across different routing strategies and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->