### PR TITLE
fix: compact routes prerender handling and router warnings

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -208,24 +208,6 @@ export default defineNuxtModule<NuxtI18nOptions>({
       nuxt.options.runtimeConfig.public.i18n.locales = simplifyLocaleOptions(ctx, nuxt)
 
       /**
-       * ignore `/` during prerender when using prefixed routing
-       */
-      if (ctx.options.strategy === 'prefix' && nuxt.options.nitro.static) {
-        const localizedEntryPages = ctx.localeCodes.map(x => '/' + x)
-        nuxt.hook('nitro:config', (config) => {
-          config.prerender ??= {}
-
-          // ignore `/` which is added by nitro by default
-          config.prerender.ignore ??= []
-          config.prerender.ignore.push(/^\/$/)
-
-          // add localized routes as entry pages for prerendering
-          config.prerender.routes ??= []
-          config.prerender.routes.push(...localizedEntryPages)
-        })
-      }
-
-      /**
        * disable preloading/prefetching of locale files
        */
       nuxt.hook('build:manifest', (manifest) => {

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -58,8 +58,26 @@ export const i18nPathToPath = ${JSON.stringify(routeResources.i18nPathToPath, nu
   if (!localeCodes.length) { return }
 
   let includeUnprefixedFallback = !nuxt.options.ssr
-  nuxt.hook('nitro:init', () => {
+  // Filled during pages:extend, drained at prerender time. nitro:init fires before
+  // pages:extend, so we can't seed nitro.options.prerender.routes directly.
+  const compactPrerenderRoutes: string[] = []
+  nuxt.hook('nitro:init', (nitro) => {
     includeUnprefixedFallback = options.strategy !== 'prefix'
+
+    if (!nuxt.options.nitro.static) { return }
+
+    // `prefix` strategy: `/` is not a valid route, ignore it.
+    if (options.strategy === 'prefix') {
+      nitro.options.prerender.ignore ??= []
+      nitro.options.prerender.ignore.push(/^\/$/)
+    }
+
+    nitro.hooks.hook('prerender:routes', (routes) => {
+      if (options.strategy === 'prefix') {
+        for (const locale of localeCodes) { routes.add('/' + locale) }
+      }
+      for (const route of compactPrerenderRoutes) { routes.add(route) }
+    })
   })
 
   const projectLayer = nuxt.options._layers[0]
@@ -126,8 +144,30 @@ export const i18nPathToPath = ${JSON.stringify(routeResources.i18nPathToPath, nu
         pages.length = 0
         pages.unshift(...localizedPages)
       }
+
+      // Expand compact regex routes into concrete per-locale paths so Nuxt's
+      // static-route extractor can prerender them. Drained by nitro:init above.
+      if (options.experimental?.compactRoutes && nuxt.options.nitro.static) {
+        compactPrerenderRoutes.push(...collectCompactPrerenderRoutes(localizedPages))
+      }
     },
   )
+}
+
+const compactRouteRE = /^\/:locale\(([^)]+)\)(.*)$/
+const remainingParamRE = /:[A-Z_]/i
+
+export function collectCompactPrerenderRoutes(pages: NarrowedNuxtPage[]): string[] {
+  const out: string[] = []
+  for (const route of pages) {
+    if (!(route.meta as Record<string, unknown> | undefined)?.__i18nCompact) { continue }
+    const match = compactRouteRE.exec(route.path)
+    if (!match || remainingParamRE.test(match[2]!)) { continue }
+    for (const locale of match[1]!.split('|')) {
+      out.push('/' + locale + match[2])
+    }
+  }
+  return out
 }
 
 /**

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -157,16 +157,43 @@ export const i18nPathToPath = ${JSON.stringify(routeResources.i18nPathToPath, nu
 const compactRouteRE = /^\/:locale\(([^)]+)\)(.*)$/
 const remainingParamRE = /:[A-Z_]/i
 
+// The `:locale(...)` prefix defeats Nuxt's static-route extractor, so we mirror its
+// behavior here: walk the tree and emit each static descendant per locale.
 export function collectCompactPrerenderRoutes(pages: NarrowedNuxtPage[]): string[] {
   const out: string[] = []
+
+  const emit = (locales: readonly string[], rest: string): boolean => {
+    if (remainingParamRE.test(rest)) { return false }
+    for (const locale of locales) { out.push('/' + locale + rest) }
+    return true
+  }
+
+  const walkChildren = (children: NarrowedNuxtPage[] | undefined, locales: readonly string[], parentRest: string) => {
+    if (!children?.length) { return }
+    for (const child of children) {
+      // Absolute path: Vue Router does not compose it with the parent.
+      if (child.path.startsWith('/')) { continue }
+      // Index child shares the parent's URL — already emitted, but its grandchildren may not be.
+      if (child.path === '') {
+        walkChildren(child.children, locales, parentRest)
+        continue
+      }
+      const rest = parentRest.replace(/\/$/, '') + '/' + child.path
+      if (!emit(locales, rest)) { continue }
+      walkChildren(child.children, locales, rest)
+    }
+  }
+
   for (const route of pages) {
     if (!(route.meta as Record<string, unknown> | undefined)?.__i18nCompact) { continue }
     const match = compactRouteRE.exec(route.path)
-    if (!match || remainingParamRE.test(match[2]!)) { continue }
-    for (const locale of match[1]!.split('|')) {
-      out.push('/' + locale + match[2])
-    }
+    if (!match) { continue }
+    const locales = match[1]!.split('|')
+    const rest = match[2]!
+    if (!emit(locales, rest)) { continue }
+    walkChildren(route.children, locales, rest)
   }
+
   return out
 }
 

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -92,14 +92,10 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
       if (__I18N_COMPACT_ROUTES__ && route.params) {
         delete (route.params as Record<string, unknown>).locale
       }
-    } else if (__I18N_COMPACT_ROUTES__ && isSupportedLocale(locale) && router.hasRoute(route.name!)) {
-      // compact route: keep base name, inject locale as route param
-      // spread existing params (e.g. slug) to satisfy all required route params
-      const resolved = router.resolve({ name: route.name!, params: { ...(route.params as Record<string, unknown> || {}), locale } })
-      if (resolved.meta?.__i18nCompact) {
-        route.params = { ...(route.params || {}), locale }
-        return route
-      }
+    } else if (__I18N_COMPACT_ROUTES__ && isSupportedLocale(locale) && getCompactRouteNames().has(route.name!)) {
+      // Compact route: keep base name, inject locale as route param.
+      route.params = { ...(route.params || {}), locale }
+      return route
     }
 
     // No per-locale or compact match: set localized name so router.resolve
@@ -109,6 +105,21 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
   }
 
   const routeByPathResolver = createLocalizedRouteByPathResolver(router)
+  // Detect compact routes by their resolved path prefix — catches the compact
+  // parent and its children (whose own meta is empty but whose path inherits
+  // the locale segment). Route records are stable after build, so cache lazily.
+  let compactRouteRecords: Set<string> | undefined
+  function getCompactRouteNames() {
+    if (compactRouteRecords) { return compactRouteRecords }
+    compactRouteRecords = new Set()
+    if (__I18N_COMPACT_ROUTES__) {
+      for (const r of router.getRoutes()) {
+        if (r.name != null && /^\/:locale\(/.test(r.path)) { compactRouteRecords.add(String(r.name)) }
+      }
+    }
+    return compactRouteRecords
+  }
+
   function resolveLocalizedRouteByPath(input: RouteLikeWithPath, locale: string) {
     const route = routeByPathResolver(input, locale) as RouteLike
     const baseName = getRouteBaseName(route)
@@ -122,15 +133,13 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
         return route
       }
 
-      if (__I18N_COMPACT_ROUTES__) {
-        // Fallback: compact route — keep base name with locale param
-        const resolved = router.resolve({ name: baseName, params: {} })
-        if (resolved.matched.some(r => r.meta?.__i18nCompact)) {
-          const compacted = route as RouteLikeWithName
-          compacted.name = baseName
-          compacted.params = { ...(compacted.params || {}), locale }
-          return compacted
-        }
+      // Path-pattern check (rather than router.resolve probe) avoids vue-router warnings
+      // when `baseName` resolves to a non-compact route, e.g. defineI18nRoute(false).
+      if (__I18N_COMPACT_ROUTES__ && getCompactRouteNames().has(baseName)) {
+        const compacted = route as RouteLikeWithName
+        compacted.name = baseName
+        compacted.params = { ...(compacted.params || {}), locale }
+        return compacted
       }
 
       // Set the localized route name — if the route doesn't exist (e.g. disabled routes),

--- a/test/pages/route_localization.test.ts
+++ b/test/pages/route_localization.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { localizeRoutes } from '../../src/routing'
 import { localizeSingleRoute, createRouteContext, canCompactRoute } from '../../src/kit/gen'
-import { buildPathToConfig, NuxtPageAnalyzeContext } from '../../src/pages'
+import { buildPathToConfig, collectCompactPrerenderRoutes, NuxtPageAnalyzeContext } from '../../src/pages'
 import { createMockOptionsResolver, createTestConfig, getNormalizedLocales } from './utils'
 
 import type { LocalizableRoute, LocalizeRouteParams } from '../../src/kit/gen'
@@ -788,6 +788,67 @@ describe('compact routes', () => {
       expect(result).toHaveLength(1)
       expect(result[0].path).toBe('/about')
       expect(result[0].name).toBe('about')
+    })
+  })
+
+  // Compact regex routes can't be enumerated by Nuxt's static-route extractor
+  // for `nuxt generate`, so we expand them back into concrete per-locale paths
+  // via `collectCompactPrerenderRoutes`. These tests pin down the edge cases.
+  describe('collectCompactPrerenderRoutes — prerender expansion of compact routes', () => {
+    const compact = (path: string, name: string) => ({
+      path,
+      name,
+      meta: { __i18nCompact: true },
+    } as unknown as Parameters<typeof collectCompactPrerenderRoutes>[0][number])
+
+    it('expands a compact regex route to one path per locale', () => {
+      const out = collectCompactPrerenderRoutes([compact('/:locale(en|fr|ja)/about', 'about')])
+      expect(out).toEqual(['/en/about', '/fr/about', '/ja/about'])
+    })
+
+    it('handles the root route — `/` becomes `/:locale(...)` with no rest', () => {
+      // `prefix` strategy compacts the home page to `/:locale(en|fr)` (no trailing path).
+      // We must emit `/en` and `/fr`, never `/en/` or `/fr/`.
+      const out = collectCompactPrerenderRoutes([compact('/:locale(en|fr)', 'index')])
+      expect(out).toEqual(['/en', '/fr'])
+    })
+
+    it('skips routes with dynamic params after the locale segment', () => {
+      // `/:locale(fr)/products/:id` — concrete `:id` values are unknown at build time,
+      // matches the non-compact case where Nuxt also can't auto-prerender these.
+      const out = collectCompactPrerenderRoutes([compact('/:locale(fr|ja)/products/:id', 'products-id')])
+      expect(out).toEqual([])
+    })
+
+    it('skips routes with optional params after the locale segment', () => {
+      const out = collectCompactPrerenderRoutes([compact('/:locale(fr)/blog/:slug?', 'blog-slug')])
+      expect(out).toEqual([])
+    })
+
+    it('ignores routes without `__i18nCompact` meta', () => {
+      const plain = { path: '/about', name: 'about' } as Parameters<typeof collectCompactPrerenderRoutes>[0][number]
+      const out = collectCompactPrerenderRoutes([plain])
+      expect(out).toEqual([])
+    })
+
+    it('ignores routes whose path does not start with the `:locale(...)` regex prefix', () => {
+      // Defensive: if a future change marks a non-prefixed route as compact,
+      // we should not emit garbage like `undefinedabout`.
+      const odd = compact('/about', 'about')
+      const out = collectCompactPrerenderRoutes([odd])
+      expect(out).toEqual([])
+    })
+
+    it('mixes compactable and non-compactable routes in the same call', () => {
+      const out = collectCompactPrerenderRoutes([
+        compact('/:locale(fr|ja)/about', 'about'),
+        // per-locale (not compacted) — already enumerable, must not be added
+        { path: '/contact', name: 'contact___en' } as Parameters<typeof collectCompactPrerenderRoutes>[0][number],
+        compact('/:locale(fr|ja)/help', 'help'),
+        // dynamic — skipped
+        compact('/:locale(fr|ja)/users/:id', 'users-id'),
+      ])
+      expect(out).toEqual(['/fr/about', '/ja/about', '/fr/help', '/ja/help'])
     })
   })
 

--- a/test/pages/route_localization.test.ts
+++ b/test/pages/route_localization.test.ts
@@ -850,6 +850,74 @@ describe('compact routes', () => {
       ])
       expect(out).toEqual(['/fr/about', '/ja/about', '/fr/help', '/ja/help'])
     })
+
+    const compactWithChildren = (
+      path: string,
+      name: string,
+      children: { path: string, name?: string, children?: unknown[] }[],
+    ) => ({
+      path,
+      name,
+      meta: { __i18nCompact: true },
+      children,
+    } as unknown as Parameters<typeof collectCompactPrerenderRoutes>[0][number])
+
+    it('expands static children of a compact parent', () => {
+      const out = collectCompactPrerenderRoutes([
+        compactWithChildren('/:locale(en|fr)/parent', 'parent', [
+          { path: 'child', name: 'parent-child' },
+        ]),
+      ])
+      expect(out).toEqual(['/en/parent', '/fr/parent', '/en/parent/child', '/fr/parent/child'])
+    })
+
+    it('walks deeply-nested static children', () => {
+      const out = collectCompactPrerenderRoutes([
+        compactWithChildren('/:locale(en|fr)/a', 'a', [
+          { path: 'b', name: 'a-b', children: [{ path: 'c', name: 'a-b-c' }] },
+        ]),
+      ])
+      expect(out).toEqual(['/en/a', '/fr/a', '/en/a/b', '/fr/a/b', '/en/a/b/c', '/fr/a/b/c'])
+    })
+
+    it('skips dynamic children but keeps static siblings', () => {
+      const out = collectCompactPrerenderRoutes([
+        compactWithChildren('/:locale(en|fr)/users', 'users', [
+          { path: '', name: 'users-index' },
+          { path: ':id', name: 'users-id' },
+          { path: 'list', name: 'users-list' },
+        ]),
+      ])
+      expect(out).toEqual(['/en/users', '/fr/users', '/en/users/list', '/fr/users/list'])
+    })
+
+    it('does not descend past a dynamic child (grandchildren are unreachable too)', () => {
+      const out = collectCompactPrerenderRoutes([
+        compactWithChildren('/:locale(en|fr)/users', 'users', [
+          { path: ':id', name: 'users-id', children: [{ path: 'profile', name: 'users-id-profile' }] },
+        ]),
+      ])
+      expect(out).toEqual(['/en/users', '/fr/users'])
+    })
+
+    it('treats an empty-path index child as the parent URL and walks its grandchildren', () => {
+      const out = collectCompactPrerenderRoutes([
+        compactWithChildren('/:locale(en|fr)', 'index', [
+          { path: '', name: 'index-root', children: [{ path: 'nested', name: 'index-nested' }] },
+        ]),
+      ])
+      expect(out).toEqual(['/en', '/fr', '/en/nested', '/fr/nested'])
+    })
+
+    it('ignores absolute child paths (they are not compacted descendants)', () => {
+      const out = collectCompactPrerenderRoutes([
+        compactWithChildren('/:locale(en|fr)/parent', 'parent', [
+          { path: '/absolute', name: 'absolute' },
+          { path: 'relative', name: 'parent-relative' },
+        ]),
+      ])
+      expect(out).toEqual(['/en/parent', '/fr/parent', '/en/parent/relative', '/fr/parent/relative'])
+    })
   })
 
   describe('mixed app — some routes compacted, some per-locale', () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More consistent prerendering for locale-prefixed static sites: locale-root pages are explicitly included and the default root is handled appropriately, with route seeding deferred until prerender time.
  * Improved detection and expansion of compact locale routes so per-locale paths are materialized reliably.

* **Tests**
  * Expanded tests covering prerender expansion, edge cases, and nested route behaviors for locale-based routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->