### PR TITLE
docs: add page for vue-i18n components inherited by the module

### DIFF
--- a/docs/content/docs/05.components/03.vue-i18n-components.md
+++ b/docs/content/docs/05.components/03.vue-i18n-components.md
@@ -1,0 +1,14 @@
+---
+title: Vue I18n components
+description: Translation, datetime and number components inherited from Vue I18n
+---
+
+In addition to the components provided by this module, the underlying [Vue I18n](https://vue-i18n.intlify.dev/) library ships its own set of components that are available in any Nuxt application using `@nuxtjs/i18n`.
+
+| Component                                                                       | Description                                                                                |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [`<i18n-t>`{lang="html"}](https://vue-i18n.intlify.dev/api/component.html#translation) | Translation component for interpolating message slots into a rendered element.        |
+| [`<i18n-d>`{lang="html"}](https://vue-i18n.intlify.dev/api/component.html#datetime-format) | Datetime formatting component for rendering locale-aware dates and times.            |
+| [`<i18n-n>`{lang="html"}](https://vue-i18n.intlify.dev/api/component.html#number-format)   | Number formatting component for rendering locale-aware numbers and currencies.       |
+
+Refer to the [Vue I18n component API reference](https://vue-i18n.intlify.dev/api/component.html) for full prop documentation and examples.


### PR DESCRIPTION
### 🔗 Linked issue

resolves #2961

### 📚 Description

Adds a `Vue I18n components` page under the Components section, listing the `<i18n-t>`, `<i18n-d>` and `<i18n-n>` components inherited from Vue I18n with links to their upstream API reference. Per @kazupon's note that "it would be good to have a page linking to the documentation on the features provided by vue-i18n".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for Vue I18n components available in Nuxt applications, including comprehensive API references and component guidance for internationalization features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nuxt-modules/i18n/pull/3986)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->