### PR TITLE
docs: add "Use with Locize" guide page

### DIFF
--- a/docs/content/docs/02.guide/18.use-with-locize.md
+++ b/docs/content/docs/02.guide/18.use-with-locize.md
@@ -1,0 +1,155 @@
+---
+title: Use with Locize
+description: How to manage translations for Nuxt i18n with Locize.
+---
+
+[Locize](https://www.locize.com/?from=nuxtjs-i18n-docs) is a translation management system created by the maintainers of [i18next](https://www.i18next.com). It supports the **vue-i18n message format natively** (pluralization within the value, named/list/index interpolation, linked messages), so Nuxt i18n projects can sync against it without any format conversion.
+
+This page documents the recommended way to pair `@nuxtjs/i18n` with Locize: translations are downloaded from the Locize CDN into your repository at build time, and your `defineI18nLocale()`{lang="ts"} wrappers pick them up via the standard [lazy-load translations](/docs/guide/lazy-load-translations) flow. Optional runtime hooks add `saveMissing` and in-context editing for translators.
+
+A runnable Nuxt 4 + `@nuxtjs/i18n` + Locize example lives at [github.com/locize/locize-nuxt-example](https://github.com/locize/locize-nuxt-example), and a step-by-step walkthrough at [How to internationalize a Nuxt 4 app with @nuxtjs/i18n and Locize](https://www.locize.com/blog/nuxt-i18n?from=nuxtjs-i18n-docs).
+
+## Install the cli
+
+```bash
+npm install --save-dev locize-cli
+```
+
+When the new-project wizard on [locize.app](https://www.locize.com/?from=nuxtjs-i18n-docs) asks for an **i18n format**, pick **vue-i18n**.
+
+## Configure `@nuxtjs/i18n` and the Locize project
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/i18n'],
+  i18n: {
+    defaultLocale: 'en',
+    strategy: 'no_prefix',
+    lazy: true,
+    locales: [
+      { code: 'en', language: 'en-US', name: 'English', file: 'en.ts' },
+      { code: 'de', language: 'de-DE', name: 'Deutsch', file: 'de.ts' }
+    ]
+  },
+  runtimeConfig: {
+    public: {
+      locizeProjectId: '<your locize project id>',
+      // Dev-only — leave empty in production so saveMissing no-ops.
+      locizeApiKey: '<your dev api key>',
+      locizeVersion: 'latest',
+      locizeCdnType: 'standard' // or 'pro'
+    }
+  }
+})
+```
+
+::callout{icon="i-heroicons-light-bulb"}
+Locize ships two CDN infrastructures. **Standard** (`api.lite.locize.app`, BunnyCDN-backed, free up to generous monthly download volumes) is the default for new projects; **Pro** (`api.locize.app`, CloudFront-backed, paid, supports private downloads) is opt-in. Match the `--cdn-type` flag on the cli (and `locizeCdnType` above) to whatever your project is on.
+::
+
+## Per-locale `defineI18nLocale` wrappers
+
+Locize stores one JSON per namespace per language. For each locale, write a tiny `.ts` wrapper that imports the per-namespace JSON files and assembles them under their namespace key — so `t('common.headTitle')` resolves naturally:
+
+```ts [i18n/locales/en.ts]
+import common from './en/common.json'
+import index from './en/index.json'
+
+export default defineI18nLocale(() => ({
+  common,
+  index
+}))
+```
+
+…and the same for `de.ts`.
+
+## Download translations at build time
+
+Add to `package.json`:
+
+```json [package.json]
+{
+  "scripts": {
+    "downloadLocales": "locize download --project-id=<your-id> --ver=latest --cdn-type=standard --clean=true --path=./i18n/locales",
+    "syncLocales": "locize sync --project-id=<your-id> --ver=latest --cdn-type=standard --api-key=<your-write-key> --path=./i18n/locales --dry=true"
+  }
+}
+```
+
+Run `npm run downloadLocales` before `npm run build` (manually, in CI, or as a `prebuild` hook) so the bundled JSON is always fresh. Use `syncLocales` (drop `--dry=true`) when you want to push locally-added keys back to Locize without a runtime `saveMissing` call.
+
+::callout{icon="i-heroicons-light-bulb"}
+This pattern is **bundle-at-build-time, not live-fetch**: both Nitro SSR and the client read the same JSON committed to your repo, so there's no per-request CDN hop. Published translation updates require re-running `downloadLocales` and redeploying — which keeps the deployment serverless-friendly.
+::
+
+## Optional — `saveMissing` via vue-i18n's `missing` hook
+
+Wire up vue-i18n's `missing` handler in `i18n/i18n.config.ts` so every newly-encountered key during development is pushed back to Locize automatically:
+
+```ts [i18n/i18n.config.ts]
+export default function () {
+  return {
+    legacy: false,
+    fallbackLocale: 'en',
+    missing(locale, key) {
+      if (!import.meta.client) return
+      const { public: cfg } = useRuntimeConfig()
+      if (!cfg.locizeApiKey) return // production no-op
+
+      const dot = key.indexOf('.')
+      const ns = dot >= 0 ? key.slice(0, dot) : 'common'
+      const actualKey = dot >= 0 ? key.slice(dot + 1) : key
+      const host = cfg.locizeCdnType === 'pro'
+        ? 'https://api.locize.app'
+        : 'https://api.lite.locize.app'
+
+      fetch(`${host}/missing/${cfg.locizeProjectId}/${cfg.locizeVersion}/${locale}/${ns}`, {
+        method: 'POST',
+        headers: { Authorization: cfg.locizeApiKey, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ [actualKey]: actualKey })
+      })
+    }
+  }
+}
+```
+
+Set `NUXT_PUBLIC_LOCIZE_API_KEY` only in dev — leave it empty in production so the handler no-ops and your write-enabled key never ships to end users. `saveMissing` is optional: if you'd rather manage keys via the Locize web app or `locize sync`, skip the handler entirely.
+
+::callout{icon="i-heroicons-exclamation-triangle" color="warning"}
+Use `useI18n({ useScope: 'global' })`{lang="ts"} in your pages. A plain `useI18n()`{lang="ts"} creates a per-component scoped composer that doesn't inherit the global `missing` handler.
+::
+
+## Optional — in-context editing for translators
+
+The [`locize`](https://github.com/locize/locize) package (4.1+) ships a `getVueI18nImplementation` helper that wires vue-i18n's composer into the Locize in-context editor. Append `?incontext=true` to any URL of your running app to open an iframe-based editor where translators can edit any string they click and save back to Locize.
+
+```ts [app/plugins/locize.client.ts]
+import { watch } from 'vue'
+import { startStandalone, getVueI18nImplementation } from 'locize'
+
+export default defineNuxtPlugin((nuxtApp) => {
+  const { public: cfg } = useRuntimeConfig()
+  const showInContext = new URLSearchParams(window.location.search).get('incontext') === 'true'
+  if (!showInContext) return
+
+  const i18n = nuxtApp.$i18n as any
+  const impl = getVueI18nImplementation(i18n, {
+    projectId: cfg.locizeProjectId,
+    version: cfg.locizeVersion,
+    sourceLng: 'en',
+    targetLngs: (i18n.availableLocales as string[]) || [],
+    watch
+  })
+  startStandalone({ implementation: impl, show: true })
+})
+```
+
+The example repo wires this with a `postTranslation` handler that uses [`i18next-subliminal`](https://github.com/locize/i18next-subliminal) markers — see the [companion blog post](https://www.locize.com/blog/nuxt-i18n?from=nuxtjs-i18n-docs) for the full code and the gotchas (`<i18n-t>` slot interpolation passes VNode arrays to `postTranslation`, hydration mismatch warnings under `?incontext=true`, etc.).
+
+## Related
+
+- Example repo: [github.com/locize/locize-nuxt-example](https://github.com/locize/locize-nuxt-example)
+- Blog walkthrough: [How to internationalize a Nuxt 4 app with @nuxtjs/i18n and Locize](https://www.locize.com/blog/nuxt-i18n?from=nuxtjs-i18n-docs)
+- [Lazy-load translations](/docs/guide/lazy-load-translations) — the underlying `@nuxtjs/i18n` mechanism this recipe builds on
+- [`locize-cli`](https://github.com/locize/locize-cli) — the build-time sync tool
+- [`locize` package](https://github.com/locize/locize) — the in-context editor helper


### PR DESCRIPTION
Adds a new `docs/content/docs/02.guide/18.use-with-locize.md` page documenting the standard `@nuxtjs/i18n` + [Locize](https://www.locize.com/?from=nuxtjs-i18n-docs) integration pattern.

[Locize](https://www.locize.com) is a translation management system created by the maintainers of [i18next](https://www.i18next.com). It supports the **vue-i18n message format natively** at the platform level (pluralization within the value, named/list/index interpolation, linked messages), so `@nuxtjs/i18n` projects can sync against it without any format conversion.

The page connects directly to the existing [Lazy-load translations](/docs/guide/lazy-load-translations) flow — translations are downloaded from the Locize CDN into your repo at build time via [`locize-cli`](https://github.com/locize/locize-cli), and the standard `defineI18nLocale()` wrappers pick them up. It covers:

- Configuring `@nuxtjs/i18n` + a `runtimeConfig.public.locize*` block
- Both Locize CDN endpoints — Standard (`api.lite.locize.app`, BunnyCDN-backed, default for new projects) and Pro (`api.locize.app`, CloudFront-backed)
- The `defineI18nLocale()` wrapper pattern for per-namespace JSON
- Build-time sync via `locize download` / `locize sync` (the bundle-only-at-runtime shape, kept serverless-friendly)
- **Optional** `saveMissing` via vue-i18n's `missing` hook (with a production no-op guard so the write apiKey never ships)
- **Optional** in-context editor via [`locize`](https://github.com/locize/locize) 4.1's `getVueI18nImplementation` helper

Additions-only (1 new file, 155 lines, 0 deletions). Sidebar entry appears automatically via the `02.guide/18.` filename prefix, after `17.install-module.md`.

A complete runnable Nuxt 4 + `@nuxtjs/i18n` + Locize example lives at [github.com/locize/locize-nuxt-example](https://github.com/locize/locize-nuxt-example), and a step-by-step walkthrough at [How to internationalize a Nuxt 4 app with @nuxtjs/i18n and Locize](https://www.locize.com/blog/nuxt-i18n?from=nuxtjs-i18n-docs).

Happy to adjust scope, wording, code-block labels, or sidebar placement (e.g. move to a later `89.` slot if a "recipe" feel reads better) if a different shape would land better.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for integrating Locize with Nuxt i18n, covering build-time translation downloads, per-locale configuration, runtime missing key auto-saving, in-context editing, and example resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nuxt-modules/i18n/pull/3990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->