### PR TITLE
feat: experimental prerenderMessages option

### DIFF
--- a/docs/content/docs/04.api/00.options.md
+++ b/docs/content/docs/04.api/00.options.md
@@ -501,6 +501,16 @@ This feature relies on [Nuxt's `experimental.typedPages`](https://nuxt.com/docs/
 This option is opt-in for now but is expected to become the default in v11. See [Compact routes](/docs/guide/new-features#compact-routes) for more details.
 ::
 
+### `prerenderMessages`
+
+- type: `boolean`{lang="ts-type"}
+- default: `false`{lang="ts"}
+- Prerender the hashed `messages.json` files into `.output/public/` at build time so lazy-loaded messages are served as static assets instead of from the dynamic Nitro route. When Nuxt's `app.cdnURL` is set the client fetches them from the CDN. See [Prerendering messages as static files](#prerendering-messages-as-static-files).
+
+::callout{icon="i-heroicons-exclamation-triangle" color="warning"}
+Only messages contributed by locale files are serialized into the prerendered files — messages declared in a `vue-i18n` config are merged at runtime and are not included.
+::
+
 ## `hmr`
 
 - type: `boolean`{lang="ts-type"}
@@ -648,18 +658,48 @@ This feature relies on [Nuxt's Auto-imports](https://nuxt.com/docs/guide/concept
 
 Sets the prefix for the server route used for loading locale messages.
 
-## Serving messages from a CDN
+## Prerendering messages as static files
 
-The module reuses Nuxt's built-in [`app.cdnURL`](https://nuxt.com/docs/4.x/api/nuxt-config#cdnurl) to serve lazy-loaded locale messages from a CDN / static origin instead of the dynamic Nitro server. There is no i18n-specific option — set Nuxt's `app.cdnURL` and the module wires the rest:
+::callout{icon="i-heroicons-beaker" color="info"}
+This is an experimental, opt-in feature. Enable [`experimental.prerenderMessages`](#prerendermessages).
+::
 
-- **Client-side** requests target `<app.cdnURL><serverRoutePrefix>/<hash>/<locale>/messages.json`.
-- The corresponding hashed `messages.json` files are emitted into `.output/public/` at build time so they can be uploaded alongside `_nuxt/*` chunks.
-- **Server-side rendering** keeps fetching from the local Nitro handler — SSR does not round-trip through the CDN.
+With `experimental.prerenderMessages` enabled, the hashed `messages.json` files are prerendered into `.output/public/` at build time so lazy-loaded locale messages ship as static assets alongside `_nuxt/*` chunks instead of being served from the dynamic Nitro route:
+
+- **Client-side** requests target `<serverRoutePrefix>/<hash>/<locale>/messages.json` — served from the relative URL by default, or from `app.cdnURL` when [it is set](#serving-messages-from-a-cdn).
+- **Server-side rendering** keeps fetching from the local Nitro handler.
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  i18n: {
+    experimental: {
+      prerenderMessages: true,
+    },
+  },
+})
+```
+
+::callout{icon="i-heroicons-exclamation-triangle" color="warning"}
+Only messages contributed by locale files are serialized into the prerendered `messages.json` files. Messages declared in a [`vue-i18n` config](/docs/getting-started/vue-i18n) (and other runtime-only configuration) are merged in-app at runtime and are **not** present in these static files — keep messages you want served as static files in locale files.
+::
+
+### Serving messages from a CDN
+
+Set Nuxt's [`app.cdnURL`](https://nuxt.com/docs/4.x/api/nuxt-config#cdnurl) in addition to `experimental.prerenderMessages` and the client fetches the prerendered files from the CDN (`<app.cdnURL><serverRoutePrefix>/<hash>/<locale>/messages.json`) instead of the relative origin. SSR does not round-trip through the CDN.
+
+::callout{icon="i-heroicons-light-bulb"}
+Statically generated sites (`nuxi generate`) already prerender the message files, so setting `app.cdnURL` is enough — `experimental.prerenderMessages` is only needed to prerender them for a regular `nuxt build`.
+::
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   app: {
     cdnURL: 'https://cdn.example.com',
+  },
+  i18n: {
+    experimental: {
+      prerenderMessages: true,
+    },
   },
 })
 ```

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -99,6 +99,9 @@ export function getDefineConfig(
     __I18N_COMPACT_ROUTES__: String(!!options.experimental?.compactRoutes),
     __I18N_STRICT_SEO__: JSON.stringify(!!options.experimental.strictSeo),
     __I18N_SERVER_ROUTE__: JSON.stringify(options.serverRoutePrefix),
+    // SSG already prerenders the messages routes (runtime `prerenderRoutes`), so they exist at the
+    // CDN origin there too — honor `app.cdnURL` for both that and the opt-in `prerenderMessages`.
+    __I18N_CDN__: String(!!nuxt.options.app.cdnURL && (!!options.experimental.prerenderMessages || !!nuxt.options.nitro.static)),
     __I18N_LOCALE_HASHES__: JSON.stringify(localeHashes),
     __I18N_SERVER_REDIRECT__: JSON.stringify(!!options.experimental.nitroContextDetection),
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,6 +29,7 @@ export const DEFAULT_OPTIONS = {
     nitroContextDetection: true,
     httpCacheDuration: 10,
     compactRoutes: false,
+    prerenderMessages: false,
   },
   bundle: {
     compositionOnly: true,

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -31,6 +31,8 @@ declare let __I18N_STRICT_SEO__: boolean
 declare let __I18N_SERVER_REDIRECT__: boolean
 /** Server route prefix for i18n message endpoints */
 declare let __I18N_SERVER_ROUTE__: string
+/** Client fetches prerendered messages from `app.cdnURL` instead of the relative origin */
+declare let __I18N_CDN__: boolean
 /** Per-locale content hash, used as the `:hash` segment of message routes */
 declare let __I18N_LOCALE_HASHES__: Record<string, string>
 /** Whether compact routes are enabled */

--- a/src/module.ts
+++ b/src/module.ts
@@ -207,13 +207,9 @@ export default defineNuxtModule<NuxtI18nOptions>({
 
       nuxt.options.runtimeConfig.public.i18n.locales = simplifyLocaleOptions(ctx, nuxt)
 
-      /**
-       * When Nuxt's `app.cdnURL` is set, emit hashed messages JSON files into `.output/public/`
-       * at build time so they ship as static assets alongside `_nuxt/*` chunks. This makes a
-       * regular `nuxt build` produce CDN-ready artifacts without the user having to compute
-       * the content hash themselves to add it to `nitro.prerender.routes`.
-       */
-      if (nuxt.options.app.cdnURL) {
+      // Prerender the hashed messages routes into `.output/public/` so lazy-loaded messages ship
+      // as static assets (uploadable to a CDN) instead of being served from the dynamic Nitro route.
+      if (ctx.options.experimental.prerenderMessages) {
         const messagesRoutes = ctx.localeCodes.map(
           locale => `${ctx.options.serverRoutePrefix}/${ctx.localeHashes[locale]}/${locale}/messages.json`,
         )

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -99,10 +99,9 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
   const loadMessagesFromServer = async (locale: string) => {
     if (locale in localeLoaders === false) { return }
     const headers: HeadersInit = getLocaleConfig(locale)?.cacheable ? {} : { 'Cache-Control': 'no-cache' }
-    // Reuse Nuxt's `app.cdnURL` so the client hits the static origin instead of the
-    // dynamic Nitro server when a CDN is configured. SSR keeps using a relative URL
-    // to avoid bouncing through the CDN for the same content the local handler can serve.
-    const prefix = import.meta.client ? (nuxt.$config.app.cdnURL || '') : ''
+    // Client fetches from `app.cdnURL` when messages are prerendered as static assets;
+    // SSR uses a relative URL so it doesn't round-trip through the CDN.
+    const prefix = import.meta.client && __I18N_CDN__ ? (nuxt.$config.app.cdnURL || '') : ''
     const url = joinURL(prefix, __I18N_SERVER_ROUTE__, __I18N_LOCALE_HASHES__[locale]!, locale, 'messages.json')
     const messages = await $fetch<LocaleMessages<DefineLocaleMessage>>(url, { headers })
     for (const k of Object.keys(messages)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -206,6 +206,13 @@ export interface ExperimentalFeatures {
    * @default false
    */
   compactRoutes?: boolean
+  /**
+   * Prerender hashed `messages.json` files into `.output/public/` at build time so lazy-loaded
+   * messages are served as static assets (from `app.cdnURL` when set) instead of the Nitro route.
+   * Messages from a `vue-i18n` config are merged at runtime and are not included in these files.
+   * @default false
+   */
+  prerenderMessages?: boolean
 }
 
 export interface BundleOptions


### PR DESCRIPTION
### 🔗 Linked issue
* #3976 
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an experimental option to prerender internationalization messages as static files at build time for optimized lazy-loaded message serving.

* **Documentation**
  * Added documentation explaining how to prerender messages as static assets and serve them from a CDN, including client vs. SSR fetch behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nuxt-modules/i18n/pull/3991?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->