### PR TITLE
fix: skip path config generation for unlocalized routes

### DIFF
--- a/src/pages.ts
+++ b/src/pages.ts
@@ -5,7 +5,7 @@ import { parse as parseSFC } from '@vue/compiler-sfc'
 import { parseAndWalk } from 'oxc-walker'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { parseSegment, toVueRouterSegment } from 'unrouting'
-import { localizeRoutes } from './routing'
+import { localizeRoutes, shouldLocalizeRoutes } from './routing'
 import { dirname, parse as parsePath, resolve } from 'pathe'
 import { createRoutesContext, resolveOptions } from 'vue-router/unplugin'
 import { transform } from './transform/resource'
@@ -104,16 +104,20 @@ export const disabledI18nPathToPath = ${JSON.stringify(routeResources.disabledI1
 
       const resolver = createPureOptionsResolver(ctx, options.defaultLocale, options.customRoutes)
 
-      const localizedPages = localizeRoutes(pages as NarrowedNuxtPage[], {
+      const localizationOptions = {
         ...options,
         includeUnprefixedFallback,
         locales: normalizedLocales,
         optionsResolver: resolver,
         compactRoutes: !!options.experimental?.compactRoutes,
-      })
+      }
+
+      const localizedPages = localizeRoutes(pages as NarrowedNuxtPage[], localizationOptions)
 
       // Build path config from original pages (not localized copies)
-      buildPathToConfig(ctx, localeCodes, resolver, pages as LocalizableRoute[])
+      if (shouldLocalizeRoutes(localizationOptions)) {
+        buildPathToConfig(ctx, localeCodes, resolver, pages as LocalizableRoute[])
+      }
 
       // keep root when using prefixed routing without prerendering
       const indexPage = pages.find(x => x.path === '/')

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -19,7 +19,7 @@ function createShouldPrefix(opts: SetupLocalizeRoutesOptions, ctx: RouteContext)
   }
 }
 
-function shouldLocalizeRoutes(options: SetupLocalizeRoutesOptions) {
+export function shouldLocalizeRoutes(options: SetupLocalizeRoutesOptions) {
   if (options.strategy !== 'no_prefix') { return true }
   // no_prefix is only supported when using a separate domain per locale
   if (!options.differentDomains) { return false }

--- a/test/pages/setup_pages.test.ts
+++ b/test/pages/setup_pages.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { setupPages } from '../../src/pages'
+import { getNormalizedLocales } from './utils'
+
+import type { Nuxt, NuxtPage } from '@nuxt/schema'
+import type { I18nNuxtContext } from '../../src/context'
+import type { NuxtI18nOptions } from '../../src/types'
+
+type NuxtHookCallback = (...args: unknown[]) => unknown | Promise<unknown>
+
+const kitMocks = vi.hoisted(() => {
+  const templates: Array<{ filename?: string, getContents?: () => string }> = []
+  return {
+    templates,
+    addTemplate: vi.fn((template: { filename?: string, getContents?: () => string }) => {
+      templates.push(template)
+      return template
+    }),
+    updateTemplates: vi.fn(),
+  }
+})
+
+vi.mock('@nuxt/kit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@nuxt/kit')>()
+  return {
+    ...actual,
+    addTemplate: kitMocks.addTemplate,
+    updateTemplates: kitMocks.updateTemplates,
+  }
+})
+
+function createNuxt() {
+  const hooks = new Map<string, NuxtHookCallback>()
+  const nuxt = {
+    options: {
+      ssr: false,
+      nitro: { static: false },
+      experimental: {
+        typedPages: false,
+        extraPageMetaExtractionKeys: [],
+      },
+      _layers: [
+        {
+          config: {
+            rootDir: '/project',
+            srcDir: '',
+            dir: { pages: 'pages' },
+          },
+        },
+      ],
+    },
+    hook: vi.fn((name: string, callback: NuxtHookCallback) => {
+      hooks.set(name, callback)
+    }),
+    apps: { default: { pages: [] } },
+  } as unknown as Nuxt
+
+  return { nuxt, hooks }
+}
+
+function createI18nContext(strategy: NuxtI18nOptions['strategy']): I18nNuxtContext {
+  const normalizedLocales = getNormalizedLocales(['en', 'fr'])
+  return {
+    localeCodes: ['en', 'fr'],
+    normalizedLocales,
+    options: {
+      customRoutes: 'config',
+      defaultLocale: 'en',
+      defaultLocaleRouteNameSuffix: 'default',
+      experimental: {},
+      locales: normalizedLocales,
+      pages: {},
+      routesNameSeparator: '___',
+      strategy,
+      trailingSlash: false,
+    },
+  } as I18nNuxtContext
+}
+
+describe('setupPages', () => {
+  beforeEach(() => {
+    kitMocks.templates.length = 0
+    kitMocks.addTemplate.mockClear()
+    kitMocks.updateTemplates.mockClear()
+  })
+
+  it('does not emit pathToI18nConfig entries when no_prefix does not localize routes', async () => {
+    const { nuxt, hooks } = createNuxt()
+    await setupPages(createI18nContext('no_prefix'), nuxt)
+
+    const pages: NuxtPage[] = [
+      { path: '/', name: 'index', file: '/project/pages/index.vue' },
+      { path: '/about', name: 'about', file: '/project/pages/about.vue' },
+    ]
+    await hooks.get('pages:extend')?.(pages)
+
+    const resourcesTemplate = kitMocks.templates.find(template => template.filename === 'i18n-route-resources.mjs')
+    expect(resourcesTemplate?.getContents?.()).toContain('export const pathToI18nConfig = {};')
+  })
+})


### PR DESCRIPTION
## Summary
Fixes #3989.

## Why
For `strategy: 'no_prefix'` without domain-based localization, routes are not localized, but `buildPathToConfig` still populated route resource mappings. This caused `pathToI18nConfig` to be non-empty for unlocalized SPA routes.

## Changes
- Reuse the same `shouldLocalizeRoutes` gate before building path config.
- Add a regression test for `setupPages` route resources under `no_prefix`.

## Testing
- pnpm vitest run test/pages/setup_pages.test.ts test/pages/route_localization.test.ts -c vitest.config.test.ts
- git diff --check

## Known Issues
- `pnpm test:types` currently fails in `src/runtime/shared/domain.ts(32,89)`, outside this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed route localization to conditionally build routes based on configuration, preventing unnecessary route generation in certain scenarios.

* **Tests**
  * Added comprehensive test coverage for page setup and localization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nuxt-modules/i18n/pull/3993?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->