### PR TITLE
test: add typed route regression coverage

### DIFF
--- a/specs/fixtures/issues/3954/app.vue
+++ b/specs/fixtures/issues/3954/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <NuxtPage />
+</template>

--- a/specs/fixtures/issues/3954/components/MyLink.vue
+++ b/specs/fixtures/issues/3954/components/MyLink.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { RouteLocationRaw } from 'vue-router'
+
+interface MyLinkProps {
+  to?: RouteLocationRaw
+  variant?: 'primary' | 'secondary'
+  disabled?: boolean
+}
+
+defineProps<MyLinkProps & { label?: string }>()
+</script>
+
+<template>
+  <NuxtLink :to="to">
+    {{ label }}
+  </NuxtLink>
+</template>

--- a/specs/fixtures/issues/3954/nuxt.config.ts
+++ b/specs/fixtures/issues/3954/nuxt.config.ts
@@ -1,0 +1,14 @@
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/i18n'],
+  experimental: {
+    typedPages: true,
+  },
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'fr'],
+    strategy: 'prefix_except_default',
+    experimental: {
+      typedPages: true,
+    },
+  },
+})

--- a/specs/fixtures/issues/3954/pages/index.vue
+++ b/specs/fixtures/issues/3954/pages/index.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>Index</div>
+</template>

--- a/specs/fixtures/issues/3954/pages/widget/[widgetId].vue
+++ b/specs/fixtures/issues/3954/pages/widget/[widgetId].vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+const route = useRoute()
+const widgetId = route.params.widgetId
+</script>
+
+<template>
+  <div>{{ widgetId }}</div>
+</template>

--- a/specs/issues/3954.spec.ts
+++ b/specs/issues/3954.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect, describe } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import ts from 'typescript'
+import { setup, useTestContext } from '../utils'
+
+const rootDir = fileURLToPath(new URL('../fixtures/issues/3954', import.meta.url))
+
+await setup({
+  rootDir,
+  browser: false,
+})
+
+function getTypeDiagnostics(source: string) {
+  const { nuxt } = useTestContext()
+  const buildDir = nuxt!.options.buildDir
+  const tempDir = mkdtempSync(join(tmpdir(), 'nuxt-i18n-3954-'))
+  const testFile = join(tempDir, 'issue-3954.ts')
+  writeFileSync(testFile, source)
+
+  try {
+    const rootNames = [
+      resolve(buildDir, 'types/typed-router.d.ts'),
+      resolve(buildDir, 'types/typed-router-i18n.d.ts'),
+      resolve(buildDir, 'types/i18n-generated-route-types.d.ts'),
+      resolve(buildDir, 'types/i18n-plugin.d.ts'),
+      testFile,
+    ]
+
+    const program = ts.createProgram(rootNames, {
+      strict: true,
+      noEmit: true,
+      skipLibCheck: true,
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      target: ts.ScriptTarget.ESNext,
+      types: [],
+      lib: ['lib.esnext.d.ts', 'lib.dom.d.ts'],
+    })
+
+    return ts.getPreEmitDiagnostics(program)
+      .filter(diagnostic => diagnostic.file?.fileName === testFile)
+      .map(diagnostic => ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'))
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true })
+  }
+}
+
+describe('#3954 - typed route regression', () => {
+  test('keeps route params narrowed when typed pages are localized', () => {
+    const diagnostics = getTypeDiagnostics(`
+      import { useRoute } from 'vue-router'
+
+      const route = useRoute()
+      const widgetId: string = route.params.widgetId
+    `)
+
+    expect(diagnostics).toEqual([])
+  })
+
+  test('does not expand RouteLocationRaw into an unrepresentable i18n route union', () => {
+    const diagnostics = getTypeDiagnostics(`
+      import type { RouteLocationRaw } from 'vue-router'
+
+      interface MyLinkProps {
+        to?: RouteLocationRaw
+        variant?: 'primary' | 'secondary'
+        disabled?: boolean
+      }
+
+      declare function defineProps<T>(): T
+      defineProps<MyLinkProps & { label?: string }>()
+    `)
+
+    expect(diagnostics).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
Add regression coverage for typed i18n routes with `useRoute().params` and `RouteLocationRaw` props.

## Why
Issue #3954 reports typed route regressions after the vue-router v5 update.

## Changes
- Add an issue-specific typedPages + i18n fixture
- Add type-level assertions for route params and `RouteLocationRaw`

## Testing
- pnpm dev:prepare
- pnpm exec vitest run specs/experimental/typed_pages.spec.ts
- pnpm exec vitest run specs/issues/3954.spec.ts
- git diff --check

## Known Issues
The minimal reproduction passes on current main, so this PR adds coverage only and does not change production types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test suite for issue `#3954` validating TypeScript type diagnostics with internationalization and typed route declarations. The tests ensure route parameters maintain correct type narrowing when using typed pages with localization, and prevent unexpected expansion of route location unions when used in component props.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nuxt-modules/i18n/pull/3994?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->