### PR TITLE
docs: clarify vue-i18n config path resolution

### DIFF
--- a/docs/content/docs/01.getting-started/03.vue-i18n.md
+++ b/docs/content/docs/01.getting-started/03.vue-i18n.md
@@ -32,7 +32,7 @@ export default defineI18nConfig(() => {
 })
 ```
 
-The config file is resolved from `<rootDir>/i18n`, and automatically looks for and loads the config file using the default filename of `i18n.config`. This can be configured using the `vueI18n` options.
+The config file is resolved from `<rootDir>/i18n`, and automatically looks for and loads the config file using the default filename of `i18n.config`. A custom filename or location can be set with the [`vueI18n`](/docs/api/options#vuei18n) option, which is also resolved relative to `<rootDir>/i18n` (use an absolute path to reference a file outside of it).
 
 ## When to use
 

--- a/docs/content/docs/04.api/00.options.md
+++ b/docs/content/docs/04.api/00.options.md
@@ -10,16 +10,23 @@ description: All the options you can use to configure Nuxt I18n.
 
 Build-time configuration for Vue I18n options that is used internally by this module. See full documentation at [here](https://vue-i18n.intlify.dev/api/general.html#createi18n)
 
-Configuration for `createI18n()`{lang="ts"} can be passed using a configuration file. By default, the module will scan for a `i18n.config{.js,.mjs,.ts}` if nothing is specified.
+Configuration for `createI18n()`{lang="ts"} can be passed using a configuration file. By default, the module scans for an `i18n.config{.js,.mjs,.ts}` file inside the project `restructureDir` (`i18n/i18n.config.ts` by default) if nothing is specified.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   modules: ['@nuxtjs/i18n'],
   i18n: {
-    vueI18n: './nuxt-i18n.js' // custom path example
+    // resolved relative to the i18n directory, i.e. `i18n/configs/i18n.config.ts`
+    vueI18n: './configs/i18n.config.ts'
   }
 })
 ```
+
+The path is resolved relative to the project `restructureDir` at the root of a project (`'i18n'`{lang="ts-type"} by default), **not** relative to `nuxt.config.ts`. Pass an absolute path to reference a file outside the i18n directory.
+
+::callout{icon="i-heroicons-exclamation-triangle" color="warning"}
+A file placed next to `nuxt.config.ts` and referenced as `'./i18n.config.ts'`{lang="ts-type"} will **not** be found — that path resolves to `i18n/i18n.config.ts`. When an explicitly configured file cannot be resolved the module logs a warning and skips it.
+::
 
 You need to `export default` with **plain object** or **function**.
 


### PR DESCRIPTION
### 🔗 Linked issue
* Resolves #3983 (combined with #3992)
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how Nuxt I18n discovers and resolves the `i18n.config.ts` file with improved explanation of default location and custom path handling.
  * Added examples and warnings to help users understand path resolution behavior and avoid configuration issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nuxt-modules/i18n/pull/3996?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->