### PR TITLE
fix: strip base URL from path in SSR locale redirect

### DIFF
--- a/specs/different_domains/base_path_ssr_redirect.spec.ts
+++ b/specs/different_domains/base_path_ssr_redirect.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, undiciRequest } from '../utils'
+
+await setup({
+  rootDir: fileURLToPath(new URL(`../fixtures/different_domains`, import.meta.url)),
+  // overrides
+  nuxtConfig: {
+    app: {
+      baseURL: '/base-path'
+    },
+    i18n: {
+      defaultLocale: 'en',
+      rootRedirect: 'about',
+      detectBrowserLanguage: false
+    }
+  }
+})
+
+// the SSR redirect location joins the locale domain and `app.baseURL`, the base
+// should appear exactly once (domain and `baseUrl` values are configured without it)
+test('(#3887) SSR root redirect includes `app.baseURL` once after the locale domain', async () => {
+  const res = await undiciRequest('/base-path/', {
+    headers: { 'X-Forwarded-Host': 'en.nuxt-app.localhost' }
+  })
+
+  expect(res.statusCode).toBe(302)
+  expect(res.headers.location).toEqual('http://en.nuxt-app.localhost/base-path/about')
+})

--- a/specs/issues/3887.spec.ts
+++ b/specs/issues/3887.spec.ts
@@ -28,6 +28,19 @@ describe('#3887', async () => {
     const res = await fetch('/base-path/about', { redirect: 'manual' })
 
     expect(res.status).toBe(302)
-    expect(res.headers.get('location')).toContain('/about')
+    expect(res.headers.get('location')).toEqual('/base-path/en/about')
+  })
+
+  test('redirects the root path to the localized root when `app.baseURL` is set', async () => {
+    const res = await fetch('/base-path/', { redirect: 'manual' })
+
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toEqual('/base-path/en')
+  })
+
+  test('does not redirect a prefixed path', async () => {
+    const res = await fetch('/base-path/en/about', { redirect: 'manual' })
+
+    expect(res.status).toBe(200)
   })
 })

--- a/specs/issues/3887.spec.ts
+++ b/specs/issues/3887.spec.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, fetch } from '../utils'
+
+describe('#3887', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL(`../fixtures/basic`, import.meta.url)),
+    nuxtConfig: {
+      app: {
+        baseURL: '/base-path'
+      },
+      i18n: {
+        strategy: 'prefix',
+        defaultLocale: 'en',
+        detectBrowserLanguage: {
+          useCookie: false,
+          redirectOn: 'no prefix'
+        }
+      }
+    }
+  })
+
+  // The SSR locale-redirect middleware used to compute the route path from `url.pathname`, which
+  // still contains `app.baseURL`. With a base set this produced a relative path (e.g. "se-path/about"),
+  // which vue-router's matcher rejected ("The Matcher cannot resolve relative paths"). `isExistingNuxtRoute`
+  // then failed to match and the redirect silently bailed - so the unprefixed path was never localized.
+  test('redirects an unprefixed path to its localized route when `app.baseURL` is set', async () => {
+    const res = await fetch('/base-path/about', { redirect: 'manual' })
+
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toContain('/about')
+  })
+})

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -1,6 +1,6 @@
 import { stringify } from 'devalue'
 import { defineI18nMiddleware } from '@intlify/h3'
-import { defineNitroPlugin, useStorage } from 'nitropack/runtime'
+import { defineNitroPlugin, useRuntimeConfig, useStorage } from 'nitropack/runtime'
 import { initializeI18nContext, tryUseI18nContext, useI18nContext } from './context'
 import { createUserLocaleDetector } from './utils/locale-detector'
 import { pickNested } from './utils/messages-utils'
@@ -125,8 +125,9 @@ export default defineNitroPlugin(async (nitro) => {
     let resolvedPath = undefined
     let redirectCode = 302
 
-    const requestURL = getRequestURL(event)
-    if (rootRedirect && requestURL.pathname === '/') {
+    // base-free pathname, `getRequestURL(event).pathname` would still contain `app.baseURL`
+    const pathname = parsePath(event.path).pathname
+    if (rootRedirect && pathname === '/') {
       locale = (detection.enabled && locale) || defaultLocale
       resolvedPath
         = (isSupportedLocale(detector.route(rootRedirect.path)) && rootRedirect.path)
@@ -138,7 +139,7 @@ export default defineNitroPlugin(async (nitro) => {
 
     switch (detection.redirectOn) {
       case 'root':
-        if (requestURL.pathname !== '/') { break }
+        if (pathname !== '/') { break }
       // fallthrough (root has no prefix)
       case 'no prefix':
         if (pathLocale) { break }
@@ -148,7 +149,7 @@ export default defineNitroPlugin(async (nitro) => {
         break
     }
 
-    if (requestURL.pathname === '/' && __I18N_STRATEGY__ === 'prefix') {
+    if (pathname === '/' && __I18N_STRATEGY__ === 'prefix') {
       resolvedPath ??= getLocalizedMatch(defaultLocale)
     }
     return { path: resolvedPath, code: redirectCode, locale }
@@ -180,12 +181,17 @@ export default defineNitroPlugin(async (nitro) => {
     }
 
     const resolved = resolveRedirectPath(event, path, pathLocale, ctx.vueI18nOptions!.defaultLocale, detector)
-    if (resolved.path && resolved.path !== url.pathname) {
+    if (resolved.path && resolved.path !== pathname) {
       ctx.detectLocale = resolved.locale
       detection.useCookie && setCookie(event, detection.cookieKey, resolved.locale, cookieOptions)
       context.response = createRedirectResponse(
         event,
-        joinURL(baseUrlGetter(event, ctx.vueI18nOptions!.defaultLocale), resolved.path + url.search),
+        // the resolved path is base-free (matched against base-free routes), re-add `app.baseURL`
+        joinURL(
+          baseUrlGetter(event, ctx.vueI18nOptions!.defaultLocale),
+          useRuntimeConfig(event).app.baseURL,
+          resolved.path + url.search,
+        ),
         resolved.code,
       )
       return

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -6,7 +6,7 @@ import { createUserLocaleDetector } from './utils/locale-detector'
 import { pickNested } from './utils/messages-utils'
 import { isSupportedLocale } from '../shared/locales'
 import { setupVueI18nOptions } from '../shared/vue-i18n'
-import { joinURL } from 'ufo'
+import { joinURL, parsePath } from 'ufo'
 // @ts-expect-error virtual file
 import { appId } from '#internal/nuxt.config.mjs'
 import { localeDetector } from '#internal/i18n-locale-detector.mjs'
@@ -169,7 +169,10 @@ export default defineNitroPlugin(async (nitro) => {
     const detector = useDetectors(event, detection)
     const localeSegment = detector.route(event.path)
     const pathLocale = (isSupportedLocale(localeSegment) && localeSegment) || undefined
-    const path = (pathLocale && url.pathname.slice(pathLocale.length + 1)) ?? url.pathname
+    // `event.path` is already stripped of `app.baseURL` by Nitro (unlike `url.pathname`), and
+    // `parsePath` drops any query string - so `path` stays an absolute, base-free route path.
+    const { pathname } = parsePath(event.path)
+    const path = (pathLocale && pathname.slice(pathLocale.length + 1)) ?? pathname
 
     // attempt to only run i18n detection for nuxt pages and i18n server routes
     if (!url.pathname.includes(__I18N_SERVER_ROUTE__) && !isExistingNuxtRoute(path)) {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #3887 (duplicate: #3999)

### ❓ Type of change

- [x] 🐞 Bug fix (non-breaking change which fixes an issue)

### 📚 Description

When `app.baseURL` is set together with `strategy: 'prefix'`, the SSR locale-redirect middleware logs:

```
[Vue Router warn]: The Matcher cannot resolve relative paths but received "ub/en/calendar". ...
```

**Root cause** — in `src/runtime/server/plugin.ts` (`render:before` hook), the route `path` was derived from `url.pathname`, which still contains `app.baseURL`, while the locale was detected from `event.path`, which Nitro has **already stripped** of the base:

```js
const localeSegment = detector.route(event.path)            // "/en/calendar" -> "en"
const path = (pathLocale && url.pathname.slice(pathLocale.length + 1)) ?? url.pathname
// '/club/en/calendar'.slice(3) -> "ub/en/calendar"   (relative!)
```

That relative string reaches `isExistingNuxtRoute(path)` -> `matcher.resolve({ path })`, which vue-router rejects (it only accepts absolute paths). The match then fails and the redirect silently bails — so an unprefixed path under a base is never localized.

**Fix** — derive the path from `event.path` (already base-stripped) and run it through `parsePath` to drop any query string, keeping `path` an absolute, base-free route path. This also resolves the existing TODO in `src/runtime/shared/matching.ts`:

```js
// TODO: path should not have base url - check if base url is stripped earlier
```

### 🧪 Test

Added `specs/issues/3887.spec.ts`: with `app.baseURL: '/base-path'` + `strategy: 'prefix'`, an unprefixed path now redirects to its localized route.

- **With the fix:** `GET /base-path/about` -> `302` (`location` contains `/about`) ✅
- **Without the fix:** the same request returns `404` (redirect bailed) — so the test fails on the unpatched code, confirming it's a real regression test.

> Note: I couldn't run the browser-based e2e specs locally (Playwright browser download was blocked in my environment), so I'm relying on CI for that matrix. The added spec is request-based and runs without a browser.

### Checklist

- [x] Lint passes on the changed file
- [x] Added a regression test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side locale redirect handling to correctly account for `app.baseURL` path prefixes, so unprefixed and root requests redirect to the right locale-prefixed URLs while already-prefixed paths do not change.
  * Ensured redirect URLs include the base path exactly once when working with locale domains.

* **Tests**
  * Added end-to-end Vitest coverage for Nuxt SSR locale redirects with `app.baseURL` set to a base path, including root, non-prefixed, and already-prefixed request scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->