### PR TITLE
feat: resolve default locale from runtime config in single-host multiDomainLocales setups

### DIFF
--- a/src/runtime/shared/detection.ts
+++ b/src/runtime/shared/detection.ts
@@ -29,6 +29,7 @@ const getHostLocale = (
   event: H3Event | undefined,
   path: string,
   domainLocales: I18nPublicRuntimeConfig['domainLocales'],
+  defaultLocale?: string,
 ) => {
   const host = import.meta.client
     ? new URL(window.location.href).host
@@ -38,7 +39,7 @@ const getHostLocale = (
     ...l,
     domain: domainLocales[l.code]?.domain ?? l.domain,
   }))
-  return matchDomainLocale(locales, host, getLocaleFromRoutePath(path))
+  return matchDomainLocale(locales, host, getLocaleFromRoutePath(path), defaultLocale)
 }
 
 export const useDetectors = (event: H3Event | undefined, config: { cookieKey: string }, nuxtApp?: NuxtApp) => {
@@ -52,7 +53,7 @@ export const useDetectors = (event: H3Event | undefined, config: { cookieKey: st
     cookie: () => getCookieLocale(event, config.cookieKey),
     header: () => (import.meta.server ? getHeaderLocale(event) : undefined),
     navigator: () => (import.meta.client ? getNavigatorLocale(event) : undefined),
-    host: (path: string) => getHostLocale(event, path, runtimeI18n.domainLocales),
+    host: (path: string) => getHostLocale(event, path, runtimeI18n.domainLocales, runtimeI18n.defaultLocale),
     route: (path: string | CompatRoute) => getRouteLocale(event, path),
   }
 }

--- a/src/runtime/shared/detection.ts
+++ b/src/runtime/shared/detection.ts
@@ -25,6 +25,16 @@ const getHeaderLocale = (event: H3Event | undefined) =>
 
 const getNavigatorLocale = (event: H3Event | undefined) => findBrowserLocale(normalizedLocales, navigator.languages)
 
+/**
+ * Resolve the locale from the request host for domain-based routing.
+ *
+ * @param event - The current H3 request event on the server; `undefined` on the client.
+ * @param path - The current route path, used to derive the path locale.
+ * @param domainLocales - Per-locale domain configuration from the public runtime config.
+ * @param defaultLocale - Runtime default locale used as the fallback when multiple locales
+ *   share a single host (single-host `multiDomainLocales` setups).
+ * @returns The matched locale code, or `undefined` when no domain matches.
+ */
 const getHostLocale = (
   event: H3Event | undefined,
   path: string,
@@ -42,6 +52,15 @@ const getHostLocale = (
   return matchDomainLocale(locales, host, getLocaleFromRoutePath(path), defaultLocale)
 }
 
+/**
+ * Build the ordered set of locale detectors (cookie, header, navigator, host, route)
+ * for the current request, wired to the active runtime i18n config.
+ *
+ * @param event - The current H3 request event; required on the server, `undefined` on the client.
+ * @param config - Detector configuration, including the cookie key used for cookie detection.
+ * @param nuxtApp - The Nuxt app instance, when available.
+ * @returns A map of detector name to a function resolving the locale for the request.
+ */
 export const useDetectors = (event: H3Event | undefined, config: { cookieKey: string }, nuxtApp?: NuxtApp) => {
   if (import.meta.server && !event) {
     throw new Error('H3Event is required for server-side locale detection')

--- a/src/runtime/shared/domain.ts
+++ b/src/runtime/shared/domain.ts
@@ -4,6 +4,22 @@ import { toArray } from './utils'
 
 import type { LocaleObject } from '#internal-i18n-types'
 
+/**
+ * Resolves the locale served by `host`.
+ *
+ * Locales declaring a matching `domain`/`domains` win. When several match the
+ * same host, the current path locale is preferred, then the domain's
+ * configured default (`defaultForDomains`/`domainDefault`), then the runtime
+ * `defaultLocale`. When NO locale declares any domain (single-host runtime
+ * mode — one build deployed to hosts unknown at build time), every locale is
+ * treated as served by the current host and the same precedence applies.
+ *
+ * @param locales - locales to match against (domains merged from runtime config)
+ * @param host - the request host
+ * @param pathLocale - locale parsed from the current path prefix, if any
+ * @param defaultLocale - runtime default locale used as the final fallback
+ * @returns the resolved locale code, or `undefined` when nothing matches
+ */
 export function matchDomainLocale(
   locales: LocaleObject[],
   host: string,

--- a/src/runtime/shared/domain.ts
+++ b/src/runtime/shared/domain.ts
@@ -4,11 +4,24 @@ import { toArray } from './utils'
 
 import type { LocaleObject } from '#internal-i18n-types'
 
-export function matchDomainLocale(locales: LocaleObject[], host: string, pathLocale: string): string | undefined {
+export function matchDomainLocale(
+  locales: LocaleObject[],
+  host: string,
+  pathLocale: string,
+  defaultLocale?: string,
+): string | undefined {
   const normalizeDomain = (domain: string = '') => domain.replace(/https?:\/\//, '')
-  const matches = locales.filter(
+  let matches = locales.filter(
     locale => normalizeDomain(locale.domain) === host || toArray(locale.domains).includes(host),
   )
+
+  // single-host runtime mode: when no locale declares any domain, every locale
+  // is served from the current host and the unprefixed default comes from
+  // runtime config (`defaultLocale`) — supports deployments where the same
+  // build runs on hosts unknown at build time (dynamic preview environments)
+  if (!matches.length && locales.every(l => !l.domain && !(Array.isArray(l.domains) && l.domains.length))) {
+    matches = locales
+  }
 
   if (matches.length <= 1) {
     return matches[0]?.code
@@ -19,6 +32,8 @@ export function matchDomainLocale(locales: LocaleObject[], host: string, pathLoc
     matches.find(l => l.code === pathLocale)?.code
     // fallback to default locale for the domain
     || matches.find(l => l.defaultForDomains?.includes(host) ?? l.domainDefault)?.code
+    // fallback to the runtime default locale
+    || (defaultLocale ? matches.find(l => l.code === defaultLocale)?.code : undefined)
   )
 }
 

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -75,6 +75,14 @@ export function useComposableContext(nuxtApp: NuxtApp): ComposableContext {
   return context
 }
 const formatTrailingSlash = __TRAILING_SLASH__ ? withTrailingSlash : withoutTrailingSlash
+/**
+ * Create the context consumed by the i18n composables for the current request,
+ * falling back to the runtime default locale when none has been resolved yet.
+ *
+ * @param ctx - The i18n context holding the resolved configuration and locale state.
+ * @param nuxtApp - The Nuxt app instance (defaults to `useNuxtApp()`).
+ * @returns The composable context with routing, locale-detection and head utilities.
+ */
 export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp = useNuxtApp()): ComposableContext {
   const router = useRouter()
   const detectors = useDetectors(useRequestEvent(), useI18nDetection(nuxtApp), nuxtApp)

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -26,7 +26,7 @@ import type {
 import type { NuxtI18nContext } from './context'
 import type { CompatRoute, I18nRouteMeta, RouteLocationGenericPath } from './types'
 import { useDetectors } from './shared/detection'
-import { useI18nDetection } from './shared/utils'
+import { useI18nDetection, useRuntimeI18n } from './shared/utils'
 
 /**
  * Common options used internally by composable functions, these
@@ -196,6 +196,7 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
       // remove prefix if path is default for domain
       if (__MULTI_DOMAIN_LOCALES__ && __I18N_STRATEGY__ === 'prefix_except_default') {
         const defaultLocale = getDefaultLocaleForDomain(useRequestURL({ xForwardedHost: true }).host)
+          || useRuntimeI18n(nuxtApp).defaultLocale
         if (locale !== defaultLocale || detectors.route(path) !== defaultLocale) {
           return path
         }

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -1,0 +1,54 @@
+import { describe, test, expect } from 'vitest'
+import { matchDomainLocale } from '../src/runtime/shared/domain'
+import type { LocaleObject } from '#internal-i18n-types'
+
+const domainLocales: LocaleObject[] = [
+  { code: 'en', domain: 'example.com' },
+  { code: 'fr', domain: 'example.fr' },
+  { code: 'de', domain: 'shared.example', domainDefault: true },
+  { code: 'nl', domain: 'shared.example' },
+]
+
+const domainlessLocales: LocaleObject[] = [
+  { code: 'de' },
+  { code: 'en' },
+  { code: 'es' },
+  { code: 'uk' },
+]
+
+describe('matchDomainLocale', () => {
+  test('matches a locale by its configured domain', () => {
+    expect(matchDomainLocale(domainLocales, 'example.fr', '')).toBe('fr')
+  })
+
+  test('prefers the path locale when several locales share a host', () => {
+    expect(matchDomainLocale(domainLocales, 'shared.example', 'nl')).toBe('nl')
+  })
+
+  test('falls back to the domain default when several locales share a host', () => {
+    expect(matchDomainLocale(domainLocales, 'shared.example', '')).toBe('de')
+  })
+
+  test('returns undefined for an unknown host when domains are configured', () => {
+    expect(matchDomainLocale(domainLocales, 'unknown.example', '')).toBeUndefined()
+  })
+
+  describe('single-host runtime mode (no locale declares a domain)', () => {
+    test('resolves the path locale for prefixed paths', () => {
+      expect(matchDomainLocale(domainlessLocales, 'preview-1234.example.dev', 'uk')).toBe('uk')
+    })
+
+    test('falls back to the runtime default locale for unprefixed paths', () => {
+      expect(matchDomainLocale(domainlessLocales, 'preview-1234.example.dev', '', 'es')).toBe('es')
+    })
+
+    test('returns undefined without a runtime default', () => {
+      expect(matchDomainLocale(domainlessLocales, 'preview-1234.example.dev', '')).toBeUndefined()
+    })
+
+    test('stays disabled when any locale declares a domain', () => {
+      const mixed: LocaleObject[] = [{ code: 'en', domain: 'example.com' }, { code: 'fr' }]
+      expect(matchDomainLocale(mixed, 'unmatched.example', '', 'fr')).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

—

### 📚 Description

`multiDomainLocales` currently resolves the per-request default locale exclusively through **build-time** domain lists (`domain` / `domains` / `defaultForDomains` on locale entries, compiled into `#build/i18n-options`). That works when every domain is known at build time, but breaks a common deployment model:

**one build artifact / container image, deployed to many hosts that are unknown at build time** — dynamic preview/dev environments, or one storefront build serving `example.de` / `example.es` / `example.ua`, each with its own default locale supplied via env.

`runtimeConfig.public.i18n.defaultLocale` is already runtime-overridable (`NUXT_PUBLIC_I18N_DEFAULT_LOCALE`), and the route table already adapts (`setupMultiDomainLocales` rebuilds the unprefixed routes from the runtime value). But the **host detector** resolves nothing when no `domain`s are configured, so detection falls through to the route detector, which on `/` picks the first `___default` route in baked order — the runtime default is ignored.

This PR adds a *single-host runtime mode* to `matchDomainLocale`:

1. When **no** locale declares `domain`/`domains`, every locale is considered served by the current host (there is only one host per process).
2. With multiple matches and no path prefix, after the existing `defaultForDomains`/`domainDefault` checks, fall back to the runtime `defaultLocale`.
3. The same runtime fallback is applied in `afterSwitchLocalePath`, so `switchLocalePath` strips the prefix for the runtime default locale (otherwise it links to the removed prefixed route of the default).

**Backward compatible:** deployments that configure domains keep the exact same resolution — the new branches only engage when no domains are configured at all, a configuration that previously could not resolve any host locale.

With strategy `prefix_except_default`, `multiDomainLocales: true` and build-time `defaultLocale: ''`, one build serves any number of environments:

| process env `NUXT_PUBLIC_I18N_DEFAULT_LOCALE` | `/` | `/de` | `/es` |
|---|---|---|---|
| `es` | es | de (200) | 404 (canonical unprefixed) |
| `de` | de | 404 | es (200) |

Validated on a production storefront (Nuxt 4, four locales): one artifact, parallel processes with different runtime defaults — correct locale at `/`, prefixed routes intact, internal links unprefixed for the default with no prefixed leaks.

### 📝 Checklist

- [x] Backward compatible — new code paths are gated on "no domains configured"
- [x] Validated against a real multi-locale storefront build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced locale detection to use a configurable default-locale fallback when host- or prefix-based resolution is ambiguous.
  * Updated domain matching to better support single-host (domainless) runtime behavior, including correct handling of prefixed vs unprefixed paths.
  * Improved fallback order when multiple locale candidates are available, including domain-default and default-locale precedence.
* **Tests**
  * Added Vitest coverage for domain and single-host locale resolution, including default-locale fallback scenarios and mixed-domain disabling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->