### PR TITLE
fix(NuxtLinkLocale): allow string paths in `to` prop (fixes #4005)

### DIFF
--- a/specs/fixtures/basic/pages/index.vue
+++ b/specs/fixtures/basic/pages/index.vue
@@ -67,5 +67,6 @@ useHead(() => ({
       <span id="issue-2020-nonexistent">{{ localePath('/i-dont-exist?foo=bar') }}</span>
     </section>
     <NuxtLink id="issue-3831-nested-root" :to="localePath('index-nested-root-page')">Nested index page</NuxtLink>
+    <NuxtLinkLocale id="string-path-link" to="/">Home</NuxtLinkLocale>
   </div>
 </template>

--- a/specs/routing_strategies/prefix.spec.ts
+++ b/specs/routing_strategies/prefix.spec.ts
@@ -220,4 +220,9 @@ describe('strategy: prefix', async () => {
     const res = await fetch('/?foo=bar')
     expect(res.url).toBe(url('/en?foo=bar'))
   })
+  test('NuxtLinkLocale accepts string path (typedPages: true)', async () => {
+  const { page } = await renderPage('/en')
+  const href = await page.getAttribute('#string-path-link', 'href')
+  expect(href).toBe('/en')
+})
 })

--- a/src/runtime/components/NuxtLinkLocale.ts
+++ b/src/runtime/components/NuxtLinkLocale.ts
@@ -18,7 +18,7 @@ import type { NuxtApp, NuxtLinkProps } from 'nuxt/app'
 import type { RouteLocation, UseLinkReturn } from 'vue-router'
 
 type NuxtLinkLocaleProps<CustomProp extends boolean = false> = Omit<NuxtLinkProps<CustomProp>, 'to'> & {
-  to?: import('vue-router').RouteLocationNamedI18n
+  to?: import('vue-router').RouteLocationRaw
   locale?: Locale
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #4005

### 📚 Description

## Problem

The `NuxtLinkLocale` component currently rejects plain string paths passed to the `to` prop, even though the [documentation shows examples like `to="/"`](https://i18n.nuxtjs.org/docs/components/nuxt-link-locale).

```vue
<NuxtLinkLocale to="/">Home</NuxtLinkLocale>  <!-- ❌ TypeScript error -->
```

TypeScript reports:

```
Type 'string' is not assignable to type 'RouteLocationNamedI18n<keyof RouteNamedMapI18n> | undefined'
```

This is because the `to` prop is incorrectly typed as `RouteLocationNamedI18n`, a generated type that only accepts named route objects.

## Solution

Change the `to` prop type to `RouteLocationRaw` (the union `string | RouteLocation`), which matches:
- The documented usage
- The actual runtime behavior (already works)
- The `<NuxtLink>` component's `to` prop type

## Changes

```diff
type NuxtLinkLocaleProps<CustomProp extends boolean = false> = Omit<NuxtLinkProps<CustomProp>, 'to'> & {
-  to?: import('vue-router').RouteLocationNamedI18n
+  to?: import('vue-router').RouteLocationRaw
  locale?: Locale
}
```

## Impact

- **Type‑only change** – no runtime impact
- **Non‑breaking** – `RouteLocationRaw` is a supertype; all existing named‑route usage remains valid
- **Matches documentation and user expectations**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for locale-aware links by broadening the accepted destination format for locale-localized `NuxtLinkLocale` routing.
* **Tests**
  * Added coverage to ensure string-path destinations correctly render localized `href` values under the `prefix` routing strategy when typed pages are enabled.
* **Chores**
  * Updated the basic routing fixture to include an additional locale-aware link for verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->