### PR TITLE
fix(NuxtLinkLocale): make component generic to support `custom` prop …

### DIFF
--- a/specs/basic_usage.spec.ts
+++ b/specs/basic_usage.spec.ts
@@ -783,5 +783,16 @@ describe('basic usage', async () => {
 
       expect(await page.locator('#per-component-hello').innerText()).toMatch('Hello!')
     })
+    test('NuxtLinkLocale with custom prop works', async () => {
+      const { page } = await renderPage('/en')
+      // Check that the custom link renders with the correct href
+      const href = await page.getAttribute('#custom-link a', 'href')
+      expect(href).toBe('/en/about')
+      
+      // Optional: click and verify navigation
+      await page.locator('#custom-link a').click()
+      await page.waitForURL(url('/en/about'))
+      expect(page.url()).toContain('/en/about')
+    })
   })
 })

--- a/specs/fixtures/basic/pages/index.vue
+++ b/specs/fixtures/basic/pages/index.vue
@@ -67,5 +67,8 @@ useHead(() => ({
       <span id="issue-2020-nonexistent">{{ localePath('/i-dont-exist?foo=bar') }}</span>
     </section>
     <NuxtLink id="issue-3831-nested-root" :to="localePath('index-nested-root-page')">Nested index page</NuxtLink>
+    <NuxtLinkLocale id="custom-link" to="/about" custom v-slot="{ navigate, href }">
+      <a :href="href" @click="navigate">Custom About Link</a>
+    </NuxtLinkLocale>
   </div>
 </template>

--- a/src/runtime/components/NuxtLinkLocale.ts
+++ b/src/runtime/components/NuxtLinkLocale.ts
@@ -9,6 +9,7 @@ import type {
   AnchorHTMLAttributes,
   DefineSetupFnComponent,
   PropType,
+  Slots,
   SlotsType,
   UnwrapRef,
   VNode,
@@ -42,7 +43,80 @@ type NuxtLinkLocaleSlots<CustomProp extends boolean = false> = {
   default?: (props: NuxtLinkLocaleSlotProps<CustomProp>) => VNode[]
 }
 
-const NuxtLinkLocaleImpl = defineComponent<NuxtLinkLocaleProps<boolean>>({
+const NuxtLinkLocaleImpl = defineComponent(<CustomProp extends boolean = false>(
+  props: NuxtLinkLocaleProps<CustomProp>,
+  { slots }: { slots: Slots },
+) => {
+  const localeRoute = useLocaleRoute()
+
+  // From https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/app/components/nuxt-link.ts#L57
+  function checkPropConflicts(
+    props: NuxtLinkLocaleProps<CustomProp>,
+    main: keyof NuxtLinkLocaleProps,
+    sub: keyof NuxtLinkProps,
+  ) {
+    if (import.meta.dev && props[main] !== undefined && props[sub] !== undefined) {
+      console.warn(`[NuxtLinkLocale] \`${main}\` and \`${sub}\` cannot be used together. \`${sub}\` will be ignored.`)
+    }
+  }
+
+  // Lazily check whether to.value has a protocol
+  const isAbsoluteUrl = computed(() => {
+    const path = props.to || props.href || ''
+    return typeof path === 'string' && hasProtocol(path, { acceptRelative: true })
+  })
+
+  const resolvedPath = computed(() => {
+    const destination = props.to ?? props.href
+    const resolved = destination != null ? localeRoute(destination, props.locale) : destination
+    if (resolved && isObject(props.to)) {
+      resolved.state = props.to?.state
+    }
+
+    return destination != null ? resolved : destination
+  })
+
+  // Resolving link type
+  const isExternal = computed<boolean>(() => {
+    // External prop is explicitly set
+    if (props.external) {
+      return true
+    }
+
+    const path = props.to || props.href || ''
+    // When `to` is a route object then it's an internal link
+    if (isObject(path)) {
+      return false
+    }
+
+    return path === '' || isAbsoluteUrl.value
+  })
+
+  /**
+   * Get props to pass to NuxtLink
+   * @returns NuxtLink props
+   */
+  const getNuxtLinkProps = () => {
+    const _props = {
+      ...props,
+    }
+
+    if (!isExternal.value) {
+      _props.to = resolvedPath.value
+    }
+
+    // Warn when both properties are used, delete `href` to prevent warning by `NuxtLink`
+    checkPropConflicts(props, 'to', 'href')
+    delete _props.href
+
+    // Remove attributes not supported by NuxtLink (#2498)
+    delete _props.locale
+
+    return _props as NuxtLinkProps<CustomProp>
+  }
+
+  return () => h(NuxtLink, getNuxtLinkProps(), slots.default)
+}, {
   name: 'NuxtLinkLocale',
   props: {
     ...NuxtLink.props,
@@ -51,77 +125,6 @@ const NuxtLinkLocaleImpl = defineComponent<NuxtLinkLocaleProps<boolean>>({
       default: undefined,
       required: false,
     },
-  },
-  setup(props, { slots }) {
-    const localeRoute = useLocaleRoute()
-
-    // From https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/app/components/nuxt-link.ts#L57
-    function checkPropConflicts(
-      props: NuxtLinkLocaleProps<boolean>,
-      main: keyof NuxtLinkLocaleProps,
-      sub: keyof NuxtLinkProps,
-    ) {
-      if (import.meta.dev && props[main] !== undefined && props[sub] !== undefined) {
-        console.warn(`[NuxtLinkLocale] \`${main}\` and \`${sub}\` cannot be used together. \`${sub}\` will be ignored.`)
-      }
-    }
-
-    // Lazily check whether to.value has a protocol
-    const isAbsoluteUrl = computed(() => {
-      const path = props.to || props.href || ''
-      return typeof path === 'string' && hasProtocol(path, { acceptRelative: true })
-    })
-
-    const resolvedPath = computed(() => {
-      const destination = props.to ?? props.href
-      const resolved = destination != null ? localeRoute(destination, props.locale) : destination
-      if (resolved && isObject(props.to)) {
-        resolved.state = props.to?.state
-      }
-
-      return destination != null ? resolved : destination
-    })
-
-    // Resolving link type
-    const isExternal = computed<boolean>(() => {
-      // External prop is explicitly set
-      if (props.external) {
-        return true
-      }
-
-      const path = props.to || props.href || ''
-      // When `to` is a route object then it's an internal link
-      if (isObject(path)) {
-        return false
-      }
-
-      return path === '' || isAbsoluteUrl.value
-    })
-
-    /**
-     * Get props to pass to NuxtLink
-     * @returns NuxtLink props
-     */
-    const getNuxtLinkProps = () => {
-      const _props = {
-        ...props,
-      }
-
-      if (!isExternal.value) {
-        _props.to = resolvedPath.value
-      }
-
-      // Warn when both properties are used, delete `href` to prevent warning by `NuxtLink`
-      checkPropConflicts(props, 'to', 'href')
-      delete _props.href
-
-      // Remove attributes not supported by NuxtLink (#2498)
-      delete _props.locale
-
-      return _props as NuxtLinkProps<boolean>
-    }
-
-    return () => h(NuxtLink, getNuxtLinkProps(), slots.default)
   },
 })
 


### PR DESCRIPTION
### 🔗 Linked issue
#3558 

### 📚 Description

Convert component definition from non‑generic `defineComponent<NuxtLinkLocaleProps<boolean>>` to a generic function pattern. This allows the `custom` prop to accept `true` and correctly infers slot props, resolving the TypeScript error `Type 'true' is not assignable to type 'false'`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Strengthened the locale link component’s handling of internal vs. external destinations, with improved TypeScript typing and safer prop preparation to reduce edge-case issues.
* **Bug Fixes**
  * Ensured locale-aware links render the expected localized URL and navigate correctly when using custom link props/slot content.
* **Tests**
  * Added coverage verifying the localized `href` output and that clicking the link routes to the correct localized page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->