### PR TITLE
fix: HMR locale messages flash

### DIFF
--- a/src/runtime/plugins/dev.ts
+++ b/src/runtime/plugins/dev.ts
@@ -1,8 +1,9 @@
-import { vueI18nConfigs } from '#build/i18n-options.mjs'
+import { deepCopy } from '@intlify/shared'
+import { localeLoaders, vueI18nConfigs } from '#build/i18n-options.mjs'
 import { defineNuxtPlugin, useNuxtApp } from '#imports'
 import { getComposer } from '../compatibility'
 import { useNuxtI18nContext } from '../context'
-import { loadVueI18nOptions } from '../shared/messages'
+import { getLocaleMessagesMerged, loadVueI18nOptions } from '../shared/messages'
 
 import type { I18nOptions } from 'vue-i18n'
 
@@ -37,9 +38,12 @@ export default defineNuxtPlugin({
       for (const k of messageLocales) {
         if (locale && k !== locale) { continue }
 
-        // set to vue-i18n messages or reset to account for removed messages
-        composer.setLocaleMessage(k, opts?.messages?.[k] ?? {})
-        await ctx.loadMessages(k)
+        const baseMessages = opts?.messages?.[k] ?? {}
+        const fileMessages = await nuxt.runWithContext(() => getLocaleMessagesMerged(k, localeLoaders[k] || []))
+        const merged: Record<string, unknown> = {}
+        deepCopy(baseMessages, merged)
+        deepCopy(fileMessages, merged)
+        composer.setLocaleMessage(k, merged)
       }
 
       // skip vue-i18n config properties if locale is passed (locale file HMR)

--- a/src/runtime/plugins/dev.ts
+++ b/src/runtime/plugins/dev.ts
@@ -39,11 +39,15 @@ export default defineNuxtPlugin({
         if (locale && k !== locale) { continue }
 
         const baseMessages = opts?.messages?.[k] ?? {}
-        const fileMessages = await nuxt.runWithContext(() => getLocaleMessagesMerged(k, localeLoaders[k] || []))
-        const merged: Record<string, unknown> = {}
-        deepCopy(baseMessages, merged)
-        deepCopy(fileMessages, merged)
-        composer.setLocaleMessage(k, merged)
+        try {
+          const fileMessages = await nuxt.runWithContext(() => getLocaleMessagesMerged(k, localeLoaders[k] || []))
+          const merged: Record<string, unknown> = {}
+          deepCopy(baseMessages, merged)
+          deepCopy(fileMessages, merged)
+          composer.setLocaleMessage(k, merged)
+        } catch (e) {
+          console.warn(`Failed to load messages for locale "${k}"`, e)
+        }
       }
 
       // skip vue-i18n config properties if locale is passed (locale file HMR)

--- a/src/runtime/plugins/dev.ts
+++ b/src/runtime/plugins/dev.ts
@@ -1,4 +1,3 @@
-import { deepCopy } from '@intlify/shared'
 import { localeLoaders, vueI18nConfigs } from '#build/i18n-options.mjs'
 import { defineNuxtPlugin, useNuxtApp } from '#imports'
 import { getComposer } from '../compatibility'
@@ -38,13 +37,11 @@ export default defineNuxtPlugin({
       for (const k of messageLocales) {
         if (locale && k !== locale) { continue }
 
-        const baseMessages = opts?.messages?.[k] ?? {}
         try {
           const fileMessages = await nuxt.runWithContext(() => getLocaleMessagesMerged(k, localeLoaders[k] || []))
-          const merged: Record<string, unknown> = {}
-          deepCopy(baseMessages, merged)
-          deepCopy(fileMessages, merged)
-          composer.setLocaleMessage(k, merged)
+          // reset to config messages to drop removed keys, merge file messages in the same tick
+          composer.setLocaleMessage(k, opts?.messages?.[k] ?? {})
+          composer.mergeLocaleMessage(k, fileMessages)
         } catch (e) {
           console.warn(`Failed to load messages for locale "${k}"`, e)
         }


### PR DESCRIPTION
### 🔗 Linked issue

Fix: https://github.com/nuxt-modules/i18n/discussions/4009

### 📚 Description

Editing locale files in dev could briefly render raw translation keys because locale messages were reset before async reload completed. This updates the HMR reset path to compute the next locale payload first, then replace composer messages in a single write.

- **Root cause**
  - `resetI18nProperties()` called `setLocaleMessage(..., {})` (or base-only config) before `loadMessages`, creating a reactive empty/intermediate state during locale-file HMR.

- **Runtime plugin update (`src/runtime/plugins/dev.ts`)**
  - Expanded imports to use `localeLoaders`, `getLocaleMessagesMerged`, and `deepCopy`.
  - Replaced two-step reset/load flow with load+merge+set:
    - read base messages from vue-i18n config
    - load locale file messages via `getLocaleMessagesMerged(locale, localeLoaders[locale])`
    - deep-merge into a fresh object
    - call `setLocaleMessage` once with the merged result

- **Behavioral impact**
  - Avoids flash of untranslated keys during HMR.
  - Keeps replacement semantics for locale messages (removed keys are not retained from prior composer state).

```ts
    const baseMessages = opts?.messages?.[k] ?? {}                                                                                                                                                                                                                                                                
    try {                                                                                                                                                                                                                                                                                                         
      const fileMessages = await nuxt.runWithContext(() =>                                                                                                                                                                                                                                                        
        getLocaleMessagesMerged(k, localeLoaders[k] || [])                                                                                                                                                                                                                                                        
      )                                                                                                                                                                                                                                                                                                           
      const merged: Record<string, unknown> = {}                                                                                                                                                                                                                                                                  
      deepCopy(baseMessages, merged)                                                                                                                                                                                                                                                                              
      deepCopy(fileMessages, merged)                                                                                                                                                                                                                                                                              
      composer.setLocaleMessage(k, merged)                                                                                                                                                                                                                                                                        
    } catch (e) {                                                                                                                                                                                                                                                                                                 
      console.warn(`Failed to load messages for locale "${k}"`, e)                                                                                                                                                                                                                                                
    }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development-mode reloading of Vue I18n locale messages by merging per-locale file messages with base configuration content.
  * Enhanced reliability when switching locales by updating composer messages in a single merged pass.
  * Added safer handling for locale reload failures: issues now trigger warnings and only the affected locale is skipped, without breaking the overall flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->