### PR TITLE
fix: resolve `bundle.onlyLocales` from the first layer that specifies it

### DIFF
--- a/docs/content/docs/04.api/00.options.md
+++ b/docs/content/docs/04.api/00.options.md
@@ -444,7 +444,7 @@ Specify the locales codes that need to be included, the rest will be removed.
 It can be useful if you have one code base (e.g. [Nuxt Layers](https://nuxt.com/docs/getting-started/layers)) for several similar projects using different languages.
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="warning"}
-The value of this **option will not be merged with other Nuxt Layers**. This option should only be specified in the final project config.
+The value of this **option will not be merged with other Nuxt Layers**. The value is resolved from the first layer that specifies this option (the project config first, then extending layers in order), specifying it in the project config overrides any layer value.
 ::
 
 ## experimental

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,8 +13,16 @@ import type { IdentifierName, Program, VariableDeclarator } from 'oxc-parser'
 import type { I18nNuxtContext } from './context'
 
 export function filterLocales(ctx: I18nNuxtContext, nuxt: Nuxt) {
-  const project = getLayerI18n(nuxt.options._layers[0]!)
-  const include = toArray(project?.bundle?.onlyLocales ?? []).filter(isString)
+  // use `onlyLocales` from the first layer that specifies it
+  let onlyLocales
+  for (const layer of nuxt.options._layers) {
+    const layerOnlyLocales = getLayerI18n(layer)?.bundle?.onlyLocales
+    if (layerOnlyLocales != null) {
+      onlyLocales = layerOnlyLocales
+      break
+    }
+  }
+  const include = toArray(onlyLocales ?? []).filter(isString)
 
   if (!include.length) {
     return ctx.options.locales

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,10 +1,65 @@
-import { resolveLocales } from '../src/utils'
-import type { LocaleObject } from '../src/types'
-import { vi, test, expect } from 'vitest'
+import { filterLocales, resolveLocales } from '../src/utils'
+import type { LocaleObject, NuxtI18nOptions } from '../src/types'
+import type { I18nNuxtContext } from '../src/context'
+import type { Nuxt, NuxtConfigLayer } from '@nuxt/schema'
+import { vi, describe, test, expect } from 'vitest'
 
 vi.mock('pathe', async () => {
   const mod = await vi.importActual<typeof import('pathe')>('pathe')
   return { ...mod, resolve: vi.fn((...args: string[]) => mod.normalize(args.join('/'))) }
+})
+
+function createLayer(i18n?: NuxtI18nOptions): NuxtConfigLayer {
+  return { config: { i18n } } as unknown as NuxtConfigLayer
+}
+
+function createContext(locales: NuxtI18nOptions['locales']): I18nNuxtContext {
+  return { options: { locales } } as I18nNuxtContext
+}
+
+function createNuxt(layers: NuxtConfigLayer[]): Nuxt {
+  return { options: { _layers: layers } } as unknown as Nuxt
+}
+
+describe('filterLocales', () => {
+  test('uses `onlyLocales` from the running project', () => {
+    const ctx = createContext(['en', 'fr', 'nl'])
+    const nuxt = createNuxt([
+      createLayer({ bundle: { onlyLocales: 'en' } }),
+      createLayer({ bundle: { onlyLocales: 'fr' } })
+    ])
+
+    expect(filterLocales(ctx, nuxt)).toEqual(['en'])
+  })
+
+  test('falls back to the first downstream layer that specifies `onlyLocales`', () => {
+    const ctx = createContext(['en', 'fr', 'nl'])
+    const nuxt = createNuxt([
+      createLayer({}),
+      createLayer({ bundle: { onlyLocales: 'fr' } }),
+      createLayer({ bundle: { onlyLocales: 'nl' } })
+    ])
+
+    expect(filterLocales(ctx, nuxt)).toEqual(['fr'])
+  })
+
+  test('returns all locales when no layer specifies `onlyLocales`', () => {
+    const ctx = createContext(['en', 'fr', 'nl'])
+    const nuxt = createNuxt([createLayer({}), createLayer({ bundle: {} })])
+
+    expect(filterLocales(ctx, nuxt)).toEqual(['en', 'fr', 'nl'])
+  })
+
+  test('treats an explicit empty `onlyLocales` as specified and stops the search', () => {
+    const ctx = createContext(['en', 'fr', 'nl'])
+    const nuxt = createNuxt([
+      createLayer({ bundle: { onlyLocales: [] } }),
+      createLayer({ bundle: { onlyLocales: 'fr' } })
+    ])
+
+    // empty `onlyLocales` means no filtering; the downstream `'fr'` must not be applied
+    expect(filterLocales(ctx, nuxt)).toEqual(['en', 'fr', 'nl'])
+  })
 })
 
 test('resolveLocales', async () => {


### PR DESCRIPTION
### 📚 Description

previously, `filterLocales` only read `bundle.onlyLocales` from the running project (`_layers[0]`) and ignored it entirely when a downstream layer set it

this pr makes it walk layers starting from the running project and use the first one that specifies it, which IMO is the expected behaviour

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `onlyLocales` handling by deriving the effective locale filter from the first configuration layer that specifies it, with behavior unchanged when no filtering is required.
* **Tests**
  * Added new test coverage for locale selection across multiple layer configurations, including fallback and the “explicit empty” edge case.
* **Documentation**
  * Updated `onlyLocales` option docs to clarify how Nuxt Layers merging works (non-merged resolution from the first defining layer, with project config taking precedence).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->