### PR TITLE
fix(compactRoutes): key NuxtPage by interpolated pattern, not full path

### DIFF
--- a/src/runtime/plugins/route-locale-detect.ts
+++ b/src/runtime/plugins/route-locale-detect.ts
@@ -16,7 +16,12 @@ export default defineNuxtPlugin({
       const router = useRouter()
       for (const route of router.getRoutes()) {
         if (route.meta?.__i18nCompact && route.meta.key == null) {
-          route.meta.key = (r: { path: string }) => r.path
+          // Key by the record's own interpolated pattern (mirrors Nuxt's default `<NuxtPage>`
+          // keying) instead of the full resolved path, so nested parent pages stay mounted
+          // across child navigation and only remount when the locale param actually changes.
+          const pattern = route.path.replace(/(:\w+)\([^)]+\)/g, '$1').replace(/(:\w+)[?+*]/g, '$1')
+          route.meta.key = (r: { params: Record<string, string | string[]> }) =>
+            pattern.replace(/:\w+/g, m => r.params[m.slice(1)]?.toString() || '')
         }
       }
     }


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #4001

### 📚 Description

With `experimental.compactRoutes`, the `route-locale-detect` plugin keys compact routes by the **full resolved path**:

```ts
route.meta.key = (r) => r.path
```

Nuxt uses `meta.key` as the `<NuxtPage>` component key, so the key changes on **every child navigation** (e.g. `/de/foo/bar` → `/de/foo/baz`). Vue then treats the parent record as a different instance and **remounts the whole nested subtree** — state held in a parent component across child navigation is wiped, and `onBeforeMount` / `onBeforeUnmount` re-run unexpectedly.

This only reproduces on **non-default locales**: the default-locale tree isn't compact (no `meta.key`), so Nuxt falls back to the record's own interpolated pattern, which is stable across child navigation.

The upstream intent — remount when the locale param actually changes, e.g. `/de/x` → `/fr/x` (introduced in #3957) — is legitimate, but keying by the full path over-fires on every child navigation.

**Fix:** key by the record's own interpolated pattern instead, matching Nuxt's default `<NuxtPage>` keying:

```ts
const pattern = route.path.replace(/(:\w+)\([^)]+\)/g, '$1').replace(/(:\w+)[?+*]/g, '$1')
route.meta.key = (r) => pattern.replace(/:\w+/g, m => r.params[m.slice(1)]?.toString() || '')
```

For a compact record `/:locale(en|de|fr)/foo`, the key resolves to `/de/foo` for any child of `foo` under `/de` — stable across `/de/foo/bar` ↔ `/de/foo/baz`, while still changing to `/fr/foo` on a locale switch, so the intended locale-change remount is preserved.

### ✅ Verification

- `pnpm test:types`, `pnpm lint`, and `pnpm test:unit` all pass.
- Verified manually on a nested-pages app: child navigation no longer remounts the parent; a locale switch (`/de/x` → `/fr/x`) still remounts as intended.

### 📝 Note on tests

`compactRoutes` is currently covered only at the route-table level (`test/pages/route_localization.test.ts`); there's no e2e fixture exercising compact-route runtime navigation, and `meta.key` is assigned inside the runtime plugin. I'm happy to add a dedicated fixture + spec (nested pages asserting the parent stays mounted across child navigation and remounts on a locale switch) if you'd like that folded into this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale-aware navigation so nested pages stay mounted when moving between child routes.
  * Routes now refresh only when the locale-related route value actually changes, reducing unnecessary remounts and page resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->