### PR TITLE
fix(compactRoutes): strip stale locale param in by-path resolver

### DIFF
--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -130,6 +130,11 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
       const localizedName = getLocalizedRouteName(baseName, locale)
       if (router.hasRoute(localizedName)) {
         route.name = localizedName
+        // Remove stale locale param inherited from a compact route — per-locale routes don't use it
+        const named = route as RouteLikeWithName
+        if (__I18N_COMPACT_ROUTES__ && named.params) {
+          delete (named.params as Record<string, unknown>).locale
+        }
         return route
       }
 


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #4002

### 📚 Description

With `experimental.compactRoutes`, the route table is asymmetric: the default-locale route has no `:locale` param, while the compact route for the other locales does. There are two resolvers in `runtime/utils.ts`:

- the **by-name** resolver correctly does `delete route.params.locale` when retargeting to the default-locale route;
- the **by-path** resolver swaps `route.name` to the default-locale route but **does not** delete `params.locale`.

So resolving a prefixed path to the default locale from a non-default-locale URL — e.g. `localeRoute(route.path, defaultLocale)`, common in SEO head composables that build `x-default` / `hreflang` links — hands vue-router a named location carrying a `locale` param the target route doesn't declare:

```
[Vue Router warn]: Discarded invalid param(s) "locale" when navigating.
```

…once per SSR request for every non-default-locale URL (default-locale URLs are silent). It's **dev-only and functionally harmless** — vue-router's `pickParams` drops the stray param, so canonical / hreflang / hrefs stay correct — but it's per-request console noise.

This is a follow-up to #3975, which fixed several compact-route router warnings but missed this code path.

**Fix:** mirror the existing `delete route.params.locale` from the by-name branch into the by-path branch, under the same `__I18N_COMPACT_ROUTES__` guard.

### ✅ Verification

- `pnpm test:types`, `pnpm lint`, and `pnpm test:unit` all pass.
- Verified locally: the warning drops to 0 across non-default-locale routes, and generated canonical / hreflang are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed localized routes so they no longer carry an outdated locale parameter when compact routing is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->