### PR TITLE
docs: remove duplicated service page in custom paths example

### DIFF
--- a/docs/content/docs/02.guide/03.custom-paths.md
+++ b/docs/content/docs/02.guide/03.custom-paths.md
@@ -113,7 +113,6 @@ You have some routes with the following `pages` directory:
 -| pages/
 ---| about.vue
 ---| services/
------| index.vue
 -----| coaching.vue
 -----| development/
 -------| app.vue


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #3997

### 📚 Description

This PR fixes a duplicated service page entry in Example 2 of the Custom Route Paths documentation.

The directory structure previously included both `services/index.vue` and `services.vue`, which could represent the same service page and cause confusion. This PR removes the extra `services/index.vue` entry to keep the example consistent with the `pages` configuration below.

### Testing

Not run. This is a documentation-only change.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the custom paths guide to reflect the current `pages/services/` directory structure.
  * Refined the example tree diagram by removing an outdated entry so the rendered layout matches the latest structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->