### PR TITLE
docs: recommend named routes over path strings for `<NuxtLinkLocale>`

### DIFF
--- a/docs/content/docs/05.components/01.nuxt-link-locale.md
+++ b/docs/content/docs/05.components/01.nuxt-link-locale.md
@@ -18,9 +18,12 @@ This component supports all [props documented for `<NuxtLink>`{lang="html"}](htt
 
 #### Basic usage
 
+The `to` prop accepts a route name or a route object using the `name` property:
+
 ```vue
 <template>
-  <NuxtLinkLocale to="/">{{ $t('home') }}</NuxtLinkLocale>
+  <NuxtLinkLocale to="index">{{ $t('home') }}</NuxtLinkLocale>
+  <NuxtLinkLocale :to="{ name: 'index' }">{{ $t('home') }}</NuxtLinkLocale>
 </template>
 
 <!-- equivalent to -->
@@ -30,7 +33,8 @@ const localePath = useLocalePath()
 </script>
 
 <template>
-  <NuxtLink :to="localePath('/')">{{ $t('home') }}</NuxtLink>
+  <NuxtLink :to="localePath('index')">{{ $t('home') }}</NuxtLink>
+  <NuxtLink :to="localePath({ name: 'index' })">{{ $t('home') }}</NuxtLink>
 </template>
 ```
 
@@ -38,7 +42,7 @@ const localePath = useLocalePath()
 
 ```vue
 <template>
-  <NuxtLinkLocale to="/" locale="nl">{{ $t('home') }}</NuxtLinkLocale>
+  <NuxtLinkLocale to="index" locale="nl">{{ $t('home') }}</NuxtLinkLocale>
 </template>
 
 <!-- equivalent to -->
@@ -48,7 +52,20 @@ const localePath = useLocalePath()
 </script>
 
 <template>
-  <NuxtLink :to="localePath('/', 'nl')">{{ $t('home') }}</NuxtLink>
+  <NuxtLink :to="localePath('index', 'nl')">{{ $t('home') }}</NuxtLink>
 </template>
 ```
 
+#### Path strings
+
+Passing a path string works at runtime and is kept for backwards compatibility:
+
+```vue
+<template>
+  <NuxtLinkLocale to="/">{{ $t('home') }}</NuxtLinkLocale>
+</template>
+```
+
+::callout{icon="i-heroicons-exclamation-triangle" color="warning"}
+We recommend using named routes (as in the examples above) instead of path strings. Paths depend on the configured [`strategy`](/docs/api/options#strategy) and [custom paths](/docs/guide/custom-paths), meaning a path that resolves correctly today can silently stop matching when the routing configuration changes. For this reason the `to` prop only accepts named routes on the type level when [`typedPages`](https://nuxt.com/docs/guide/going-further/experimental-features#typedpages) is enabled.
+::


### PR DESCRIPTION
* closes #4005
* closes #4006

### 📚 Description

Updates the `<NuxtLinkLocale>` examples to use named routes (name strings and route objects) and documents why path strings are discouraged: they still work at runtime and are kept for backwards compatibility, but paths depend on the configured `strategy` and custom paths, so the `to` prop deliberately only accepts named routes on the type level when `typedPages` is enabled. The string examples predate typed routes, which is why the docs contradicted the types.