### PR TITLE
feat: resolve route options from meta in all `customRoutes` modes

### DIFF
--- a/docs/content/docs/02.guide/03.custom-paths.md
+++ b/docs/content/docs/02.guide/03.custom-paths.md
@@ -5,7 +5,13 @@ description: Customize the names of the paths for specific locale.
 
 In some cases, you might want to translate URLs in addition to having them prefixed with the locale code. There are two methods of configuring custom paths, through [Module configuration](#module-configuration) or from within each [Page component](#definepagemeta).
 
-Which method is used is configured by setting the [`customRoutes` options](/docs/api/options#customroutes) this is set to `'page'`{lang="ts-type"} by default. Using both methods at the same time is not possible.
+Custom paths set with [`definePageMeta()`](#definepagemeta) are used in all [`customRoutes`](/docs/api/options#customroutes) modes, the mode configures which additional source is used:
+
+- `'page'`{lang="ts-type"} (default): the deprecated [`defineI18nRoute()`](#definei18nroute) macro
+- `'config'`{lang="ts-type"}: the [`pages` option](#module-configuration) in the module configuration
+- `'meta'`{lang="ts-type"}: none, `definePageMeta()`{lang="ts"} is the only source
+
+If a route has custom paths from multiple sources, the `definePageMeta()`{lang="ts"} value takes precedence and a warning is logged during build.
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="warning"}
 Custom paths are not supported when using the `'no_prefix'`{lang="ts-type"} [strategy](/docs/guide) unless combined with [`differentDomains`](/docs/guide/different-domains).
@@ -18,7 +24,7 @@ Make sure you set the `customRoutes` option to `'config'`{lang="ts-type"} and ad
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   i18n: {
-    customRoutes: 'config', // disable custom route with page components
+    customRoutes: 'config', // enable custom routes from the `pages` option
     pages: {
       about: {
         en: '/about-us', // -> accessible at /about-us (no prefix since it's the default locale)
@@ -183,9 +189,9 @@ export default defineNuxtConfig({
 ```
 
 ## `definePageMeta`
-You can use the `i18n` property in `definePageMeta()`{lang="ts"} to set custom paths for each page component.
+You can use the `i18n` property in `definePageMeta()`{lang="ts"} to set custom paths for each page component, this works in all `customRoutes` modes and takes precedence over the other methods.
 
-To use this feature you will need to set `customRoutes: 'meta'`{lang="ts-type"} in your `nuxt.config.ts`:
+You can set `customRoutes: 'meta'`{lang="ts-type"} in your `nuxt.config.ts` to make this the only source of custom paths:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
@@ -225,6 +231,10 @@ definePageMeta({
 })
 </script>
 ```
+
+::callout{icon="i-heroicons-light-bulb"}
+The `i18n` property is consumed at build time and removed from route meta, only the boolean form (`i18n: false`{lang="ts"}, see [Ignoring Localized Routes](/docs/guide/ignoring-localized-routes)) is available at runtime.
+::
 
 ## `defineI18nRoute`
 

--- a/docs/content/docs/02.guide/04.ignoring-localized-routes.md
+++ b/docs/content/docs/02.guide/04.ignoring-localized-routes.md
@@ -9,6 +9,10 @@ This feature is not supported when using the `'no_prefix'`{lang="ts-type"} [stra
 
 If you'd like some pages to be available in some languages only, you can configure the list of supported languages to override the global settings. The options can be specified within either the page components themselves or globally, within the module configuration.
 
+::callout{icon="i-heroicons-light-bulb"}
+The `definePageMeta()`{lang="ts"} examples work in all [`customRoutes`](/docs/api/options#customroutes) modes, the `defineI18nRoute()`{lang="ts"} and `pages` examples require `customRoutes` to be set to `'page'`{lang="ts-type"} (default) or `'config'`{lang="ts-type"} respectively.
+::
+
 ### Pick localized routes
 
 ::code-group
@@ -33,6 +37,7 @@ defineI18nRoute({
 
 ```ts [nuxt.config.ts]
 i18n: {
+  customRoutes: 'config',
   pages: {
     about: {
       en: false,

--- a/docs/content/docs/02.guide/91.new-features.md
+++ b/docs/content/docs/02.guide/91.new-features.md
@@ -8,7 +8,7 @@ toc:
 
 ### Custom routes via `definePageMeta()`{lang="ts"}
 We have added support for setting custom routes for pages using the `definePageMeta()`{lang="ts"} API, which is now the recommended way to set custom routes for pages.
-This method is enabled by setting `customRoutes: 'meta'`{lang="ts"} in the module options.
+This method is used in all `customRoutes` modes and takes precedence over custom routes set with the `pages` option or the `defineI18nRoute()`{lang="ts"} macro.
 
 To migrate from the `defineI18nRoute()`{lang="ts"} macro, you can simply replace it with `definePageMeta()`{lang="ts"} and set the `i18n` property with the same options:
 ```vue [pages/about.vue]

--- a/docs/content/docs/04.api/00.options.md
+++ b/docs/content/docs/04.api/00.options.md
@@ -195,18 +195,20 @@ Routes generation strategy. Can be set to one of the following:
 - type: `'meta' | 'page' | 'config'`{lang="ts-type"}
 - default: `'page'`{lang="ts-type"}
 
-Whether [custom paths](/docs/guide/custom-paths) are extracted from page files or configured in the module configuration:
+Which source is used for [custom paths](/docs/guide/custom-paths) in addition to `definePageMeta()`{lang="ts"}:
 
-- `'meta'`{lang="ts-type"}: custom paths are extracted from the `definePageMeta()`{lang="ts"} function in page components.
-- `'page'`{lang="ts-type"}: custom paths are extracted from the `defineI18nRoute()`{lang="ts"} macro in page components.
-- `'config'`{lang="ts-type"}: custom paths are configured in the `pages` option of the module configuration.
+- `'meta'`{lang="ts-type"}: custom paths are extracted from `definePageMeta()`{lang="ts"} in page components only.
+- `'page'`{lang="ts-type"}: custom paths are additionally extracted from the deprecated `defineI18nRoute()`{lang="ts"} macro in page components.
+- `'config'`{lang="ts-type"}: custom paths are additionally configured in the `pages` option of the module configuration.
+
+Custom paths set with `definePageMeta()`{lang="ts"} are used in all modes and take precedence over the other sources, a warning is logged during build if a route has custom paths from multiple sources.
 
 ## pages
 
 - type: `object`{lang="ts-type"}
 - default: `{}`{lang="ts-type"}
 
-If `customRoutes` option is disabled with `config`, the module will look for custom routes in the `pages` option. Refer to the [Routing](/docs/guide) for usage.
+If the `customRoutes` option is set to `'config'`{lang="ts-type"}, the module will look for custom routes in the `pages` option. Refer to [Custom Route Paths](/docs/guide/custom-paths) for usage.
 
 ## skipSettingLocaleOnNavigate
 

--- a/docs/content/docs/07.compiler-macros/01.define-i18n-route.md
+++ b/docs/content/docs/07.compiler-macros/01.define-i18n-route.md
@@ -3,7 +3,7 @@ title: defineI18nRoute
 ---
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="warning" title="notice"}
-This macro is deprecated in favor of setting localized paths using `definePageMeta()`{lang="ts"} and will be removed in v11.
+This macro is deprecated in favor of setting localized paths using `definePageMeta()`{lang="ts"} and will be removed in v11, values set with `definePageMeta()`{lang="ts"} take precedence over this macro.
 :br
 See its [section in Custom Paths](/docs/guide/custom-paths#definepagemeta) for more details.
 ::

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -464,7 +464,7 @@ function getRouteFromConfig(
 
 /** Convert a raw `pages` config entry to the route meta `i18n` shape */
 function configValueToI18nRoute(
-  value: Record<string, string | false> | false,
+  value: Partial<Record<string, `/${string}` | false>> | false,
   localeCodes: string[],
 ): I18nRoute | false {
   if (value === false) { return false }
@@ -473,7 +473,7 @@ function configValueToI18nRoute(
   for (const [locale, path] of Object.entries(value)) {
     if (path === false) {
       hasDisabled = true
-    } else {
+    } else if (path != null) {
       paths[locale] = path
     }
   }

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -6,6 +6,7 @@ import { parseAndWalk } from 'oxc-walker'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { parseSegment, toVueRouterSegment } from 'unrouting'
 import { localizeRoutes, shouldLocalizeRoutes } from './routing'
+import { logger } from './utils'
 import { dirname, parse as parsePath, resolve } from 'pathe'
 import { createRoutesContext, resolveOptions } from 'vue-router/unplugin'
 import { transform } from './transform/resource'
@@ -102,6 +103,9 @@ export const disabledI18nPathToPath = ${JSON.stringify(routeResources.disabledI1
         await typedRouter.createContext(pages).scanPages(false)
       }
 
+      // normalize per-mode route options into route meta before localization
+      normalizeRouteMeta(ctx, pages, localeCodes, options.customRoutes ?? 'page', nuxt.vfs)
+
       const resolver = createPureOptionsResolver(ctx, options.defaultLocale, options.customRoutes)
 
       const localizationOptions = {
@@ -124,6 +128,10 @@ export const disabledI18nPathToPath = ${JSON.stringify(routeResources.disabledI1
       if (options.strategy === 'prefix' && indexPage != null) {
         localizedPages.unshift(indexPage as NarrowedNuxtPage)
       }
+
+      // custom path config is consumed at build time, drop it from the routes manifest
+      // (the boolean form is kept, it marks routes with disabled localization at runtime)
+      stripRouteMetaI18n(localizedPages)
 
       const invertedMap = {} as Record<string, Record<string, string | false>>
       const localizedMapInvert: Record<string, string> = {}
@@ -432,24 +440,103 @@ function resolveRoutePath(path: string): string {
   return '/' + toVueRouterSegment(tokens)
 }
 
+/** Raw `pages` config entry for a route, matched by analyzed name or path */
+function getConfigValue(ctx: NuxtPageAnalyzeContext, route: NuxtPage) {
+  const pageMeta = ctx.pages.get(route.file!)
+  if (pageMeta == null) { return undefined }
+
+  const valueByName = pageMeta?.name ? ctx.config?.[pageMeta.name] : undefined
+  return valueByName ?? (pageMeta?.path != null ? ctx.config?.[pageMeta.path] : undefined)
+}
+
 function getRouteFromConfig(
   ctx: NuxtPageAnalyzeContext,
   route: NuxtPage,
   localeCodes: string[],
 ): ComputedRouteOptions | false | undefined {
-  const pageMeta = ctx.pages.get(route.file!)
-
-  if (pageMeta == null) {
-    return undefined
-  }
-
-  const valueByName = pageMeta?.name ? ctx.config?.[pageMeta.name] : undefined
-  const valueByPath = pageMeta?.path != null ? ctx.config?.[pageMeta.path] : undefined
-  const resolved = valueByName ?? valueByPath
+  const resolved = getConfigValue(ctx, route)
   if (!resolved) { return resolved }
   return {
     paths: (resolved ?? {}) as Record<string, string>,
     locales: localeCodes.filter(locale => resolved[locale] !== false),
+  }
+}
+
+/** Convert a raw `pages` config entry to the route meta `i18n` shape */
+function configValueToI18nRoute(
+  value: Record<string, string | false> | false,
+  localeCodes: string[],
+): I18nRoute | false {
+  if (value === false) { return false }
+  const paths: Record<string, string> = {}
+  let hasDisabled = false
+  for (const [locale, path] of Object.entries(value)) {
+    if (path === false) {
+      hasDisabled = true
+    } else {
+      paths[locale] = path
+    }
+  }
+  const route: I18nRoute = { paths: paths as I18nRoute['paths'] }
+  if (hasDisabled) {
+    route.locales = localeCodes.filter(locale => value[locale] !== false)
+  }
+  return route
+}
+
+/** Remove object-form `i18n` route meta after localization to keep it out of the routes manifest */
+function stripRouteMetaI18n(pages: NuxtPage[]): void {
+  for (const page of pages) {
+    if (typeof page.meta?.i18n === 'object') {
+      delete page.meta.i18n
+      if (Object.keys(page.meta).length === 0) {
+        delete page.meta
+      }
+    }
+    if (page.children?.length) {
+      stripRouteMetaI18n(page.children)
+    }
+  }
+}
+
+/**
+ * Normalize the mode-specific route options (`pages` config or `defineI18nRoute()`)
+ * as the `i18n` property in route meta. Routes with an explicit meta value keep it —
+ * meta is the canonical source and takes precedence in all `customRoutes` modes.
+ */
+export function normalizeRouteMeta(
+  ctx: NuxtPageAnalyzeContext,
+  pages: NuxtPage[],
+  localeCodes: string[],
+  mode: NonNullable<NuxtI18nOptions['customRoutes']>,
+  vfs: Record<string, string> = {},
+): void {
+  for (const page of pages) {
+    if (page.file != null) {
+      let value: I18nRoute | false | undefined
+      if (mode === 'config') {
+        const raw = getConfigValue(ctx, page)
+        value = raw === undefined ? undefined : configValueToI18nRoute(raw, localeCodes)
+      } else if (mode === 'page') {
+        value = getI18nRouteConfig(page.file, vfs)
+      }
+
+      if ((page.meta?.i18n as I18nRoute | false | undefined) === undefined) {
+        if (value !== undefined) {
+          page.meta ??= {}
+          page.meta.i18n = value
+        }
+      } else if (value !== undefined) {
+        const source = mode === 'config' ? 'a `pages` config entry' : '`defineI18nRoute()`'
+        logger.warn(
+          `Route \`${String(page.name || page.path)}\` has both \`i18n\` route meta and ${source} — the route meta value takes precedence.`,
+        )
+      }
+    }
+
+    if (page.children?.length) {
+      normalizeRouteMeta(ctx, page.children, localeCodes, mode, vfs)
+    }
   }
 }
 
@@ -472,13 +559,14 @@ function getRouteOptions(
   mode: 'config' | 'page' | 'meta' = 'config',
 ) {
   let resolvedOptions
-  if (mode === 'config') {
+  const metaValue = route.meta?.i18n as I18nRoute | false | undefined
+  if (metaValue !== undefined) {
+    // meta is the canonical source in all modes (see `normalizeRouteMeta`)
+    resolvedOptions = getRouteFromResource(localeCodes, metaValue)
+  } else if (mode === 'config') {
     resolvedOptions = getRouteFromConfig(ctx, route, localeCodes)
-  } else {
-    resolvedOptions = getRouteFromResource(
-      localeCodes,
-      mode === 'page' ? getI18nRouteConfig(route.file!) : (route.meta?.i18n as I18nRoute | false | undefined),
-    )
+  } else if (mode === 'page') {
+    resolvedOptions = getRouteFromResource(localeCodes, getI18nRouteConfig(route.file!))
   }
 
   // routing disabled

--- a/test/pages/__snapshots__/custom_route.test.ts.snap
+++ b/test/pages/__snapshots__/custom_route.test.ts.snap
@@ -99,29 +99,12 @@ exports[`Extract page meta > 'JavaScript' (meta) 1`] = `
 [
   {
     "children": [],
-    "meta": {
-      "i18n": {
-        "paths": {
-          "en": "/about-us",
-          "fr": "/a-propos",
-          "ja": "/about-ja",
-        },
-      },
-    },
     "name": "about___en",
     "path": "/about-us",
   },
   {
     "children": [],
-    "meta": {
-      "i18n": {
-        "paths": {
-          "en": "/about-us",
-          "fr": "/a-propos",
-          "ja": "/about-ja",
-        },
-      },
-    },
+    "meta": {},
     "name": "about___ja",
     "path": "/ja/about-ja",
   },
@@ -132,29 +115,12 @@ exports[`Extract page meta > 'dynamic route' (meta) 1`] = `
 [
   {
     "children": [],
-    "meta": {
-      "i18n": {
-        "paths": {
-          "en": "/articles/[name]",
-          "fr": "/articles/[name]",
-          "ja": "/記事/[name]",
-        },
-      },
-    },
     "name": "name___en",
     "path": "/articles/:name()",
   },
   {
     "children": [],
-    "meta": {
-      "i18n": {
-        "paths": {
-          "en": "/articles/[name]",
-          "fr": "/articles/[name]",
-          "ja": "/記事/[name]",
-        },
-      },
-    },
+    "meta": {},
     "name": "name___ja",
     "path": "/ja/%E8%A8%98%E4%BA%8B/:name()",
   },
@@ -178,29 +144,12 @@ exports[`Extract page meta > 'simple' (meta) 1`] = `
 [
   {
     "children": [],
-    "meta": {
-      "i18n": {
-        "paths": {
-          "en": "/about-us",
-          "fr": "/a-propos",
-          "ja": "/about-ja",
-        },
-      },
-    },
     "name": "about___en",
     "path": "/about-us",
   },
   {
     "children": [],
-    "meta": {
-      "i18n": {
-        "paths": {
-          "en": "/about-us",
-          "fr": "/a-propos",
-          "ja": "/about-ja",
-        },
-      },
-    },
+    "meta": {},
     "name": "about___ja",
     "path": "/ja/about-ja",
   },
@@ -215,13 +164,6 @@ exports[`Extract page meta > 'with definePageMeta' (meta) 1`] = `
       "__nuxt_dynamic_meta_key": Set {
         "meta",
       },
-      "i18n": {
-        "paths": {
-          "en": "/about-us",
-          "fr": "/a-propos",
-          "ja": "/about-ja",
-        },
-      },
     },
     "name": "about___en",
     "path": "/about-us",
@@ -231,13 +173,6 @@ exports[`Extract page meta > 'with definePageMeta' (meta) 1`] = `
     "meta": {
       "__nuxt_dynamic_meta_key": Set {
         "meta",
-      },
-      "i18n": {
-        "paths": {
-          "en": "/about-us",
-          "fr": "/a-propos",
-          "ja": "/about-ja",
-        },
       },
     },
     "name": "about___ja",

--- a/test/pages/meta_unification.test.ts
+++ b/test/pages/meta_unification.test.ts
@@ -1,0 +1,119 @@
+import { resolve } from 'node:path'
+import { describe, test, expect } from 'vitest'
+import { localizeRoutes } from '../../src/routing'
+import { getRouteOptionsResolver, analyzeNuxtPages, normalizeRouteMeta, NuxtPageAnalyzeContext } from '../../src/pages'
+import { getNuxtOptions } from './utils'
+
+import type { NuxtPage } from '@nuxt/schema'
+
+const localeCodes = ['en', 'ja', 'fr']
+
+function localize(pages: NuxtPage[], options: ReturnType<typeof getNuxtOptions>) {
+  const ctx = new NuxtPageAnalyzeContext(options.pages)
+  analyzeNuxtPages(ctx, 'pages', pages)
+  normalizeRouteMeta(ctx, pages, localeCodes, options.customRoutes!)
+  return localizeRoutes(pages, {
+    ...options,
+    includeUnprefixedFallback: false,
+    optionsResolver: getRouteOptionsResolver(ctx, options.defaultLocale!, options.customRoutes!),
+  } as Parameters<typeof localizeRoutes>[1])
+}
+
+describe('normalizeRouteMeta', () => {
+  test('normalizes `pages` config into route meta', () => {
+    const pages: NuxtPage[] = [
+      { path: '/about', file: '/path/to/nuxt-app/pages/about.vue', children: [] },
+      { path: '/blocked', file: '/path/to/nuxt-app/pages/blocked.vue', children: [] },
+    ]
+    const options = getNuxtOptions({
+      about: { en: '/about-us', fr: '/a-propos', ja: false },
+      blocked: false,
+    })
+
+    const ctx = new NuxtPageAnalyzeContext(options.pages)
+    analyzeNuxtPages(ctx, 'pages', pages)
+    normalizeRouteMeta(ctx, pages, localeCodes, 'config')
+
+    expect(pages[0]!.meta?.i18n).toEqual({
+      paths: { en: '/about-us', fr: '/a-propos' },
+      locales: ['en', 'fr'],
+    })
+    expect(pages[1]!.meta?.i18n).toBe(false)
+  })
+
+  test('normalizes `defineI18nRoute()` into route meta', () => {
+    const pages: NuxtPage[] = [
+      {
+        path: '/about',
+        file: resolve(__dirname, '../fixtures/custom_route/simple/pages/about.vue'),
+        children: [],
+      },
+      {
+        path: '/disabled',
+        file: resolve(__dirname, '../fixtures/ignore_route/disable/pages/about.vue'),
+        children: [],
+      },
+    ]
+    const options = getNuxtOptions({}, 'page')
+
+    const ctx = new NuxtPageAnalyzeContext(options.pages)
+    analyzeNuxtPages(ctx, 'pages', pages)
+    normalizeRouteMeta(ctx, pages, localeCodes, 'page')
+
+    expect(pages[0]!.meta?.i18n).toEqual({
+      paths: { en: '/about-us', fr: '/a-propos', ja: '/about-ja' },
+    })
+    expect(pages[1]!.meta?.i18n).toBe(false)
+  })
+
+  test('existing meta takes precedence over `pages` config', () => {
+    const pages: NuxtPage[] = [
+      {
+        name: 'about',
+        path: '/about',
+        file: '/path/to/nuxt-app/pages/about.vue',
+        meta: { i18n: { paths: { fr: '/meta-wins' } } },
+        children: [],
+      },
+    ]
+    const options = getNuxtOptions({ about: { fr: '/config-loses' } })
+
+    const localized = localize(pages, options)
+    const fr = localized.find(x => x.name === 'about___fr')
+    expect(fr?.path).toBe('/fr/meta-wins')
+  })
+
+  test('meta `i18n: false` disables localization in `config` mode (#3951)', () => {
+    const pages: NuxtPage[] = [
+      {
+        name: 'cms-dashboard',
+        path: '/dashboard/:catchAll(.*)?',
+        file: '/path/to/nuxt-app/pages/dashboard.vue',
+        meta: { i18n: false },
+        children: [],
+      },
+      { name: 'about', path: '/about', file: '/path/to/nuxt-app/pages/about.vue', children: [] },
+    ]
+    const options = getNuxtOptions({})
+
+    const localized = localize(pages, options)
+    expect(localized.filter(x => String(x.name).startsWith('cms-dashboard'))).toEqual([pages[0]])
+    expect(localized.find(x => x.name === 'about___fr')).toBeTruthy()
+  })
+
+  test('meta `i18n: false` disables localization in `page` mode (#3951)', () => {
+    const pages: NuxtPage[] = [
+      {
+        name: 'cms-dashboard',
+        path: '/dashboard/:catchAll(.*)?',
+        file: '/path/to/nuxt-app/pages/dashboard.vue',
+        meta: { i18n: false },
+        children: [],
+      },
+    ]
+    const options = getNuxtOptions({}, 'page')
+
+    const localized = localize(pages, options)
+    expect(localized).toEqual([pages[0]])
+  })
+})


### PR DESCRIPTION
Normalizes `pages` config and `defineI18nRoute()` options into route meta during page resolution and resolves options from meta first in all `customRoutes` modes, making meta the canonical source. This allows modules that inject pages to disable localization via `meta: { i18n: false }` (e.g. in `pages:extend`) regardless of the project's `customRoutes` mode. Object-form meta is stripped after localization to keep custom path config out of the routes manifest, the boolean form is kept as a runtime marker for routes with disabled localization.

* Related to #3951

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how localized custom paths are sourced and prioritized across configuration modes.
  - Documented that `definePageMeta()` paths take precedence and work in all modes.
  - Added guidance on compatibility, build-time handling, and warnings for conflicting sources.
  - Marked `defineI18nRoute()` as deprecated in favor of `definePageMeta()`.

- **Bug Fixes**
  - Ensured localized routes consistently honor `definePageMeta()` settings.
  - Prevented internal localized path data from appearing in runtime route metadata.
  - Added support for disabling localization with `i18n: false`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->