### PR TITLE
fix: type locale detector file in server tsconfig

### DIFF
--- a/docs/content/docs/02.guide/16.server-side-translations.md
+++ b/docs/content/docs/02.guide/16.server-side-translations.md
@@ -45,6 +45,12 @@ export default defineI18nLocaleDetector((event, config) => {
 
 The locale detector function is used to detect the locale on the server-side. It's called per request on the server.
 
+The `defineI18nLocaleDetector()`{lang="ts"} composable and the [`@intlify/utils/h3` utilities](https://github.com/intlify/utils#-usage) used in the example are auto imported. If you have auto imports disabled you can import these explicitly from `#imports`:
+
+```ts [i18n/localeDetector.ts]
+import { defineI18nLocaleDetector, tryCookieLocale, tryHeaderLocale, tryQueryLocale } from '#imports'
+```
+
 When you define the locale detector, you need to pass the path to the locale detector to the `experimental.localeDetector` option.
 
 The following is an example of a locale detector configuration defined directly in the Nuxt application:

--- a/docs/content/docs/06.composables/12.define-i18n-locale-detector.md
+++ b/docs/content/docs/06.composables/12.define-i18n-locale-detector.md
@@ -8,6 +8,12 @@ The function needs to return a locale string.
 
 You can use [`@intlify/h3` utilities](https://github.com/intlify/h3#%EF%B8%8F-utilites--helpers) in the locale detector function, these are auto imported.
 
+The composable and the utilities can also be imported explicitly from `#imports` (e.g. when auto imports are disabled):
+
+```ts [i18n/localeDetector.ts]
+import { defineI18nLocaleDetector, tryCookieLocale, tryHeaderLocale, tryQueryLocale } from '#imports'
+```
+
 ::callout{icon="i-heroicons-exclamation-triangle" color="warning"}
 **This composable is experimental.** You need to configure filepath to [`experimental.localeDetector` option](/docs/api/options#experimental).
 ::

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -5,6 +5,7 @@ import { addServerHandler, addServerImports, addServerPlugin, addServerTemplate,
 import yamlPlugin from '@rollup/plugin-yaml'
 import json5Plugin from '@miyaneee/rollup-plugin-json5'
 import { getDefineConfig } from './bundler'
+import { relative } from 'pathe'
 import { logger, toArray } from './utils'
 import { EXECUTABLE_EXTENSIONS } from './constants'
 
@@ -25,12 +26,12 @@ export async function setupNitro(ctx: I18nNuxtContext, nuxt: Nuxt) {
     getContents: () => nuxt.vfs['#build/i18n-route-resources.mjs'] || '',
   })
 
-  const localeDetectorPath = await resolveLocaleDetectorPath(ctx, nuxt)
+  const localeDetector = await resolveLocaleDetectorPath(ctx, nuxt)
   addServerTemplate({
     filename: '#internal/i18n-locale-detector.mjs',
     getContents: () =>
-      localeDetectorPath
-        ? `export { default as localeDetector } from ${JSON.stringify(localeDetectorPath)}`
+      localeDetector.exists
+        ? `export { default as localeDetector } from ${JSON.stringify(localeDetector.path)}`
         : `export const localeDetector = undefined`,
   })
 
@@ -60,6 +61,14 @@ export async function setupNitro(ctx: I18nNuxtContext, nuxt: Nuxt) {
     nitroConfig.externals = defu(nitroConfig.externals ?? {}, { inline: [ctx.resolver.resolve('./runtime'), ...new Set(ctx.localeInfo.flatMap(x => x.meta.map(m => m.path)))] })
     nitroConfig.alias!['#i18n'] = ctx.resolver.resolve('./runtime/composables/index-server')
 
+    // type the locale detector file in the server tsconfig, where `#i18n` resolves server composables
+    if (localeDetector.path) {
+      const relativeDetectorPath = relative(nuxt.options.buildDir, localeDetector.path)
+      nuxt.options.typescript.tsConfig.exclude ||= []
+      nuxt.options.typescript.tsConfig.exclude.push(relativeDetectorPath)
+      nitroConfig.typescript = defu(nitroConfig.typescript ?? {}, { tsConfig: { include: [relativeDetectorPath] } })
+    }
+
     nitroConfig.rollupConfig!.plugins = (await nitroConfig.rollupConfig!.plugins) || []
     nitroConfig.rollupConfig!.plugins = toArray(nitroConfig.rollupConfig!.plugins)
 
@@ -79,16 +88,15 @@ export async function setupNitro(ctx: I18nNuxtContext, nuxt: Nuxt) {
 
 async function resolveLocaleDetectorPath(ctx: I18nNuxtContext, nuxt: Nuxt) {
   const detector = ctx.i18nLayers.find(l => !!l.i18nDetector)?.i18nDetector
-  if (detector == null) { return '' }
+  if (detector == null) { return { path: '', exists: false } }
 
   const resolved = await resolvePath(detector, { cwd: nuxt.options.rootDir, extensions: EXECUTABLE_EXTENSIONS })
   const exists = existsSync(resolved)
   if (!exists) {
     logger.warn(`localeDetector file '${resolved}' does not exist.`)
-    return ''
   }
 
-  return resolved
+  return { path: resolved, exists }
 }
 
 function getResourcePathsGrouped(localeInfo: LocaleInfo[]) {


### PR DESCRIPTION
* Resolves #4011

The locale detector file was included in the app tsconfig (via the `i18nDir` include), where `#i18n` resolves to the app composables which do not export `defineI18nLocaleDetector`. This broke editor completion and typechecking for the explicit import, even though it works at runtime.

The locale detector file is now excluded from the app tsconfig and included in the server tsconfig instead, which maps `#i18n` to the server composables. The tsconfig entries are generated whenever a detector is configured, so types are correct even if the file is created later.

This also documents importing the composable and the `@intlify/utils/h3` helpers explicitly from `#imports` for projects with auto imports disabled.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the locale-detector composable and related translation utilities in the server-side example are auto-imported.
  * Added explicit import guidance for environments where auto-imports are disabled.

* **Build & Configuration**
  * Improved locale-detector resolution to more reliably detect presence and availability.
  * Updated TypeScript build configuration to ensure the detector path is included/excluded correctly, reducing missing or incorrectly generated artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

