### PR TITLE
fix: drop full-path `<NuxtPage>` keys for `compactRoutes`

### DIFF
--- a/specs/experimental/compact_routes.spec.ts
+++ b/specs/experimental/compact_routes.spec.ts
@@ -1,0 +1,50 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+import { renderPage } from '../helper'
+import { setup, url } from '../utils'
+
+await setup({
+  rootDir: fileURLToPath(new URL(`../fixtures/routing`, import.meta.url)),
+  browser: true,
+  // overrides
+  nuxtConfig: {
+    i18n: {
+      defaultLocale: 'en',
+      strategy: 'prefix_except_default',
+      experimental: {
+        compactRoutes: true
+      }
+    }
+  }
+})
+
+describe('compact routes `<NuxtPage>` keys', () => {
+  it('keeps nested parent mounted across child navigation on non-default locale', async () => {
+    const { page } = await renderPage('/ja/foo/bar')
+
+    await page.locator('#counter').click()
+    await page.locator('#counter').click()
+    expect(await page.locator('#counter').innerText()).toEqual('parent state: 2')
+
+    await page.locator('#to-baz').clickNavigate()
+    await page.waitForURL(url('/ja/foo/baz'))
+
+    expect(await page.locator('#child').innerText()).toEqual('child: baz')
+    // parent state survives — the parent page was not remounted
+    expect(await page.locator('#counter').innerText()).toEqual('parent state: 2')
+  })
+
+  it('remounts the page when the locale param changes within a compact route', async () => {
+    const { page } = await renderPage('/ja/foo/bar')
+
+    await page.locator('#counter').click()
+    expect(await page.locator('#counter').innerText()).toEqual('parent state: 1')
+
+    await page.locator('#to-fr').clickNavigate()
+    await page.waitForURL(url('/fr/foo/bar'))
+
+    // state reset — locale change remounts so transitions can trigger
+    expect(await page.locator('#counter').innerText()).toEqual('parent state: 0')
+  })
+})

--- a/specs/fixtures/routing/nuxt.config.ts
+++ b/specs/fixtures/routing/nuxt.config.ts
@@ -3,7 +3,7 @@ export default defineNuxtConfig({
 
   i18n: {
     baseUrl: 'http://localhost:3000',
-    locales: ['en', 'ja'],
+    locales: ['en', 'ja', 'fr'],
     detectBrowserLanguage: false
   }
 })

--- a/specs/fixtures/routing/pages/foo.vue
+++ b/specs/fixtures/routing/pages/foo.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const count = ref(0)
+</script>
+
+<template>
+  <div>
+    <button id="counter" @click="count++">parent state: {{ count }}</button>
+    <nav>
+      <NuxtLink id="to-bar" :to="$localePath('/foo/bar')">bar</NuxtLink>
+      <NuxtLink id="to-baz" :to="$localePath('/foo/baz')">baz</NuxtLink>
+      <NuxtLink id="to-fr" :to="$switchLocalePath('fr')">fr</NuxtLink>
+    </nav>
+    <NuxtPage />
+  </div>
+</template>

--- a/specs/fixtures/routing/pages/foo/bar.vue
+++ b/specs/fixtures/routing/pages/foo/bar.vue
@@ -1,0 +1,3 @@
+<template>
+  <p id="child">child: bar</p>
+</template>

--- a/specs/fixtures/routing/pages/foo/baz.vue
+++ b/specs/fixtures/routing/pages/foo/baz.vue
@@ -1,0 +1,3 @@
+<template>
+  <p id="child">child: baz</p>
+</template>

--- a/src/runtime/plugins/route-locale-detect.ts
+++ b/src/runtime/plugins/route-locale-detect.ts
@@ -1,6 +1,6 @@
 import { useNuxtI18nContext, useResolvedLocale } from '../context'
 import { detectLocale, loadAndSetLocale, navigate } from '../utils'
-import { addRouteMiddleware, defineNuxtPlugin, defineNuxtRouteMiddleware, useNuxtApp, useRouter } from '#imports'
+import { addRouteMiddleware, defineNuxtPlugin, defineNuxtRouteMiddleware, useNuxtApp } from '#imports'
 
 export default defineNuxtPlugin({
   name: 'i18n:plugin:route-locale-detect',
@@ -9,17 +9,6 @@ export default defineNuxtPlugin({
     // @ts-expect-error untyped internal id parameter
     const nuxt = useNuxtApp(_nuxt._id)
     const ctx = useNuxtI18nContext(nuxt)
-
-    // Set meta.key on compact routes so NuxtPage triggers transitions when the locale param changes.
-    // This must be done at runtime because functions in route meta don't survive Nuxt's build-time serialization.
-    if (__I18N_COMPACT_ROUTES__) {
-      const router = useRouter()
-      for (const route of router.getRoutes()) {
-        if (route.meta?.__i18nCompact && route.meta.key == null) {
-          route.meta.key = (r: { path: string }) => r.path
-        }
-      }
-    }
 
     const resolvedLocale = useResolvedLocale()
     await nuxt.runWithContext(() =>


### PR DESCRIPTION
* Resolves #4001
* Related to #4014

With `experimental.compactRoutes` enabled, compact routes were keyed by the full resolved path, so `<NuxtPage>` remounted nested parent pages (and wiped their state) on every child navigation on non-default locales.

This drops the `meta.key` assignment entirely, Nuxt's default keying interpolates the matched record's own path pattern which already changes when the locale param does, so remounts on locale switch (and their transitions) still work without it. This also adds specs covering both behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation for localized nested routes so parent page state is preserved when moving between child pages.
  * Ensured pages remount correctly when switching locales, allowing locale-specific transitions and content updates to take effect.

* **Tests**
  * Added coverage for localized nested-route navigation and state persistence across route changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->