### PR TITLE
fix: pass `strictSeo.canonicalQueries` to runtime head options

### DIFF
--- a/specs/experimental/strict_seo_canonical_queries.spec.ts
+++ b/specs/experimental/strict_seo_canonical_queries.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect, describe } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, url } from '../utils'
+import { renderPage } from '../helper'
+
+await setup({
+  rootDir: fileURLToPath(new URL(`../fixtures/basic_usage`, import.meta.url)),
+  browser: true,
+  // overrides
+  nuxtConfig: {
+    i18n: {
+      experimental: {
+        strictSeo: {
+          canonicalQueries: ['page']
+        }
+      }
+    }
+  }
+})
+
+describe('experimental.strictSeo object form', async () => {
+  test('canonical link keeps queries listed in `canonicalQueries`', async () => {
+    const { page } = await renderPage('/post/my-post?page=2&foo=bar')
+
+    expect(await page.locator('link[rel=canonical]').getAttribute('href')).toEqual(
+      'http://localhost:3000/post/my-post?page=2'
+    )
+    expect(await page.locator('link[rel=alternate][hreflang=fr]').getAttribute('href')).toEqual(
+      'http://localhost:3000/fr/post/mon-article?page=2'
+    )
+
+    await page.goto(url('/post/my-post?foo=bar'))
+    expect(await page.locator('link[rel=canonical]').getAttribute('href')).toEqual(
+      'http://localhost:3000/post/my-post'
+    )
+  })
+
+  test('`useSetI18nParams` seo attributes override the global `canonicalQueries`', async () => {
+    // the products page passes `{ canonicalQueries: ['canonical'] }` explicitly
+    const { page } = await renderPage('/products/big-chair?page=2&canonical=1')
+
+    expect(await page.locator('link[rel=canonical]').getAttribute('href')).toEqual(
+      'http://localhost:3000/products/big-chair?canonical=1'
+    )
+  })
+})

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -141,7 +141,8 @@ export default defineNuxtPlugin({
     if (__I18N_STRICT_SEO__) {
       // enable head tag management after most of the i18n setup is done
       nuxt.hook(import.meta.server ? 'app:rendered' : 'app:mounted', () => {
-        _useLocaleHead(nuxt._nuxtI18n.composableCtx, { dir: true, lang: true, seo: true })
+        const composableCtx = nuxt._nuxtI18n.composableCtx
+        _useLocaleHead(composableCtx, composableCtx.seoSettings as Required<I18nHeadOptions>)
       })
     }
   },

--- a/src/runtime/routing/head.ts
+++ b/src/runtime/routing/head.ts
@@ -15,7 +15,8 @@ function createHeadContext(
   baseUrl = ctx.getBaseUrl(),
 ): HeadContext {
   const currentLocale = locales.find(l => l.code === locale) || { code: locale }
-  const canonicalQueries = (typeof config.seo === 'object' && config.seo?.canonicalQueries) || []
+  // deduplicate, layered configs merge `canonicalQueries` arrays with duplicate entries
+  const canonicalQueries = [...new Set((typeof config.seo === 'object' && config.seo?.canonicalQueries) || [])]
 
   if (!baseUrl && !__DIFFERENT_DOMAINS__ && !__MULTI_DOMAIN_LOCALES__) {
     if (__I18N_STRICT_SEO__) {

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -172,7 +172,9 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
     seoSettings: {
       dir: __I18N_STRICT_SEO__,
       lang: __I18N_STRICT_SEO__,
-      seo: __I18N_STRICT_SEO__,
+      // the object form carries `canonicalQueries`, `__I18N_STRICT_SEO__` only compiles its truthiness
+      seo: (typeof ctx.config.experimental.strictSeo === 'object' && ctx.config.experimental.strictSeo)
+        || __I18N_STRICT_SEO__,
     },
     localePathPayload: getLocalePathPayload(),
     routingOptions: {


### PR DESCRIPTION
* Resolves #3980

`experimental.strictSeo.canonicalQueries` never reached the runtime, the head context initialized `seo` as a boolean and the strict SEO hook passed hardcoded options, so canonical links always stripped all query params. The object form is now passed through to the head options, and `canonicalQueries` is deduplicated since layered configs merge the arrays with duplicate entries.

This also adds a spec covering canonical and alternate links using the global config, and the per-page `useSetI18nParams` override taking precedence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SEO canonical URL handling for configured query parameters.
  * Canonical URLs now retain only approved parameters and remove unrelated ones.
  * Added support for page-level SEO settings to override global canonical query rules.
  * Ensured strict SEO configuration is consistently applied to generated locale and canonical metadata.

* **Tests**
  * Added coverage for global canonical query filtering, query-free routes, and page-level overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->