### PR TITLE
fix: use `domainLocales` runtime config in `localeProperties` and `locales`

### DIFF
--- a/specs/different_domains/different_domains.spec.ts
+++ b/specs/different_domains/different_domains.spec.ts
@@ -160,6 +160,19 @@ test('(#2931) detect using runtimeConfig domain', async () => {
   expect(await dom.locator('#welcome-text').textContent()).toEqual('환영하다')
 })
 
+test('(#3988) `localeProperties` and `locales` use runtimeConfig domain', async () => {
+  const res = await undiciRequest('/', {
+    headers: {
+      host: 'kr.staging.nuxt-app.localhost'
+    }
+  })
+  const dom = await getDom(await res.body.text())
+  expect(await dom.locator('#locale-properties-domain').textContent()).toEqual('kr.staging.nuxt-app.localhost')
+  expect(await dom.locator('#locales-domains').textContent()).toEqual(
+    'en:en.nuxt-app.localhost,fr:fr.nuxt-app.localhost,kr:kr.staging.nuxt-app.localhost,no:no.nuxt-app.localhost,nl:layer-nl.example.com,ja:layer-ja.example.com'
+  )
+})
+
 test('(#2374) detect with x-forwarded-host on server', async () => {
   const html = await $fetch('/', {
     headers: {

--- a/specs/fixtures/different_domains/pages/index.vue
+++ b/specs/fixtures/different_domains/pages/index.vue
@@ -2,7 +2,7 @@
 import { useHead } from '#imports'
 import { useI18n, useLocalePath, useLocaleHead } from '#i18n'
 
-const { t } = useI18n()
+const { t, locales, localeProperties } = useI18n()
 const localePath = useLocalePath()
 const i18nHead = useLocaleHead({ seo: { canonicalQueries: ['page'] } })
 
@@ -21,6 +21,8 @@ useHead(() => ({
   <div>
     <h1 id="home-header">{{ $t('home') }}</h1>
     <div id="welcome-text">{{ t('welcome') }}</div>
+    <code id="locale-properties-domain">{{ localeProperties.domain }}</code>
+    <code id="locales-domains">{{ locales.map(l => `${l.code}:${l.domain}`).join(',') }}</code>
     <BasicUsage />
     <LangSwitcher />
     <section>

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -13,6 +13,7 @@ import { type NuxtI18nContext, createNuxtI18nContext, useLocaleConfigs } from '.
 import { useI18nDetection, useRuntimeI18n } from '../shared/utils'
 import { useDetectors } from '../shared/detection'
 import { setupMultiDomainLocales } from '../routing/domain'
+import { withRuntimeDomain } from '../shared/domain'
 
 import type { Composer, TranslateOptions } from 'vue-i18n'
 import type { I18nHeadOptions } from '#internal-i18n-types'
@@ -59,7 +60,9 @@ export default defineNuxtPlugin({
     // extend i18n instance
     extendI18n(i18n, {
       extendComposer(composer) {
-        composer.locales = computed(() => runtimeI18n.locales)
+        composer.locales = computed(() =>
+          runtimeI18n.locales.map(locale => withRuntimeDomain(locale, runtimeI18n.domainLocales)),
+        )
         composer.localeCodes = computed(() => localeCodes)
 
         const _baseUrl = ref(ctx.getBaseUrl())
@@ -70,8 +73,11 @@ export default defineNuxtPlugin({
         }
 
         composer.strategy = __I18N_STRATEGY__
-        composer.localeProperties = computed(
-          () => normalizedLocales.find(l => l.code === composer.locale.value) || { code: composer.locale.value },
+        composer.localeProperties = computed(() =>
+          withRuntimeDomain(
+            normalizedLocales.find(l => l.code === composer.locale.value) || { code: composer.locale.value },
+            runtimeI18n.domainLocales,
+          ),
         )
         composer.setLocale = async (locale: string) => {
           await loadAndSetLocale(nuxt, locale)

--- a/src/runtime/shared/domain.ts
+++ b/src/runtime/shared/domain.ts
@@ -2,7 +2,7 @@ import { hasProtocol } from 'ufo'
 import { normalizedLocales } from '#build/i18n-options.mjs'
 import { toArray } from './utils'
 
-import type { LocaleObject } from '#internal-i18n-types'
+import type { I18nPublicRuntimeConfig, LocaleObject } from '#internal-i18n-types'
 
 export function matchDomainLocale(locales: LocaleObject[], host: string, pathLocale: string): string | undefined {
   const normalizeDomain = (domain: string = '') => domain.replace(/https?:\/\//, '')
@@ -41,4 +41,19 @@ export function domainFromLocale(
   }
 
   return url.protocol + '//' + domain
+}
+
+/**
+ * Returns the locale object with the domain overridden by `domainLocales` runtime config (see also `getHostLocale`)
+ */
+export function withRuntimeDomain<T extends string | LocaleObject>(
+  locale: T,
+  domainLocales: I18nPublicRuntimeConfig['domainLocales'],
+): T {
+  if ((!__DIFFERENT_DOMAINS__ && !__MULTI_DOMAIN_LOCALES__) || typeof locale === 'string') {
+    return locale
+  }
+  const properties = locale as LocaleObject
+  const domain = domainLocales[properties.code]?.domain
+  return domain && domain !== properties.domain ? ({ ...properties, domain } as T) : locale
 }


### PR DESCRIPTION
* Resolves #3988

The `domainLocales` runtime config was only used for URL generation and domain detection, `localeProperties` and `locales` kept returning the build-time domain, which is what the reproduction checks. Both now apply the runtime override through a small helper, projects without domain options compile it away through build-time flags.

This also adds assertions to the `different_domains` spec covering overridden and non-overridden domains.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Locale information now correctly reflects runtime-configured domains when using multi-domain internationalization.
  - Locale properties and locale lists display the appropriate domain for each locale, including runtime overrides.

- **Tests**
  - Added coverage to verify domain resolution for requests served from configured runtime domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->