### PR TITLE
fix: derive `og:locale:alternate` from locale `language` tags with `strictSeo`

### DIFF
--- a/specs/experimental/experimental_seo.spec.ts
+++ b/specs/experimental/experimental_seo.spec.ts
@@ -38,7 +38,7 @@ describe('experimental.strictSeo', async () => {
       Meta:
         og:url: http://localhost:3000/products/big-chair
         og:locale: en
-        og:locale:alternate: fr, ja, ja_JP, nl, nl_NL"
+        og:locale:alternate: fr, ja_JP, nl_NL"
     `)
 
     await page.goto(url('/nl/products/rode-mok'))
@@ -58,7 +58,7 @@ describe('experimental.strictSeo', async () => {
       Meta:
         og:url: http://localhost:3000/nl/products/rode-mok
         og:locale: nl_NL
-        og:locale:alternate: en, fr, nl"
+        og:locale:alternate: en, fr"
     `)
   })
 })

--- a/src/runtime/kit/head.ts
+++ b/src/runtime/kit/head.ts
@@ -88,12 +88,7 @@ export function localeHead(
     metaObject.meta = metaObject.meta.concat(
       getOgUrl(options),
       getCurrentOgLocale(options),
-      getAlternateOgLocales(
-        options,
-        strictSeo
-          ? alternateLinks.map(x => x.hreflang).filter(x => x !== 'x-default') as string[]
-          : options.locales.map(x => x.language || x.code),
-      ),
+      getAlternateOgLocales(options, getAlternateOgLanguages(options, alternateLinks)),
     )
   }
 
@@ -209,6 +204,19 @@ function getCurrentOgLocale(options: HeadContext, currentLanguage = options.getC
       ? { property: 'og:locale', content: formatOgLanguage(currentLanguage) }
       : { [options.key]: 'i18n-og', property: 'og:locale', content: formatOgLanguage(currentLanguage) },
   ]
+}
+
+/**
+ * The hreflang list contains bare-language catchall entries which are not valid `og:locale` values,
+ * limit to the locales' own `language` tags while keeping the availability filtering of the links.
+ */
+function getAlternateOgLanguages(options: HeadContext, alternateLinks: MetaAttrs[]): string[] {
+  const languages = options.locales.map(x => x.language || x.code)
+  if (!strictSeo) {
+    return languages
+  }
+  const available = new Set(alternateLinks.map(x => x.hreflang))
+  return languages.filter(x => available.has(x))
 }
 
 function getAlternateOgLocales(


### PR DESCRIPTION
* Resolves #4013

With `experimental.strictSeo` the `og:locale:alternate` metas were derived from the hreflang link list, which contains bare-language catchall entries (`de`, `fr`). These are not valid `og:locale` values per the Open Graph protocol, and the current page's own language slipped past the self-exclusion filter. The alternates are now derived from the locales' `language` tags like the non-strict path, filtered by the hreflang links so locales disabled for the current page are still excluded.

This also updates the strictSeo head snapshots, which locked in the invalid output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SEO metadata for alternate locales.
  * Under strict SEO settings, alternate Open Graph locales now match only languages represented by available hreflang links.
  * Removed redundant language variants from generated locale metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->