### PR TITLE
chore: compatibility with `@unhead/vue` v3 head input types

### DIFF
--- a/src/runtime/routing/head.ts
+++ b/src/runtime/routing/head.ts
@@ -7,6 +7,13 @@ import type { ComposableContext } from '../utils'
 import type { I18nRouteMeta } from '../types'
 import { localeRoute, switchLocalePath } from './routing'
 
+// unhead v3 narrows head input to per-property unions which the loose public `I18nHeadMetaInfo`
+// cannot satisfy, patch through a single boundary cast compatible with both v2 and v3
+type HeadEntryInput = Parameters<NonNullable<ComposableContext['head']>['patch']>[0]
+function patchHead(head: ComposableContext['head'] | undefined, input: I18nHeadMetaInfo): void {
+  head?.patch(input as unknown as HeadEntryInput)
+}
+
 function createHeadContext(
   ctx: ComposableContext,
   config: Required<I18nHeadOptions>,
@@ -73,14 +80,14 @@ export function _useLocaleHead(ctx: ComposableContext, options: Required<I18nHea
   if (import.meta.client) {
     const unsub = watch([() => ctx.router.currentRoute.value, () => ctx.getLocale()], () => {
       metaObject.value = _localeHead(createHeadContext(ctx, options))
-      __I18N_STRICT_SEO__ && ctx.head?.patch(metaObject.value)
+      __I18N_STRICT_SEO__ && patchHead(ctx.head, metaObject.value)
     })
     if (getCurrentScope()) {
       onScopeDispose(unsub)
     }
   }
 
-  __I18N_STRICT_SEO__ && ctx.head?.patch(metaObject.value)
+  __I18N_STRICT_SEO__ && patchHead(ctx.head, metaObject.value)
 
   return metaObject
 }
@@ -121,7 +128,7 @@ export function _useSetI18nParams(
 
   function updateState() {
     ctx.metaState = _localeHead(createHeadContext(ctx, ctxOptions.value as Required<I18nHeadOptions>))
-    head?.patch(ctx.metaState)
+    patchHead(head, ctx.metaState)
   }
 
   const ctxOptions = ref({
@@ -135,7 +142,7 @@ export function _useSetI18nParams(
     __I18N_STRICT_SEO__ && updateState()
     if (!__I18N_STRICT_SEO__) {
       const val = _localeHead(createHeadContext(ctx, ctxOptions.value as Required<I18nHeadOptions>))
-      head?.patch(val)
+      patchHead(head, val)
     }
   }
 }


### PR DESCRIPTION
Nuxt is moving to unhead v3, which narrows the head input types to per-property unions that our loose public `I18nHeadMetaInfo` can't satisfy, breaking type checking at the `head.patch()` call sites. This routes the patches through a single boundary cast derived from the installed head client, so the same code checks against both v2 and v3 without version-specific imports or public type changes.

Verified with a `resolutions` override to `@unhead/vue@3.1.7`: type checking and the full e2e suite pass on both versions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with strict SEO metadata updates.
  * Preserved safe handling when head metadata services are unavailable.
  * Maintained conditional application of localized SEO metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->