### PR TITLE
fix(types): prevent duplicate tsconfig paths for aliased deps

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -114,7 +114,7 @@ export default defineNuxtModule<NuxtI18nOptions>({
      */
     nuxt.options.typescript.hoist ||= []
     nuxt.options.typescript.hoist.push(
-      ...deps.filter((dep) => !(dep in nuxt.options.alias))
+      ...deps.filter(dep => !(dep in nuxt.options.alias)),
     )
 
     nuxt.options.typescript.tsConfig.include ||= []

--- a/src/module.ts
+++ b/src/module.ts
@@ -113,7 +113,9 @@ export default defineNuxtModule<NuxtI18nOptions>({
      * hoist deps and include i18n directories
      */
     nuxt.options.typescript.hoist ||= []
-    nuxt.options.typescript.hoist.push(...deps)
+    nuxt.options.typescript.hoist.push(
+      ...deps.filter((dep) => !(dep in nuxt.options.alias))
+    )
 
     nuxt.options.typescript.tsConfig.include ||= []
     nuxt.options.typescript.tsConfig.include.push(


### PR DESCRIPTION
alias

### 🔗 Linked issue

[Resolves #4030](https://github.com/nuxt-modules/i18n/issues/4030)

### 📚 Description

`@nuxtjs/i18n` explicitly aliases its `vue-i18n` and `@intlify/*` dependencies and also adds the same dependencies to `nuxt.options.typescript.hoist`.

Nuxt merges both sources into `compilerOptions.paths`, producing multiple targets for exact, non-wildcard paths such as `vue-i18n`.

Although TypeScript accepts multiple fallback targets, SWC requires an exact path to have exactly one target. This causes Nx and other SWC-based tooling to abort while reading Nuxt's generated TypeScript configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript dependency handling by preventing dependencies already configured as aliases from being hoisted.
  * Hoisting now respects the project’s alias configuration for more accurate build behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->