### PR TITLE
refactor: extract locale file path retrieval into a utility function

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -1,6 +1,6 @@
 import { addBuildPlugin, useNuxt } from '@nuxt/kit'
 import VueI18nPlugin from '@intlify/unplugin-vue-i18n'
-import { toArray } from './utils'
+import { getLocaleFilePaths, toArray } from './utils'
 import { TransformMacroPlugin } from './transform/macros'
 import { ResourcePlugin } from './transform/resource'
 import { TransformI18nFunctionPlugin } from './transform/i18n-function-injection'
@@ -34,7 +34,7 @@ export async function extendBundler(ctx: I18nNuxtContext, nuxt: Nuxt) {
   /**
    * shared plugins (vite/webpack/rspack)
    */
-  const localePaths = [...new Set(ctx.localeInfo.flatMap(x => x.meta.map(m => m.path)))]
+  const localePaths = getLocaleFilePaths(ctx.localeInfo)
   ctx.fullStatic = ctx.localeInfo.flatMap(x => x.meta).every(x => x.type === 'static' || x.cache !== false)
 
   const vueI18nPluginOptions: PluginOptions = {

--- a/src/module.ts
+++ b/src/module.ts
@@ -14,7 +14,7 @@ import { relative } from 'pathe'
 import { generateTemplateNuxtI18nOptions } from './template'
 import { generateI18nTypes, generateLoaderOptions, simplifyLocaleOptions } from './gen'
 import { applyLayerOptions, resolveLayerVueI18nConfigInfo } from './layers'
-import { computeLocaleHashes, filterLocales, resolveLocales } from './utils'
+import { computeLocaleHashes, filterLocales, getLocaleFilePaths, resolveLocales } from './utils'
 import { isString } from '@intlify/shared'
 
 export * from './types'
@@ -232,10 +232,7 @@ export default defineNuxtModule<NuxtI18nOptions>({
        * disable preloading/prefetching of locale files
        */
       nuxt.hook('build:manifest', (manifest) => {
-        const langFiles = ctx.localeInfo
-          .flatMap(locale => locale.meta.map(m => m.path))
-          .map(x => relative(nuxt.options.srcDir, x))
-        const langPaths = [...new Set(langFiles)]
+        const langPaths = getLocaleFilePaths(ctx.localeInfo).map(x => relative(nuxt.options.srcDir, x))
 
         for (const key in manifest) {
           if (langPaths.some(x => key.startsWith(x))) {

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -6,7 +6,7 @@ import yamlPlugin from '@rollup/plugin-yaml'
 import json5Plugin from '@miyaneee/rollup-plugin-json5'
 import { getDefineConfig } from './bundler'
 import { relative } from 'pathe'
-import { logger, toArray } from './utils'
+import { getLocaleFilePaths, logger, toArray } from './utils'
 import { EXECUTABLE_EXTENSIONS } from './constants'
 
 import type { Nuxt } from '@nuxt/schema'
@@ -58,7 +58,7 @@ export async function setupNitro(ctx: I18nNuxtContext, nuxt: Nuxt) {
 
   nuxt.hook('nitro:config', async (nitroConfig) => {
     // inline module runtime in Nitro bundle
-    nitroConfig.externals = defu(nitroConfig.externals ?? {}, { inline: [ctx.resolver.resolve('./runtime'), ...new Set(ctx.localeInfo.flatMap(x => x.meta.map(m => m.path)))] })
+    nitroConfig.externals = defu(nitroConfig.externals ?? {}, { inline: [ctx.resolver.resolve('./runtime'), ...getLocaleFilePaths(ctx.localeInfo)] })
     nitroConfig.alias!['#i18n'] = ctx.resolver.resolve('./runtime/composables/index-server')
 
     // type the locale detector file in the server tsconfig, where `#i18n` resolves server composables

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,6 +56,13 @@ export function resolveLocales(srcDir: string, locales: LocaleObject[], vfs: Rec
   return localesResolved
 }
 
+/**
+ * Unique resolved locale file paths across all locales
+ */
+export function getLocaleFilePaths(localeInfo: LocaleInfo[]): string[] {
+  return [...new Set(localeInfo.flatMap(locale => locale.meta.map(m => m.path)))]
+}
+
 const analyzedMap = { object: 'static', function: 'dynamic', unknown: 'unknown' } as const
 function getLocaleType(path: string, vfs: Record<string, string>): LocaleType {
   if (!EXECUTABLE_EXT_RE.test(path)) { return 'static' }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale file handling across client builds, server bundles, and asset configuration.
  * Prevented duplicate locale files from being processed.
  * Ensured locale message assets are correctly identified and managed during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->