### PR TITLE
refactor: remove dead `includeUnprefixedFallback` handling

### DIFF
--- a/src/pages.ts
+++ b/src/pages.ts
@@ -60,13 +60,10 @@ export const disabledI18nPathToPath = ${JSON.stringify(routeResources.disabledI1
   })
   if (!localeCodes.length) { return }
 
-  let includeUnprefixedFallback = !nuxt.options.ssr
   // Filled during pages:extend, drained at prerender time. nitro:init fires before
   // pages:extend, so we can't seed nitro.options.prerender.routes directly.
   const compactPrerenderRoutes: string[] = []
   nuxt.hook('nitro:init', (nitro) => {
-    includeUnprefixedFallback = options.strategy !== 'prefix'
-
     if (!nuxt.options.nitro.static) { return }
 
     // `prefix` strategy: `/` is not a valid route, ignore it.
@@ -110,7 +107,6 @@ export const disabledI18nPathToPath = ${JSON.stringify(routeResources.disabledI1
 
       const localizationOptions = {
         ...options,
-        includeUnprefixedFallback,
         locales: normalizedLocales,
         optionsResolver: resolver,
         compactRoutes: !!options.experimental?.compactRoutes,

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -66,7 +66,6 @@ type SetupLocalizeRoutesOptions = {
   trailingSlash?: boolean
   differentDomains?: boolean
   multiDomainLocales?: boolean
-  includeUnprefixedFallback?: boolean
   locales: LocaleObject[]
   routesNameSeparator: string
   defaultLocaleRouteNameSuffix: string
@@ -100,7 +99,6 @@ export function localizeRoutes(routes: LocalizableRoute[], config: SetupLocalize
     && strategy !== 'no_prefix'
     && !config.differentDomains
     && !config.multiDomainLocales
-    && !(strategy === 'prefix' && config.includeUnprefixedFallback)
   ) {
     const defaultLocale = config.defaultLocale ?? ''
     ctx.compactRoute = (route, routeOptions, params) => {
@@ -188,18 +186,6 @@ export function localizeRoutes(routes: LocalizableRoute[], config: SetupLocalize
       localizer: ({ unprefixed, route, ctx, locale }) => [
         { ...route, name: ctx.localizeRouteName(route, locale, true), path: unprefixed },
       ],
-    })
-  }
-
-  /**
-   * Unprefixed fallback routes
-   */
-  const includeUnprefixedFallback = config.includeUnprefixedFallback ?? false
-  if (strategy === 'prefix' && includeUnprefixedFallback) {
-    // unshift to preserve test snapshots
-    ctx.localizers.unshift({
-      enabled: ({ usePrefix, locale }) => usePrefix && ctx.isDefaultLocale(locale),
-      localizer: ({ route }) => [route],
     })
   }
 

--- a/test/pages/__snapshots__/localize_routes.test.ts.snap
+++ b/test/pages/__snapshots__/localize_routes.test.ts.snap
@@ -104,20 +104,12 @@ exports[`localizeRoutes > strategy: "no_prefix" > should be localized routing 1`
 exports[`localizeRoutes > strategy: "prefix" > should be localized routing 1`] = `
 [
   {
-    "name": "home",
-    "path": "/",
-  },
-  {
     "name": "home___en",
     "path": "/en",
   },
   {
     "name": "home___ja",
     "path": "/ja",
-  },
-  {
-    "name": "about",
-    "path": "/about",
   },
   {
     "name": "about___en",

--- a/test/pages/custom_route.test.ts
+++ b/test/pages/custom_route.test.ts
@@ -120,7 +120,6 @@ describe.each([
     analyzeNuxtPages(ctx, 'pages', pages)
     const localizedPages = localizeRoutes(pages, {
       ...options,
-      includeUnprefixedFallback: false,
       optionsResolver: getRouteOptionsResolver(ctx, options.defaultLocale!, options.customRoutes!)
     } as Parameters<typeof localizeRoutes>[1])
 
@@ -233,7 +232,6 @@ describe('Page components', () => {
     analyzeNuxtPages(ctx, 'pages', pages)
     const localizedPages = localizeRoutes(pages, {
       ...options,
-      includeUnprefixedFallback: false,
       optionsResolver: getRouteOptionsResolver(ctx, options.defaultLocale!, options.customRoutes!)
     } as Parameters<typeof localizeRoutes>[1])
     expect(stripFilePropertyFromPages(localizedPages)).toMatchSnapshot()
@@ -292,7 +290,6 @@ test('#1649', () => {
   analyzeNuxtPages(ctx, 'pages', pages)
   const localizedPages = localizeRoutes(pages, {
     ...options,
-    includeUnprefixedFallback: false,
     optionsResolver: getRouteOptionsResolver(ctx, options.defaultLocale!, options.customRoutes!)
   } as Parameters<typeof localizeRoutes>[1])
 
@@ -355,7 +352,6 @@ test('#3781', () => {
   analyzeNuxtPages(ctx, 'pages', pages)
   const localizedPages = localizeRoutes(pages, {
     ...options,
-    includeUnprefixedFallback: false,
     optionsResolver: getRouteOptionsResolver(ctx, options.defaultLocale!, options.customRoutes!)
   } as Parameters<typeof localizeRoutes>[1])
 
@@ -447,7 +443,6 @@ test('pages config using route name', () => {
   analyzeNuxtPages(ctx, 'pages', pages)
   const localizedPages = localizeRoutes(pages, {
     ...options,
-    includeUnprefixedFallback: false,
     optionsResolver: getRouteOptionsResolver(ctx, options.defaultLocale!, options.customRoutes!)
   } as Parameters<typeof localizeRoutes>[1])
   expect(localizedPages).toMatchSnapshot()

--- a/test/pages/ignore_route/disable.test.ts
+++ b/test/pages/ignore_route/disable.test.ts
@@ -117,7 +117,6 @@ describe.each([
     analyzeNuxtPages(ctx, 'pages', pages)
     const localizedPages = localizeRoutes(pages, {
       ...options,
-      includeUnprefixedFallback: false,
       optionsResolver: getRouteOptionsResolver(ctx, options.defaultLocale!, options.customRoutes!)
     } as Parameters<typeof localizeRoutes>[1])
     expect(localizedPages).toMatchSnapshot()
@@ -142,7 +141,6 @@ describe.each([
     analyzeNuxtPages(ctx, 'pages', pages)
     const localizedPages = localizeRoutes(pages, {
       ...options,
-      includeUnprefixedFallback: false,
       optionsResolver: getRouteOptionsResolver(ctx, options.defaultLocale!, options.customRoutes!)
     } as Parameters<typeof localizeRoutes>[1])
     expect(stripFilePropertyFromPages(localizedPages)).toMatchSnapshot()

--- a/test/pages/ignore_route/pick.test.ts
+++ b/test/pages/ignore_route/pick.test.ts
@@ -135,7 +135,6 @@ describe.each([
     analyzeNuxtPages(ctx, 'pages', pages)
     const localizedPages = localizeRoutes(pages, {
       ...options,
-      includeUnprefixedFallback: false,
       optionsResolver: getRouteOptionsResolver(ctx, options.defaultLocale!, options.customRoutes!)
     } as Parameters<typeof localizeRoutes>[1])
     expect(localizedPages).toMatchSnapshot()
@@ -172,7 +171,6 @@ describe.each([
     analyzeNuxtPages(ctx, 'pages', pages)
     const localizedPages = localizeRoutes(pages, {
       ...options,
-      includeUnprefixedFallback: false,
       optionsResolver: getRouteOptionsResolver(ctx, options.defaultLocale!, options.customRoutes!)
     } as Parameters<typeof localizeRoutes>[1])
     expect(stripFilePropertyFromPages(localizedPages)).toMatchSnapshot()

--- a/test/pages/localize_routes.test.ts
+++ b/test/pages/localize_routes.test.ts
@@ -309,7 +309,6 @@ describe('localizeRoutes', function () {
         defaultLocale: 'en',
         strategy: 'prefix',
         locales: getNormalizedLocales(['en', 'ja']),
-        includeUnprefixedFallback: true
       })
 
       expect(localizedRoutes).toMatchSnapshot()

--- a/test/pages/meta_unification.test.ts
+++ b/test/pages/meta_unification.test.ts
@@ -14,7 +14,6 @@ function localize(pages: NuxtPage[], options: ReturnType<typeof getNuxtOptions>)
   normalizeRouteMeta(ctx, pages, localeCodes, options.customRoutes!)
   return localizeRoutes(pages, {
     ...options,
-    includeUnprefixedFallback: false,
     optionsResolver: getRouteOptionsResolver(ctx, options.defaultLocale!, options.customRoutes!),
   } as Parameters<typeof localizeRoutes>[1])
 }

--- a/test/pages/route_localization.test.ts
+++ b/test/pages/route_localization.test.ts
@@ -284,26 +284,6 @@ describe('localizeRoutes strategies', () => {
       expect(findRoute(result, 'home___fr')?.path).toBe('/fr')
       expect(findRoute(result, 'about___fr')?.path).toBe('/fr/about')
     })
-
-    it('with includeUnprefixedFallback, default locale also gets unprefixed copy', () => {
-      const config = createTestConfig({
-        locales: ['en', 'fr'],
-        strategy: 'prefix',
-        defaultLocale: 'en',
-        includeUnprefixedFallback: true,
-      })
-      const result = localizeRoutes(routes, config)
-
-      // unprefixed fallback for default locale (original route without locale suffix)
-      const homeUnprefixed = result.find(r => r.name === 'home' && r.path === '/')
-      expect(homeUnprefixed).toBeDefined()
-      const aboutUnprefixed = result.find(r => r.name === 'about' && r.path === '/about')
-      expect(aboutUnprefixed).toBeDefined()
-
-      // prefixed routes still exist
-      expect(findRoute(result, 'home___en')?.path).toBe('/en')
-      expect(findRoute(result, 'home___fr')?.path).toBe('/fr')
-    })
   })
 
   describe('no_prefix', () => {
@@ -700,55 +680,6 @@ describe('compact routes', () => {
       // no per-locale routes
       expect(findRoute(result, 'about___en')).toBeUndefined()
       expect(findRoute(result, 'about___fr')).toBeUndefined()
-    })
-  })
-
-  // The Nuxt module wrapper passes `includeUnprefixedFallback: true` for any
-  // strategy other than `prefix`, even though the flag is only consulted when
-  // strategy === 'prefix'. The compactRoutes gate must not treat that as a
-  // disable signal — see issue #3971.
-  describe('compactRoutes is not blocked by includeUnprefixedFallback for non-prefix strategies', () => {
-    it('compacts under prefix_except_default + includeUnprefixedFallback: true', () => {
-      const config = createTestConfig({
-        locales,
-        strategy: 'prefix_except_default',
-        defaultLocale: 'en',
-        compactRoutes: true,
-        includeUnprefixedFallback: true,
-      })
-      const result = localizeRoutes(routes, config)
-
-      expect(result.find(r => r.path === '/:locale(fr|ja)/about')).toBeDefined()
-      expect(findRoute(result, 'about___fr')).toBeUndefined()
-      expect(findRoute(result, 'about___ja')).toBeUndefined()
-    })
-
-    it('compacts under prefix_and_default + includeUnprefixedFallback: true', () => {
-      const config = createTestConfig({
-        locales,
-        strategy: 'prefix_and_default',
-        defaultLocale: 'en',
-        compactRoutes: true,
-        includeUnprefixedFallback: true,
-      })
-      const result = localizeRoutes(routes, config)
-
-      expect(result.find(r => r.path === '/:locale(en|fr|ja)/about')).toBeDefined()
-      expect(findRoute(result, 'about___fr')).toBeUndefined()
-      expect(findRoute(result, 'about___ja')).toBeUndefined()
-    })
-
-    it('still blocks compaction under prefix + includeUnprefixedFallback: true', () => {
-      const config = createTestConfig({
-        locales,
-        strategy: 'prefix',
-        defaultLocale: 'en',
-        compactRoutes: true,
-        includeUnprefixedFallback: true,
-      })
-      const result = localizeRoutes(routes, config)
-
-      expect(result.find(r => r.path?.includes(':locale'))).toBeUndefined()
     })
   })
 

--- a/test/pages/utils.ts
+++ b/test/pages/utils.ts
@@ -84,7 +84,6 @@ export function createTestConfig(opts: {
   defaultLocale?: string
   trailingSlash?: boolean
   optionsResolver?: RouteOptionsResolver
-  includeUnprefixedFallback?: boolean
   differentDomains?: boolean
   multiDomainLocales?: boolean
   routesNameSeparator?: string
@@ -99,7 +98,6 @@ export function createTestConfig(opts: {
     routesNameSeparator: opts.routesNameSeparator ?? '___',
     defaultLocaleRouteNameSuffix: opts.defaultLocaleRouteNameSuffix ?? 'default',
     optionsResolver: opts.optionsResolver,
-    includeUnprefixedFallback: opts.includeUnprefixedFallback ?? false,
     differentDomains: opts.differentDomains,
     multiDomainLocales: opts.multiDomainLocales,
     compactRoutes: opts.compactRoutes,


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This internal option was a holdover from the nuxt 2 version of this module, the option has been dead since #2538, unprefixed routes for the prefix strategy respond with a 404 by design. 
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved localized route generation for multi-domain and default-domain configurations.
  - Updated route compaction to handle domain-based localization settings more consistently.
  - Removed legacy unprefixed fallback route behavior that could create unexpected duplicate routes.

- **Improvements**
  - Localization routing now accounts for trailing-slash and domain configuration more reliably.
  - Prerendered localized routes continue to be collected and expanded correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->