### PR TITLE
fix: skip localizing `routeRules` redirect stub pages

### DIFF
--- a/src/pages.ts
+++ b/src/pages.ts
@@ -81,6 +81,8 @@ export const disabledPaths = ${JSON.stringify(routeResources.disabledPaths, null
 
   const projectLayer = nuxt.options._layers[0]
   const typedRouter = await setupExperimentalTypedRoutes(options, nuxt)
+  // nuxt's pages runtime dir is a sibling of `appDir` in its dist
+  const stubFile = resolve(nuxt.options.appDir, '../pages/runtime/component-stub')
 
   nuxt.options.experimental.extraPageMetaExtractionKeys ??= []
   nuxt.options.experimental.extraPageMetaExtractionKeys.push('i18n')
@@ -102,7 +104,7 @@ export const disabledPaths = ${JSON.stringify(routeResources.disabledPaths, null
       // normalize per-mode route options into route meta before localization
       normalizeRouteMeta(ctx, pages, localeCodes, options.customRoutes ?? 'page', nuxt.vfs)
 
-      const resolver = createPureOptionsResolver(ctx, options.defaultLocale, options.customRoutes)
+      const resolver = createPureOptionsResolver(ctx, options.defaultLocale, options.customRoutes, stubFile)
       const resources = createRouteResourcesCollector()
 
       const localizationOptions = {
@@ -352,9 +354,13 @@ export function createPureOptionsResolver(
   ctx: NuxtPageAnalyzeContext,
   defaultLocale: string,
   customRoutes: NuxtI18nOptions['customRoutes'],
+  /** extensionless path of nuxt's page component stub */
+  stubFile?: string,
 ): RouteOptionsResolver {
   const cache = new Map<string, ComputedRouteOptions | undefined>()
   return (route, localeCodes) => {
+    // skip - stub pages nuxt injects for `routeRules` redirects, the rules only match unprefixed paths (#3606)
+    if (stubFile && route.file?.replace(/\.\w+$/, '') === stubFile) { return undefined }
     const key = `${route.file ?? route.name ?? route.path}::${localeCodes.join(',')}`
     if (cache.has(key)) { return cache.get(key) }
     const resolved = getRouteOptions(route, localeCodes, ctx, defaultLocale, customRoutes)

--- a/test/pages/route_localization.test.ts
+++ b/test/pages/route_localization.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { createRouteResourcesCollector, localizeRoutes } from '../../src/routing'
 import { localizeSingleRoute, createRouteContext, canCompactRoute } from '../../src/kit/gen'
-import { collectCompactPrerenderRoutes } from '../../src/pages'
+import { collectCompactPrerenderRoutes, createPureOptionsResolver, NuxtPageAnalyzeContext } from '../../src/pages'
 import { createMockOptionsResolver, createTestConfig, getNormalizedLocales } from './utils'
 
 import type { LocalizableRoute, LocalizeRouteParams } from '../../src/kit/gen'
@@ -636,6 +636,54 @@ describe('createRouteResourcesCollector', () => {
     )
     expect(resources.localizedPaths).toEqual([])
     expect(resources.pathToI18nConfig).toEqual({})
+  })
+})
+
+// nuxt injects stub pages for `routeRules` redirects, the rules only match unprefixed paths (#3606)
+describe.each([false, true])('routeRules redirect stubs (compactRoutes: %s)', (compactRoutes) => {
+  const stubFile = '/app/node_modules/nuxt/dist/pages/runtime/component-stub'
+
+  function makeConfig(resolver: ReturnType<typeof createPureOptionsResolver>) {
+    return createTestConfig({
+      locales: ['en', 'fr'],
+      strategy: 'prefix_except_default',
+      defaultLocale: 'en',
+      optionsResolver: resolver,
+      compactRoutes,
+    })
+  }
+
+  it('passes stubs through unlocalized and keeps them out of route resources', () => {
+    const resolver = createPureOptionsResolver(new NuxtPageAnalyzeContext({}), 'en', 'config', stubFile)
+    const collector = createRouteResourcesCollector()
+    const result = localizeRoutes(
+      [
+        { path: '/about', name: 'about', file: '/pages/about.vue' },
+        { _sync: true, path: '/old-path', file: `${stubFile}.js` },
+      ],
+      { ...makeConfig(resolver), onLocalize: collector.collect },
+    )
+
+    const stubs = result.filter(r => r.path.includes('old-path'))
+    expect(stubs).toHaveLength(1)
+    expect(stubs[0]!.path).toBe('/old-path')
+    expect(result.find(r => r.path === (compactRoutes ? '/:locale(fr)/about' : '/fr/about'))).toBeDefined()
+
+    const resources = collector.toResources()
+    expect(resources.localizedPaths).not.toContain('/old-path')
+    expect(resources.disabledPaths).not.toContain('/old-path')
+  })
+
+  it('does not skip a project page named component-stub', () => {
+    const resolver = createPureOptionsResolver(new NuxtPageAnalyzeContext({}), 'en', 'config', stubFile)
+    const result = localizeRoutes(
+      [{ path: '/runtime/component-stub', name: 'stub-page', file: '/pages/runtime/component-stub.vue' }],
+      makeConfig(resolver),
+    )
+    expect(result.find(r => r.name === 'stub-page___en')).toBeDefined()
+    expect(
+      result.find(r => r.path === (compactRoutes ? '/:locale(fr)/runtime/component-stub' : '/fr/runtime/component-stub')),
+    ).toBeDefined()
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue
- Resolves #3606
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This change prevents the localization of route redirects. Nuxt adds stub routes for route redirects which are included in the `pages:resolved` hook, localizing these routes can cause issues like 404's during prerendering (#3606) and may have cause issues with language detection and redirection.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed route localization for Nuxt redirect stub pages.
  * Redirect targets now remain concrete, unlocalized paths and are excluded from localized or disabled route lists.
  * Project pages matching the runtime stub name continue to be localized correctly.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->