### PR TITLE
fix: locale head type compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "oxc-walker": "^0.7.0",
     "pathe": "^2.0.3",
     "ufo": "^1.6.1",
+    "unhead": "^3.2.1",
     "unplugin": "^3.0.0",
     "unrouting": "^0.1.5",
     "unstorage": "^1.17.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       ufo:
         specifier: ^1.6.1
         version: 1.6.4
+      unhead:
+        specifier: ^3.2.1
+        version: 3.2.1(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))
       unplugin:
         specifier: ^3.0.0
         version: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))
@@ -167,7 +170,7 @@ importers:
         version: 1.1.2
       docus:
         specifier: ^5.9.0
-        version: 5.10.0(f31fdbfb4b3ba05640a92adcd940571d)
+        version: 5.10.0(b726f09bb6cc24bfa4e74bcba1d1b04e)
     devDependencies:
       '@iconify-json/logos':
         specifier: ^1.2.11
@@ -195,7 +198,7 @@ importers:
         version: 4.5.0(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.39)(better-sqlite3@12.9.0)(cac@6.7.14)(crossws@0.4.5(srvx@0.11.22))(db0@0.3.4(better-sqlite3@12.9.0))(esbuild@0.28.0)(eslint@10.2.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxc-parser@0.127.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.2))(rollup@4.60.2)(srvx@0.11.22)(terser@5.46.2)(typescript@5.9.3)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@5.9.3))(yaml@2.9.0)
       nuxt-llms:
         specifier: 0.2.0
-        version: 0.2.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)
+        version: 0.2.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))
 
   playground:
     devDependencies:
@@ -7963,6 +7966,14 @@ packages:
       vite:
         optional: true
 
+  unhead@3.2.1:
+    resolution: {integrity: sha512-Z7VNRf0QJlRZmwA1p5gsnmKYkjnbvV/CXdJAL+VMDmMF+RS2P4FqLouEhBA6WOuKPe3ZZ8EZgX2zQm7ZkAGDPg==}
+    peerDependencies:
+      vite: '>=6.4.2'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
   unicode-emoji-modifier-base@1.0.0:
     resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
     engines: {node: '>=4'}
@@ -9867,7 +9878,7 @@ snapshots:
 
   '@nuxt/devtools-kit@4.0.0-alpha.3(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))':
     dependencies:
-      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)
+      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))
       tinyexec: 1.2.4
       vite: 8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -10093,9 +10104,9 @@ snapshots:
       - vite
       - vue
 
-  '@nuxt/image@2.0.0(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(srvx@0.11.22)(unplugin@2.3.11)':
+  '@nuxt/image@2.0.0(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(srvx@0.11.22)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))':
     dependencies:
-      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)
+      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))
       consola: 3.4.2
       defu: 6.1.7
       h3: 1.15.11
@@ -10606,7 +10617,7 @@ snapshots:
 
   '@nuxt/telemetry@2.8.0(@nuxt/kit@4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))))':
     dependencies:
-      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)
+      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))
       citty: 0.2.2
       consola: 3.4.2
       ofetch: 2.0.0-alpha.3
@@ -10628,7 +10639,7 @@ snapshots:
       '@iconify/vue': 5.0.0(vue@3.5.39(typescript@5.9.3))
       '@nuxt/fonts': 0.14.0(db0@0.3.4(better-sqlite3@12.9.0))(esbuild@0.28.0)(ioredis@5.10.1)(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))
       '@nuxt/icon': 2.2.1(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))
-      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)
+      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))
       '@nuxt/schema': 4.5.0
       '@nuxtjs/color-mode': 3.5.2(magicast@0.5.2)
       '@standard-schema/spec': 1.1.0
@@ -10879,10 +10890,10 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxtjs/mcp-toolkit@0.13.4(h3@2.0.1-rc.22(crossws@0.4.5(srvx@0.11.22)))(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)(zod@4.4.1)':
+  '@nuxtjs/mcp-toolkit@0.13.4(h3@2.0.1-rc.22(crossws@0.4.5(srvx@0.11.22)))(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))(zod@4.4.1)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.1)
-      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)
+      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))
       h3: 2.0.1-rc.22(crossws@0.4.5(srvx@0.11.22))
       tinyglobby: 0.2.17
       zod: 4.4.1
@@ -10948,9 +10959,9 @@ snapshots:
       - supports-color
       - unplugin
 
-  '@nuxtjs/mdc@0.21.1(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)':
+  '@nuxtjs/mdc@0.21.1(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))':
     dependencies:
-      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)
+      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))
       '@shikijs/core': 4.0.2
       '@shikijs/engine-javascript': 4.0.2
       '@shikijs/langs': 4.0.2
@@ -11002,14 +11013,14 @@ snapshots:
       - supports-color
       - unplugin
 
-  '@nuxtjs/robots@6.0.8(@nuxt/schema@4.5.0)(magic-string@0.30.21)(magicast@0.5.2)(nuxt@4.5.0(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.39)(better-sqlite3@12.9.0)(cac@6.7.14)(crossws@0.4.5(srvx@0.11.22))(db0@0.3.4(better-sqlite3@12.9.0))(esbuild@0.28.0)(eslint@10.2.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxc-parser@0.127.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.2))(rollup@4.60.2)(srvx@0.11.22)(terser@5.46.2)(typescript@5.9.3)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@5.9.3))(yaml@2.9.0))(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(zod@4.4.1)':
+  '@nuxtjs/robots@6.0.8(a96faa2757b4f776d84eecbf8e11b969)':
     dependencies:
       '@fingerprintjs/botd': 2.0.0
-      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)
+      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))
       consola: 3.4.2
       defu: 6.1.7
       h3: 1.15.11
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.5.0)(magic-string@0.30.21)(magicast@0.5.2)(nuxt@4.5.0(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.39)(better-sqlite3@12.9.0)(cac@6.7.14)(crossws@0.4.5(srvx@0.11.22))(db0@0.3.4(better-sqlite3@12.9.0))(esbuild@0.28.0)(eslint@10.2.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxc-parser@0.127.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.2))(rollup@4.60.2)(srvx@0.11.22)(terser@5.46.2)(typescript@5.9.3)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@5.9.3))(yaml@2.9.0))(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(zod@4.4.1)
+      nuxt-site-config: 4.0.8(a96faa2757b4f776d84eecbf8e11b969)
       nuxtseo-shared: 5.1.3(19708da37fd097b2a352e7985737dd11)
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -13695,7 +13706,7 @@ snapshots:
 
   diff@8.0.4: {}
 
-  docus@5.10.0(f31fdbfb4b3ba05640a92adcd940571d):
+  docus@5.10.0(b726f09bb6cc24bfa4e74bcba1d1b04e):
     dependencies:
       '@ai-sdk/gateway': 3.0.105(zod@4.4.1)
       '@ai-sdk/mcp': 1.0.37(zod@4.4.1)
@@ -13704,13 +13715,13 @@ snapshots:
       '@iconify-json/simple-icons': 1.2.80
       '@iconify-json/vscode-icons': 1.2.45
       '@nuxt/content': 3.12.0(@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@5.9.3)))(better-sqlite3@12.9.0)(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(valibot@1.4.2(typescript@5.9.3))
-      '@nuxt/image': 2.0.0(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(srvx@0.11.22)(unplugin@2.3.11)
-      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)
+      '@nuxt/image': 2.0.0(db0@0.3.4(better-sqlite3@12.9.0))(ioredis@5.10.1)(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(srvx@0.11.22)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))
+      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))
       '@nuxt/ui': 4.7.1(1acbe56838b9fcfeb884431d38159a40)
       '@nuxtjs/i18n': 'link:'
-      '@nuxtjs/mcp-toolkit': 0.13.4(h3@2.0.1-rc.22(crossws@0.4.5(srvx@0.11.22)))(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)(zod@4.4.1)
-      '@nuxtjs/mdc': 0.21.1(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)
-      '@nuxtjs/robots': 6.0.8(@nuxt/schema@4.5.0)(magic-string@0.30.21)(magicast@0.5.2)(nuxt@4.5.0(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.39)(better-sqlite3@12.9.0)(cac@6.7.14)(crossws@0.4.5(srvx@0.11.22))(db0@0.3.4(better-sqlite3@12.9.0))(esbuild@0.28.0)(eslint@10.2.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxc-parser@0.127.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.2))(rollup@4.60.2)(srvx@0.11.22)(terser@5.46.2)(typescript@5.9.3)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@5.9.3))(yaml@2.9.0))(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(zod@4.4.1)
+      '@nuxtjs/mcp-toolkit': 0.13.4(h3@2.0.1-rc.22(crossws@0.4.5(srvx@0.11.22)))(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))(zod@4.4.1)
+      '@nuxtjs/mdc': 0.21.1(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))
+      '@nuxtjs/robots': 6.0.8(a96faa2757b4f776d84eecbf8e11b969)
       '@shikijs/core': 4.0.2
       '@shikijs/engine-javascript': 4.0.2
       '@shikijs/langs': 4.0.2
@@ -13724,7 +13735,7 @@ snapshots:
       git-url-parse: 16.1.0
       motion-v: 2.2.1(@vueuse/core@14.3.0(vue@3.5.39(typescript@5.9.3)))(vue@3.5.39(typescript@5.9.3))
       nuxt: 4.5.0(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.39)(better-sqlite3@12.9.0)(cac@6.7.14)(crossws@0.4.5(srvx@0.11.22))(db0@0.3.4(better-sqlite3@12.9.0))(esbuild@0.28.0)(eslint@10.2.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxc-parser@0.127.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.2))(rollup@4.60.2)(srvx@0.11.22)(terser@5.46.2)(typescript@5.9.3)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@5.9.3))(yaml@2.9.0)
-      nuxt-llms: 0.2.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)
+      nuxt-llms: 0.2.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))
       nuxt-og-image: 6.4.8(4ccc85307cdbed54c35f36512c19632e)
       pkg-types: 2.3.1
       scule: 1.3.0
@@ -16066,9 +16077,9 @@ snapshots:
 
   nuxt-define@1.0.0: {}
 
-  nuxt-llms@0.2.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11):
+  nuxt-llms@0.2.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))):
     dependencies:
-      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)
+      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))
     transitivePeerDependencies:
       - magic-string
       - magicast
@@ -16092,7 +16103,7 @@ snapshots:
       magic-string: 0.30.21
       magicast: 0.5.2
       mocked-exports: 0.1.1
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.5.0)(magic-string@0.30.21)(magicast@0.5.2)(nuxt@4.5.0(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.39)(better-sqlite3@12.9.0)(cac@6.7.14)(crossws@0.4.5(srvx@0.11.22))(db0@0.3.4(better-sqlite3@12.9.0))(esbuild@0.28.0)(eslint@10.2.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxc-parser@0.127.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.2))(rollup@4.60.2)(srvx@0.11.22)(terser@5.46.2)(typescript@5.9.3)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@5.9.3))(yaml@2.9.0))(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(zod@4.4.1)
+      nuxt-site-config: 4.0.8(a96faa2757b4f776d84eecbf8e11b969)
       nuxtseo-shared: 5.1.3(19708da37fd097b2a352e7985737dd11)
       nypm: 0.6.8
       ofetch: 1.5.1
@@ -16138,7 +16149,7 @@ snapshots:
 
   nuxt-site-config-kit@4.0.8(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))(vue@3.5.39(typescript@5.9.3)):
     dependencies:
-      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)
+      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))
       site-config-stack: 4.0.8(vue@3.5.39(typescript@5.9.3))
       std-env: 4.2.0
       ufo: 1.6.4
@@ -16150,9 +16161,9 @@ snapshots:
       - unplugin
       - vue
 
-  nuxt-site-config@4.0.8(@nuxt/schema@4.5.0)(magic-string@0.30.21)(magicast@0.5.2)(nuxt@4.5.0(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.39)(better-sqlite3@12.9.0)(cac@6.7.14)(crossws@0.4.5(srvx@0.11.22))(db0@0.3.4(better-sqlite3@12.9.0))(esbuild@0.28.0)(eslint@10.2.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxc-parser@0.127.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.2))(rollup@4.60.2)(srvx@0.11.22)(terser@5.46.2)(typescript@5.9.3)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@5.9.3))(yaml@2.9.0))(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(zod@4.4.1):
+  nuxt-site-config@4.0.8(a96faa2757b4f776d84eecbf8e11b969):
     dependencies:
-      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)
+      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))
       h3: 1.15.11
       nuxt-site-config-kit: 4.0.8(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))(vue@3.5.39(typescript@5.9.3))
       nuxtseo-shared: 5.1.3(19708da37fd097b2a352e7985737dd11)
@@ -16226,7 +16237,7 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 3.0.0(magic-string@1.0.0)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))
       undici: 8.7.0
-      unhead: 3.1.8(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))
+      unhead: 3.2.1(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))
       unimport: 6.3.0(esbuild@0.28.0)(oxc-parser@0.127.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))
       unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))
       unrouting: 0.1.7
@@ -16367,7 +16378,7 @@ snapshots:
       uncrypto: 0.1.3
       unctx: 3.0.0(magic-string@1.0.0)(oxc-parser@0.128.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))
       undici: 8.7.0
-      unhead: 3.1.8(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))
+      unhead: 3.2.1(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))
       unimport: 6.3.0(esbuild@0.28.0)(oxc-parser@0.128.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))
       unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))
       unrouting: 0.1.7
@@ -16458,7 +16469,7 @@ snapshots:
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.3(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))
-      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)
+      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))
       '@nuxt/schema': 4.5.0
       birpc: 4.0.0
       consola: 3.4.2
@@ -16473,7 +16484,7 @@ snapshots:
       ufo: 1.6.4
       vue: 3.5.39(typescript@5.9.3)
     optionalDependencies:
-      nuxt-site-config: 4.0.8(@nuxt/schema@4.5.0)(magic-string@0.30.21)(magicast@0.5.2)(nuxt@4.5.0(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.1))(@parcel/watcher@2.5.6)(@types/node@25.5.0)(@vue/compiler-sfc@3.5.39)(better-sqlite3@12.9.0)(cac@6.7.14)(crossws@0.4.5(srvx@0.11.22))(db0@0.3.4(better-sqlite3@12.9.0))(esbuild@0.28.0)(eslint@10.2.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxc-parser@0.127.0)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.60.2))(rollup@4.60.2)(srvx@0.11.22)(terser@5.46.2)(typescript@5.9.3)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))(vue-tsc@3.3.7(typescript@5.9.3))(yaml@2.9.0))(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))(zod@4.4.1)
+      nuxt-site-config: 4.0.8(a96faa2757b4f776d84eecbf8e11b969)
       zod: 4.4.1
     transitivePeerDependencies:
       - magic-string
@@ -18367,6 +18378,22 @@ snapshots:
       - unloader
       - webpack
 
+  unhead@3.2.1(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)):
+    dependencies:
+      hookable: 6.1.1
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))
+    optionalDependencies:
+      vite: 8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@farmfe/core'
+      - '@rspack/core'
+      - bun-types-no-globals
+      - esbuild
+      - rolldown
+      - rollup
+      - unloader
+      - webpack
+
   unicode-emoji-modifier-base@1.0.0: {}
 
   unicode-trie@2.0.0:
@@ -18513,7 +18540,7 @@ snapshots:
       unplugin: 2.3.11
       unplugin-utils: 0.3.2
     optionalDependencies:
-      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)
+      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))
       '@vueuse/core': 14.3.0(vue@3.5.39(typescript@5.9.3))
 
   unplugin-utils@0.3.2:
@@ -18534,7 +18561,7 @@ snapshots:
       unplugin-utils: 0.3.2
       vue: 3.5.39(typescript@5.9.3)
     optionalDependencies:
-      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)
+      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))
     transitivePeerDependencies:
       - '@farmfe/core'
       - '@rspack/core'
@@ -18733,7 +18760,7 @@ snapshots:
       vite: 8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)
       vite-dev-rpc: 1.1.0(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0))
     optionalDependencies:
-      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@2.3.11)
+      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.2)(oxc-parser@0.127.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.0)(rollup@4.60.2)(vite@8.1.5(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.2)(yaml@2.9.0)))
     transitivePeerDependencies:
       - supports-color
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -17,7 +17,7 @@ declare let __SWITCH_LOCALE_PATH_LINK_IDENTIFIER__: string
 declare let __I18N_STRATEGY__: 'no_prefix' | 'prefix' | 'prefix_except_default' | 'prefix_and_default'
 declare let __ROUTE_NAME_SEPARATOR__: string
 declare let __ROUTE_NAME_DEFAULT_SUFFIX__: string
-declare let __DEFAULT_DIRECTION__: string
+declare let __DEFAULT_DIRECTION__: 'ltr' | 'rtl' | 'auto'
 declare let __I18N_CACHE__: boolean
 declare let __I18N_CACHE_LIFETIME__: number
 declare let __I18N_HTTP_CACHE_DURATION__: number

--- a/src/runtime/kit/head.ts
+++ b/src/runtime/kit/head.ts
@@ -3,21 +3,16 @@ import { hasProtocol, joinURL, withQuery } from 'ufo'
 import type { QueryValue } from 'ufo'
 import type { RouteLocationNormalizedLoadedGeneric, RouteLocationResolvedGeneric } from 'vue-router'
 import type { HeadLocale } from './types'
-
-/**
- * Meta attributes for head properties.
- * @internal
- */
-export type MetaAttrs = Record<string, string>
+import type { AlternateLanguageLink, CanonicalLink, HtmlAttributes, PropertyMeta, ResolvableLink, ResolvableMeta } from 'unhead/types'
 
 /**
  * I18n header meta info.
  * @internal
  */
 export interface I18nHeadMetaInfo {
-  htmlAttrs: MetaAttrs
-  meta: MetaAttrs[]
-  link: MetaAttrs[]
+  htmlAttrs: HtmlAttributes
+  meta: ResolvableMeta[]
+  link: ResolvableLink[]
 }
 
 type SeoAttributesOptions = {
@@ -45,7 +40,7 @@ export type HeadContext = {
   strictCanonicals: boolean
   canonicalQueries: string[]
   getCurrentLanguage: () => string | undefined
-  getCurrentDirection: () => string
+  getCurrentDirection: () => 'ltr' | 'rtl' | 'auto'
   getRouteBaseName: (route: RouteLocationResolvedGeneric | RouteLocationNormalizedLoadedGeneric) => string | undefined
   getLocaleRoute: (route: RouteLocationResolvedGeneric) => RouteLocationResolvedGeneric | undefined
   getCurrentRoute: () => RouteLocationNormalizedLoadedGeneric
@@ -119,7 +114,7 @@ function createLocaleMap(locales: HeadLocale[]) {
 function getHreflangLinks(options: HeadContext) {
   if (!options.hreflangLinks) { return [] }
 
-  const links: MetaAttrs[] = []
+  const links: AlternateLanguageLink[] = []
   const localeMap = createLocaleMap(options.locales)
   for (const [language, locale] of localeMap.entries()) {
     const link = getHreflangLink(language, locale, options)
@@ -143,7 +138,7 @@ function getHreflangLink(
   locale: HeadLocale,
   options: HeadContext,
   routeWithoutQuery = options.strictCanonicals ? options.getRouteWithoutQuery() : undefined,
-): MetaAttrs | undefined {
+): AlternateLanguageLink | undefined {
   const localePath = options.getLocalizedRoute(locale.code, routeWithoutQuery)
   if (!localePath) { return undefined }
 
@@ -165,7 +160,7 @@ function getCanonicalUrl(options: HeadContext, route = options.getCurrentRoute()
   return withQuery(joinURL(options.baseUrl, currentRoute.path), getCanonicalQueryParams(options))
 }
 
-function getCanonicalLink(options: HeadContext, href = getCanonicalUrl(options)): MetaAttrs[] {
+function getCanonicalLink(options: HeadContext, href = getCanonicalUrl(options)): CanonicalLink[] {
   if (!href) { return [] }
   return [options.strictSeo ? { rel: 'canonical', href } : { [options.key]: 'i18n-can', rel: 'canonical', href }]
 }
@@ -187,7 +182,7 @@ function getCanonicalQueryParams(options: HeadContext, route = options.getCurren
   return params
 }
 
-function getOgUrl(options: HeadContext, href = getCanonicalUrl(options)): MetaAttrs[] {
+function getOgUrl(options: HeadContext, href = getCanonicalUrl(options)): PropertyMeta[] {
   if (!href) { return [] }
   return [
     options.strictSeo
@@ -196,7 +191,7 @@ function getOgUrl(options: HeadContext, href = getCanonicalUrl(options)): MetaAt
   ]
 }
 
-function getCurrentOgLocale(options: HeadContext, currentLanguage = options.getCurrentLanguage()): MetaAttrs[] {
+function getCurrentOgLocale(options: HeadContext, currentLanguage = options.getCurrentLanguage()): PropertyMeta[] {
   if (!currentLanguage) { return [] }
   return [
     options.strictSeo
@@ -209,7 +204,7 @@ function getCurrentOgLocale(options: HeadContext, currentLanguage = options.getC
  * The hreflang list contains bare-language catchall entries which are not valid `og:locale` values,
  * limit to the locales' own `language` tags while keeping the availability filtering of the links.
  */
-function getAlternateOgLanguages(options: HeadContext, alternateLinks: MetaAttrs[]): string[] {
+function getAlternateOgLanguages(options: HeadContext, alternateLinks: AlternateLanguageLink[]): string[] {
   const languages = options.locales.map(x => x.language || x.code)
   if (!options.strictSeo) {
     return languages
@@ -222,7 +217,7 @@ function getAlternateOgLocales(
   options: HeadContext,
   languages: string[],
   currentLanguage = options.getCurrentLanguage(),
-): MetaAttrs[] {
+): PropertyMeta[] {
   const alternateLocales = languages.filter(locale => locale && locale !== currentLanguage)
 
   return alternateLocales.map(locale =>

--- a/src/runtime/routing/head.ts
+++ b/src/runtime/routing/head.ts
@@ -8,11 +8,8 @@ import type { ComposableContext } from '../composable-context'
 import type { I18nRouteMeta } from '../types'
 import { localeRoute, switchLocalePath } from './routing'
 
-// unhead v3 narrows head input to per-property unions which the loose public `I18nHeadMetaInfo`
-// cannot satisfy, patch through a single boundary cast compatible with both v2 and v3
-type HeadEntryInput = Parameters<NonNullable<ComposableContext['head']>['patch']>[0]
 function patchHead(head: ComposableContext['head'] | undefined, input: I18nHeadMetaInfo): void {
-  head?.patch(input as unknown as HeadEntryInput)
+  head?.patch(input)
 }
 
 function createHeadContext(

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import type { I18nOptions, Locale } from 'vue-i18n'
 import type { PluginOptions } from '@intlify/unplugin-vue-i18n'
 import type { RouteMapGeneric, RouteMapI18n } from 'vue-router'
 import type { STRATEGIES } from './constants'
+import type { HtmlAttributes, ResolvableLink, ResolvableMeta } from 'unhead/types'
 
 export type {
   STRATEGY_NO_PREFIX,
@@ -587,6 +588,7 @@ export interface I18nHeadOptions {
 /**
  * Meta attributes for head properties.
  * @public
+ * @deprecated incompatible with unhead v3 - use `ResolvableMeta`, `ResolvableLink` and `HtmlAttributes` from `unhead/types` instead.
  */
 export type MetaAttrs = Record<string, string>
 
@@ -596,11 +598,11 @@ export type MetaAttrs = Record<string, string>
  */
 export interface I18nHeadMetaInfo {
   /** HTML attributes for the HTML element */
-  htmlAttrs: MetaAttrs
+  htmlAttrs: HtmlAttributes
   /** Meta tags */
-  meta: MetaAttrs[]
+  meta: ResolvableMeta[]
   /** Link tags */
-  link: MetaAttrs[]
+  link: ResolvableLink[]
 }
 
 /**


### PR DESCRIPTION
### 🔗 Linked issue
* Resolves #4054
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Deprecates the public `MetaAttrs` type as it's too loose for the latest unhead release, narrowed locale head types with the types exported from `unhead/types`.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved compatibility and type safety for page metadata, SEO tags, and document head settings.
  * Added clearer support for text directions: left-to-right, right-to-left, and automatic detection.
  * Strengthened validation for language alternate links, canonical links, and other metadata.
* **Documentation**
  * Clarified the recommended metadata types for current head-management integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->