### PR TITLE
fix: validate locale codes to ensure path segment safety

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -14,7 +14,7 @@ import { relative } from 'pathe'
 import { generateTemplateNuxtI18nOptions } from './template'
 import { generateI18nTypes, generateLoaderOptions, simplifyLocaleOptions } from './gen'
 import { applyLayerOptions, resolveLayerVueI18nConfigInfo } from './layers'
-import { computeLocaleHashes, filterLocales, getLocaleFilePaths, normalizeDomainLocale, resolveLocales } from './utils'
+import { computeLocaleHashes, filterLocales, getLocaleFilePaths, normalizeDomainLocale, resolveLocales, validateLocaleCodes } from './utils'
 import { isString } from '@intlify/shared'
 
 export * from './types'
@@ -181,6 +181,7 @@ export default defineNuxtModule<NuxtI18nOptions>({
         normalizeDomainLocale(isString(x) ? { code: x, language: x } : x),
       )
       ctx.localeCodes = ctx.normalizedLocales.map(locale => locale.code)
+      validateLocaleCodes(ctx.localeCodes)
       ctx.localeInfo = resolveLocales(nuxt.options.srcDir, ctx.normalizedLocales, nuxt.vfs)
 
       ctx.vueI18nConfigPaths = await resolveLayerVueI18nConfigInfo(ctx)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,6 +31,19 @@ export function filterLocales(ctx: I18nNuxtContext, nuxt: Nuxt) {
   return ctx.options.locales.filter(x => include.includes(isString(x) ? x : x.code)) as string[] | LocaleObject[]
 }
 
+// locale codes are used as single URL path segments (route prefixes, messages endpoint), in route names and in cookies (#4036)
+const INVALID_LOCALE_CODE_CHAR_RE = /[/\\?#%:\s]/
+
+export function validateLocaleCodes(codes: string[]) {
+  const invalid = codes.filter(code => !code || INVALID_LOCALE_CODE_CHAR_RE.test(code))
+  if (invalid.length) {
+    throw new Error(
+      `[nuxt-i18n] Invalid locale code${invalid.length > 1 ? 's' : ''}: ${invalid.map(x => JSON.stringify(x)).join(', ')}. `
+      + 'Locale codes are used as URL path segments and must not be empty or contain `/ \\ ? # % :` or whitespace.',
+    )
+  }
+}
+
 /**
  * Normalizes the single-domain fields (`domain`/`domainDefault`) into their multi-domain forms
  * (`domains`/`defaultForDomains`) so runtime domain resolution only handles one shape,

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,4 +1,4 @@
-import { filterLocales, resolveLocales } from '../src/utils'
+import { filterLocales, resolveLocales, validateLocaleCodes } from '../src/utils'
 import type { LocaleObject, NuxtI18nOptions } from '../src/types'
 import type { I18nNuxtContext } from '../src/context'
 import type { Nuxt, NuxtConfigLayer } from '@nuxt/schema'
@@ -59,6 +59,22 @@ describe('filterLocales', () => {
 
     // empty `onlyLocales` means no filtering; the downstream `'fr'` must not be applied
     expect(filterLocales(ctx, nuxt)).toEqual(['en', 'fr', 'nl'])
+  })
+})
+
+describe('validateLocaleCodes', () => {
+  test('accepts path-segment-safe codes', () => {
+    expect(() => validateLocaleCodes(['en', 'de-AT', 'zh-Hans', 'pt_BR', 'kr.v2'])).not.toThrow()
+  })
+
+  test.each(['at/de', 'at\\de', 'en us', 'en?', 'en#x', 'en%20', 'en:us', ''])('throws for %j', code => {
+    expect(() => validateLocaleCodes([code])).toThrowError('[nuxt-i18n] Invalid locale code')
+  })
+
+  test('lists all invalid codes', () => {
+    expect(() => validateLocaleCodes(['en', 'at/de', 'at/en'])).toThrowError(
+      /Invalid locale codes: "at\/de", "at\/en"/,
+    )
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue
* Resolves #4036
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This prevents projects from using locale codes that would cause unexpected behavior.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for locale codes before locale configuration is generated.
  * Invalid, empty, or unsafe locale codes are now detected with clear error messages.
  * Multiple invalid locale codes are reported together, helping identify configuration issues quickly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->