### PR TITLE
fix(types): narrow locale head types to support `useHeadSafe`

### DIFF
--- a/docs/content/docs/06.composables/04.use-locale-head.md
+++ b/docs/content/docs/06.composables/04.use-locale-head.md
@@ -49,3 +49,11 @@ useHead(() => ({
 </script>
 ```
 
+The returned value can also be passed to `useHeadSafe()`{lang="ts"} directly:
+
+```vue
+<script setup>
+useHeadSafe(useLocaleHead())
+</script>
+```
+

--- a/specs/fixtures/typed_routes/app/head-types.ts
+++ b/specs/fixtures/typed_routes/app/head-types.ts
@@ -1,0 +1,16 @@
+/**
+ * Type-level assertions for `useLocaleHead` (#4061).
+ *
+ * Never executed, only checked by this fixture's `test:types` script. The return
+ * value must stay narrow enough to be accepted by `useHeadSafe`, not just `useHead`.
+ */
+import { describe, it } from 'vitest'
+import { useHead, useHeadSafe, useLocaleHead } from '#imports'
+
+describe('useLocaleHead', () => {
+  it('is accepted by both useHead and useHeadSafe', () => {
+    const head = useLocaleHead()
+    useHead(head)
+    useHeadSafe(head)
+  })
+})

--- a/src/runtime/kit/head.ts
+++ b/src/runtime/kit/head.ts
@@ -3,16 +3,16 @@ import { hasProtocol, joinURL, withQuery } from 'ufo'
 import type { QueryValue } from 'ufo'
 import type { RouteLocationNormalizedLoadedGeneric, RouteLocationResolvedGeneric } from 'vue-router'
 import type { HeadLocale } from './types'
-import type { AlternateLanguageLink, CanonicalLink, HtmlAttributes, PropertyMeta, ResolvableLink, ResolvableMeta } from 'unhead/types'
+import type { AlternateLanguageLink, CanonicalLink, HtmlAttributes, PropertyMeta } from 'unhead/types'
 
 /**
  * I18n header meta info.
  * @internal
  */
 export interface I18nHeadMetaInfo {
-  htmlAttrs: HtmlAttributes
-  meta: ResolvableMeta[]
-  link: ResolvableLink[]
+  htmlAttrs: Pick<HtmlAttributes, 'lang' | 'dir'>
+  meta: PropertyMeta[]
+  link: (AlternateLanguageLink | CanonicalLink)[]
 }
 
 type SeoAttributesOptions = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import type { I18nOptions, Locale } from 'vue-i18n'
 import type { PluginOptions } from '@intlify/unplugin-vue-i18n'
 import type { RouteMapGeneric, RouteMapI18n } from 'vue-router'
 import type { STRATEGIES } from './constants'
-import type { HtmlAttributes, ResolvableLink, ResolvableMeta } from 'unhead/types'
+import type { AlternateLanguageLink, CanonicalLink, HtmlAttributes, PropertyMeta } from 'unhead/types'
 
 export type {
   STRATEGY_NO_PREFIX,
@@ -598,11 +598,11 @@ export type MetaAttrs = Record<string, string>
  */
 export interface I18nHeadMetaInfo {
   /** HTML attributes for the HTML element */
-  htmlAttrs: HtmlAttributes
+  htmlAttrs: Pick<HtmlAttributes, 'lang' | 'dir'>
   /** Meta tags */
-  meta: ResolvableMeta[]
+  meta: PropertyMeta[]
   /** Link tags */
-  link: ResolvableLink[]
+  link: (AlternateLanguageLink | CanonicalLink)[]
 }
 
 /**


### PR DESCRIPTION
* Resolves #4061

Since #4055 the locale head types cover every tag unhead supports, which is wider than what `useHeadSafe()` accepts, so passing the return value of `useLocaleHead()` to it no longer compiled. This narrows `I18nHeadMetaInfo` to the tags we actually produce (`lang`/`dir` attributes, `og:*` property metas, alternate and canonical links), making it compatible with both `useHead()` and `useHeadSafe()`.

Constructing an `I18nHeadMetaInfo` with tags we never emit will now error, consuming the returned value is unaffected.

This also adds a type test to the `typed_routes` fixture and documents `useHeadSafe()` usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an example showing that `useLocaleHead()` output can be passed directly to `useHeadSafe()`.

* **Bug Fixes**
  * Improved type compatibility for localized head metadata with `useHead()` and `useHeadSafe()`.
  * Refined the supported types for language attributes, metadata, and alternate or canonical links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->