### PR TITLE
fix: expand inline route rules on compact routes per locale

### DIFF
--- a/src/pages.ts
+++ b/src/pages.ts
@@ -1,4 +1,5 @@
 import { addTemplate, updateTemplates } from '@nuxt/kit'
+import { defu } from 'defu'
 import { readFileSync } from 'node:fs'
 import { isString } from '@intlify/shared'
 import { parse as parseSFC } from '@vue/compiler-sfc'
@@ -13,6 +14,7 @@ import { createRoutesContext, resolveOptions } from 'vue-router/unplugin'
 import { transform } from './transform/resource'
 
 import type { Nuxt, NuxtPage, ResolvedNuxtTemplate } from '@nuxt/schema'
+import type { NitroRouteConfig } from 'nitropack/types'
 import type { EditableTreeNode, Options as TypedRouterOptions } from 'vue-router/unplugin'
 import type { NuxtI18nOptions } from './types'
 import type { I18nNuxtContext } from './context'
@@ -36,6 +38,8 @@ export class NuxtPageAnalyzeContext {
 type NarrowedNuxtPage = Omit<NuxtPage, 'redirect' | 'children'> & {
   redirect?: (Omit<NarrowedNuxtPage, 'name'> & { name?: string }) | string
   children?: NarrowedNuxtPage[]
+  /** inline route rules extracted by nuxt */
+  rules?: NitroRouteConfig
 }
 
 export async function setupPages({ localeCodes, options, normalizedLocales }: I18nNuxtContext, nuxt: Nuxt) {
@@ -78,6 +82,21 @@ export const disabledPaths = ${JSON.stringify(routeResources.disabledPaths, null
       for (const route of compactPrerenderRoutes) { routes.add(route) }
     })
   })
+
+  // Consume inline route rules before nuxt's own collection (see `collectRouteRulesFromPages`)
+  const handleRouteRules = !!nuxt.options.experimental.inlineRouteRules && !!options.experimental?.compactRoutes
+  let routeRulesFromPages: Record<string, NitroRouteConfig> = {}
+  let applyRouteRules: (() => Promise<void>) | undefined
+  if (handleRouteRules) {
+    nuxt.hook('nitro:init', (nitro) => {
+      let applied = {} as Record<string, NitroRouteConfig>
+      applyRouteRules = async () => {
+        if (JSON.stringify(applied) === JSON.stringify(routeRulesFromPages)) { return }
+        applied = routeRulesFromPages
+        await nitro.updateConfig({ routeRules: defu(routeRulesFromPages, nitro.options._config.routeRules) })
+      }
+    })
+  }
 
   const projectLayer = nuxt.options._layers[0]
   const typedRouter = await setupExperimentalTypedRoutes(options, nuxt)
@@ -144,6 +163,11 @@ export const disabledPaths = ${JSON.stringify(routeResources.disabledPaths, null
       if (options.experimental?.compactRoutes && nuxt.options.nitro.static) {
         compactPrerenderRoutes.push(...collectCompactPrerenderRoutes(localizedPages))
       }
+
+      if (handleRouteRules) {
+        routeRulesFromPages = collectRouteRulesFromPages(localizedPages)
+        await applyRouteRules?.()
+      }
     },
   )
 }
@@ -189,6 +213,46 @@ export function collectCompactPrerenderRoutes(pages: NarrowedNuxtPage[]): string
   }
 
   return out
+}
+
+// Ported from nuxt's `pathToNitroGlob`
+const PATH_TO_NITRO_GLOB_RE = /\/[^:/]*:\w.*$/
+function pathToNitroGlob(path: string): string | null {
+  if (!path) { return null }
+  if (path.indexOf(':') !== path.lastIndexOf(':')) { return null }
+  return path.replace(PATH_TO_NITRO_GLOB_RE, '/**')
+}
+
+/** `/:locale(en|nl)/about` -> `['/en/about', '/nl/about']` */
+function expandCompactPath(path: string): string[] {
+  const match = compactRouteRE.exec(path)
+  if (!match) { return [path] }
+  return match[1]!.split('|').map(locale => '/' + locale + match[2]!)
+}
+
+// Nuxt maps rules on compact `/:locale(...)` paths to an overly broad `/**` rule
+// (https://github.com/nuxt/nuxt/pull/35455), we mirror `globRouteRulesFromPages` here
+// to expand the locale prefix instead, removing the rules before nuxt collects them.
+export function collectRouteRulesFromPages(
+  pages: NarrowedNuxtPage[],
+  rules: Record<string, NitroRouteConfig> = {},
+  prefix = '',
+): Record<string, NitroRouteConfig> {
+  for (const page of pages) {
+    if (page.rules) {
+      if (Object.keys(page.rules).length) {
+        for (const path of expandCompactPath(prefix + page.path)) {
+          const glob = pathToNitroGlob(path)
+          if (glob) { rules[glob] = page.rules }
+        }
+      }
+      delete page.rules
+    }
+    if (page.children?.length) {
+      collectRouteRulesFromPages(page.children, rules, prefix + page.path + '/')
+    }
+  }
+  return rules
 }
 
 /**

--- a/test/pages/route_localization.test.ts
+++ b/test/pages/route_localization.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { createRouteResourcesCollector, localizeRoutes } from '../../src/routing'
 import { localizeSingleRoute, createRouteContext, canCompactRoute } from '../../src/kit/gen'
-import { collectCompactPrerenderRoutes, createPureOptionsResolver, NuxtPageAnalyzeContext } from '../../src/pages'
+import { collectCompactPrerenderRoutes, collectRouteRulesFromPages, createPureOptionsResolver, NuxtPageAnalyzeContext } from '../../src/pages'
 import { createMockOptionsResolver, createTestConfig, getNormalizedLocales } from './utils'
 
 import type { LocalizableRoute, LocalizeRouteParams } from '../../src/kit/gen'
@@ -945,6 +945,83 @@ describe('compact routes', () => {
         ]),
       ])
       expect(out).toEqual(['/en/parent', '/fr/parent', '/en/parent/relative', '/fr/parent/relative'])
+    })
+  })
+
+  // Nuxt maps rules on compact `/:locale(...)` paths to a `/**` rule (nuxt#35455),
+  // `collectRouteRulesFromPages` consumes them first and expands per locale instead.
+  describe('collectRouteRulesFromPages — inline route rules on compact routes', () => {
+    type RulesPage = Parameters<typeof collectRouteRulesFromPages>[0][number]
+    const page = (path: string, rules?: Record<string, unknown>, children?: RulesPage[]) =>
+      ({ path, rules, children } as RulesPage)
+
+    it('expands a compact route to one rule per locale', () => {
+      const pages = [page('/:locale(en|fr)/account', { prerender: true })]
+      expect(collectRouteRulesFromPages(pages)).toEqual({
+        '/en/account': { prerender: true },
+        '/fr/account': { prerender: true },
+      })
+    })
+
+    it('handles the root route — `/:locale(...)` with no rest', () => {
+      const pages = [page('/:locale(en|fr)', { swr: 60 })]
+      expect(collectRouteRulesFromPages(pages)).toEqual({
+        '/en': { swr: 60 },
+        '/fr': { swr: 60 },
+      })
+    })
+
+    it('converts non-compact paths like nuxt does', () => {
+      const pages = [page('/about', { prerender: true }), page('/blog/:slug', { swr: 60 })]
+      expect(collectRouteRulesFromPages(pages)).toEqual({
+        '/about': { prerender: true },
+        '/blog/**': { swr: 60 },
+      })
+    })
+
+    it('converts a dynamic tail after the locale segment to a per-locale glob', () => {
+      // nuxt drops this path entirely (two dynamic params), expansion makes it representable
+      const pages = [page('/:locale(en|fr)/blog/:slug', { swr: 60 })]
+      expect(collectRouteRulesFromPages(pages)).toEqual({
+        '/en/blog/**': { swr: 60 },
+        '/fr/blog/**': { swr: 60 },
+      })
+    })
+
+    it('skips paths with multiple dynamic params after expansion', () => {
+      const pages = [page('/:locale(en|fr)/:foo/:bar', { swr: 60 })]
+      expect(collectRouteRulesFromPages(pages)).toEqual({})
+      expect(pages[0]!.rules).toBeUndefined()
+    })
+
+    it('collects rules from children of a compact parent', () => {
+      const pages = [
+        page('/:locale(en|fr)/parent', undefined, [page('child', { prerender: true })]),
+      ]
+      expect(collectRouteRulesFromPages(pages)).toEqual({
+        '/en/parent/child': { prerender: true },
+        '/fr/parent/child': { prerender: true },
+      })
+    })
+
+    it('removes rules from the pages, including empty rules', () => {
+      const pages = [page('/:locale(en|fr)/account', { prerender: true }), page('/about', {})]
+      collectRouteRulesFromPages(pages)
+      expect(pages[0]!.rules).toBeUndefined()
+      expect(pages[1]!.rules).toBeUndefined()
+    })
+
+    it('collects expanded and plain rules across localized routes', () => {
+      const config = createTestConfig({ locales, strategy: 'prefix_except_default', defaultLocale: 'en', compactRoutes: true })
+      const input: LocalizableRoute[] = [{ path: '/about', name: 'about', rules: { prerender: true } } as LocalizableRoute]
+      const result = localizeRoutes(input, config)
+
+      expect(collectRouteRulesFromPages(result as Parameters<typeof collectRouteRulesFromPages>[0])).toEqual({
+        '/about': { prerender: true },
+        '/fr/about': { prerender: true },
+        '/ja/about': { prerender: true },
+      })
+      expect(result.every(r => (r as { rules?: unknown }).rules === undefined)).toBe(true)
     })
   })
 


### PR DESCRIPTION
* Related https://github.com/nuxt/nuxt/pull/35455
* Related #3019

Proof of concept: this expands inline route rules on compact routes into separate per-locale rules (`/en/account`, `/nl/account`) instead of nuxt mapping these to `/**`. We consume all page rules before nuxt's collection and duplicate nuxt's `globRouteRulesFromPages`/`pathToNitroGlob` to do so, I suspect this approach might conflict with nuxt's inline route rules handling and needs a closer look.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for inline route rules on localized and compact routes.
  - Route-specific settings are now automatically applied across expanded locale paths, including nested and dynamic routes.
  - Existing route configuration is preserved and merged with inline rules.

- **Bug Fixes**
  - Improved handling of localized route patterns so their associated settings apply consistently to all generated paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->