### PR TITLE
perf: skip client locale chunks when using messages endpoint

### DIFF
--- a/specs/lazy_load/stripped_client_chunks.spec.ts
+++ b/specs/lazy_load/stripped_client_chunks.spec.ts
@@ -1,0 +1,31 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, test } from 'vitest'
+
+import { renderPage, waitForLocaleNetwork } from '../helper'
+import { setup, useTestContext } from '../utils'
+
+await setup({
+  rootDir: fileURLToPath(new URL(`../fixtures/lazy`, import.meta.url)),
+  browser: true
+})
+
+describe('client locale chunks stripped in endpoint mode', () => {
+  test('client assets contain no bundled locale messages', async () => {
+    // ssr builds always load messages from the endpoint, so client locale chunks are not emitted
+    const assetsDir = join(useTestContext().nuxt!.options.nitro.output!.dir!, 'public/_nuxt')
+    const chunks = readdirSync(assetsDir).filter(x => x.endsWith('.js'))
+    expect(chunks.length).toBeGreaterThan(0)
+    for (const chunk of chunks) {
+      expect(readFileSync(join(assetsDir, chunk), 'utf8')).not.toContain('Homepage')
+    }
+  })
+
+  test('client-side locale switch fetches messages from the endpoint', async () => {
+    const { page } = await renderPage('/')
+
+    await Promise.all([waitForLocaleNetwork(page, 'fr', 'response'), page.click('#nuxt-locale-link-fr')])
+    expect(await page.locator('#home-header').innerText()).toEqual('Accueil')
+  })
+})

--- a/src/template.ts
+++ b/src/template.ts
@@ -75,9 +75,18 @@ export function generateTemplateNuxtI18nOptions(
         '}',
       ].join('\n\n')
 
+  // the production client only imports locale files when `dynamicResourcesSSG` (runtime/context.ts)
+  // resolves to true - in endpoint mode the loaders are unreachable, stubbing them behind
+  // `import.meta.client` (folded per graph) skips compiling and emitting client locale chunks
+  const stripClientLoaders = !server
+    && !nuxt.options.dev
+    && nuxt.options.ssr
+    && (ctx.fullStatic || !nuxt.options.nitro.static)
+  const clientLoad = (load: string) => (stripClientLoaders ? `import.meta.client ? () => Promise.resolve({}) : ${load}` : load)
+
   const localeLoaderEntries: Record<string, { key: string, load: string, cache: boolean }[]> = {}
   for (const locale in opts.localeLoaders) {
-    localeLoaderEntries[locale] = opts.localeLoaders[locale]!.map(({ key, load, loadServer, cache }) => ({ key, load: server ? loadServer : load, cache }))
+    localeLoaderEntries[locale] = opts.localeLoaders[locale]!.map(({ key, load, loadServer, cache }) => ({ key, load: server ? loadServer : clientLoad(load), cache }))
   }
 
   return `// @ts-nocheck


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
We can omit the locale files from the client bundle when messages are always loaded through the server endpoint. Should reduce bundle size and speed up client build a bit.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced client bundle size by excluding locale messages from production client assets when endpoint loading is enabled.

* **Bug Fixes**
  * Fixed client-side locale switching so translations continue loading correctly through the locale endpoint.
  * Added coverage to verify locale messages are not bundled while switching to French still updates the interface correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->