### PR TITLE
refactor: consolidate build-time context resolution

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -1,6 +1,6 @@
 import { addBuildPlugin, addVitePlugin, addWebpackPlugin, useNuxt } from '@nuxt/kit'
 import VueI18nPlugin from '@intlify/unplugin-vue-i18n'
-import { getLocaleFilePaths, toArray } from './utils'
+import { toArray } from './utils'
 import { TransformMacroPlugin } from './transform/macros'
 import { ResourcePlugin } from './transform/resource'
 import { JsonParseMessagesPlugin, STATIC_RESOURCE_RE } from './transform/json-parse'
@@ -11,11 +11,11 @@ import { addDefinePlugin } from 'nuxt-define'
 import type { Nuxt } from '@nuxt/schema'
 import type { PluginOptions } from '@intlify/unplugin-vue-i18n'
 import type { BundlerPluginOptions } from './transform/utils'
-import type { I18nNuxtContext } from './context'
+import type { ResolvedI18nContext } from './context'
 import { DEFAULT_COOKIE_KEY, DYNAMIC_PARAMS_KEY, FULL_STATIC_LIFETIME, SWITCH_LOCALE_PATH_LINK_IDENTIFIER } from './constants'
 import { version } from '../package.json'
 
-export async function extendBundler(ctx: I18nNuxtContext, nuxt: Nuxt) {
+export async function extendBundler(ctx: ResolvedI18nContext, nuxt: Nuxt) {
   /**
    * shared plugins (nuxt/nitro)
    */
@@ -41,8 +41,7 @@ export async function extendBundler(ctx: I18nNuxtContext, nuxt: Nuxt) {
    */
   // exclude dynamic locale files - optimization is a no-op for these, and since vite 8 matching them
   // makes unplugin-vue-i18n load them raw during dev SSR, skipping the `defineI18nLocale` transform (#4049)
-  const localePaths = getLocaleFilePaths(ctx.localeInfo.map(x => ({ ...x, meta: x.meta.filter(m => m.type !== 'dynamic') })))
-  ctx.fullStatic = ctx.localeInfo.flatMap(x => x.meta).every(x => x.type === 'static' || x.cache !== false)
+  const localePaths = [...new Set(ctx.localeFileMetas.filter(m => m.type !== 'dynamic').map(m => m.path))]
 
   const vueI18nPluginOptions: PluginOptions = {
     ...ctx.options.bundle,
@@ -82,7 +81,7 @@ export async function extendBundler(ctx: I18nNuxtContext, nuxt: Nuxt) {
 }
 
 export function getDefineConfig(
-  { options, fullStatic, localeHashes }: I18nNuxtContext,
+  { options, fullStatic, localeHashes }: ResolvedI18nContext,
   server = false,
   nuxt = useNuxt(),
 ) {

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -81,7 +81,7 @@ export async function extendBundler(ctx: ResolvedI18nContext, nuxt: Nuxt) {
 }
 
 export function getDefineConfig(
-  { options, fullStatic, localeHashes }: ResolvedI18nContext,
+  { options, rawOptions, fullStatic, localeHashes }: ResolvedI18nContext,
   server = false,
   nuxt = useNuxt(),
 ) {
@@ -89,10 +89,7 @@ export function getDefineConfig(
   const isCacheEnabled = cacheLifetime >= 0 && (!nuxt.options.dev || !!options.experimental.devCache)
 
   // `stripMessagesPayload` is enabled by default when `experimental.preload` is set to true
-  let stripMessagesPayload = !!options.experimental.preload
-  if (nuxt.options.i18n && nuxt.options.i18n.experimental?.stripMessagesPayload != null) {
-    stripMessagesPayload = nuxt.options.i18n.experimental.stripMessagesPayload
-  }
+  const stripMessagesPayload = rawOptions.experimental?.stripMessagesPayload ?? !!options.experimental.preload
 
   const common = {
     __IS_SSR__: String(nuxt.options.ssr),

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,24 +1,38 @@
 import { createResolver } from '@nuxt/kit'
 import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'pathe'
+import { assign, isString } from '@intlify/shared'
+import { applyLayerOptions, resolveLayerVueI18nConfigInfo } from './layers'
+import { computeLocaleHashes, filterLocales, getLayerI18n, normalizeDomainLocale, resolveLocales, validateLocaleCodes } from './utils'
+import { generateLoaderOptions } from './gen'
+
 import type { Resolver } from '@nuxt/kit'
 import type { FileMeta, LocaleInfo, LocaleObject, NuxtI18nOptions } from './types'
 import type { Nuxt, NuxtConfigLayer } from '@nuxt/schema'
-import { getLayerI18n } from './utils'
 
 export interface I18nNuxtContext {
   resolver: Resolver
-  userOptions: NuxtI18nOptions
   options: Required<NuxtI18nOptions>
+  distDir: string
+  runtimeDir: string
+  i18nLayers: LayerWithI18n[]
+}
+
+/**
+ * Locale-derived context, resolved in `modules:done` once all modules have registered locales.
+ */
+export interface ResolvedI18nContext extends I18nNuxtContext {
   normalizedLocales: LocaleObject<string>[]
   localeCodes: string[]
   localeInfo: LocaleInfo[]
+  /** flattened `localeInfo` file metas */
+  localeFileMetas: FileMeta[]
+  /** unique resolved locale file paths */
+  localeFilePaths: string[]
   vueI18nConfigPaths: Omit<FileMeta, 'cache'>[]
-  distDir: string
-  runtimeDir: string
-  fullStatic: boolean
   localeHashes: Record<string, string>
-  i18nLayers: LayerWithI18n[]
+  fullStatic: boolean
+  loaderOptions: ReturnType<typeof generateLoaderOptions>
 }
 
 type LayerWithI18n = { config: NuxtConfigLayer, i18n: Partial<NuxtI18nOptions>, i18nDir: string, i18nDetector?: string }
@@ -38,18 +52,39 @@ export function createContext(userOptions: NuxtI18nOptions, nuxt: Nuxt): I18nNux
     i18nLayers.push({ config: l, i18n, i18nDir, i18nDetector })
   }
 
-  return {
-    options,
-    resolver,
-    userOptions,
-    distDir,
-    runtimeDir,
-    i18nLayers,
-    localeInfo: undefined!,
-    localeCodes: undefined!,
-    normalizedLocales: undefined!,
-    vueI18nConfigPaths: undefined!,
-    fullStatic: undefined!,
-    localeHashes: undefined!,
-  }
+  return { options, resolver, distDir, runtimeDir, i18nLayers }
+}
+
+export async function resolveContext(ctx: I18nNuxtContext, nuxt: Nuxt): Promise<ResolvedI18nContext> {
+  ctx.options.locales = await applyLayerOptions(ctx, nuxt)
+  ctx.options.locales = filterLocales(ctx)
+
+  const normalizedLocales = ctx.options.locales.map(x =>
+    normalizeDomainLocale(isString(x) ? { code: x, language: x } : x),
+  )
+  const localeCodes = normalizedLocales.map(locale => locale.code)
+  validateLocaleCodes(localeCodes)
+
+  const localeInfo = resolveLocales(nuxt.options.srcDir, normalizedLocales, nuxt.vfs)
+  const localeFileMetas = localeInfo.flatMap(x => x.meta)
+  const vueI18nConfigPaths = await resolveLayerVueI18nConfigInfo(ctx)
+
+  const resolved = assign(ctx as ResolvedI18nContext, {
+    normalizedLocales,
+    localeCodes,
+    localeInfo,
+    localeFileMetas,
+    localeFilePaths: [...new Set(localeFileMetas.map(meta => meta.path))],
+    vueI18nConfigPaths,
+    /**
+     * content-hash locale files now that all locales and configs are known,
+     * used to cache-bust per-locale message server routes without churning
+     * on every build
+     */
+    localeHashes: computeLocaleHashes(localeInfo, vueI18nConfigPaths),
+    fullStatic: localeFileMetas.every(meta => meta.type === 'static' || meta.cache !== false),
+  })
+  resolved.loaderOptions = generateLoaderOptions(resolved)
+
+  return resolved
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -13,6 +13,8 @@ import type { Nuxt, NuxtConfigLayer } from '@nuxt/schema'
 export interface I18nNuxtContext {
   resolver: Resolver
   options: Required<NuxtI18nOptions>
+  /** `nuxt.options.i18n` unmerged with defaults, to detect explicitly set options */
+  rawOptions: Partial<NuxtI18nOptions>
   distDir: string
   runtimeDir: string
   i18nLayers: LayerWithI18n[]
@@ -42,6 +44,8 @@ const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))
 
 export function createContext(userOptions: NuxtI18nOptions, nuxt: Nuxt): I18nNuxtContext {
   const options = userOptions as Required<NuxtI18nOptions>
+  // the `i18n` key may be configured with a falsy non-object value (#3900)
+  const rawOptions = (nuxt.options.i18n || {}) as Partial<NuxtI18nOptions>
 
   const i18nLayers: LayerWithI18n[] = []
   for (const l of nuxt.options._layers) {
@@ -52,7 +56,7 @@ export function createContext(userOptions: NuxtI18nOptions, nuxt: Nuxt): I18nNux
     i18nLayers.push({ config: l, i18n, i18nDir, i18nDetector })
   }
 
-  return { options, resolver, distDir, runtimeDir, i18nLayers }
+  return { options, rawOptions, resolver, distDir, runtimeDir, i18nLayers }
 }
 
 export async function resolveContext(ctx: I18nNuxtContext, nuxt: Nuxt): Promise<ResolvedI18nContext> {

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -1,4 +1,4 @@
-import { isString } from '@intlify/shared'
+import { assign, isString } from '@intlify/shared'
 import { genDynamicImport, genImport, genSafeVariableName, genString } from 'knitwork'
 import { basename, join, relative, resolve } from 'pathe'
 import { asI18nVirtual } from './transform/utils'
@@ -6,15 +6,17 @@ import { normalizeDomainLocale } from './utils'
 
 import type { Nuxt } from '@nuxt/schema'
 import type { LocaleObject } from './types'
-import type { I18nNuxtContext } from './context'
+import type { ResolvedI18nContext } from './context'
 
+// copy - generators run repeatedly (template re-emits) and must not alter context locales
 function stripLocaleFiles(locale: LocaleObject) {
-  delete locale.files
-  delete locale.file
-  return locale
+  const stripped = assign({}, locale)
+  delete stripped.files
+  delete stripped.file
+  return stripped
 }
 
-export function simplifyLocaleOptions(ctx: I18nNuxtContext, _nuxt: Nuxt) {
+export function simplifyLocaleOptions(ctx: ResolvedI18nContext, _nuxt: Nuxt) {
   const locales = (ctx.options.locales ?? []) as LocaleObject[]
   const hasLocaleObjects = locales?.some(x => !isString(x))
   // normalize so runtime locale consumers (e.g. `defaultForDomains` reads) only handle one shape
@@ -30,7 +32,7 @@ type LocaleLoaderData = {
 }
 
 export function generateLoaderOptions(
-  ctx: Pick<I18nNuxtContext, 'options' | 'vueI18nConfigPaths' | 'localeInfo' | 'normalizedLocales'>,
+  ctx: Pick<ResolvedI18nContext, 'options' | 'vueI18nConfigPaths' | 'localeInfo' | 'normalizedLocales'>,
 ) {
   /**
    * Prepare locale file imports
@@ -184,8 +186,8 @@ declare module 'vue-router' {
   }
 }`
 
-export function generateI18nTypes(nuxt: Nuxt, ctx: I18nNuxtContext) {
-  const legacyTypes = ctx.userOptions.types === 'legacy'
+export function generateI18nTypes(nuxt: Nuxt, ctx: ResolvedI18nContext) {
+  const legacyTypes = ctx.options.types === 'legacy'
   const i18nType = legacyTypes ? 'VueI18n' : 'Composer'
   const generatedLocales = simplifyLocaleOptions(ctx, nuxt)
   const resolvedLocaleType = isString(generatedLocales.at(0)) ? 'Locale[]' : 'LocaleObject[]'
@@ -245,7 +247,7 @@ declare module 'vue-router' {
 
 ${typedRouterAugmentations}
 
-${(ctx.userOptions.autoDeclare && globalTranslationTypes) || ''}
+${(ctx.options.autoDeclare && globalTranslationTypes) || ''}
 
 export {}`
 }

--- a/src/layers.ts
+++ b/src/layers.ts
@@ -1,5 +1,5 @@
 import { findPath, useNuxt } from '@nuxt/kit'
-import { getLayerI18n, getLocaleFiles, logger, mergeConfigLocales, resolveVueI18nConfigInfo } from './utils'
+import { getLocaleFiles, logger, mergeConfigLocales, resolveVueI18nConfigInfo } from './utils'
 
 import { isAbsolute, resolve } from 'pathe'
 import { assign, isString } from '@intlify/shared'
@@ -7,17 +7,13 @@ import { EXECUTABLE_EXTENSIONS } from './constants'
 
 import type { LocaleConfig } from './utils'
 import type { Nuxt } from '@nuxt/schema'
-import type { FileMeta, LocaleObject, NuxtI18nOptions } from './types'
+import type { FileMeta, LocaleObject } from './types'
 import type { I18nNuxtContext } from './context'
 
-export function checkLayerOptions(_options: NuxtI18nOptions, nuxt: Nuxt) {
+export function checkLayerOptions(ctx: I18nNuxtContext, nuxt: Nuxt) {
   const project = nuxt.options._layers[0]!
-  const layers = nuxt.options._layers
 
-  for (const layer of layers) {
-    const layerI18n = getLayerI18n(layer)
-    if (layerI18n == null) { continue }
-
+  for (const { config: layer, i18n: layerI18n } of ctx.i18nLayers) {
     const configLocation = project.config.rootDir === layer.config.rootDir ? 'project' : 'extended'
     const layerHint = `In ${configLocation} layer (\`${resolve(project.config.rootDir, layer.configFile)}\`) -`
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -7,15 +7,12 @@ import { DEFAULT_OPTIONS } from './constants'
 import type { HookResult } from '@nuxt/schema'
 import type { I18nPublicRuntimeConfig, LocaleObject, NuxtI18nOptions } from './types'
 import type { Locale } from 'vue-i18n'
-import { createContext } from './context'
+import { createContext, resolveContext } from './context'
 import { prepareOptions } from './prepare/options'
 import { prepareTypeGeneration } from './prepare/type-generation'
 import { relative } from 'pathe'
 import { generateTemplateNuxtI18nOptions } from './template'
-import { generateI18nTypes, generateLoaderOptions, simplifyLocaleOptions } from './gen'
-import { applyLayerOptions, resolveLayerVueI18nConfigInfo } from './layers'
-import { computeLocaleHashes, filterLocales, getLocaleFilePaths, normalizeDomainLocale, resolveLocales, validateLocaleCodes } from './utils'
-import { isString } from '@intlify/shared'
+import { generateI18nTypes, simplifyLocaleOptions } from './gen'
 
 export * from './types'
 
@@ -129,20 +126,6 @@ export default defineNuxtModule<NuxtI18nOptions>({
     addPlugin(ctx.resolver.resolve('./runtime/plugins/ssg-detect'))
     addPlugin(ctx.resolver.resolve('./runtime/plugins/switch-locale-path-ssr'))
 
-    addTemplate({
-      filename: 'i18n-options.mjs',
-      getContents: () => generateTemplateNuxtI18nOptions(ctx, generateLoaderOptions(ctx)),
-    })
-
-    /**
-     * `$i18n` type narrowing based on 'legacy' or 'composition'
-     * `locales` type narrowing based on generated configuration
-     */
-    addTypeTemplate({
-      filename: 'types/i18n-plugin.d.ts',
-      getContents: () => generateI18nTypes(nuxt, ctx),
-    })
-
     /**
      * HMR plugin
      */
@@ -174,40 +157,37 @@ export default defineNuxtModule<NuxtI18nOptions>({
      * allow other modules to register i18n hooks - locales and options will be resolved in this hook
      */
     nuxt.hook('modules:done', async () => {
-      ctx.options.locales = await applyLayerOptions(ctx, nuxt)
-      ctx.options.locales = filterLocales(ctx, nuxt)
+      const resolved = await resolveContext(ctx, nuxt)
 
-      ctx.normalizedLocales = ctx.options.locales.map(x =>
-        normalizeDomainLocale(isString(x) ? { code: x, language: x } : x),
-      )
-      ctx.localeCodes = ctx.normalizedLocales.map(locale => locale.code)
-      validateLocaleCodes(ctx.localeCodes)
-      ctx.localeInfo = resolveLocales(nuxt.options.srcDir, ctx.normalizedLocales, nuxt.vfs)
-
-      ctx.vueI18nConfigPaths = await resolveLayerVueI18nConfigInfo(ctx)
+      addTemplate({
+        filename: 'i18n-options.mjs',
+        getContents: () => generateTemplateNuxtI18nOptions(resolved),
+      })
 
       /**
-       * content-hash locale files now that all locales and configs are known,
-       * used to cache-bust per-locale message server routes without churning
-       * on every build
+       * `$i18n` type narrowing based on 'legacy' or 'composition'
+       * `locales` type narrowing based on generated configuration
        */
-      ctx.localeHashes = computeLocaleHashes(ctx.localeInfo, ctx.vueI18nConfigPaths)
+      addTypeTemplate({
+        filename: 'types/i18n-plugin.d.ts',
+        getContents: () => generateI18nTypes(nuxt, resolved),
+      })
 
       /**
        * expose i18n options via runtime config for use in app/server contexts
        */
       // @ts-expect-error generated type
       nuxt.options.runtimeConfig.public.i18n = defu(nuxt.options.runtimeConfig.public.i18n, {
-        baseUrl: ctx.options.baseUrl,
-        defaultLocale: ctx.options.defaultLocale,
-        rootRedirect: ctx.options.rootRedirect,
-        redirectStatusCode: ctx.options.redirectStatusCode,
-        skipSettingLocaleOnNavigate: ctx.options.skipSettingLocaleOnNavigate,
-        locales: ctx.options.locales,
-        detectBrowserLanguage: ctx.options.detectBrowserLanguage ?? DEFAULT_OPTIONS.detectBrowserLanguage,
-        experimental: ctx.options.experimental,
+        baseUrl: resolved.options.baseUrl,
+        defaultLocale: resolved.options.defaultLocale,
+        rootRedirect: resolved.options.rootRedirect,
+        redirectStatusCode: resolved.options.redirectStatusCode,
+        skipSettingLocaleOnNavigate: resolved.options.skipSettingLocaleOnNavigate,
+        locales: resolved.options.locales,
+        detectBrowserLanguage: resolved.options.detectBrowserLanguage ?? DEFAULT_OPTIONS.detectBrowserLanguage,
+        experimental: resolved.options.experimental,
         domainLocales: Object.fromEntries(
-          ctx.options.locales.map((l) => {
+          resolved.options.locales.map((l) => {
             if (typeof l === 'string') {
               return [l, { domain: '' }]
             }
@@ -216,13 +196,13 @@ export default defineNuxtModule<NuxtI18nOptions>({
         ) as I18nPublicRuntimeConfig['domainLocales'],
       })
 
-      nuxt.options.runtimeConfig.public.i18n.locales = simplifyLocaleOptions(ctx, nuxt)
+      nuxt.options.runtimeConfig.public.i18n.locales = simplifyLocaleOptions(resolved, nuxt)
 
       // Prerender the hashed messages routes into `.output/public/` so lazy-loaded messages ship
       // as static assets (uploadable to a CDN) instead of being served from the dynamic Nitro route.
-      if (ctx.options.experimental.prerenderMessages) {
-        const messagesRoutes = ctx.localeCodes.map(
-          locale => `${ctx.options.serverRoutePrefix}/${ctx.localeHashes[locale]}/${locale}/messages.json`,
+      if (resolved.options.experimental.prerenderMessages) {
+        const messagesRoutes = resolved.localeCodes.map(
+          locale => `${resolved.options.serverRoutePrefix}/${resolved.localeHashes[locale]}/${locale}/messages.json`,
         )
         nuxt.hook('nitro:config', (config) => {
           config.prerender ??= {}
@@ -235,7 +215,7 @@ export default defineNuxtModule<NuxtI18nOptions>({
        * disable preloading/prefetching of locale files
        */
       nuxt.hook('build:manifest', (manifest) => {
-        const langPaths = getLocaleFilePaths(ctx.localeInfo).map(x => relative(nuxt.options.srcDir, x))
+        const langPaths = resolved.localeFilePaths.map(x => relative(nuxt.options.srcDir, x))
 
         for (const key in manifest) {
           if (langPaths.some(x => key.startsWith(x))) {
@@ -245,11 +225,11 @@ export default defineNuxtModule<NuxtI18nOptions>({
         }
       })
 
-      await setupPages(ctx, nuxt)
+      await setupPages(resolved, nuxt)
 
-      await extendBundler(ctx, nuxt)
+      await extendBundler(resolved, nuxt)
 
-      await setupNitro(ctx, nuxt)
+      await setupNitro(resolved, nuxt)
     })
   },
 })

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -6,19 +6,18 @@ import yamlPlugin from '@rollup/plugin-yaml'
 import json5Plugin from '@miyaneee/rollup-plugin-json5'
 import { getDefineConfig } from './bundler'
 import { relative } from 'pathe'
-import { getLocaleFilePaths, logger, toArray } from './utils'
+import { logger, toArray } from './utils'
 import { EXECUTABLE_EXTENSIONS } from './constants'
 
 import type { Nuxt } from '@nuxt/schema'
-import type { LocaleInfo } from './types'
-import type { I18nNuxtContext } from './context'
-import { generateLoaderOptions } from './gen'
+import type { FileMeta } from './types'
+import type { ResolvedI18nContext } from './context'
 import { generateTemplateNuxtI18nOptions } from './template'
 
-export async function setupNitro(ctx: I18nNuxtContext, nuxt: Nuxt) {
+export async function setupNitro(ctx: ResolvedI18nContext, nuxt: Nuxt) {
   addServerTemplate({
     filename: '#internal/i18n-options.mjs',
-    getContents: () => generateTemplateNuxtI18nOptions(ctx, generateLoaderOptions(ctx), true),
+    getContents: () => generateTemplateNuxtI18nOptions(ctx, true),
   })
 
   addServerTemplate({
@@ -58,7 +57,7 @@ export async function setupNitro(ctx: I18nNuxtContext, nuxt: Nuxt) {
 
   nuxt.hook('nitro:config', async (nitroConfig) => {
     // inline module runtime in Nitro bundle
-    nitroConfig.externals = defu(nitroConfig.externals ?? {}, { inline: [ctx.resolver.resolve('./runtime'), ...getLocaleFilePaths(ctx.localeInfo)] })
+    nitroConfig.externals = defu(nitroConfig.externals ?? {}, { inline: [ctx.resolver.resolve('./runtime'), ...ctx.localeFilePaths] })
     nitroConfig.alias!['#i18n'] = ctx.resolver.resolve('./runtime/composables/index-server')
 
     // type the locale detector file in the server tsconfig, where `#i18n` resolves server composables
@@ -72,7 +71,7 @@ export async function setupNitro(ctx: I18nNuxtContext, nuxt: Nuxt) {
     nitroConfig.rollupConfig!.plugins = (await nitroConfig.rollupConfig!.plugins) || []
     nitroConfig.rollupConfig!.plugins = toArray(nitroConfig.rollupConfig!.plugins)
 
-    const localePathsByType = getResourcePathsGrouped(ctx.localeInfo)
+    const localePathsByType = getResourcePathsGrouped(ctx.localeFileMetas)
     // install server resource transform plugin for yaml / json5 format
     if (localePathsByType.yaml.length > 0) {
       nitroConfig.rollupConfig!.plugins.push(yamlPlugin({ include: localePathsByType.yaml }))
@@ -86,7 +85,7 @@ export async function setupNitro(ctx: I18nNuxtContext, nuxt: Nuxt) {
   })
 }
 
-async function resolveLocaleDetectorPath(ctx: I18nNuxtContext, nuxt: Nuxt) {
+async function resolveLocaleDetectorPath(ctx: ResolvedI18nContext, nuxt: Nuxt) {
   const detector = ctx.i18nLayers.find(l => !!l.i18nDetector)?.i18nDetector
   if (detector == null) { return { path: '', exists: false } }
 
@@ -99,11 +98,9 @@ async function resolveLocaleDetectorPath(ctx: I18nNuxtContext, nuxt: Nuxt) {
   return { path: resolved, exists }
 }
 
-function getResourcePathsGrouped(localeInfo: LocaleInfo[]) {
-  const groups: { yaml: string[], json5: string[] } = { yaml: [], json5: [] }
-  for (const locale of localeInfo) {
-    groups.yaml = groups.yaml.concat(locale.meta.filter(meta => /\.ya?ml$/.test(meta.path)).map(x => x.path))
-    groups.json5 = groups.json5.concat(locale.meta.filter(meta => /\.json5?$/.test(meta.path)).map(x => x.path))
+function getResourcePathsGrouped(fileMetas: FileMeta[]) {
+  return {
+    yaml: fileMetas.filter(meta => /\.ya?ml$/.test(meta.path)).map(x => x.path),
+    json5: fileMetas.filter(meta => /\.json5?$/.test(meta.path)).map(x => x.path),
   }
-  return groups
 }

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -15,7 +15,7 @@ import { transform } from './transform/resource'
 import type { Nuxt, NuxtPage, ResolvedNuxtTemplate } from '@nuxt/schema'
 import type { EditableTreeNode, Options as TypedRouterOptions } from 'vue-router/unplugin'
 import type { NuxtI18nOptions } from './types'
-import type { I18nNuxtContext } from './context'
+import type { ResolvedI18nContext } from './context'
 import type { ComputedRouteOptions, RouteOptionsResolver } from './kit/gen'
 import type { I18nRoute } from './runtime/composables'
 import { type CallExpression, type ExpressionStatement, type ObjectExpression, parseSync } from 'oxc-parser'
@@ -38,7 +38,7 @@ type NarrowedNuxtPage = Omit<NuxtPage, 'redirect' | 'children'> & {
   children?: NarrowedNuxtPage[]
 }
 
-export async function setupPages({ localeCodes, options, normalizedLocales }: I18nNuxtContext, nuxt: Nuxt) {
+export async function setupPages({ localeCodes, options, normalizedLocales }: ResolvedI18nContext, nuxt: Nuxt) {
   let routeResources: RouteResources = {
     localizedPaths: [],
     pathToI18nConfig: {},

--- a/src/prepare/options.ts
+++ b/src/prepare/options.ts
@@ -4,8 +4,9 @@ import { logger } from '../utils'
 import { checkLayerOptions } from '../layers'
 import { isString } from '@intlify/shared'
 
-export function prepareOptions({ options }: I18nNuxtContext, nuxt: Nuxt) {
-  checkLayerOptions(options, nuxt)
+export function prepareOptions(ctx: I18nNuxtContext, nuxt: Nuxt) {
+  const { options } = ctx
+  checkLayerOptions(ctx, nuxt)
 
   /**
    * Check conflicting options

--- a/src/prepare/options.ts
+++ b/src/prepare/options.ts
@@ -5,7 +5,7 @@ import { checkLayerOptions } from '../layers'
 import { isString } from '@intlify/shared'
 
 export function prepareOptions(ctx: I18nNuxtContext, nuxt: Nuxt) {
-  const { options } = ctx
+  const { options, rawOptions } = ctx
   checkLayerOptions(ctx, nuxt)
 
   /**
@@ -18,25 +18,22 @@ export function prepareOptions(ctx: I18nNuxtContext, nuxt: Nuxt) {
     )
   }
 
-  if (nuxt.options.i18n && nuxt.options.i18n.autoDeclare && nuxt.options.imports.autoImport === false) {
+  if (rawOptions.autoDeclare && nuxt.options.imports.autoImport === false) {
     logger.warn(
       'Disabling `autoImports` in Nuxt is not compatible with `autoDeclare`, either enable `autoImports` or disable `autoDeclare`.',
     )
   }
 
-  const strategy = (nuxt.options.i18n && nuxt.options.i18n.strategy) || options.strategy
-  const defaultLocale = (nuxt.options.i18n && nuxt.options.i18n.defaultLocale) || options.defaultLocale
-  const hasMultiDomainLocales = (nuxt.options.i18n && nuxt.options.i18n.multiDomainLocales) || options.multiDomainLocales
+  const { strategy, defaultLocale, multiDomainLocales } = options
 
-  if (strategy.endsWith('_default') && !defaultLocale && !hasMultiDomainLocales) {
+  if (strategy.endsWith('_default') && !defaultLocale && !multiDomainLocales) {
     logger.warn(
-      `The \`${strategy}\` i18n strategy${(nuxt.options.i18n && nuxt.options.i18n.strategy) == null ? ' (used by default)' : ''} needs \`defaultLocale\` to be set.`,
+      `The \`${strategy}\` i18n strategy${rawOptions.strategy == null ? ' (used by default)' : ''} needs \`defaultLocale\` to be set.`,
     )
   }
 
-  if (hasMultiDomainLocales) {
-    const locales = (nuxt.options.i18n && nuxt.options.i18n.locales) || options.locales || []
-    const hasDomainLocales = locales.some(locale => !isString(locale) && locale.domains?.length)
+  if (multiDomainLocales) {
+    const hasDomainLocales = (options.locales || []).some(locale => !isString(locale) && locale.domains?.length)
 
     if (!hasDomainLocales) {
       logger.warn(
@@ -55,7 +52,7 @@ export function prepareOptions(ctx: I18nNuxtContext, nuxt: Nuxt) {
     const conflicts: string[] = []
     if (strategy === 'no_prefix') { conflicts.push('`strategy: "no_prefix"`') }
     if (options.differentDomains) { conflicts.push('`differentDomains`') }
-    if (hasMultiDomainLocales) { conflicts.push('`multiDomainLocales`') }
+    if (multiDomainLocales) { conflicts.push('`multiDomainLocales`') }
     if (conflicts.length) {
       logger.warn(
         `\`experimental.compactRoutes\` is enabled but has no effect due to incompatible option(s): ${conflicts.join(', ')}. Routes will fall back to per-locale duplication.`,

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,7 +1,7 @@
 import { useNuxt } from '@nuxt/kit'
 import type { generateLoaderOptions } from './gen'
 import { genArrayFromRaw, genObjectFromRaw, genObjectFromValues, genString } from 'knitwork'
-import type { I18nNuxtContext } from './context'
+import type { ResolvedI18nContext } from './context'
 
 type TemplateNuxtI18nOptions = ReturnType<typeof generateLoaderOptions>
 
@@ -59,11 +59,11 @@ function genVueI18nConfigHMR(configs: TemplateNuxtI18nOptions['vueI18nConfigs'])
 }
 
 export function generateTemplateNuxtI18nOptions(
-  ctx: I18nNuxtContext,
-  opts: TemplateNuxtI18nOptions,
+  ctx: ResolvedI18nContext,
   server: boolean = false,
   nuxt = useNuxt(),
 ): string {
+  const opts = ctx.loaderOptions
   const codeHMR
     = nuxt.options.dev
       && ctx.options.hmr

--- a/src/transform/heist.ts
+++ b/src/transform/heist.ts
@@ -2,7 +2,7 @@ import MagicString from 'magic-string'
 import { createUnplugin } from 'unplugin'
 
 import type { BundlerPluginOptions } from './utils'
-import type { I18nNuxtContext } from '../context'
+import type { ResolvedI18nContext } from '../context'
 import { relative } from 'pathe'
 import { useNuxt } from '@nuxt/kit'
 
@@ -11,7 +11,7 @@ import { useNuxt } from '@nuxt/kit'
  * - replaces "#app" import with a mock variable definition
  * - replaces `useNuxtApp()` with the mock variable
  */
-export const HeistPlugin = (options: BundlerPluginOptions, ctx: I18nNuxtContext, nuxt = useNuxt()) => {
+export const HeistPlugin = (options: BundlerPluginOptions, ctx: ResolvedI18nContext, nuxt = useNuxt()) => {
   // transform `runtime/shared` to be nuxt/nitro context agnostic
   const shared = ctx.resolver.resolve(ctx.distDir, 'runtime/shared/*')
 

--- a/src/transform/json-parse.ts
+++ b/src/transform/json-parse.ts
@@ -5,7 +5,7 @@ import { parseJSON5, parseYAML } from 'confbox'
 import { createUnplugin } from 'unplugin'
 import { asI18nVirtual } from './utils'
 
-import type { I18nNuxtContext } from '../context'
+import type { ResolvedI18nContext } from '../context'
 
 const JSON_PARSE_VIRTUAL_PREFIX = '\0i18n-json-parse/'
 
@@ -45,10 +45,10 @@ function validateMessages(value: unknown, options: { strictMessage: boolean, esc
  * skipping bundler AST/sourcemap work over message data (precompiled message ASTs are ~3x raw size).
  * Must resolve before `ResourcePlugin`: both claim the `#nuxt-i18n/<hash>` ids at `enforce: 'pre'`.
  */
-export const JsonParseMessagesPlugin = (ctx: I18nNuxtContext) =>
+export const JsonParseMessagesPlugin = (ctx: ResolvedI18nContext) =>
   createUnplugin(() => {
     const virtualToPath = new Map<string, string>()
-    for (const fileMeta of ctx.localeInfo.flatMap(x => x.meta)) {
+    for (const fileMeta of ctx.localeFileMetas) {
       if (STATIC_RESOURCE_RE.test(fileMeta.path)) {
         virtualToPath.set(asI18nVirtual(fileMeta.hash), fileMeta.path)
       }

--- a/src/transform/resource.ts
+++ b/src/transform/resource.ts
@@ -8,7 +8,7 @@ import { transformSync as oxcTransform } from 'oxc-transform'
 import type { TransformOptions, TransformResult } from 'oxc-transform'
 
 import type { BundlerPluginOptions } from './utils'
-import type { I18nNuxtContext } from '../context'
+import type { ResolvedI18nContext } from '../context'
 
 export function transform(id: string, input: string, options?: TransformOptions): TransformResult {
   const oxcOptions = (tryUseNuxt()?.options?.oxc?.transform?.options ?? {}) as TransformOptions
@@ -17,10 +17,10 @@ export function transform(id: string, input: string, options?: TransformOptions)
 
 const DEFINE_I18N_FN_RE = /\b(defineI18nLocale|defineI18nConfig)\s*\((.+)\)/gs
 
-export const ResourcePlugin = (options: BundlerPluginOptions, ctx: I18nNuxtContext) =>
+export const ResourcePlugin = (options: BundlerPluginOptions, ctx: ResolvedI18nContext) =>
   createUnplugin(() => {
     // TODO: track all i18n files found in configuration
-    const i18nFileMetas = [...ctx.localeInfo.flatMap(x => x.meta), ...ctx.vueI18nConfigPaths]
+    const i18nFileMetas = [...ctx.localeFileMetas, ...ctx.vueI18nConfigPaths]
     const i18nPathSet = new Set<string>()
     const i18nFileHashSet = new Map<string, string>()
     for (const meta of i18nFileMetas) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,20 +8,13 @@ import { EXECUTABLE_EXT_RE } from './constants'
 import { parseSync } from 'oxc-parser'
 
 import type { FileMeta, LocaleFile, LocaleInfo, LocaleObject, LocaleType, NuxtI18nOptions } from './types'
-import type { Nuxt, NuxtConfigLayer } from '@nuxt/schema'
+import type { NuxtConfigLayer } from '@nuxt/schema'
 import type { IdentifierName, Program, VariableDeclarator } from 'oxc-parser'
 import type { I18nNuxtContext } from './context'
 
-export function filterLocales(ctx: I18nNuxtContext, nuxt: Nuxt) {
+export function filterLocales(ctx: I18nNuxtContext) {
   // use `onlyLocales` from the first layer that specifies it
-  let onlyLocales
-  for (const layer of nuxt.options._layers) {
-    const layerOnlyLocales = getLayerI18n(layer)?.bundle?.onlyLocales
-    if (layerOnlyLocales != null) {
-      onlyLocales = layerOnlyLocales
-      break
-    }
-  }
+  const onlyLocales = ctx.i18nLayers.map(layer => layer.i18n.bundle?.onlyLocales).find(x => x != null)
   const include = toArray(onlyLocales ?? []).filter(isString)
 
   if (!include.length) {
@@ -83,13 +76,6 @@ export function resolveLocales(srcDir: string, locales: LocaleObject[], vfs: Rec
   }
 
   return localesResolved
-}
-
-/**
- * Unique resolved locale file paths across all locales
- */
-export function getLocaleFilePaths(localeInfo: LocaleInfo[]): string[] {
-  return [...new Set(localeInfo.flatMap(locale => locale.meta.map(m => m.path)))]
 }
 
 const analyzedMap = { object: 'static', function: 'dynamic', unknown: 'unknown' } as const

--- a/test/resource-transform.test.ts
+++ b/test/resource-transform.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import { ResourcePlugin } from '../src/transform/resource'
 
-import type { I18nNuxtContext } from '../src/context'
+import type { ResolvedI18nContext } from '../src/context'
 
 function createPlugin(paths: string[]) {
   const ctx = {
-    localeInfo: [{ meta: paths.map(path => ({ path, hash: path })) }],
+    localeFileMetas: paths.map(path => ({ path, hash: path })),
     vueI18nConfigPaths: []
-  } as unknown as I18nNuxtContext
+  } as unknown as ResolvedI18nContext
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return ResourcePlugin({ sourcemap: false }, ctx).raw({}, { framework: 'vite' } as any) as any
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,7 +1,6 @@
 import { filterLocales, resolveLocales, validateLocaleCodes } from '../src/utils'
-import type { LocaleObject, NuxtI18nOptions } from '../src/types'
+import type { NuxtI18nOptions } from '../src/types'
 import type { I18nNuxtContext } from '../src/context'
-import type { Nuxt, NuxtConfigLayer } from '@nuxt/schema'
 import { vi, describe, test, expect } from 'vitest'
 
 vi.mock('pathe', async () => {
@@ -9,56 +8,47 @@ vi.mock('pathe', async () => {
   return { ...mod, resolve: vi.fn((...args: string[]) => mod.normalize(args.join('/'))) }
 })
 
-function createLayer(i18n?: NuxtI18nOptions): NuxtConfigLayer {
-  return { config: { i18n } } as unknown as NuxtConfigLayer
-}
-
-function createContext(locales: NuxtI18nOptions['locales']): I18nNuxtContext {
-  return { options: { locales } } as I18nNuxtContext
-}
-
-function createNuxt(layers: NuxtConfigLayer[]): Nuxt {
-  return { options: { _layers: layers } } as unknown as Nuxt
+function createContext(locales: NuxtI18nOptions['locales'], layerI18ns: NuxtI18nOptions[] = []): I18nNuxtContext {
+  return {
+    options: { locales },
+    i18nLayers: layerI18ns.map(i18n => ({ i18n })),
+  } as I18nNuxtContext
 }
 
 describe('filterLocales', () => {
   test('uses `onlyLocales` from the running project', () => {
-    const ctx = createContext(['en', 'fr', 'nl'])
-    const nuxt = createNuxt([
-      createLayer({ bundle: { onlyLocales: 'en' } }),
-      createLayer({ bundle: { onlyLocales: 'fr' } })
+    const ctx = createContext(['en', 'fr', 'nl'], [
+      { bundle: { onlyLocales: 'en' } },
+      { bundle: { onlyLocales: 'fr' } },
     ])
 
-    expect(filterLocales(ctx, nuxt)).toEqual(['en'])
+    expect(filterLocales(ctx)).toEqual(['en'])
   })
 
   test('falls back to the first downstream layer that specifies `onlyLocales`', () => {
-    const ctx = createContext(['en', 'fr', 'nl'])
-    const nuxt = createNuxt([
-      createLayer({}),
-      createLayer({ bundle: { onlyLocales: 'fr' } }),
-      createLayer({ bundle: { onlyLocales: 'nl' } })
+    const ctx = createContext(['en', 'fr', 'nl'], [
+      {},
+      { bundle: { onlyLocales: 'fr' } },
+      { bundle: { onlyLocales: 'nl' } },
     ])
 
-    expect(filterLocales(ctx, nuxt)).toEqual(['fr'])
+    expect(filterLocales(ctx)).toEqual(['fr'])
   })
 
   test('returns all locales when no layer specifies `onlyLocales`', () => {
-    const ctx = createContext(['en', 'fr', 'nl'])
-    const nuxt = createNuxt([createLayer({}), createLayer({ bundle: {} })])
+    const ctx = createContext(['en', 'fr', 'nl'], [{}, { bundle: {} }])
 
-    expect(filterLocales(ctx, nuxt)).toEqual(['en', 'fr', 'nl'])
+    expect(filterLocales(ctx)).toEqual(['en', 'fr', 'nl'])
   })
 
   test('treats an explicit empty `onlyLocales` as specified and stops the search', () => {
-    const ctx = createContext(['en', 'fr', 'nl'])
-    const nuxt = createNuxt([
-      createLayer({ bundle: { onlyLocales: [] } }),
-      createLayer({ bundle: { onlyLocales: 'fr' } })
+    const ctx = createContext(['en', 'fr', 'nl'], [
+      { bundle: { onlyLocales: [] } },
+      { bundle: { onlyLocales: 'fr' } },
     ])
 
     // empty `onlyLocales` means no filtering; the downstream `'fr'` must not be applied
-    expect(filterLocales(ctx, nuxt)).toEqual(['en', 'fr', 'nl'])
+    expect(filterLocales(ctx)).toEqual(['en', 'fr', 'nl'])
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Cleans up the fragmented property writes to the build time context.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Locale configuration is now resolved more consistently across layers and build stages.
  * Locale files and metadata are handled more reliably, including deduplication and filtering of dynamic resources.
  * Generated i18n options, types, pages, bundler settings, and server resources now use finalized locale configuration.
  * Locale filtering now respects layer-specific locale settings more accurately.
* **Bug Fixes**
  * Prevented locale configuration data from being unintentionally modified during repeated generation.
  * Improved handling of locale resources and static asset processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->