### PR TITLE
perf: avoid copying locale messages per ssr request

### DIFF
--- a/specs/fixtures/lazy/app/pages/merge-message.vue
+++ b/specs/fixtures/lazy/app/pages/merge-message.vue
@@ -1,0 +1,23 @@
+<script lang="ts" setup>
+import { useI18n } from '#i18n'
+import { useRoute } from '#imports'
+import { computed } from 'vue'
+
+const { mergeLocaleMessage, messages } = useI18n()
+const id = String(useRoute().query.id ?? 'none')
+
+mergeLocaleMessage('en', { [`merged-${id}`]: `merged ${id}` })
+
+const mergedKeys = computed(() =>
+  Object.keys(messages.value.en)
+    .filter(key => key.startsWith('merged-'))
+    .sort()
+    .join(',')
+)
+</script>
+
+<template>
+  <div>
+    <span id="merged-keys">{{ mergedKeys }}</span>
+  </div>
+</template>

--- a/specs/fixtures/lazy/app/pages/mutate-message.vue
+++ b/specs/fixtures/lazy/app/pages/mutate-message.vue
@@ -1,0 +1,25 @@
+<script lang="ts" setup>
+import { useI18n } from '#i18n'
+import { useState } from '#imports'
+
+const { messages, t } = useI18n()
+
+// cached messages are handed to vue-i18n by reference and deep-frozen - a direct nested
+// mutation must throw, which doubles as proof that the shared (not copied) path was taken
+const threw = useState('mutation-threw', () => false)
+if (import.meta.server) {
+  try {
+    // @ts-expect-error intentional stray mutation
+    messages.value.en.__direct = 'polluted'
+  } catch {
+    threw.value = true
+  }
+}
+</script>
+
+<template>
+  <div>
+    <span id="mutation-threw">{{ String(threw) }}</span>
+    <span id="translated">{{ t('home') }}</span>
+  </div>
+</template>

--- a/specs/fixtures/lazy/app/pages/mutate-message.vue
+++ b/specs/fixtures/lazy/app/pages/mutate-message.vue
@@ -4,13 +4,13 @@ import { useState } from '#imports'
 
 const { messages, t } = useI18n()
 
-// cached messages are handed to vue-i18n by reference and deep-frozen - a direct nested
-// mutation must throw, which doubles as proof that the shared (not copied) path was taken
+// cached messages are handed to vue-i18n by reference and deep-frozen - writing to a nested
+// message must throw, which doubles as proof that the shared (not copied) path was taken
 const threw = useState('mutation-threw', () => false)
 if (import.meta.server) {
   try {
     // @ts-expect-error intentional stray mutation
-    messages.value.en.__direct = 'polluted'
+    messages.value.en.nested.deep = 'polluted'
   } catch {
     threw.value = true
   }

--- a/specs/fixtures/lazy/i18n/lang/lazy-locale-en.json
+++ b/specs/fixtures/lazy/i18n/lang/lazy-locale-en.json
@@ -5,5 +5,8 @@
   "dynamic": "Dynamic",
   "html": "<span>This is the danger</span>",
   "dynamicTime": "Not dynamic",
-  "welcome": "Welcome!"
+  "welcome": "Welcome!",
+  "nested": {
+    "deep": "Deeply nested"
+  }
 }

--- a/specs/lazy_load/basic_lazy_load.spec.ts
+++ b/specs/lazy_load/basic_lazy_load.spec.ts
@@ -41,7 +41,7 @@ describe('basic lazy loading', async () => {
     // `en` present on initial load
     expect(await getLocalesMessageKeyCount(page)).toMatchInlineSnapshot(`
       {
-        "en": 7,
+        "en": 8,
       }
     `)
 
@@ -51,7 +51,7 @@ describe('basic lazy loading', async () => {
     // `fr` locale has been fetched
     expect(await getLocalesMessageKeyCount(page)).toMatchInlineSnapshot(`
       {
-        "en": 7,
+        "en": 8,
         "fr": 5,
       }
     `)
@@ -62,7 +62,7 @@ describe('basic lazy loading', async () => {
     // `nl` (module) locale has been fetched
     expect(await getLocalesMessageKeyCount(page)).toMatchInlineSnapshot(`
       {
-        "en": 7,
+        "en": 8,
         "fr": 5,
         "nl": 3,
       }

--- a/specs/lazy_load/message_isolation.spec.ts
+++ b/specs/lazy_load/message_isolation.spec.ts
@@ -29,6 +29,23 @@ describe('cached messages during SSR', () => {
     expect(await third.locator('#merged-keys')!.textContent()).toEqual('merged-c')
   })
 
+  test('cached messages are shared by reference and frozen', async () => {
+    // canary for the mechanism itself: direct mutation throws only when the store holds the
+    // frozen shared cache object - a fresh copy (e.g. a silent fallback to `$fetch`) would
+    // accept the write and this assertion would catch the regression
+    const dom = await getDom(await $fetch('/mutate-message'))
+    expect(await dom.locator('#mutation-threw')!.textContent()).toEqual('true')
+    expect(await dom.locator('#translated')!.textContent()).toEqual('Homepage')
+  })
+
+  test('merge after mutation attempt still isolates requests', async () => {
+    const merged = await getDom(await $fetch('/merge-message?id=z'))
+    expect(await merged.locator('#merged-keys')!.textContent()).toEqual('merged-z')
+
+    const canary = await getDom(await $fetch('/mutate-message'))
+    expect(await canary.locator('#mutation-threw')!.textContent()).toEqual('true')
+  })
+
   test('cached messages are still translated correctly', async () => {
     const dom = await getDom(await $fetch('/'))
     expect(await dom.locator('#home-header')!.textContent()).toEqual('Homepage')

--- a/specs/lazy_load/message_isolation.spec.ts
+++ b/specs/lazy_load/message_isolation.spec.ts
@@ -1,0 +1,36 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, test } from 'vitest'
+
+import { getDom } from '../helper'
+import { $fetch, setup } from '../utils'
+
+// `cacheLifetime` enables the message cache, which hands the same message object to every request
+await setup({
+  rootDir: fileURLToPath(new URL(`../fixtures/lazy`, import.meta.url)),
+  // overrides
+  nuxtConfig: {
+    i18n: {
+      experimental: {
+        cacheLifetime: 60
+      }
+    }
+  }
+})
+
+describe('cached messages during SSR', () => {
+  test('messages merged during a request do not leak into other requests', async () => {
+    const first = await getDom(await $fetch('/merge-message?id=a'))
+    expect(await first.locator('#merged-keys')!.textContent()).toEqual('merged-a')
+
+    const second = await getDom(await $fetch('/merge-message?id=b'))
+    expect(await second.locator('#merged-keys')!.textContent()).toEqual('merged-b')
+
+    const third = await getDom(await $fetch('/merge-message?id=c'))
+    expect(await third.locator('#merged-keys')!.textContent()).toEqual('merged-c')
+  })
+
+  test('cached messages are still translated correctly', async () => {
+    const dom = await getDom(await $fetch('/'))
+    expect(await dom.locator('#home-header')!.textContent()).toEqual('Homepage')
+  })
+})

--- a/specs/ssg/basic_lazy_load.spec.ts
+++ b/specs/ssg/basic_lazy_load.spec.ts
@@ -45,7 +45,7 @@ describe('basic lazy loading', async () => {
     // `en` present on initial load
     expect(await getLocalesMessageKeyCount(page)).toMatchInlineSnapshot(`
       {
-        "en": 7,
+        "en": 8,
       }
     `)
 
@@ -58,7 +58,7 @@ describe('basic lazy loading', async () => {
     // `fr` locale has been fetched
     expect(await getLocalesMessageKeyCount(page)).toMatchInlineSnapshot(`
       {
-        "en": 7,
+        "en": 8,
         "fr": 5,
       }
     `)
@@ -72,7 +72,7 @@ describe('basic lazy loading', async () => {
     // `nl` (module) locale has been fetched
     expect(await getLocalesMessageKeyCount(page)).toMatchInlineSnapshot(`
       {
-        "en": 7,
+        "en": 8,
         "fr": 5,
         "nl": 3,
       }

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -177,24 +177,27 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
       if (serverCtx?.loadMessages) {
         const messages = await serverCtx.loadMessages(locale)
         const flatJson = !!serverCtx.vueI18nOptions?.flatJson
-        // non-cacheable locales get a fresh object per load, so sharing would only add a
-        // pointless copy-on-write later; flatJson trees are rewritten in place by vue-i18n's merge
         const cacheable = getLocaleConfig(locale)?.cacheable ?? false
-        const canShare = shareLocaleMessage && cacheable && !flatJson
         for (const k of Object.keys(messages)) {
           const message = messages[k]
           if (message == null) { continue }
           // `mergeLocaleMessage` deep copies the whole tree - on a fresh instance there is nothing
-          // to merge with, so hand vue-i18n the cached object directly. (With `preload`, the
-          // payload plugin aliases the store objects and `loadMessages` fills them first, so the
-          // store is never empty here and sharing simply doesn't fire - both paths are correct.)
-          if (canShare && Object.keys(i18n.getLocaleMessage(k)).length === 0) {
-            shareLocaleMessage(k, message)
-          } else {
-            // vue-i18n's merge runs `handleFlatJson` on its *source* - a frozen cached tree must
-            // not be handed to it directly
-            i18n.mergeLocaleMessage(k, flatJson && cacheable ? cloneDeep(message) : message)
+          // to merge with, so hand vue-i18n the loaded object directly: the frozen shared cache
+          // with copy-on-write armed, or a request-fresh (non-cacheable) tree as-is. (With
+          // `preload`, the payload plugin aliases the store objects and `loadMessages` fills them
+          // first, so the store is never empty here and neither fast path fires.)
+          if (Object.keys(i18n.getLocaleMessage(k)).length === 0) {
+            // flatJson is the exception: `setLocaleMessage` runs `handleFlatJson` on its input,
+            // which a frozen cached tree must not undergo
+            if (shareLocaleMessage && cacheable && !flatJson) {
+              shareLocaleMessage(k, message)
+              continue
+            }
+            i18n.setLocaleMessage(k, flatJson && cacheable ? cloneDeep(message) : message)
+            continue
           }
+          // vue-i18n's merge also runs `handleFlatJson` on its *source*
+          i18n.mergeLocaleMessage(k, flatJson && cacheable ? cloneDeep(message) : message)
         }
         return
       }

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -130,6 +130,20 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
 
   const loadMessagesFromServer = async (locale: string) => {
     if (locale in localeLoaders === false) { return }
+
+    // during SSR the messages endpoint runs in this same process - calling it over `$fetch` would
+    // serialize the whole message tree to JSON and parse it back on every request
+    if (import.meta.server) {
+      const serverCtx = nuxt.ssrContext?.event?.context?.nuxtI18n
+      if (serverCtx?.loadMessages) {
+        const messages = await serverCtx.loadMessages(locale)
+        for (const k of Object.keys(messages)) {
+          i18n.mergeLocaleMessage(k, messages[k])
+        }
+        return
+      }
+    }
+
     const headers: HeadersInit = getLocaleConfig(locale)?.cacheable ? {} : { 'Cache-Control': 'no-cache' }
     // Client fetches from `app.cdnURL` when messages are prerendered as static assets;
     // SSR uses a relative URL so it doesn't round-trip through the CDN.

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -2,17 +2,17 @@ import { isRef, unref } from 'vue'
 
 import { useCookie, useRequestURL, useState } from '#imports'
 import { localeLoaders } from '#build/i18n-options.mjs'
-import { getLocaleMessagesMergedCached } from './shared/messages'
+import { cloneDeep, getLocaleMessagesMergedCached } from './shared/messages'
 import { createComposableContext } from './composable-context'
-import { getI18nTarget } from './compatibility'
+import { getComposer, getI18nTarget } from './compatibility'
 import { domainFromLocale } from './shared/domain'
 import { isSupportedLocale } from './shared/locales'
 import { resolveRootRedirect, useI18nDetection, useRuntimeI18n } from './shared/utils'
 import { joinURL } from 'ufo'
-import { deepCopy, isFunction, isString } from '@intlify/shared'
+import { isFunction, isString } from '@intlify/shared'
 
 import type { NuxtApp } from '#app'
-import type { DefineLocaleMessage, I18n, Locale, LocaleMessages } from 'vue-i18n'
+import type { Composer, DefineLocaleMessage, I18n, Locale, LocaleMessages } from 'vue-i18n'
 import type { ComposableContext } from './composable-context'
 import type {
   BaseUrlResolveHandler,
@@ -95,20 +95,25 @@ function useI18nCookie({ cookieCrossOrigin, cookieDomain, cookieSecure, cookieKe
 /**
  * Hands a locale's messages to vue-i18n by reference instead of deep copying them.
  *
- * The messages come from a cache shared by every request, so a locale has to be made request-local
+ * The messages come from a cache shared by every request (deep-frozen at cache time, so stray
+ * mutation throws instead of leaking between requests), and a locale has to be made request-local
  * again before anything merges into it - `mergeLocaleMessage` deep copies into its target, which
- * would otherwise write into that shared cache and leak between requests.
+ * would otherwise write into that shared cache.
+ *
+ * Wraps the composer, not the VueI18n facade: in legacy mode `useI18n()` and `<i18n>` blocks call
+ * the raw composer methods directly, and the facade delegates to the composer at call time anyway.
+ * @internal exported for unit tests
  */
-function createMessageSharer(i18n: ReturnType<typeof getI18nTarget>) {
+export function createMessageSharer(i18n: Pick<Composer, 'getLocaleMessage' | 'setLocaleMessage' | 'mergeLocaleMessage'>) {
   const shared = new Set<string>()
   const merge = i18n.mergeLocaleMessage.bind(i18n) as (locale: string, message: object) => void
   const set = i18n.setLocaleMessage.bind(i18n) as (locale: string, message: object) => void
 
   i18n.mergeLocaleMessage = ((locale: string, message: object) => {
     if (shared.delete(locale)) {
-      const unshared = {}
-      deepCopy(i18n.getLocaleMessage(locale), unshared)
-      set(locale, unshared)
+      // cloneDeep, not @intlify deepCopy: deepCopy assigns arrays by reference, which would keep
+      // the "private" tree aliased into the frozen cache
+      set(locale, cloneDeep(i18n.getLocaleMessage(locale)))
     }
     merge(locale, message)
   }) as typeof i18n.mergeLocaleMessage
@@ -127,7 +132,7 @@ function createMessageSharer(i18n: ReturnType<typeof getI18nTarget>) {
 
 export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocale: string): NuxtI18nContext {
   const i18n = getI18nTarget(vueI18n)
-  const shareLocaleMessage = import.meta.server ? createMessageSharer(i18n) : undefined
+  const shareLocaleMessage = import.meta.server ? createMessageSharer(getComposer(vueI18n)) : undefined
   const runtimeI18n = useRuntimeI18n(nuxt)
   const detectConfig = useI18nDetection(nuxt)
   const serverLocaleConfigs = useLocaleConfigs()
@@ -171,17 +176,24 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
       const serverCtx = nuxt.ssrContext?.event?.context?.nuxtI18n
       if (serverCtx?.loadMessages) {
         const messages = await serverCtx.loadMessages(locale)
-        // `flatJson` rewrites the message tree in place, which the shared cache must not undergo
-        const canShare = shareLocaleMessage && !serverCtx.vueI18nOptions?.flatJson
+        const flatJson = !!serverCtx.vueI18nOptions?.flatJson
+        // non-cacheable locales get a fresh object per load, so sharing would only add a
+        // pointless copy-on-write later; flatJson trees are rewritten in place by vue-i18n's merge
+        const cacheable = getLocaleConfig(locale)?.cacheable ?? false
+        const canShare = shareLocaleMessage && cacheable && !flatJson
         for (const k of Object.keys(messages)) {
           const message = messages[k]
           if (message == null) { continue }
           // `mergeLocaleMessage` deep copies the whole tree - on a fresh instance there is nothing
-          // to merge with, so hand vue-i18n the cached object directly
+          // to merge with, so hand vue-i18n the cached object directly. (With `preload`, the
+          // payload plugin aliases the store objects and `loadMessages` fills them first, so the
+          // store is never empty here and sharing simply doesn't fire - both paths are correct.)
           if (canShare && Object.keys(i18n.getLocaleMessage(k)).length === 0) {
             shareLocaleMessage(k, message)
           } else {
-            i18n.mergeLocaleMessage(k, message)
+            // vue-i18n's merge runs `handleFlatJson` on its *source* - a frozen cached tree must
+            // not be handed to it directly
+            i18n.mergeLocaleMessage(k, flatJson && cacheable ? cloneDeep(message) : message)
           }
         }
         return

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -92,47 +92,48 @@ function useI18nCookie({ cookieCrossOrigin, cookieDomain, cookieSecure, cookieKe
   })
 }
 
+type MessageStore = Pick<Composer, 'getLocaleMessage' | 'setLocaleMessage' | 'mergeLocaleMessage'>
+
 /**
- * Hands a locale's messages to vue-i18n by reference instead of deep copying them.
+ * Returns a function installing loaded messages into `i18n`, by reference where the locale is
+ * empty. Installed trees may be shared with the message cache, so `mergeLocaleMessage` - which
+ * deep copies into its target - gets a private copy first.
  *
- * The messages come from a cache shared by every request (deep-frozen at cache time, so stray
- * mutation throws instead of leaking between requests), and a locale has to be made request-local
- * again before anything merges into it - `mergeLocaleMessage` deep copies into its target, which
- * would otherwise write into that shared cache.
- *
- * Wraps the composer, not the VueI18n facade: in legacy mode `useI18n()` and `<i18n>` blocks call
- * the raw composer methods directly, and the facade delegates to the composer at call time anyway.
- * @internal exported for unit tests
+ * Patches the composer, not the VueI18n facade: legacy `useI18n()` and `<i18n>` blocks reach
+ * composer methods directly, and the facade delegates to it at call time.
+ * @internal exported for testing
  */
-export function createMessageSharer(i18n: Pick<Composer, 'getLocaleMessage' | 'setLocaleMessage' | 'mergeLocaleMessage'>) {
-  const shared = new Set<string>()
+export function createMessageInstaller(i18n: MessageStore) {
+  const byRef = new Set<string>()
   const merge = i18n.mergeLocaleMessage.bind(i18n) as (locale: string, message: object) => void
   const set = i18n.setLocaleMessage.bind(i18n) as (locale: string, message: object) => void
 
   i18n.mergeLocaleMessage = ((locale: string, message: object) => {
-    if (shared.delete(locale)) {
-      // cloneDeep, not @intlify deepCopy: deepCopy assigns arrays by reference, which would keep
-      // the "private" tree aliased into the frozen cache
+    // `deepCopy` shares arrays, which would leave the copy aliased into the cache
+    if (byRef.delete(locale)) {
       set(locale, cloneDeep(i18n.getLocaleMessage(locale)))
     }
     merge(locale, message)
   }) as typeof i18n.mergeLocaleMessage
 
-  // replaces the reference rather than mutating it, so the shared messages stay untouched
   i18n.setLocaleMessage = ((locale: string, message: object) => {
-    shared.delete(locale)
+    byRef.delete(locale)
     set(locale, message)
   }) as typeof i18n.setLocaleMessage
 
   return (locale: string, message: object) => {
+    if (Object.keys(i18n.getLocaleMessage(locale)).length > 0) {
+      i18n.mergeLocaleMessage(locale, message)
+      return
+    }
     set(locale, message)
-    shared.add(locale)
+    byRef.add(locale)
   }
 }
 
 export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocale: string): NuxtI18nContext {
   const i18n = getI18nTarget(vueI18n)
-  const shareLocaleMessage = import.meta.server ? createMessageSharer(getComposer(vueI18n)) : undefined
+  const installMessages = import.meta.server ? createMessageInstaller(getComposer(vueI18n)) : undefined
   const runtimeI18n = useRuntimeI18n(nuxt)
   const detectConfig = useI18nDetection(nuxt)
   const serverLocaleConfigs = useLocaleConfigs()
@@ -170,37 +171,15 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
   const loadMessagesFromServer = async (locale: string) => {
     if (locale in localeLoaders === false) { return }
 
-    // during SSR the messages endpoint runs in this same process - calling it over `$fetch` would
-    // serialize the whole message tree to JSON and parse it back on every request
-    if (import.meta.server) {
-      const serverCtx = nuxt.ssrContext?.event?.context?.nuxtI18n
-      if (serverCtx?.loadMessages) {
-        const messages = await serverCtx.loadMessages(locale)
-        const flatJson = !!serverCtx.vueI18nOptions?.flatJson
-        const cacheable = getLocaleConfig(locale)?.cacheable ?? false
-        for (const k of Object.keys(messages)) {
-          const message = messages[k]
-          if (message == null) { continue }
-          // `mergeLocaleMessage` deep copies the whole tree - on a fresh instance there is nothing
-          // to merge with, so hand vue-i18n the loaded object directly: the frozen shared cache
-          // with copy-on-write armed, or a request-fresh (non-cacheable) tree as-is. (With
-          // `preload`, the payload plugin aliases the store objects and `loadMessages` fills them
-          // first, so the store is never empty here and neither fast path fires.)
-          if (Object.keys(i18n.getLocaleMessage(k)).length === 0) {
-            // flatJson is the exception: `setLocaleMessage` runs `handleFlatJson` on its input,
-            // which a frozen cached tree must not undergo
-            if (shareLocaleMessage && cacheable && !flatJson) {
-              shareLocaleMessage(k, message)
-              continue
-            }
-            i18n.setLocaleMessage(k, flatJson && cacheable ? cloneDeep(message) : message)
-            continue
-          }
-          // vue-i18n's merge also runs `handleFlatJson` on its *source*
-          i18n.mergeLocaleMessage(k, flatJson && cacheable ? cloneDeep(message) : message)
-        }
-        return
+    // during SSR the messages endpoint runs in this same process - `$fetch` would serialize the
+    // whole message tree to JSON and parse it back on every request
+    const serverCtx = import.meta.server ? nuxt.ssrContext?.event?.context?.nuxtI18n : undefined
+    if (serverCtx?.loadMessages && installMessages) {
+      const messages = await serverCtx.loadMessages(locale)
+      for (const k of Object.keys(messages)) {
+        installMessages(k, messages[k]!)
       }
+      return
     }
 
     const headers: HeadersInit = getLocaleConfig(locale)?.cacheable ? {} : { 'Cache-Control': 'no-cache' }

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -9,7 +9,7 @@ import { domainFromLocale } from './shared/domain'
 import { isSupportedLocale } from './shared/locales'
 import { resolveRootRedirect, useI18nDetection, useRuntimeI18n } from './shared/utils'
 import { joinURL } from 'ufo'
-import { isFunction, isString } from '@intlify/shared'
+import { deepCopy, isFunction, isString } from '@intlify/shared'
 
 import type { NuxtApp } from '#app'
 import type { DefineLocaleMessage, I18n, Locale, LocaleMessages } from 'vue-i18n'
@@ -92,8 +92,42 @@ function useI18nCookie({ cookieCrossOrigin, cookieDomain, cookieSecure, cookieKe
   })
 }
 
+/**
+ * Hands a locale's messages to vue-i18n by reference instead of deep copying them.
+ *
+ * The messages come from a cache shared by every request, so a locale has to be made request-local
+ * again before anything merges into it - `mergeLocaleMessage` deep copies into its target, which
+ * would otherwise write into that shared cache and leak between requests.
+ */
+function createMessageSharer(i18n: ReturnType<typeof getI18nTarget>) {
+  const shared = new Set<string>()
+  const merge = i18n.mergeLocaleMessage.bind(i18n) as (locale: string, message: object) => void
+  const set = i18n.setLocaleMessage.bind(i18n) as (locale: string, message: object) => void
+
+  i18n.mergeLocaleMessage = ((locale: string, message: object) => {
+    if (shared.delete(locale)) {
+      const unshared = {}
+      deepCopy(i18n.getLocaleMessage(locale), unshared)
+      set(locale, unshared)
+    }
+    merge(locale, message)
+  }) as typeof i18n.mergeLocaleMessage
+
+  // replaces the reference rather than mutating it, so the shared messages stay untouched
+  i18n.setLocaleMessage = ((locale: string, message: object) => {
+    shared.delete(locale)
+    set(locale, message)
+  }) as typeof i18n.setLocaleMessage
+
+  return (locale: string, message: object) => {
+    set(locale, message)
+    shared.add(locale)
+  }
+}
+
 export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocale: string): NuxtI18nContext {
   const i18n = getI18nTarget(vueI18n)
+  const shareLocaleMessage = import.meta.server ? createMessageSharer(i18n) : undefined
   const runtimeI18n = useRuntimeI18n(nuxt)
   const detectConfig = useI18nDetection(nuxt)
   const serverLocaleConfigs = useLocaleConfigs()
@@ -137,8 +171,18 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
       const serverCtx = nuxt.ssrContext?.event?.context?.nuxtI18n
       if (serverCtx?.loadMessages) {
         const messages = await serverCtx.loadMessages(locale)
+        // `flatJson` rewrites the message tree in place, which the shared cache must not undergo
+        const canShare = shareLocaleMessage && !serverCtx.vueI18nOptions?.flatJson
         for (const k of Object.keys(messages)) {
-          i18n.mergeLocaleMessage(k, messages[k])
+          const message = messages[k]
+          if (message == null) { continue }
+          // `mergeLocaleMessage` deep copies the whole tree - on a fresh instance there is nothing
+          // to merge with, so hand vue-i18n the cached object directly
+          if (canShare && Object.keys(i18n.getLocaleMessage(k)).length === 0) {
+            shareLocaleMessage(k, message)
+          } else {
+            i18n.mergeLocaleMessage(k, message)
+          }
         }
         return
       }

--- a/src/runtime/server/context.ts
+++ b/src/runtime/server/context.ts
@@ -5,6 +5,7 @@ import { type H3Event, type H3EventContext, getRequestURL } from 'h3'
 import { type ResolvedI18nOptions, setupVueI18nOptions } from '../shared/vue-i18n'
 import { useRuntimeI18n } from '../shared/utils'
 import { createLocaleConfigs, getDefaultLocaleForDomain } from '../shared/locales'
+import { cloneDeep } from '../shared/messages'
 import { getMergedMessages } from './utils/messages'
 
 export function useI18nContext(event: H3Event) {
@@ -65,7 +66,8 @@ export function createI18nContext(): NonNullable<H3EventContext['nuxtI18n']> {
       if (__I18N_PRELOAD__) {
         deepCopy(messages, this.messages)
       }
-      return messages
+      // vue-i18n rewrites flat keys in place, so it can't be handed cached messages
+      return this.vueI18nOptions?.flatJson ? cloneDeep(messages) : messages
     },
   }
 }
@@ -111,7 +113,7 @@ declare module 'h3' {
        */
       trackKey: (key: string, locale: string) => void
       /**
-       * Load merged messages for a locale in-process, skipping the messages endpoint round-trip
+       * Load merged messages for a locale, skipping the messages endpoint round-trip
        * @internal
        */
       loadMessages: (locale: string) => Promise<LocaleMessages<DefineLocaleMessage>>

--- a/src/runtime/server/context.ts
+++ b/src/runtime/server/context.ts
@@ -1,9 +1,11 @@
 import type { LocaleMessages } from '@intlify/core'
 import type { DefineLocaleMessage } from '@intlify/h3'
+import { deepCopy } from '@intlify/shared'
 import { type H3Event, type H3EventContext, getRequestURL } from 'h3'
 import { type ResolvedI18nOptions, setupVueI18nOptions } from '../shared/vue-i18n'
 import { useRuntimeI18n } from '../shared/utils'
 import { createLocaleConfigs, getDefaultLocaleForDomain } from '../shared/locales'
+import { getMergedMessages } from './utils/messages'
 
 export function useI18nContext(event: H3Event) {
   if (event.context.nuxtI18n == null) {
@@ -57,6 +59,14 @@ export function createI18nContext(): NonNullable<H3EventContext['nuxtI18n']> {
       this.trackMap[locale] ??= new Set<string>()
       this.trackMap[locale].add(key)
     },
+    async loadMessages(locale: string) {
+      const messages = (await getMergedMessages(locale, this.localeConfigs?.[locale]?.fallbacks ?? [])) ?? {}
+      // only the payload reads `ctx.messages`, and copying the full tree per request is expensive
+      if (__I18N_PRELOAD__) {
+        deepCopy(messages, this.messages)
+      }
+      return messages
+    },
   }
 }
 
@@ -100,6 +110,11 @@ declare module 'h3' {
        * @internal
        */
       trackKey: (key: string, locale: string) => void
+      /**
+       * Load merged messages for a locale in-process, skipping the messages endpoint round-trip
+       * @internal
+       */
+      loadMessages: (locale: string) => Promise<LocaleMessages<DefineLocaleMessage>>
       detectLocale?: string
       vueI18nOptions?: ResolvedI18nOptions
     }

--- a/src/runtime/server/routes/messages.ts
+++ b/src/runtime/server/routes/messages.ts
@@ -1,8 +1,6 @@
-import { deepCopy } from '@intlify/shared'
 import { defineCachedEventHandler, defineCachedFunction } from 'nitropack/runtime'
 import { createError, defineEventHandler, getRouterParam } from 'h3'
 import { initializeI18nContext, tryUseI18nContext, useI18nContext } from '../context'
-import { getMergedMessages } from '../utils/messages'
 
 import type { H3Event } from 'h3'
 
@@ -21,10 +19,7 @@ const _messagesHandler = defineEventHandler(async (event: H3Event) => {
     throw createError({ status: 404, message: `Locale '${locale}' not found.` })
   }
 
-  const messages = await getMergedMessages(locale, ctx.localeConfigs?.[locale]?.fallbacks ?? [])
-  deepCopy(messages, ctx.messages)
-
-  return ctx.messages
+  return await ctx.loadMessages(locale)
 })
 
 const _cachedMessageLoader = defineCachedFunction(_messagesHandler, {

--- a/src/runtime/server/utils/cache.ts
+++ b/src/runtime/server/utils/cache.ts
@@ -17,6 +17,19 @@ const storage = prefixStorage(useStorage(), 'i18n')
 type CachedValue<T> = { ttl: number, value: T, mtime: number }
 
 /**
+ * Cached values are served by reference to every request, so freezing them turns any stray
+ * per-request mutation into a loud error instead of silent cross-request state pollution.
+ * Functions are left mutable: vue-i18n stamps `locale`/`key` onto message functions.
+ */
+function deepFreeze<T>(value: T): T {
+  if (value == null || typeof value !== 'object' || Object.isFrozen(value)) { return value }
+  for (const key of Object.keys(value)) {
+    deepFreeze((value as Record<string, unknown>)[key])
+  }
+  return Object.freeze(value)
+}
+
+/**
  * Create a cached function
  * Adapted from nitropack/runtime `cachedFunction`
  */
@@ -53,6 +66,8 @@ export function cachedFunctionI18n<T, ArgsT extends unknown[] = any[]>(
       const value = await get(key, () => fn(...args))
 
       if (isCacheable) {
+        // the first caller receives the same object that is stored, so freeze covers both
+        deepFreeze(value)
         await storage.setItemRaw(key, { ttl: Date.now() + maxAge * 1000, value, mtime: Date.now() })
       }
 

--- a/src/runtime/server/utils/cache.ts
+++ b/src/runtime/server/utils/cache.ts
@@ -17,9 +17,9 @@ const storage = prefixStorage(useStorage(), 'i18n')
 type CachedValue<T> = { ttl: number, value: T, mtime: number }
 
 /**
- * Cached values are served by reference to every request, so freezing them turns any stray
- * per-request mutation into a loud error instead of silent cross-request state pollution.
- * Functions are left mutable: vue-i18n stamps `locale`/`key` onto message functions.
+ * Cached values are served by reference to every request, so freezing turns a stray mutation into
+ * an error instead of cross-request pollution. Functions are skipped - vue-i18n stamps `locale`
+ * and `key` onto message functions.
  */
 function deepFreeze<T>(value: T): T {
   if (value == null || typeof value !== 'object' || Object.isFrozen(value)) { return value }
@@ -66,7 +66,7 @@ export function cachedFunctionI18n<T, ArgsT extends unknown[] = any[]>(
       const value = await get(key, () => fn(...args))
 
       if (isCacheable) {
-        // the first caller receives the same object that is stored, so freeze covers both
+        // the first caller receives the stored object itself, so freeze covers both
         deepFreeze(value)
         await storage.setItemRaw(key, { ttl: Date.now() + maxAge * 1000, value, mtime: Date.now() })
       }

--- a/src/runtime/server/utils/messages.ts
+++ b/src/runtime/server/utils/messages.ts
@@ -32,14 +32,16 @@ const _getMessagesCached = cachedFunctionI18n(_getMessages, {
 const getMessages = import.meta.dev ? _getMessages : _getMessagesCached
 
 const _getMergedMessages = async (locale: string, fallbackLocales: string[]) => {
-  const merged = {} as LocaleMessages<DefineLocaleMessage>
-
   try {
-    if (fallbackLocales.length > 0) {
-      const messages = await Promise.all(fallbackLocales.map(getMessages))
-      for (const message of messages) {
-        deepCopy(message, merged)
-      }
+    // nothing to merge - copying the per-locale result would only duplicate the tree
+    if (fallbackLocales.length === 0) {
+      return (await getMessages(locale)) ?? {}
+    }
+
+    const merged = {} as LocaleMessages<DefineLocaleMessage>
+    const messages = await Promise.all(fallbackLocales.map(getMessages))
+    for (const message of messages) {
+      deepCopy(message, merged)
     }
 
     const message = await getMessages(locale)
@@ -64,9 +66,12 @@ export const getMergedMessages = cachedFunctionI18n(_getMergedMessages, {
 })
 
 const _getAllMergedMessages = async (locales: string[]) => {
-  const merged = {} as LocaleMessages<DefineLocaleMessage>
-
   try {
+    if (locales.length === 1) {
+      return (await getMessages(locales[0]!)) ?? {}
+    }
+
+    const merged = {} as LocaleMessages<DefineLocaleMessage>
     const messages = await Promise.all(locales.map(getMessages))
 
     for (const message of messages) {

--- a/src/runtime/server/utils/messages.ts
+++ b/src/runtime/server/utils/messages.ts
@@ -33,7 +33,7 @@ const getMessages = import.meta.dev ? _getMessages : _getMessagesCached
 
 const _getMergedMessages = async (locale: string, fallbackLocales: string[]) => {
   try {
-    // nothing to merge - copying the per-locale result would only duplicate the tree
+    // with nothing to merge, copying would only duplicate the tree
     if (fallbackLocales.length === 0) {
       return (await getMessages(locale)) ?? {}
     }
@@ -44,8 +44,7 @@ const _getMergedMessages = async (locale: string, fallbackLocales: string[]) => 
       deepCopy(message, merged)
     }
 
-    const message = await getMessages(locale)
-    deepCopy(message, merged)
+    deepCopy(await getMessages(locale), merged)
 
     return merged
   } catch (e) {
@@ -63,30 +62,4 @@ export const getMergedMessages = cachedFunctionI18n(_getMergedMessages, {
   maxAge: !__I18N_CACHE__ ? -1 : 60 * 60 * 24,
   getKey: (locale, fallbackLocales) => `${locale}-[${[...new Set(fallbackLocales)].sort().join('-')}]`,
   shouldBypassCache: (locale, fallbackLocales) => !isLocaleWithFallbacksCacheable(locale, fallbackLocales),
-})
-
-const _getAllMergedMessages = async (locales: string[]) => {
-  try {
-    if (locales.length === 1) {
-      return (await getMessages(locales[0]!)) ?? {}
-    }
-
-    const merged = {} as LocaleMessages<DefineLocaleMessage>
-    const messages = await Promise.all(locales.map(getMessages))
-
-    for (const message of messages) {
-      deepCopy(message, merged)
-    }
-
-    return merged
-  } catch (e) {
-    throw new Error('Failed to merge messages: ' + (e as Error).message, { cause: e })
-  }
-}
-
-export const getAllMergedMessages = cachedFunctionI18n(_getAllMergedMessages, {
-  name: 'merged-all',
-  maxAge: !__I18N_CACHE__ ? -1 : 60 * 60 * 24,
-  getKey: locales => locales.join('-'),
-  shouldBypassCache: locales => !locales.every(locale => isLocaleCacheable(locale)),
 })

--- a/src/runtime/shared/messages.ts
+++ b/src/runtime/shared/messages.ts
@@ -17,8 +17,8 @@ type LocaleLoader<T = LocaleMessages<DefineLocaleMessage>> = {
 const cacheMessages = new Map<string, { ttl: number, value: LocaleMessages<DefineLocaleMessage> }>()
 
 /**
- * Clone a message tree. Unlike `@intlify/shared`'s `deepCopy`, arrays are copied instead of
- * assigned by reference; message functions are shared (vue-i18n treats them as opaque values).
+ * Clone a message tree. Unlike `@intlify/shared`'s `deepCopy` this copies arrays instead of
+ * sharing them; message functions are shared, vue-i18n treats them as opaque values.
  */
 export function cloneDeep<T>(value: T): T {
   if (value == null || typeof value !== 'object') { return value }

--- a/src/runtime/shared/messages.ts
+++ b/src/runtime/shared/messages.ts
@@ -16,6 +16,20 @@ type LocaleLoader<T = LocaleMessages<DefineLocaleMessage>> = {
 
 const cacheMessages = new Map<string, { ttl: number, value: LocaleMessages<DefineLocaleMessage> }>()
 
+/**
+ * Clone a message tree. Unlike `@intlify/shared`'s `deepCopy`, arrays are copied instead of
+ * assigned by reference; message functions are shared (vue-i18n treats them as opaque values).
+ */
+export function cloneDeep<T>(value: T): T {
+  if (value == null || typeof value !== 'object') { return value }
+  if (Array.isArray(value)) { return value.map(cloneDeep) as T }
+  const out = create(null) as Record<string, unknown>
+  for (const key of Object.keys(value)) {
+    out[key] = cloneDeep((value as Record<string, unknown>)[key])
+  }
+  return out as T
+}
+
 const merger = createDefu((obj, key, value) => {
   if (key === 'messages' || key === 'datetimeFormats' || key === 'numberFormats') {
     // @ts-expect-error generic object

--- a/test/message-installer.test.ts
+++ b/test/message-installer.test.ts
@@ -1,14 +1,15 @@
 import { describe, expect, test } from 'vitest'
 import { deepCopy } from '@intlify/shared'
-import { createMessageSharer } from '../src/runtime/context'
+import { createMessageInstaller } from '../src/runtime/context'
 import { cloneDeep } from '../src/runtime/shared/messages'
 
 import type { Composer } from 'vue-i18n'
 
-// minimal composer stand-in with vue-i18n's real semantics: set assigns by reference,
-// merge deep-copies into the stored tree via @intlify/shared `deepCopy`
+type Store = Record<string, Record<string, unknown>>
+
+// stand-in with vue-i18n's semantics: set assigns by reference, merge deep copies into the target
 function createFakeComposer() {
-  const store: Record<string, Record<string, unknown>> = {}
+  const store: Store = {}
   return {
     store,
     getLocaleMessage: (locale: string) => store[locale] || {},
@@ -19,34 +20,43 @@ function createFakeComposer() {
       store[locale] ||= {}
       deepCopy(message, store[locale])
     },
-  } as unknown as Pick<Composer, 'getLocaleMessage' | 'setLocaleMessage' | 'mergeLocaleMessage'> & {
-    store: Record<string, Record<string, unknown>>
-  }
+  } as unknown as Pick<Composer, 'getLocaleMessage' | 'setLocaleMessage' | 'mergeLocaleMessage'> & { store: Store }
 }
 
-function frozenTree() {
+function cachedTree() {
   const tree = { greeting: 'hello', nested: { deep: 'value' }, list: ['a', 'b'] }
   Object.freeze(tree.nested)
   Object.freeze(tree.list)
   return Object.freeze(tree)
 }
 
-describe('createMessageSharer', () => {
-  test('share hands the object to the store by reference', () => {
+describe('createMessageInstaller', () => {
+  test('installs into an empty locale by reference', () => {
     const i18n = createFakeComposer()
-    const share = createMessageSharer(i18n)
-    const cached = frozenTree()
+    const install = createMessageInstaller(i18n)
+    const cached = cachedTree()
 
-    share('en', cached)
+    install('en', cached)
     expect(i18n.store.en).toBe(cached)
   })
 
-  test('merge into a shared locale copies first and leaves the shared object untouched', () => {
+  test('merges into a locale that already has messages', () => {
     const i18n = createFakeComposer()
-    const share = createMessageSharer(i18n)
-    const cached = frozenTree()
+    const install = createMessageInstaller(i18n)
+    i18n.setLocaleMessage('en', { fromConfig: 'keep' })
 
-    share('en', cached)
+    install('en', cachedTree())
+
+    expect(i18n.store.en.fromConfig).toBe('keep')
+    expect(i18n.store.en.greeting).toBe('hello')
+  })
+
+  test('merging after a by-reference install copies first', () => {
+    const i18n = createFakeComposer()
+    const install = createMessageInstaller(i18n)
+    const cached = cachedTree()
+
+    install('en', cached)
     i18n.mergeLocaleMessage('en', { added: 'x' })
 
     expect(i18n.store.en).not.toBe(cached)
@@ -55,12 +65,12 @@ describe('createMessageSharer', () => {
     expect('added' in cached).toBe(false)
   })
 
-  test('the private copy does not alias arrays of the shared object', () => {
+  test('the copy does not alias arrays of the installed tree', () => {
     const i18n = createFakeComposer()
-    const share = createMessageSharer(i18n)
-    const cached = frozenTree()
+    const install = createMessageInstaller(i18n)
+    const cached = cachedTree()
 
-    share('en', cached)
+    install('en', cached)
     i18n.mergeLocaleMessage('en', { added: 'x' })
 
     const list = i18n.store.en.list as string[]
@@ -69,42 +79,38 @@ describe('createMessageSharer', () => {
     expect(cached.list).toEqual(['a', 'b'])
   })
 
-  test('merge into a non-shared locale passes through without copying', () => {
+  test('only copies once per install', () => {
     const i18n = createFakeComposer()
-    createMessageSharer(i18n)
+    const install = createMessageInstaller(i18n)
 
-    i18n.mergeLocaleMessage('fr', { salut: 'y' })
-    expect(i18n.store.fr.salut).toBe('y')
+    install('en', cachedTree())
+    i18n.mergeLocaleMessage('en', { a: '1' })
+    const afterFirst = i18n.store.en
+    i18n.mergeLocaleMessage('en', { b: '2' })
+
+    expect(i18n.store.en).toBe(afterFirst)
+    expect(i18n.store.en).toMatchObject({ a: '1', b: '2' })
   })
 
-  test('setLocaleMessage un-shares without copying', () => {
+  test('setLocaleMessage replaces the reference without copying', () => {
     const i18n = createFakeComposer()
-    const share = createMessageSharer(i18n)
-    const cached = frozenTree()
-    share('en', cached)
+    const install = createMessageInstaller(i18n)
+    install('en', cachedTree())
 
     const replacement = { fresh: 'tree' }
     i18n.setLocaleMessage('en', replacement)
-    expect(i18n.store.en).toBe(replacement)
-
-    // merging afterwards must not clone (locale is no longer marked shared)
     i18n.mergeLocaleMessage('en', { more: 'z' })
+
     expect(i18n.store.en).toBe(replacement)
     expect(replacement).toEqual({ fresh: 'tree', more: 'z' })
   })
 
-  test('sharing again after un-share re-arms the copy-on-write', () => {
+  test('leaves locales it never installed alone', () => {
     const i18n = createFakeComposer()
-    const share = createMessageSharer(i18n)
-    const cached = frozenTree()
+    createMessageInstaller(i18n)
 
-    share('en', cached)
-    i18n.mergeLocaleMessage('en', { a: '1' })
-    share('en', cached)
-    i18n.mergeLocaleMessage('en', { b: '2' })
-
-    expect('b' in cached).toBe(false)
-    expect(i18n.store.en.b).toBe('2')
+    i18n.mergeLocaleMessage('fr', { salut: 'y' })
+    expect(i18n.store.fr.salut).toBe('y')
   })
 })
 
@@ -122,8 +128,9 @@ describe('cloneDeep', () => {
     expect(out).toEqual(src)
   })
 
-  test('clone of a frozen tree is mutable throughout', () => {
-    const out = cloneDeep(frozenTree())
+  test('the clone of a frozen tree is mutable throughout', () => {
+    const out = cloneDeep(cachedTree())
+
     expect(Object.isFrozen(out)).toBe(false)
     ;(out.nested as Record<string, string>).deep = 'changed'
     ;(out.list as string[]).push('c')

--- a/test/message-installer.test.ts
+++ b/test/message-installer.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'vitest'
 import { deepCopy } from '@intlify/shared'
+import { createI18n } from 'vue-i18n'
 import { createMessageInstaller } from '../src/runtime/context'
+import { getComposer } from '../src/runtime/compatibility'
 import { cloneDeep } from '../src/runtime/shared/messages'
 
 import type { Composer } from 'vue-i18n'
@@ -111,6 +113,21 @@ describe('createMessageInstaller', () => {
 
     i18n.mergeLocaleMessage('fr', { salut: 'y' })
     expect(i18n.store.fr.salut).toBe('y')
+  })
+
+  // in legacy mode `useI18n()` reaches the composer while `$i18n` goes through the VueI18n
+  // facade - patching the composer has to cover both
+  test('a legacy VueI18n instance protects composer and facade merges alike', () => {
+    const i18n = createI18n({ legacy: true, locale: 'en', messages: { en: {} } })
+    const install = createMessageInstaller(getComposer(i18n))
+    const cached = cachedTree()
+
+    install('en', cached)
+    getComposer(i18n).mergeLocaleMessage('en', { viaComposer: 'x' })
+    i18n.global.mergeLocaleMessage('en', { viaFacade: 'y' })
+
+    expect(cached).toEqual({ greeting: 'hello', nested: { deep: 'value' }, list: ['a', 'b'] })
+    expect(i18n.global.getLocaleMessage('en')).toMatchObject({ viaComposer: 'x', viaFacade: 'y' })
   })
 })
 

--- a/test/message-sharer.test.ts
+++ b/test/message-sharer.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from 'vitest'
+import { deepCopy } from '@intlify/shared'
+import { createMessageSharer } from '../src/runtime/context'
+import { cloneDeep } from '../src/runtime/shared/messages'
+
+import type { Composer } from 'vue-i18n'
+
+// minimal composer stand-in with vue-i18n's real semantics: set assigns by reference,
+// merge deep-copies into the stored tree via @intlify/shared `deepCopy`
+function createFakeComposer() {
+  const store: Record<string, Record<string, unknown>> = {}
+  return {
+    store,
+    getLocaleMessage: (locale: string) => store[locale] || {},
+    setLocaleMessage: (locale: string, message: Record<string, unknown>) => {
+      store[locale] = message
+    },
+    mergeLocaleMessage: (locale: string, message: Record<string, unknown>) => {
+      store[locale] ||= {}
+      deepCopy(message, store[locale])
+    },
+  } as unknown as Pick<Composer, 'getLocaleMessage' | 'setLocaleMessage' | 'mergeLocaleMessage'> & {
+    store: Record<string, Record<string, unknown>>
+  }
+}
+
+function frozenTree() {
+  const tree = { greeting: 'hello', nested: { deep: 'value' }, list: ['a', 'b'] }
+  Object.freeze(tree.nested)
+  Object.freeze(tree.list)
+  return Object.freeze(tree)
+}
+
+describe('createMessageSharer', () => {
+  test('share hands the object to the store by reference', () => {
+    const i18n = createFakeComposer()
+    const share = createMessageSharer(i18n)
+    const cached = frozenTree()
+
+    share('en', cached)
+    expect(i18n.store.en).toBe(cached)
+  })
+
+  test('merge into a shared locale copies first and leaves the shared object untouched', () => {
+    const i18n = createFakeComposer()
+    const share = createMessageSharer(i18n)
+    const cached = frozenTree()
+
+    share('en', cached)
+    i18n.mergeLocaleMessage('en', { added: 'x' })
+
+    expect(i18n.store.en).not.toBe(cached)
+    expect(i18n.store.en.added).toBe('x')
+    expect(i18n.store.en.greeting).toBe('hello')
+    expect('added' in cached).toBe(false)
+  })
+
+  test('the private copy does not alias arrays of the shared object', () => {
+    const i18n = createFakeComposer()
+    const share = createMessageSharer(i18n)
+    const cached = frozenTree()
+
+    share('en', cached)
+    i18n.mergeLocaleMessage('en', { added: 'x' })
+
+    const list = i18n.store.en.list as string[]
+    expect(list).not.toBe(cached.list)
+    list.push('c')
+    expect(cached.list).toEqual(['a', 'b'])
+  })
+
+  test('merge into a non-shared locale passes through without copying', () => {
+    const i18n = createFakeComposer()
+    createMessageSharer(i18n)
+
+    i18n.mergeLocaleMessage('fr', { salut: 'y' })
+    expect(i18n.store.fr.salut).toBe('y')
+  })
+
+  test('setLocaleMessage un-shares without copying', () => {
+    const i18n = createFakeComposer()
+    const share = createMessageSharer(i18n)
+    const cached = frozenTree()
+    share('en', cached)
+
+    const replacement = { fresh: 'tree' }
+    i18n.setLocaleMessage('en', replacement)
+    expect(i18n.store.en).toBe(replacement)
+
+    // merging afterwards must not clone (locale is no longer marked shared)
+    i18n.mergeLocaleMessage('en', { more: 'z' })
+    expect(i18n.store.en).toBe(replacement)
+    expect(replacement).toEqual({ fresh: 'tree', more: 'z' })
+  })
+
+  test('sharing again after un-share re-arms the copy-on-write', () => {
+    const i18n = createFakeComposer()
+    const share = createMessageSharer(i18n)
+    const cached = frozenTree()
+
+    share('en', cached)
+    i18n.mergeLocaleMessage('en', { a: '1' })
+    share('en', cached)
+    i18n.mergeLocaleMessage('en', { b: '2' })
+
+    expect('b' in cached).toBe(false)
+    expect(i18n.store.en.b).toBe('2')
+  })
+})
+
+describe('cloneDeep', () => {
+  test('copies nested objects and arrays, keeps primitives and functions', () => {
+    const fn = () => 'msg'
+    const src = { a: { b: [1, { c: 2 }] }, d: fn, e: null, f: 'str' }
+    const out = cloneDeep(src)
+
+    expect(out).not.toBe(src)
+    expect(out.a).not.toBe(src.a)
+    expect(out.a.b).not.toBe(src.a.b)
+    expect(out.a.b[1]).not.toBe(src.a.b[1])
+    expect(out.d).toBe(fn)
+    expect(out).toEqual(src)
+  })
+
+  test('clone of a frozen tree is mutable throughout', () => {
+    const out = cloneDeep(frozenTree())
+    expect(Object.isFrozen(out)).toBe(false)
+    ;(out.nested as Record<string, string>).deep = 'changed'
+    ;(out.list as string[]).push('c')
+    expect(out.nested.deep).toBe('changed')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Loading messages during SSR fetched them from the messages endpoint through `$fetch` and merged the result into the request's vue-i18n instance, so every request serialized, parsed and copied the full message tree, per-request cost scaled with locale file size rather than with what a page renders.

This loads messages in-process and hands the cached tree to vue-i18n by reference (frozen, with copy-on-write for merges), keeping per-request cost flat as message volume grows: 947 to 2285 rps at 2k keys per locale and 175 to 2331 rps at 20k on the bench fixture.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented cross-request i18n cache pollution by isolating merged messages per SSR request.
  - Added stronger protection for cached translations via deep freezing to stop accidental mutations.
  - Ensured locale merges and fallback handling don’t overwrite existing translations.

- **Performance**
  - Improved message retrieval with fast paths when fewer/only one locale or no fallbacks are needed.

- **Tests**
  - Added message installer + cloning/immutability coverage and updated lazy-loading snapshots (English key count increased).
  - Added SSR message isolation tests validating stable cached translations across requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->