### PR TITLE
perf: enable `experimental.optimizeMessageBundling` by default

### DIFF
--- a/docs/content/docs/02.guide/91.new-features.md
+++ b/docs/content/docs/02.guide/91.new-features.md
@@ -99,14 +99,14 @@ This option is opt-in for now but is expected to become the default in v11. Plea
 
 ### Optimized message bundling
 
-We have added a new experimental option `optimizeMessageBundling`{lang="yml"} that changes how locale messages reach server builds. Static locale files (JSON/JSON5/YAML) are normally handed to the bundler, which expands them into modules and generates source maps for them. Since the server compiles messages at runtime either way, this work only slows the build down. With this option enabled these files are embedded as raw messages instead, and served to the runtime as Nitro server assets.
+We have changed how locale messages reach server builds. Static locale files (JSON/JSON5/YAML) used to be handed to the bundler, which expands them into modules and generates source maps for them. Since the server compiles messages at runtime either way, this work only slowed the build down. These files are now embedded as raw messages instead, and served to the runtime as Nitro server assets.
 
-This can be enabled in `nuxt.config.ts`:
+This is controlled by `optimizeMessageBundling`{lang="yml"}, which is enabled by default and can be turned off in `nuxt.config.ts`:
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   i18n: {
     experimental: {
-      optimizeMessageBundling: true
+      optimizeMessageBundling: false
     }
   }
 })
@@ -117,12 +117,17 @@ export default defineNuxtConfig({
 * **Lower memory usage** — Peak build memory scales with message volume, projects with very large locale files could previously run out of memory during the server build.
 * **Smaller server output** — Message data is no longer expanded into module declarations, reducing the size of the server bundle.
 
-The client bundle is unaffected, and messages are compiled at runtime on the server as they were before, so there is no behavioral change for rendered messages. The Nitro build benefits with any builder; Vite projects also skip this work in the server graph.
+The client bundle is unaffected, and messages are compiled at runtime on the server as they were before, so there is no behavioral change for rendered messages.
+
+**When to turn it off:**
+* A custom Nitro Rollup plugin transforms your locale files — it no longer sees them, since they are not imported into the server graph at all.
+
+A locale file the module cannot parse is left to the bundler instead of failing the build, so files your bundler accepts keep working — they just miss out on the optimization.
 
 ::callout{icon="i-heroicons-light-bulb"}
-Available from `v10.6.0`, or on the [edge channel](/docs/getting-started#edge-channel) before that. This option is opt-in for now but is expected to become the default in v11. Please try it out and report any issues you encounter.
+Enabled by default from `v10.6.0`, available as an opt-in before that. Set `optimizeMessageBundling: false`{lang="yml"} if you hit a problem, and please report it.
 ::
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="warning"}
-Static locale files are read and parsed by the module rather than the bundler when this option is enabled. If a locale file contains HTML, it is reported as a build warning — see [`compilation.strictMessage`](/docs/api/options#strictmessage).
+Static locale files are read and parsed by the module rather than the bundler. If a locale file contains HTML, it is reported as a build warning — see [`compilation.strictMessage`](/docs/api/options#strictmessage).
 ::

--- a/docs/content/docs/02.guide/91.new-features.md
+++ b/docs/content/docs/02.guide/91.new-features.md
@@ -99,7 +99,7 @@ This option is opt-in for now but is expected to become the default in v11. Plea
 
 ### Optimized message bundling
 
-We have added a new experimental option `optimizeMessageBundling`{lang="yml"} that changes how locale messages are bundled for server builds. Locale messages are normally precompiled during the build, which only benefits the client bundle. With this option enabled, static locale files (JSON/JSON5/YAML) are embedded in server builds as raw messages and compiled at runtime instead, skipping most of the bundler work over message data.
+We have added a new experimental option `optimizeMessageBundling`{lang="yml"} that changes how locale messages reach server builds. Static locale files (JSON/JSON5/YAML) are normally handed to the bundler, which expands them into modules and generates source maps for them. Since the server compiles messages at runtime either way, this work only slows the build down. With this option enabled these files are embedded as raw messages instead, and served to the runtime as Nitro server assets.
 
 This can be enabled in `nuxt.config.ts`:
 ```ts [nuxt.config.ts]
@@ -115,14 +115,14 @@ export default defineNuxtConfig({
 **Why this is an improvement:**
 * **Faster builds** — The bundler no longer parses and generates source maps for the entire message data in server builds, in our benchmarks this cut build time by more than half for projects with large locale files.
 * **Lower memory usage** — Peak build memory scales with message volume, projects with very large locale files could previously run out of memory during the server build.
-* **Smaller server output** — Precompiled messages are roughly 3x the size of the raw JSON, embedding raw messages reduces the size of the server bundle.
+* **Smaller server output** — Message data is no longer expanded into module declarations, reducing the size of the server bundle.
 
-The client bundle is unaffected and keeps precompiled messages, so there is no runtime cost in the browser. This option currently only applies to projects using Vite.
+The client bundle is unaffected, and messages are compiled at runtime on the server as they were before, so there is no behavioral change for rendered messages. The Nitro build benefits with any builder; Vite projects also skip this work in the server graph.
 
 ::callout{icon="i-heroicons-light-bulb"}
 Available from `v10.6.0`, or on the [edge channel](/docs/getting-started#edge-channel) before that. This option is opt-in for now but is expected to become the default in v11. Please try it out and report any issues you encounter.
 ::
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="warning"}
-This option is not compatible with `no_prefix` strategy, `differentDomains`, or `multiDomainLocales`.
+Static locale files are read and parsed by the module rather than the bundler when this option is enabled. If a locale file contains HTML, it is reported as a build warning — see [`compilation.strictMessage`](/docs/api/options#strictmessage).
 ::

--- a/docs/content/docs/02.guide/91.new-features.md
+++ b/docs/content/docs/02.guide/91.new-features.md
@@ -125,7 +125,7 @@ The client bundle is unaffected, and messages are compiled at runtime on the ser
 A locale file the module cannot parse is left to the bundler instead of failing the build, so files your bundler accepts keep working — they just miss out on the optimization.
 
 ::callout{icon="i-heroicons-light-bulb"}
-Enabled by default from `v10.6.0`, available as an opt-in before that. Set `optimizeMessageBundling: false`{lang="yml"} if you hit a problem, and please report it.
+New in `v10.6.0`. Set `optimizeMessageBundling: false`{lang="yml"} if you hit a problem, and please report it.
 ::
 
 ::callout{icon="i-heroicons-exclamation-triangle" color="warning"}

--- a/docs/content/docs/04.api/00.options.md
+++ b/docs/content/docs/04.api/00.options.md
@@ -527,11 +527,11 @@ Only messages contributed by locale files are serialized into the prerendered fi
 ### `optimizeMessageBundling`
 
 - type: `boolean`{lang="ts-type"}
-- default: `false`{lang="ts"}
+- default: `true`{lang="ts"}
 - Embed static locale files (JSON/JSON5/YAML) in server builds as raw messages instead of letting the bundler expand them into modules. This reduces build time and memory usage, especially for projects with large locale files. The client bundle is unaffected.
 
 ::callout{icon="i-heroicons-light-bulb"}
-Available from `v10.6.0`. This option is opt-in for now but is expected to become the default in v11. See [Optimized message bundling](/docs/guide/new-features#optimized-message-bundling) for more details.
+Enabled by default from `v10.6.0`. Set it to `false`{lang="ts"} to hand locale files back to the bundler — needed if a custom Nitro Rollup plugin transforms them. See [Optimized message bundling](/docs/guide/new-features#optimized-message-bundling) for more details.
 ::
 
 ## `hmr`

--- a/docs/content/docs/04.api/00.options.md
+++ b/docs/content/docs/04.api/00.options.md
@@ -374,6 +374,10 @@ Strictly check that the locale message does not contain HTML tags. If HTML tags 
 If you do not want the error to be thrown, you can work around it by setting it to false. However, **this means that the locale message might cause security issues with XSS**. In that case, we recommend setting the `escapeHtml` option to `true`.
 ::
 
+::callout{icon="i-heroicons-light-bulb"}
+Static locale files read directly by the server build are not precompiled and were never checked. While this option is left at its default, HTML in those files is reported as a build warning instead of an error — set it explicitly to `true`{lang="ts"} to reject them, or to `false`{lang="ts"} to silence the warning.
+::
+
 ### `escapeHtml`
 
 - type: `boolean`{lang="ts-type"}
@@ -524,7 +528,7 @@ Only messages contributed by locale files are serialized into the prerendered fi
 
 - type: `boolean`{lang="ts-type"}
 - default: `false`{lang="ts"}
-- Skip precompiling static locale files (JSON/JSON5/YAML) in server builds, embedding them as raw messages compiled at runtime instead. This reduces build time and memory usage, especially for projects with large locale files. The client bundle is unaffected and keeps precompiled messages. Vite only.
+- Embed static locale files (JSON/JSON5/YAML) in server builds as raw messages instead of letting the bundler expand them into modules. This reduces build time and memory usage, especially for projects with large locale files. The client bundle is unaffected.
 
 ::callout{icon="i-heroicons-light-bulb"}
 Available from `v10.6.0`. This option is opt-in for now but is expected to become the default in v11. See [Optimized message bundling](/docs/guide/new-features#optimized-message-bundling) for more details.

--- a/docs/content/docs/04.api/00.options.md
+++ b/docs/content/docs/04.api/00.options.md
@@ -531,7 +531,7 @@ Only messages contributed by locale files are serialized into the prerendered fi
 - Embed static locale files (JSON/JSON5/YAML) in server builds as raw messages instead of letting the bundler expand them into modules. This reduces build time and memory usage, especially for projects with large locale files. The client bundle is unaffected.
 
 ::callout{icon="i-heroicons-light-bulb"}
-Enabled by default from `v10.6.0`. Set it to `false`{lang="ts"} to hand locale files back to the bundler — needed if a custom Nitro Rollup plugin transforms them. See [Optimized message bundling](/docs/guide/new-features#optimized-message-bundling) for more details.
+New in `v10.6.0`. Set it to `false`{lang="ts"} to hand locale files back to the bundler — needed if a custom Nitro Rollup plugin transforms them. See [Optimized message bundling](/docs/guide/new-features#optimized-message-bundling) for more details.
 ::
 
 ## `hmr`

--- a/specs/lazy_load/basic_lazy_load.spec.ts
+++ b/specs/lazy_load/basic_lazy_load.spec.ts
@@ -9,7 +9,15 @@ import { Page } from 'playwright-core'
 describe('basic lazy loading', async () => {
   await setup({
     rootDir: fileURLToPath(new URL(`../fixtures/lazy`, import.meta.url)),
-    browser: true
+    browser: true,
+    // pins the opt-out, `optimize_message_bundling.spec.ts` covers the default on the same fixture
+    nuxtConfig: {
+      i18n: {
+        experimental: {
+          optimizeMessageBundling: false
+        }
+      }
+    }
   })
 
   test('dynamic locale files are not cached', async () => {

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -4,7 +4,6 @@ import { toArray } from './utils'
 import { TransformMacroPlugin } from './transform/macros'
 import { ResourcePlugin } from './transform/resource'
 import { JsonParseMessagesPlugin } from './transform/json-parse'
-import { STATIC_RESOURCE_RE } from './resources'
 import { TransformI18nFunctionPlugin } from './transform/i18n-function-injection'
 import { HeistPlugin } from './transform/heist'
 import { addDefinePlugin } from 'nuxt-define'
@@ -59,7 +58,7 @@ export async function extendBundler(ctx: ResolvedI18nContext, nuxt: Nuxt) {
       ...vueI18nPluginOptions,
       dropMessageCompiler: false,
       runtimeOnly: false,
-      include: localePaths.filter(x => !STATIC_RESOURCE_RE.test(x)),
+      include: localePaths.filter(x => !ctx.rawResourcePaths.has(x)),
     }
     // `prepend` - without it kit appends after ResourcePlugin, which then claims the virtual ids
     addVitePlugin(() => jsonParsePlugin!.vite(), { client: false, prepend: true })

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,7 +30,7 @@ export const DEFAULT_OPTIONS = {
     httpCacheDuration: 10,
     compactRoutes: false,
     prerenderMessages: false,
-    optimizeMessageBundling: false,
+    optimizeMessageBundling: true,
   },
   bundle: {
     compositionOnly: true,

--- a/src/context.ts
+++ b/src/context.ts
@@ -4,7 +4,7 @@ import { dirname, resolve } from 'pathe'
 import { assign, isString } from '@intlify/shared'
 import { applyLayerOptions, resolveLayerVueI18nConfigInfo } from './layers'
 import { computeLocaleHashes, filterLocales, getLayerI18n, normalizeDomainLocale, resolveLocales, validateLocaleCodes } from './utils'
-import { STATIC_RESOURCE_RE } from './resources'
+import { resolveRawResourcePaths } from './resources'
 import { generateLoaderOptions } from './gen'
 
 import type { Resolver } from '@nuxt/kit'
@@ -32,6 +32,8 @@ export interface ResolvedI18nContext extends I18nNuxtContext {
   localeFileMetas: FileMeta[]
   /** unique resolved locale file paths */
   localeFilePaths: string[]
+  /** locale file paths served as raw messages instead of being handed to the bundler */
+  rawResourcePaths: Set<string>
   vueI18nConfigPaths: Omit<FileMeta, 'cache'>[]
   localeHashes: Record<string, string>
   fullStatic: boolean
@@ -74,11 +76,16 @@ export async function resolveContext(ctx: I18nNuxtContext, nuxt: Nuxt): Promise<
   const localeFileMetas = localeInfo.flatMap(x => x.meta)
   const vueI18nConfigPaths = await resolveLayerVueI18nConfigInfo(ctx)
 
-  // static resources ship as lazily read nitro server assets, keeping message data out of the
+  const localeFilePaths = [...new Set(localeFileMetas.map(meta => meta.path))]
+  const rawResourcePaths = ctx.options.experimental.optimizeMessageBundling
+    ? resolveRawResourcePaths(localeFilePaths)
+    : new Set<string>()
+
+  // raw resources ship as lazily read nitro server assets, keeping message data out of the
   // server bundles - dev keeps eager imports for HMR and virtual file support
-  if (ctx.options.experimental.optimizeMessageBundling && !nuxt.options.dev) {
+  if (!nuxt.options.dev) {
     for (const meta of localeFileMetas) {
-      if (STATIC_RESOURCE_RE.test(meta.path)) {
+      if (rawResourcePaths.has(meta.path)) {
         meta.assetKey = `${meta.hash}.json`
       }
     }
@@ -89,7 +96,8 @@ export async function resolveContext(ctx: I18nNuxtContext, nuxt: Nuxt): Promise<
     localeCodes,
     localeInfo,
     localeFileMetas,
-    localeFilePaths: [...new Set(localeFileMetas.map(meta => meta.path))],
+    localeFilePaths,
+    rawResourcePaths,
     vueI18nConfigPaths,
     /**
      * content-hash locale files now that all locales and configs are known,

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -2,19 +2,30 @@ import { readFileSync } from 'node:fs'
 import { detectHtmlTag } from '@intlify/message-compiler'
 import { escapeHtml, isString } from '@intlify/shared'
 import { parseJSON5, parseYAML } from 'confbox'
+import { tryUseNuxt } from '@nuxt/kit'
+import { relative } from 'pathe'
+import { logger } from './utils'
 
 import type { ResolvedI18nContext } from './context'
 
 export const STATIC_RESOURCE_RE = /\.(?:json5?|ya?ml)$/
+const BOM_RE = /^\uFEFF/
 
 function parseResource(path: string) {
-  const content = readFileSync(path, 'utf8')
-  if (path.endsWith('.json5')) { return parseJSON5(content) }
-  if (/\.ya?ml$/.test(path)) { return parseYAML(content) }
-  return JSON.parse(content)
+  // locale files added as unwritten templates only exist in the virtual file system
+  const raw = tryUseNuxt()?.vfs?.[path] ?? readFileSync(path, 'utf8')
+  // the vite/rollup JSON loaders strip a byte order mark before parsing, `JSON.parse` does not
+  const content = raw.replace(BOM_RE, '')
+  try {
+    if (path.endsWith('.json5')) { return parseJSON5(content) }
+    if (/\.ya?ml$/.test(path)) { return parseYAML(content) }
+    return JSON.parse(content)
+  } catch (err) {
+    throw new Error(`Could not parse locale file (${path}): ${(err as Error).message}`, { cause: err })
+  }
 }
 
-type ValidateOptions = { strictMessage: boolean, escapeHtml: boolean }
+type ValidateOptions = { strictMessage: boolean | undefined, escapeHtml: boolean, htmlKeys: string[] }
 
 // mirrors the `@intlify/bundle-utils` compile-time checks skipped for resources that are not
 // precompiled - `keys` tracks the message path for errors and is mutated to avoid copying it per node
@@ -27,6 +38,7 @@ function validateMessages(value: unknown, options: ValidateOptions, path: string
           + ` Recommend not using HTML messages to avoid XSS.`,
         )
       }
+      if (options.strictMessage == null) { options.htmlKeys.push(keys.join('.')) }
       if (options.escapeHtml) { return escapeHtml(value) }
     }
     return value
@@ -50,11 +62,30 @@ function validateMessages(value: unknown, options: ValidateOptions, path: string
   return value
 }
 
+const warnedPaths = new Set<string>()
+
+function warnHtmlMessages(path: string, keys: string[]) {
+  if (warnedPaths.has(path)) { return }
+  warnedPaths.add(path)
+  logger.warn(
+    `Detected HTML in ${keys.length} message${keys.length > 1 ? 's' : ''} in `
+    + `${relative(tryUseNuxt()?.options.rootDir ?? '', path)} (first: "${keys[0]}"). `
+    + 'Set `compilation.strictMessage` to `true` to reject these, or to `false` to silence this warning.',
+  )
+}
+
 /** parse, validate and minify a static locale resource */
-export function readStaticResource(ctx: Pick<ResolvedI18nContext, 'options'>, path: string): string {
+export function readStaticResource(ctx: Pick<ResolvedI18nContext, 'options' | 'rawOptions'>, path: string): string {
+  const htmlKeys: string[] = []
   const messages = validateMessages(parseResource(path), {
-    strictMessage: ctx.options.compilation.strictMessage ?? true,
+    // these resources are not precompiled, so nothing checked them before `optimizeMessageBundling` -
+    // applying the `strictMessage` default here would reject messages that always built fine
+    strictMessage: ctx.rawOptions.compilation?.strictMessage,
     escapeHtml: !!ctx.options.compilation.escapeHtml,
+    htmlKeys,
   }, path, [])
+
+  if (htmlKeys.length) { warnHtmlMessages(path, htmlKeys) }
+
   return JSON.stringify(messages)
 }

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -14,23 +14,37 @@ function parseResource(path: string) {
   return JSON.parse(content)
 }
 
-// mirrors the `@intlify/bundle-utils` compile-time checks skipped for resources that are not precompiled
-function validateMessages(value: unknown, options: { strictMessage: boolean, escapeHtml: boolean }, path: string): unknown {
+type ValidateOptions = { strictMessage: boolean, escapeHtml: boolean }
+
+// mirrors the `@intlify/bundle-utils` compile-time checks skipped for resources that are not
+// precompiled - `keys` tracks the message path for errors and is mutated to avoid copying it per node
+function validateMessages(value: unknown, options: ValidateOptions, path: string, keys: string[]): unknown {
   if (isString(value)) {
     if (detectHtmlTag(value)) {
       if (options.strictMessage) {
-        throw new Error(`Detected HTML in '${value}' message (${path}). Recommend not using HTML messages to avoid XSS.`)
+        throw new Error(
+          `Detected HTML in '${value}' message at "${keys.join('.')}" (${path}).`
+          + ` Recommend not using HTML messages to avoid XSS.`,
+        )
       }
       if (options.escapeHtml) { return escapeHtml(value) }
     }
     return value
   }
   if (Array.isArray(value)) {
-    return value.map(x => validateMessages(x, options, path))
+    return value.map((entry, i) => {
+      keys.push(String(i))
+      const validated = validateMessages(entry, options, path, keys)
+      keys.pop()
+      return validated
+    })
   }
   if (value && typeof value === 'object') {
-    for (const k of Object.keys(value)) {
-      ;(value as Record<string, unknown>)[k] = validateMessages((value as Record<string, unknown>)[k], options, path)
+    const record = value as Record<string, unknown>
+    for (const k of Object.keys(record)) {
+      keys.push(k)
+      record[k] = validateMessages(record[k], options, path, keys)
+      keys.pop()
     }
   }
   return value
@@ -41,6 +55,6 @@ export function readStaticResource(ctx: Pick<ResolvedI18nContext, 'options'>, pa
   const messages = validateMessages(parseResource(path), {
     strictMessage: ctx.options.compilation.strictMessage ?? true,
     escapeHtml: !!ctx.options.compilation.escapeHtml,
-  }, path)
+  }, path, [])
   return JSON.stringify(messages)
 }

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -8,7 +8,7 @@ import { logger } from './utils'
 
 import type { ResolvedI18nContext } from './context'
 
-export const STATIC_RESOURCE_RE = /\.(?:json5?|ya?ml)$/
+const STATIC_RESOURCE_RE = /\.(?:json5?|ya?ml)$/
 const BOM_RE = /^\uFEFF/
 
 function parseResource(path: string) {
@@ -23,6 +23,27 @@ function parseResource(path: string) {
   } catch (err) {
     throw new Error(`Could not parse locale file (${path}): ${(err as Error).message}`, { cause: err })
   }
+}
+
+const toRelative = (path: string) => relative(tryUseNuxt()?.options.rootDir ?? '', path)
+
+/**
+ * The static resources we can read ourselves, the rest are left to the bundler loaders. A resource
+ * we fail to parse may be one they accept, and where it is not they report it with better context -
+ * either way falling back keeps this from breaking a build that worked without the optimization.
+ */
+export function resolveRawResourcePaths(paths: string[]): Set<string> {
+  const raw = new Set<string>()
+  for (const path of new Set(paths)) {
+    if (!STATIC_RESOURCE_RE.test(path)) { continue }
+    try {
+      parseResource(path)
+      raw.add(path)
+    } catch (err) {
+      logger.warn(`Leaving ${toRelative(path)} to the bundler: ${(err as Error).message}`)
+    }
+  }
+  return raw
 }
 
 type ValidateOptions = { strictMessage: boolean | undefined, escapeHtml: boolean, htmlKeys: string[] }
@@ -68,8 +89,8 @@ function warnHtmlMessages(path: string, keys: string[]) {
   if (warnedPaths.has(path)) { return }
   warnedPaths.add(path)
   logger.warn(
-    `Detected HTML in ${keys.length} message${keys.length > 1 ? 's' : ''} in `
-    + `${relative(tryUseNuxt()?.options.rootDir ?? '', path)} (first: "${keys[0]}"). `
+    `Detected HTML in ${keys.length} message${keys.length > 1 ? 's' : ''} in ${toRelative(path)} `
+    + `(first: "${keys[0]}"). `
     + 'Set `compilation.strictMessage` to `true` to reject these, or to `false` to silence this warning.',
   )
 }

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -86,6 +86,11 @@ function validateMessages(value: unknown, options: ValidateOptions, path: string
 const warnedPaths = new Set<string>()
 
 function warnHtmlMessages(path: string, keys: string[]) {
+  // dev re-reads a file on every edit - re-arm once it comes back clean so a later regression warns again
+  if (!keys.length) {
+    warnedPaths.delete(path)
+    return
+  }
   if (warnedPaths.has(path)) { return }
   warnedPaths.add(path)
   logger.warn(
@@ -106,7 +111,7 @@ export function readStaticResource(ctx: Pick<ResolvedI18nContext, 'options' | 'r
     htmlKeys,
   }, path, [])
 
-  if (htmlKeys.length) { warnHtmlMessages(path, htmlKeys) }
+  warnHtmlMessages(path, htmlKeys)
 
   return JSON.stringify(messages)
 }

--- a/src/transform/json-parse.ts
+++ b/src/transform/json-parse.ts
@@ -1,5 +1,5 @@
 import { createUnplugin } from 'unplugin'
-import { STATIC_RESOURCE_RE, readStaticResource } from '../resources'
+import { readStaticResource } from '../resources'
 import { asI18nVirtual } from './utils'
 
 import type { ResolvedI18nContext } from '../context'
@@ -15,7 +15,7 @@ export const JsonParseMessagesPlugin = (ctx: ResolvedI18nContext) =>
   createUnplugin(() => {
     const virtualToPath = new Map<string, string>()
     for (const fileMeta of ctx.localeFileMetas) {
-      if (STATIC_RESOURCE_RE.test(fileMeta.path)) {
+      if (ctx.rawResourcePaths.has(fileMeta.path)) {
         virtualToPath.set(asI18nVirtual(fileMeta.hash), fileMeta.path)
       }
     }

--- a/src/transform/resource.ts
+++ b/src/transform/resource.ts
@@ -18,7 +18,7 @@ export function transform(id: string, input: string, options?: TransformOptions)
 const DEFINE_I18N_FN_RE = /\b(defineI18nLocale|defineI18nConfig)\s*\((.+)\)/gs
 
 export const ResourcePlugin = (options: BundlerPluginOptions, ctx: ResolvedI18nContext) =>
-  createUnplugin(() => {
+  createUnplugin((_options, meta) => {
     // TODO: track all i18n files found in configuration
     const i18nFileMetas = [...ctx.localeFileMetas, ...ctx.vueI18nConfigPaths]
     const i18nPathSet = new Set<string>()
@@ -39,9 +39,10 @@ export const ResourcePlugin = (options: BundlerPluginOptions, ctx: ResolvedI18nC
           return
         }
 
-        // claim i18n file paths so other plugins (e.g. `unplugin-vue-i18n` since vite 8) cannot
-        // resolve these to virtual modules loaded from disk, which would skip our transforms (#4049)
-        if (i18nPathSet.has(id)) {
+        // claim i18n file paths so `unplugin-vue-i18n` cannot resolve these to virtual modules
+        // loaded from disk, which would skip our transforms (#4049) - it only does so under vite,
+        // and webpack reads a path resolving to itself as `Recursion in resolving`
+        if (meta.framework === 'vite' && i18nPathSet.has(id)) {
           return id
         }
 

--- a/src/transform/resource.ts
+++ b/src/transform/resource.ts
@@ -23,10 +23,10 @@ export const ResourcePlugin = (options: BundlerPluginOptions, ctx: ResolvedI18nC
     const i18nFileMetas = [...ctx.localeFileMetas, ...ctx.vueI18nConfigPaths]
     const i18nPathSet = new Set<string>()
     const i18nFileHashSet = new Map<string, string>()
-    for (const meta of i18nFileMetas) {
-      if (i18nPathSet.has(meta.path)) { continue }
-      i18nPathSet.add(meta.path)
-      i18nFileHashSet.set(asI18nVirtual(meta.hash), meta.path)
+    for (const fileMeta of i18nFileMetas) {
+      if (i18nPathSet.has(fileMeta.path)) { continue }
+      i18nPathSet.add(fileMeta.path)
+      i18nFileHashSet.set(asI18nVirtual(fileMeta.hash), fileMeta.path)
     }
 
     return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -217,10 +217,11 @@ export interface ExperimentalFeatures {
    */
   prerenderMessages?: boolean
   /**
-   * Skip precompiling static locale resources (JSON/JSON5/YAML) in server builds, embedding them as
-   * raw messages instead to reduce build time and memory. The client bundle keeps precompiled
-   * messages, the server compiles messages at runtime. Vite only.
-   * @default false
+   * Embed static locale resources (JSON/JSON5/YAML) in server builds as raw messages instead of
+   * handing them to the bundler, reducing build time and memory. The client bundle is unaffected.
+   * Disable this if a custom Nitro Rollup plugin transforms your locale files, they are no longer
+   * imported into the server graph.
+   * @default true
    */
   optimizeMessageBundling?: boolean
 }
@@ -236,6 +237,9 @@ export interface CustomBlocksOptions extends Pick<PluginOptions, 'defaultSFCLang
 export interface LocaleMessageCompilationOptions {
   /**
    * Whether to strictly check that the locale message does not contain HTML tags. If HTML tags are included, an error is thrown.
+   *
+   * Resources that are not precompiled were never checked, so HTML in those is reported as a build
+   * warning while this option is left at its default. Set it explicitly to reject or allow them.
    *
    * @default true
    */

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -98,6 +98,20 @@ describe('readStaticResource', () => {
     expect(warn.mock.calls[0]![0]).toContain('Detected HTML in 2 messages in warn.json (first: "a")')
   })
 
+  test('warns again after a file comes back clean', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    const path = writeResource('rearm.json', '{"a":"<b>hello</b>"}')
+    readStaticResource(createCtx(), path)
+
+    writeResource('rearm.json', '{"a":"plain"}')
+    readStaticResource(createCtx(), path)
+
+    writeResource('rearm.json', '{"a":"<i>back</i>"}')
+    readStaticResource(createCtx(), path)
+
+    expect(warn).toHaveBeenCalledTimes(2)
+  })
+
   test('stays silent when `strictMessage` is explicitly disabled', () => {
     const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
     const path = writeResource('silent.json', '{"greeting":"<b>hello</b>"}')

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -1,15 +1,25 @@
 import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 import { readStaticResource } from '../src/resources'
+import { logger } from '../src/utils'
 
 import type { ResolvedI18nContext } from '../src/context'
 
 const dir = mkdtempSync(join(tmpdir(), 'i18n-resources-'))
+const nuxt = { vfs: {} as Record<string, string>, options: { rootDir: dir } }
+
+vi.mock('@nuxt/kit', async importOriginal => ({
+  ...(await importOriginal<typeof import('@nuxt/kit')>()),
+  tryUseNuxt: () => nuxt,
+}))
 
 function createCtx(compilation: { strictMessage?: boolean, escapeHtml?: boolean } = {}) {
-  return { options: { compilation } } as unknown as Pick<ResolvedI18nContext, 'options'>
+  return { options: { compilation }, rawOptions: { compilation } } as unknown as Pick<
+    ResolvedI18nContext,
+    'options' | 'rawOptions'
+  >
 }
 
 function writeResource(name: string, contents: string) {
@@ -17,6 +27,11 @@ function writeResource(name: string, contents: string) {
   writeFileSync(path, contents)
   return path
 }
+
+afterEach(() => {
+  nuxt.vfs = {}
+  vi.restoreAllMocks()
+})
 
 describe('readStaticResource', () => {
   test('minifies json', () => {
@@ -37,17 +52,57 @@ describe('readStaticResource', () => {
     expect(readStaticResource(createCtx(), path)).toBe('{"n":1,"b":true,"nil":null,"list":["a","b"]}')
   })
 
-  test('throws for HTML messages when `strictMessage` is enabled (the default)', () => {
+  test('strips a byte order mark', () => {
+    const path = writeResource('bom.json', '﻿{"hello":"world"}')
+    expect(readStaticResource(createCtx(), path)).toBe('{"hello":"world"}')
+  })
+
+  test('reports the file path when parsing fails', () => {
+    const path = writeResource('broken.json', '{"hello":')
+    expect(() => readStaticResource(createCtx(), path)).toThrow(new RegExp(`Could not parse locale file \\(${path}\\)`))
+  })
+
+  test('reads locale files from the virtual file system', () => {
+    const path = join(dir, 'virtual.json')
+    nuxt.vfs[path] = '{"hello":"virtual"}'
+
+    expect(readStaticResource(createCtx(), path)).toBe('{"hello":"virtual"}')
+  })
+
+  test('throws for HTML messages when `strictMessage` is explicitly enabled', () => {
     const path = writeResource('strict.json', '{"greeting":"<b>hello</b>"}')
-    expect(() => readStaticResource(createCtx(), path)).toThrow(/Detected HTML/)
+    expect(() => readStaticResource(createCtx({ strictMessage: true }), path)).toThrow(/Detected HTML/)
   })
 
   test('reports the message path of the offending message', () => {
+    const ctx = createCtx({ strictMessage: true })
+
     const path = writeResource('nested.json', '{"a":{"b":{"c":"<b>hello</b>"}}}')
-    expect(() => readStaticResource(createCtx(), path)).toThrow(/at "a\.b\.c"/)
+    expect(() => readStaticResource(ctx, path)).toThrow(/at "a\.b\.c"/)
 
     const inArray = writeResource('array.json', '{"list":["ok","<i>bad</i>"]}')
-    expect(() => readStaticResource(createCtx(), inArray)).toThrow(/at "list\.1"/)
+    expect(() => readStaticResource(ctx, inArray)).toThrow(/at "list\.1"/)
+  })
+
+  // these resources are not precompiled, so nothing rejected HTML in them before
+  // `optimizeMessageBundling` - warn rather than break builds that have always passed
+  test('warns once per file instead of throwing when `strictMessage` is not set', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    const path = writeResource('warn.json', '{"a":"<b>hello</b>","b":{"c":"<i>hi</i>"},"d":"plain"}')
+
+    expect(JSON.parse(readStaticResource(createCtx(), path)).a).toBe('<b>hello</b>')
+    readStaticResource(createCtx(), path)
+
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0]![0]).toContain('Detected HTML in 2 messages in warn.json (first: "a")')
+  })
+
+  test('stays silent when `strictMessage` is explicitly disabled', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    const path = writeResource('silent.json', '{"greeting":"<b>hello</b>"}')
+
+    expect(JSON.parse(readStaticResource(createCtx({ strictMessage: false }), path)).greeting).toBe('<b>hello</b>')
+    expect(warn).not.toHaveBeenCalled()
   })
 
   test('escapes HTML when `escapeHtml` is enabled and strict is off', () => {
@@ -57,12 +112,5 @@ describe('readStaticResource', () => {
     expect(result.greeting).toBe('&lt;b&gt;hello&lt;&#x2F;b&gt;')
     // no tag detected, left untouched - matches `@intlify/bundle-utils`
     expect(result.plain).toBe('a > b')
-  })
-
-  test('leaves HTML untouched when both checks are disabled', () => {
-    const path = writeResource('loose.json', '{"greeting":"<b>hello</b>"}')
-    const ctx = createCtx({ strictMessage: false, escapeHtml: false })
-
-    expect(JSON.parse(readStaticResource(ctx, path)).greeting).toBe('<b>hello</b>')
   })
 })

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, test, vi } from 'vitest'
-import { readStaticResource } from '../src/resources'
+import { readStaticResource, resolveRawResourcePaths } from '../src/resources'
 import { logger } from '../src/utils'
 
 import type { ResolvedI18nContext } from '../src/context'
@@ -112,5 +112,38 @@ describe('readStaticResource', () => {
     expect(result.greeting).toBe('&lt;b&gt;hello&lt;&#x2F;b&gt;')
     // no tag detected, left untouched - matches `@intlify/bundle-utils`
     expect(result.plain).toBe('a > b')
+  })
+})
+
+describe('resolveRawResourcePaths', () => {
+  test('collects static resources and ignores executable locale files', () => {
+    const json = writeResource('raw-en.json', '{"hello":"world"}')
+    const yaml = writeResource('raw-en.yaml', 'hello: world')
+    const json5 = writeResource('raw-en.json5', '{ hello: "world" }')
+    const ts = writeResource('raw-en.ts', 'export default defineI18nLocale(() => ({}))')
+
+    expect(resolveRawResourcePaths([json, yaml, json5, ts])).toEqual(new Set([json, yaml, json5]))
+  })
+
+  test('leaves unparseable resources to the bundler instead of throwing', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+    const ok = writeResource('raw-ok.json', '{"hello":"world"}')
+    const broken = writeResource('raw-broken.json', '{"hello":')
+
+    expect(resolveRawResourcePaths([ok, broken])).toEqual(new Set([ok]))
+    expect(warn.mock.calls[0]![0]).toContain('Leaving raw-broken.json to the bundler')
+  })
+
+  test('does not validate messages, HTML is rejected on read instead', () => {
+    const path = writeResource('raw-html.json', '{"greeting":"<b>hello</b>"}')
+
+    expect(resolveRawResourcePaths([path])).toEqual(new Set([path]))
+    expect(() => readStaticResource(createCtx({ strictMessage: true }), path)).toThrow(/Detected HTML/)
+  })
+
+  test('deduplicates paths shared by several locales', () => {
+    const path = writeResource('raw-shared.json', '{"hello":"world"}')
+
+    expect(resolveRawResourcePaths([path, path])).toEqual(new Set([path]))
   })
 })

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -1,0 +1,68 @@
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, test } from 'vitest'
+import { readStaticResource } from '../src/resources'
+
+import type { ResolvedI18nContext } from '../src/context'
+
+const dir = mkdtempSync(join(tmpdir(), 'i18n-resources-'))
+
+function createCtx(compilation: { strictMessage?: boolean, escapeHtml?: boolean } = {}) {
+  return { options: { compilation } } as unknown as Pick<ResolvedI18nContext, 'options'>
+}
+
+function writeResource(name: string, contents: string) {
+  const path = join(dir, name)
+  writeFileSync(path, contents)
+  return path
+}
+
+describe('readStaticResource', () => {
+  test('minifies json', () => {
+    const path = writeResource('en.json', '{\n  "hello": "world"\n}')
+    expect(readStaticResource(createCtx(), path)).toBe('{"hello":"world"}')
+  })
+
+  test('parses json5 and yaml into json', () => {
+    const json5 = writeResource('en.json5', '{ hello: "world" /* comment */ }')
+    expect(readStaticResource(createCtx(), json5)).toBe('{"hello":"world"}')
+
+    const yaml = writeResource('en.yaml', 'hello: world\nnested:\n  key: value\n')
+    expect(readStaticResource(createCtx(), yaml)).toBe('{"hello":"world","nested":{"key":"value"}}')
+  })
+
+  test('keeps non-string values as-is', () => {
+    const path = writeResource('values.json', '{"n":1,"b":true,"nil":null,"list":["a","b"]}')
+    expect(readStaticResource(createCtx(), path)).toBe('{"n":1,"b":true,"nil":null,"list":["a","b"]}')
+  })
+
+  test('throws for HTML messages when `strictMessage` is enabled (the default)', () => {
+    const path = writeResource('strict.json', '{"greeting":"<b>hello</b>"}')
+    expect(() => readStaticResource(createCtx(), path)).toThrow(/Detected HTML/)
+  })
+
+  test('reports the message path of the offending message', () => {
+    const path = writeResource('nested.json', '{"a":{"b":{"c":"<b>hello</b>"}}}')
+    expect(() => readStaticResource(createCtx(), path)).toThrow(/at "a\.b\.c"/)
+
+    const inArray = writeResource('array.json', '{"list":["ok","<i>bad</i>"]}')
+    expect(() => readStaticResource(createCtx(), inArray)).toThrow(/at "list\.1"/)
+  })
+
+  test('escapes HTML when `escapeHtml` is enabled and strict is off', () => {
+    const path = writeResource('escape.json', '{"greeting":"<b>hello</b>","plain":"a > b"}')
+    const result = JSON.parse(readStaticResource(createCtx({ strictMessage: false, escapeHtml: true }), path))
+
+    expect(result.greeting).toBe('&lt;b&gt;hello&lt;&#x2F;b&gt;')
+    // no tag detected, left untouched - matches `@intlify/bundle-utils`
+    expect(result.plain).toBe('a > b')
+  })
+
+  test('leaves HTML untouched when both checks are disabled', () => {
+    const path = writeResource('loose.json', '{"greeting":"<b>hello</b>"}')
+    const ctx = createCtx({ strictMessage: false, escapeHtml: false })
+
+    expect(JSON.parse(readStaticResource(ctx, path)).greeting).toBe('<b>hello</b>')
+  })
+})

--- a/test/resources.test.ts
+++ b/test/resources.test.ts
@@ -59,7 +59,8 @@ describe('readStaticResource', () => {
 
   test('reports the file path when parsing fails', () => {
     const path = writeResource('broken.json', '{"hello":')
-    expect(() => readStaticResource(createCtx(), path)).toThrow(new RegExp(`Could not parse locale file \\(${path}\\)`))
+    // string matcher - a path interpolated into a regex escapes its own separators on windows
+    expect(() => readStaticResource(createCtx(), path)).toThrow(`Could not parse locale file (${path})`)
   })
 
   test('reads locale files from the virtual file system', () => {


### PR DESCRIPTION
### 🔗 Linked issue
* Related #4068  
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

`optimizeMessageBundling` skips handing static locale files to the bundler, since the server compiles messages at runtime either way this work only slowed the build down. This enables it by default, the option hasn't been released yet so nothing changes for projects on 10.5.0

We parse these files ourselves when it's enabled, which is a risk for files the bundler accepts but we don't. Locale files we can't parse are now left to the bundler, so they only miss out on the optimization, and if they really are broken the bundler reports it with better context. Nothing checked these resources for HTML before either, so `compilation.strictMessage` only rejects them when it's set explicitly and warns once per file otherwise.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optimized message bundling is now enabled by default; server builds embed supported locale files as raw messages to reduce server output size (client rendering behavior unchanged).
* **Bug Fixes**
  * Improved locale resource handling: UTF-8 BOM stripping, better JSON/JSON5/YAML parsing, clearer parse-failure errors, and more accurate HTML handling aligned with `strictMessage` (warn/escape or reject).
* **Documentation**
  * Refreshed `optimizeMessageBundling` and `strictMessage` guidance, including how to opt out and expected warning behavior.
* **Tests**
  * Added Vitest coverage for static resource reading and raw message path resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->