### PR TITLE
fix(routing): resolve the unprefixed locale per domain

### DIFF
--- a/docs/content/docs/02.guide/10.multi-domain-locales.md
+++ b/docs/content/docs/02.guide/10.multi-domain-locales.md
@@ -167,3 +167,6 @@ The same requests when using the `'prefix_except_default'`{lang="ts-type"} strat
 - https://es.mydomain.com -> https://es.mydomain.com (es language)
 - https://fr.mydomain.com -> https://fr.mydomain.com (fr language)
 - https://fr.mydomain.com/de -> https://fr.mydomain.com/de (de language)
+- https://fr.mydomain.com/en -> https://fr.mydomain.com/en (en language)
+
+A locale is only unprefixed on the domains it is the default for, on every other domain it keeps its prefix. This includes the locale set as `defaultLocale`.

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -119,12 +119,29 @@ function getDomainDefaultLocales(locales: LocaleObject[]): string[] {
   return locales.filter(locale => locale.defaultForDomains?.length || locale.domainDefault).map(locale => locale.code)
 }
 
+const usesDefaultVariants = (strategy: Strategies | undefined) =>
+  strategy === 'prefix_except_default' || strategy === 'prefix_and_default'
+
+/**
+ * Locales getting an unprefixed `___default` tree alongside their prefixed routes.
+ */
+function resolveDefaultTreeLocales(config: SetupLocalizeRoutesOptions, strategy: Strategies): string[] {
+  if (config.differentDomains || config.multiDomainLocales) {
+    // `setupMultiDomainLocales` keeps the current host's variant at runtime
+    return usesDefaultVariants(strategy) ? getDomainDefaultLocales(config.locales) : []
+  }
+  return strategy === 'prefix_and_default' && config.defaultLocale ? [config.defaultLocale] : []
+}
+
 function resolveDefaultLocales(config: SetupLocalizeRoutesOptions) {
+  // under the `*_default` strategies the unprefixed locale differs per domain, `___default`
+  // variants + runtime surgery resolve it - a build time default would claim the same path
+  if ((config.differentDomains || config.multiDomainLocales) && usesDefaultVariants(config.strategy)) {
+    return []
+  }
+
   let defaultLocales = [config.defaultLocale ?? '']
-  // under the `*_default` strategies domain defaults use `___default` variants + runtime surgery instead
-  const usesDefaultVariants
-    = config.strategy === 'prefix_except_default' || config.strategy === 'prefix_and_default'
-  if (config.differentDomains && !usesDefaultVariants) {
+  if (config.differentDomains) {
     defaultLocales = defaultLocales.concat(getDomainDefaultLocales(config.locales))
   }
   return defaultLocales
@@ -232,32 +249,14 @@ export function localizeRoutes(routes: LocalizableRoute[], config: SetupLocalize
     }
   }
 
-  /**
-   * Default tree for prefix_and_default strategy
-   */
-  if (strategy === 'prefix_and_default') {
+  const defaultTreeLocales = new Set(resolveDefaultTreeLocales(config, strategy))
+  if (defaultTreeLocales.size) {
     // unshift to preserve test snapshots
     ctx.localizers.unshift({
-      enabled: ({ options, locale }) => ctx.isDefaultLocale(locale) && !options.defaultTree && options.parent == null,
+      enabled: ({ locale, options }) =>
+        defaultTreeLocales.has(locale) && !options.defaultTree && options.parent == null,
       localizer: ({ route, ctx, locale, options }) =>
         localizeSingleRoute(route, { ...options, locales: [locale], defaultTree: true }, ctx),
-    })
-  }
-
-  /**
-   * Unprefixed default routes for multi domain locales
-   */
-  const domainLocales = (config.multiDomainLocales || config.differentDomains) ?? false
-  if (domainLocales && (config.strategy === 'prefix_except_default' || config.strategy === 'prefix_and_default')) {
-    // only locales that are the default for some domain need an unprefixed variant,
-    // `setupMultiDomainLocales` rebuilds the current domain's default routes from these at runtime
-    const domainDefaults = new Set(getDomainDefaultLocales(config.locales))
-    // unshift to preserve test snapshots
-    ctx.localizers.unshift({
-      enabled: ({ usePrefix, locale }) => usePrefix && domainDefaults.has(locale),
-      localizer: ({ unprefixed, route, ctx, locale }) => [
-        { ...route, name: ctx.localizeRouteName(route, locale, true), path: unprefixed },
-      ],
     })
   }
 

--- a/test/pages/__snapshots__/localize_routes.test.ts.snap
+++ b/test/pages/__snapshots__/localize_routes.test.ts.snap
@@ -126,6 +126,16 @@ exports[`localizeRoutes > strategy: "prefix_and_default" + multiDomainLocales > 
 [
   {
     "children": [],
+    "name": "user-profile___en",
+    "path": "/en/user/:id/profile",
+  },
+  {
+    "children": [],
+    "name": "user-posts___en",
+    "path": "/en/user/:id/posts",
+  },
+  {
+    "children": [],
     "name": "user-profile___ja",
     "path": "/ja/user/:id/profile",
   },
@@ -133,6 +143,20 @@ exports[`localizeRoutes > strategy: "prefix_and_default" + multiDomainLocales > 
     "children": [],
     "name": "user-posts___ja",
     "path": "/ja/user/:id/posts",
+  },
+  {
+    "children": [
+      {
+        "name": "user-profile___en",
+        "path": "profile",
+      },
+      {
+        "name": "user-posts___en",
+        "path": "posts",
+      },
+    ],
+    "name": "user___en",
+    "path": "/en/user/:id",
   },
   {
     "children": [
@@ -150,37 +174,47 @@ exports[`localizeRoutes > strategy: "prefix_and_default" + multiDomainLocales > 
   },
   {
     "children": [],
+    "name": "about___en",
+    "path": "/en/about",
+  },
+  {
+    "children": [],
     "name": "about___ja",
     "path": "/ja/about",
   },
   {
     "children": [],
-    "name": "user-profile___en",
+    "name": "user-profile___en___default",
     "path": "/user/:id/profile",
   },
   {
     "children": [],
-    "name": "user-posts___en",
+    "name": "user-posts___en___default",
     "path": "/user/:id/posts",
   },
   {
     "children": [
       {
-        "name": "user-profile___en",
+        "name": "user-profile___en___default",
         "path": "profile",
       },
       {
-        "name": "user-posts___en",
+        "name": "user-posts___en___default",
         "path": "posts",
       },
     ],
-    "name": "user___en",
+    "name": "user___en___default",
     "path": "/user/:id",
   },
   {
     "children": [],
-    "name": "home___en",
+    "name": "home___en___default",
     "path": "/",
+  },
+  {
+    "children": [],
+    "name": "home___en",
+    "path": "/en",
   },
   {
     "children": [],
@@ -189,7 +223,7 @@ exports[`localizeRoutes > strategy: "prefix_and_default" + multiDomainLocales > 
   },
   {
     "children": [],
-    "name": "about___en",
+    "name": "about___en___default",
     "path": "/about",
   },
 ]
@@ -257,13 +291,13 @@ exports[`localizeRoutes > strategy: "prefix_and_default" + multiDomainLocales > 
   },
   {
     "children": [],
-    "name": "home___en",
-    "path": "/",
+    "name": "about___en",
+    "path": "/about",
   },
   {
     "children": [],
-    "name": "about___en",
-    "path": "/about",
+    "name": "home___en",
+    "path": "/",
   },
 ]
 `;

--- a/test/pages/localize_routes.test.ts
+++ b/test/pages/localize_routes.test.ts
@@ -249,7 +249,8 @@ describe('localizeRoutes', function () {
       })
 
       const paths = Object.fromEntries(localizedRoutes.map(x => [x.name, x.path]))
-      expect(paths['about___en']).toBe('/about')
+      // every locale is prefixed, `defaultLocale` is not the default on every domain
+      expect(paths['about___en']).toBe('/en/about')
       expect(paths['about___ja']).toBe('/ja/about')
       // domain defaults are prefixed with an unprefixed `___default` variant
       expect(paths['about___fr']).toBe('/fr/about')
@@ -265,6 +266,109 @@ describe('localizeRoutes', function () {
       expect(domainPaths['about___nl']).toBe('/nl/about')
       expect(domainPaths['about___fr___default']).toBeUndefined()
       expect(domainPaths['about___nl___default']).toBeUndefined()
+      // `en` keeps its prefix here, it is only unprefixed on the domains it is the default for
+      expect(domainPaths['about___en']).toBe('/en/about')
+    })
+
+    it('unprefixes the domain default without breaking nested routes', function () {
+      const routes: NuxtPage[] = [
+        { path: '/', name: 'home' },
+        { path: '/user/:id', name: 'user', children: [{ path: 'profile', name: 'user-profile' }] }
+      ]
+
+      const localizedRoutes = localizeRoutes(routes as LocalizableRoute[], {
+        ...nuxtOptions,
+        defaultLocale: 'en',
+        strategy: 'prefix_except_default',
+        differentDomains: true,
+        locales: [
+          { code: 'en', domain: 'en.example.com' },
+          { code: 'fr', domain: 'fr.example.com', defaultForDomains: ['fr.example.com'] }
+        ]
+      })
+
+      const router = createRouter({ routes: localizedRoutes as any, history: createMemoryHistory() })
+      setupMultiDomainLocales('fr', 'prefix_except_default', router)
+
+      expect(router.resolve('/').name).toBe('home___fr')
+      expect(router.resolve('/en').name).toBe('home___en')
+      // the re-added child is registered under its parent, not as a route of its own
+      const profile = router.resolve('/user/1/profile')
+      expect(profile.name).toBe('user-profile___fr')
+      expect(profile.matched.map(x => x.name)).toEqual(['user___fr', 'user-profile___fr'])
+      expect(router.resolve('/en/user/1/profile').name).toBe('user-profile___en')
+    })
+
+    it('keeps the configured trailing slash when unprefixing', function () {
+      const routes: NuxtPage[] = [{ path: '/', name: 'home' }, { path: '/about', name: 'about' }]
+
+      const localizedRoutes = localizeRoutes(routes as LocalizableRoute[], {
+        ...nuxtOptions,
+        defaultLocale: 'en',
+        strategy: 'prefix_except_default',
+        trailingSlash: true,
+        differentDomains: true,
+        locales: [
+          { code: 'en', domain: 'en.example.com' },
+          { code: 'fr', domain: 'fr.example.com', defaultForDomains: ['fr.example.com'] }
+        ]
+      })
+
+      const router = createRouter({ routes: localizedRoutes as any, history: createMemoryHistory() })
+      setupMultiDomainLocales('fr', 'prefix_except_default', router)
+      const domainPaths = Object.fromEntries(router.getRoutes().map(x => [x.name, x.path]))
+      expect(domainPaths['home___fr']).toBe('/')
+      expect(domainPaths['home___en']).toBe('/en/')
+      expect(domainPaths['about___en']).toBe('/en/about/')
+    })
+
+    it('localizes the children of a domain default\'s unprefixed variant', function () {
+      const routes: NuxtPage[] = [
+        { path: '/user/:id', name: 'user', children: [{ path: 'profile', name: 'user-profile' }] }
+      ]
+
+      const localizedRoutes = localizeRoutes(routes as LocalizableRoute[], {
+        ...nuxtOptions,
+        defaultLocale: 'en',
+        strategy: 'prefix_except_default',
+        differentDomains: true,
+        locales: [
+          { code: 'en', domain: 'en.example.com' },
+          { code: 'fr', domain: 'fr.example.com', defaultForDomains: ['fr.example.com'] }
+        ]
+      })
+
+      const tree = localizedRoutes.find(r => r.name === 'user___fr___default')
+      expect(tree?.children?.map(c => c.name)).toEqual(['user-profile___fr___default'])
+    })
+  })
+
+  describe('strategy: "prefix_and_default" + differentDomains', function () {
+    it('only generates an unprefixed variant for domain defaults, not for `defaultLocale`', function () {
+      const routes: NuxtPage[] = [{ path: '/about', name: 'about' }]
+
+      const localizedRoutes = localizeRoutes(routes as LocalizableRoute[], {
+        ...nuxtOptions,
+        defaultLocale: 'en',
+        strategy: 'prefix_and_default',
+        differentDomains: true,
+        locales: [
+          { code: 'en', domain: 'en.example.com' },
+          { code: 'fr', domain: 'fr.example.com', defaultForDomains: ['fr.example.com'] }
+        ]
+      })
+
+      const paths = Object.fromEntries(localizedRoutes.map(x => [x.name, x.path]))
+      expect(paths['about___en']).toBe('/en/about')
+      expect(paths['about___en___default']).toBeUndefined()
+      expect(paths['about___fr']).toBe('/fr/about')
+      expect(paths['about___fr___default']).toBe('/about')
+
+      const router = createRouter({ routes: localizedRoutes as any, history: createMemoryHistory() })
+      setupMultiDomainLocales('fr', 'prefix_and_default', router)
+      const domainPaths = Object.fromEntries(router.getRoutes().map(x => [x.name, x.path]))
+      expect(domainPaths['about___fr']).toBe('/about')
+      expect(domainPaths['about___en']).toBe('/en/about')
     })
   })
 


### PR DESCRIPTION
* Related #4080

Under `differentDomains`/`multiDomainLocales` with the `prefix_except_default` and `prefix_and_default` strategies, the build time `defaultLocale` was still generated as the unprefixed locale. On a domain where a different locale is the default that left two routes claiming the same path and the first one registered won, so the domain's own default was unreachable at `/`. It also meant `defaultLocale` had no prefixed route on the other domains.

Domain routing now leaves the unprefixed variant entirely to the `___default` routes generated for domain defaults, which `setupMultiDomainLocales` already resolves per host at runtime. The two localizers producing those trees are merged into one, which also fixes child routes of a domain default keeping their unlocalized names (`user-profile` instead of `user-profile___fr___default`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-domain locale routing for `prefix_except_default` and `prefix_and_default` strategies.
  * Default locales now remain prefixed on domains where they are not the domain default.
  * Preserved nested routes, route matching, and configured trailing slashes when domain-default routes are unprefixed.

* **Documentation**
  * Expanded routing examples to clarify locale prefixes and redirects across domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->