### PR TITLE
fix(domain): resolve locale availability from host membership

### DIFF
--- a/docs/content/docs/02.guide/09.different-domains.md
+++ b/docs/content/docs/02.guide/09.different-domains.md
@@ -9,7 +9,7 @@ Here is how to achieve this:
 
 - Set `differentDomains` option to `true`{lang="ts"}
 - Configure the `locales` option as an array of objects, where each object has a `domain` key whose value is the domain name you'd like to use for that locale. Optionally include a port (if non-standard) and/or a protocol. If the protocol is not provided then an attempt will be made to auto-detect it but that might not work correctly in some cases like when the pages are statically generated.
-- Optionally set `detectBrowserLanguage` to `false`{lang="ts"}. When enabled (which it is by default), user can get redirected to a different domain on first visit. Set to `false`{lang="ts"} if you want to ensure that visiting given domain always shows page in the corresponding locale.
+- Optionally set `detectBrowserLanguage` to `false`{lang="ts"}. When enabled (which it is by default), a first visit can be redirected to the locale detected from the browser, within the current domain. Set to `false`{lang="ts"} if you want to ensure that visiting a given domain always shows the page in that domain's own locale.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/docs/content/docs/02.guide/10.multi-domain-locales.md
+++ b/docs/content/docs/02.guide/10.multi-domain-locales.md
@@ -9,7 +9,7 @@ How to set up multi domain locales:
 - Configure the `locales` option as an array of objects:
   - Each object has a `domains` key whose value is a array of the domains you'd like to use for that locale. Optionally include a port (if non-standard) and/or a protocol. If the protocol is not provided then an attempt will be made to auto-detect it but that might not work correctly in some cases like when the pages are statically generated.
   - Optionally set for each object a `defaultForDomains` key whose value is a array of the default domains you'd like to use for that locale. Optionally include a port (if non-standard) and/or a protocol. If the protocol is not provided then an attempt will be made to auto-detect it but that might not work correctly in some cases like when the pages are statically generated.
-- Optionally set `detectBrowserLanguage` to `false`{lang="ts"}. When enabled (which it is by default), user can get redirected to a different domain on first visit. Set to `false`{lang="ts"} if you want to ensure that visiting given domain always shows page in the corresponding locale.
+- Optionally set `detectBrowserLanguage` to `false`{lang="ts"}. When enabled (which it is by default), a first visit can be redirected to the locale detected from the browser, within the current domain. Set to `false`{lang="ts"} if you want to ensure that visiting a given domain always shows the page in that domain's own locale.
 
 ```ts [nuxt.config.ts]
 const i18nDomains = ['mydomain.com', 'es.mydomain.com', 'fr.mydomain.com', 'http://pl.mydomain.com', 'https://ua.mydomain.com']

--- a/src/runtime/shared/detection.ts
+++ b/src/runtime/shared/detection.ts
@@ -5,11 +5,11 @@ import { normalizedLocales } from '#build/i18n-options.mjs'
 import { getLocaleFromRoute, getLocaleFromRoutePath } from '#i18n-kit/routing'
 import { findBrowserLocale } from '#i18n-kit/browser'
 import { parseAcceptLanguage } from '@intlify/utils'
-import { matchDomainLocale, withRuntimeDomain } from './domain'
+import { isLocaleServedOnHost, matchDomainLocale, withRuntimeDomain } from './domain'
 import { isString } from '@intlify/shared'
 import { isSupportedLocale } from './locales'
 import { type useI18nDetection, useRuntimeI18n } from '../shared/utils'
-import type { I18nPublicRuntimeConfig } from '../../types'
+import type { I18nPublicRuntimeConfig, LocaleObject } from '../../types'
 
 import type { H3Event } from 'h3'
 import type { CompatRoute } from '../types'
@@ -28,18 +28,11 @@ const getHeaderLocale = (event: H3Event | undefined) =>
 
 const getNavigatorLocale = (event: H3Event | undefined) => findBrowserLocale(normalizedLocales, navigator.languages)
 
-const getHostLocale = (
-  event: H3Event | undefined,
-  path: string,
-  domainLocales: I18nPublicRuntimeConfig['domainLocales'],
-) => {
-  const host = import.meta.client
-    ? new URL(window.location.href).host
-    : getRequestURL(event!, { xForwardedHost: true }).host
+const getRequestHost = (event: H3Event | undefined) =>
+  import.meta.client ? new URL(window.location.href).host : getRequestURL(event!, { xForwardedHost: true }).host
 
-  const locales = normalizedLocales.map(l => withRuntimeDomain(l, domainLocales))
-  return matchDomainLocale(locales, host, getLocaleFromRoutePath(path))
-}
+const getDomainLocales = (domainLocales: I18nPublicRuntimeConfig['domainLocales']) =>
+  normalizedLocales.map(l => withRuntimeDomain(l, domainLocales))
 
 export const useDetectors = (event: H3Event | undefined, config: { cookieKey: string }, nuxtApp?: NuxtApp) => {
   if (import.meta.server && !event) {
@@ -47,13 +40,21 @@ export const useDetectors = (event: H3Event | undefined, config: { cookieKey: st
   }
 
   const runtimeI18n = useRuntimeI18n(nuxtApp)
+  // constant for the lifetime of these detectors, a fresh set is created per request
+  let host: string | undefined
+  let locales: LocaleObject[] | undefined
+  const getHost = () => (host ??= getRequestHost(event))
+  const getLocales = () => (locales ??= getDomainLocales(runtimeI18n.domainLocales))
 
   return {
     cookie: () => getCookieLocale(event, config.cookieKey),
     header: () => (import.meta.server ? getHeaderLocale(event) : undefined),
     navigator: () => (import.meta.client ? getNavigatorLocale(event) : undefined),
-    host: (path: string) => getHostLocale(event, path, runtimeI18n.domainLocales),
+    host: (path: string) => matchDomainLocale(getLocales(), getHost(), getLocaleFromRoutePath(path)),
     route: (path: string | CompatRoute) => getRouteLocale(event, path),
+    /** Passes the locale through when the current host serves it, `undefined` otherwise */
+    onHost: (locale: string | null | undefined) =>
+      !locale || isLocaleServedOnHost(getLocales(), getHost(), locale) ? locale : undefined,
   }
 }
 
@@ -103,12 +104,15 @@ export function createLocaleDetector(config: LocaleDetectorConfig) {
     // route objects carry a query-free `path`, server paths may include a query string
     const path = isString(route) ? parsePath(route).pathname : route.path
 
+    // detection never moves the visitor to another domain
+    const onHost = domains ? detectors.onHost : (locale: string | null | undefined) => locale
+
     function* detect() {
       const detecting = initial && detection.enabled && !skipDetect(path, detectors.route(path))
       if (detecting) {
-        yield detectors.cookie()
-        yield detectors.header()
-        yield detectors.navigator()
+        yield onHost(detectors.cookie())
+        yield onHost(detectors.header())
+        yield onHost(detectors.navigator())
       }
 
       if (domains) {
@@ -122,7 +126,7 @@ export function createLocaleDetector(config: LocaleDetectorConfig) {
       // the detection fallback only applies when no other source resolves (e.g. root or
       // unprefixed paths), the route locale is not overridden by a failed browser detection
       if (detecting) {
-        yield detection.fallbackLocale
+        yield onHost(detection.fallbackLocale)
       }
     }
 

--- a/src/runtime/shared/domain.ts
+++ b/src/runtime/shared/domain.ts
@@ -9,7 +9,7 @@ import type { I18nPublicRuntimeConfig, LocaleObject } from '#internal-i18n-types
  * against the request host use the host part only. `ufo` helpers are unsuitable here
  * as they treat the `host:port` shape as a protocol.
  */
-export const normalizeDomain = (domain: string = '') => domain.replace(/^https?:\/\//, '')
+export const normalizeDomain = (domain: string = '') => domain.replace(/^https?:\/\//, '').toLowerCase()
 
 /**
  * Whether the locale is served on the given host
@@ -18,6 +18,29 @@ export function isLocaleOnHost(locale: LocaleObject | undefined, host: string): 
   return (
     !!locale && (normalizeDomain(locale.domain) === host || toArray(locale.domains).some(x => normalizeDomain(x) === host))
   )
+}
+
+/**
+ * Whether the locale can be served on the given host. Unlike {@link isLocaleOnHost} a locale
+ * configured without domains qualifies, as does any locale on a host configured for none of
+ * them (a staging domain, a health check by IP) so the site keeps working there.
+ */
+export function isLocaleServedOnHost(locales: LocaleObject[], host: string, locale: string): boolean {
+  const target = locales.find(l => l.code === locale)
+  if (!target?.domain && !target?.domains?.length) { return true }
+  return isLocaleOnHost(target, host) || !locales.some(l => isLocaleOnHost(l, host))
+}
+
+/**
+ * The domain that should serve `locale` when `host` does not, preferring the one it is the
+ * default for. Undefined when the current host can serve it, which keeps hosts that match no
+ * configured domain on relative URLs instead of sending them to a configured domain.
+ */
+function relocateHostForLocale(host: string, locale: string, locales: LocaleObject[]): string | undefined {
+  if (isLocaleServedOnHost(locales, host, locale)) { return }
+
+  const target = locales.find(l => l.code === locale)
+  return target?.defaultForDomains?.[0] || target?.domain || target?.domains?.[0]
 }
 
 export function matchDomainLocale(locales: LocaleObject[], host: string, pathLocale: string): string | undefined {
@@ -42,8 +65,12 @@ export function domainFromLocale(
   locales: LocaleObject[] = normalizedLocales,
 ): string | undefined {
   const lang = locales.find(x => x.code === locale)
-  // lookup the `differentDomain` origin associated with given locale.
-  const domain = domainLocales?.[locale]?.domain || lang?.domain || lang?.domains?.find(v => normalizeDomain(v) === url.host)
+  // lookup the `differentDomain` origin associated with given locale
+  const domain
+    = domainLocales?.[locale]?.domain
+      || lang?.domain
+      || lang?.domains?.find(v => normalizeDomain(v) === url.host)
+      || relocateHostForLocale(url.host, locale, locales)
 
   if (!domain) {
     import.meta.dev && console.warn('[nuxt-i18n] Could not find domain name for locale ' + locale)

--- a/test/detection.test.ts
+++ b/test/detection.test.ts
@@ -16,7 +16,12 @@ const createDetectors = () => ({
   navigator: (): string | undefined => undefined,
   host: (): string | undefined => undefined,
   route: (path: string | object) => getLocaleFromRoutePath(String(path)),
+  onHost: (locale: string | null | undefined) => locale,
 })
+
+/** Mirrors `useDetectors().onHost`, which passes a locale through only when the host serves it */
+const servedExcept = (restricted: string) => (locale: string | null | undefined) =>
+  locale === restricted ? undefined : locale
 
 const detection = (overrides: Partial<LocaleDetectorConfig['detection']> = {}) =>
   ({ enabled: true, cookieKey: 'i18n_redirected', ...overrides }) as LocaleDetectorConfig['detection']
@@ -88,6 +93,29 @@ describe('createLocaleDetector', () => {
     const detect = createDetector({ domains: true, detection: detection({ fallbackLocale: 'en' }) })
     expect(detect(detectors({ host: () => 'fr' }), '/', true)).toBe('fr')
     expect(detect(detectors({ cookie: () => 'en', host: () => 'fr' }), '/', true)).toBe('en')
+  })
+
+  test('domains: a browser locale the host does not serve falls through to the host locale', () => {
+    const detect = createDetector({ domains: true })
+    const onHost = servedExcept('en')
+    expect(detect(detectors({ cookie: () => 'en', host: () => 'fr', onHost }), '/', true)).toBe('fr')
+    expect(detect(detectors({ header: () => 'en', host: () => 'fr', onHost }), '/', true)).toBe('fr')
+    expect(detect(detectors({ navigator: () => 'en', host: () => 'fr', onHost }), '/', true)).toBe('fr')
+  })
+
+  test('domains: a `fallbackLocale` the host does not serve is not adopted', () => {
+    const detect = createDetector({ domains: true, detection: detection({ fallbackLocale: 'en' }) })
+    expect(detect(detectors({ host: () => undefined, onHost: servedExcept('en') }), '/', true)).toBe('')
+  })
+
+  test('browser locales are unrestricted without domain routing', () => {
+    const detect = createDetector({ domains: false })
+    expect(detect(detectors({ cookie: () => 'fr', onHost: () => undefined }), '/', true)).toBe('fr')
+  })
+
+  test('domains: the restriction does not apply to the route locale', () => {
+    const detect = createDetector({ domains: true, detection: detection({ redirectOn: 'all' }) })
+    expect(detect(detectors({ host: () => undefined, onHost: servedExcept('fr') }), '/fr/about', true)).toBe('fr')
   })
 
   test('(#2158) the route locale is not overridden by `fallbackLocale`', () => {

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'vitest'
-import { domainFromLocale, matchDomainLocale, normalizeDomain, withRuntimeDomain } from '../src/runtime/shared/domain'
+import {
+  domainFromLocale,
+  isLocaleServedOnHost,
+  matchDomainLocale,
+  normalizeDomain,
+  withRuntimeDomain,
+} from '../src/runtime/shared/domain'
 import { getDefaultLocaleForDomain } from '../src/runtime/shared/locales'
 import { createBaseUrlGetter } from '../src/runtime/context'
 import { normalizeDomainLocale } from '../src/utils'
@@ -20,6 +26,8 @@ describe('normalizeDomain', () => {
     expect(normalizeDomain('localhost:3000')).toBe('localhost:3000')
     expect(normalizeDomain('http://127.0.0.1:7787')).toBe('127.0.0.1:7787')
     expect(normalizeDomain()).toBe('')
+    // request hosts are always lowercase, a configured domain may not be
+    expect(normalizeDomain('https://EN.Example.com')).toBe('en.example.com')
   })
 })
 
@@ -46,6 +54,31 @@ describe('matchDomainLocale', () => {
 
   test('returns undefined for unknown host', () => {
     expect(matchDomainLocale(locales, 'unknown.example.com', '')).toBeUndefined()
+  })
+})
+
+describe('isLocaleServedOnHost', () => {
+  test('a restricted locale is served on its own domains', () => {
+    expect(isLocaleServedOnHost(locales, 'shared.example.com', 'de')).toBe(true)
+    expect(isLocaleServedOnHost(locales, 'fr.example.com', 'fr')).toBe(true)
+  })
+
+  test('a restricted locale is not served on another configured domain', () => {
+    expect(isLocaleServedOnHost(locales, 'shared.example.com', 'en')).toBe(false)
+    expect(isLocaleServedOnHost(locales, 'en.example.com', 'de')).toBe(false)
+  })
+
+  test('a locale without domains is served everywhere', () => {
+    expect(isLocaleServedOnHost([...locales, { code: 'pl' }], 'en.example.com', 'pl')).toBe(true)
+  })
+
+  test('an unconfigured host is not restricted', () => {
+    expect(isLocaleServedOnHost(locales, 'staging.example.com', 'en')).toBe(true)
+    expect(isLocaleServedOnHost(locales, '127.0.0.1:3000', 'de')).toBe(true)
+  })
+
+  test('an unknown locale is not restricted', () => {
+    expect(isLocaleServedOnHost(locales, 'en.example.com', 'xx')).toBe(true)
   })
 })
 
@@ -104,8 +137,20 @@ describe('domainFromLocale', () => {
     )
   })
 
-  test('returns undefined without a matching domain', () => {
-    expect(domainFromLocale({}, url, 'nl', locales)).toBeUndefined()
+  test('a locale served on none of the current host resolves to the domain it belongs to', () => {
+    expect(domainFromLocale({}, url, 'nl', locales)).toBe('http://shared.example.com')
+    // the domain the locale is the default for wins over the rest of its `domains`
+    const multi = [...locales, { code: 'pt', domains: ['a.example.com', 'b.example.com'], defaultForDomains: ['b.example.com'] }]
+    expect(domainFromLocale({}, url, 'pt', multi)).toBe('http://b.example.com')
+  })
+
+  test('returns undefined for a locale without domains', () => {
+    expect(domainFromLocale({}, url, 'pl', [...locales, { code: 'pl' }])).toBeUndefined()
+  })
+
+  test('a host matching no configured domain resolves no domain, so URLs stay relative', () => {
+    // otherwise `nuxt dev` and staging would link and redirect to the configured domains
+    expect(domainFromLocale({}, { host: 'localhost:3000', protocol: 'http:' }, 'nl', locales)).toBeUndefined()
   })
 })
 

--- a/test/redirect.test.ts
+++ b/test/redirect.test.ts
@@ -17,6 +17,7 @@ const detectors = () => ({
   navigator: (): string | undefined => undefined,
   host: (): string | undefined => undefined,
   route: (path: string | object) => getLocaleFromRoutePath(String(path)),
+  onHost: (locale: string | null | undefined) => locale,
 })
 
 // mirrors the `matchLocalized` contract for paths that match a route
@@ -162,5 +163,26 @@ describe('createRedirectResolver', () => {
   test('resolves the locale from the route prefix', () => {
     const resolve = createResolver({ strategy: 'prefix_except_default' })
     expect(resolve('/fr/about', '/about', 'fr', 'en', createDetectors()).locale).toBe('fr')
+  })
+
+  describe('domains', () => {
+    const resolveDomain = () =>
+      createResolver({
+        strategy: 'prefix_except_default',
+        domains: true,
+        detection: detection({ enabled: true, redirectOn: 'root' }),
+      })
+
+    test('a cookie locale the host does not serve resolves to the host default without redirecting', () => {
+      const resolve = resolveDomain()
+      const offHost = createDetectors({ cookie: () => 'fr', host: () => 'en', onHost: l => (l === 'fr' ? undefined : l) })
+      expect(resolve('/', '/', undefined, 'en', offHost)).toMatchObject({ path: undefined, locale: 'en' })
+    })
+
+    test('a cookie locale the host serves still redirects', () => {
+      const resolve = resolveDomain()
+      const onHost = createDetectors({ cookie: () => 'fr', host: () => 'en' })
+      expect(resolve('/', '/', undefined, 'en', onHost)).toMatchObject({ path: '/fr', locale: 'fr' })
+    })
   })
 })


### PR DESCRIPTION
`domainFromLocale` only resolved a locale's domain when that domain matched the current host, so a locale configured through `domains` fell back to the default locale's domain when linked from anywhere else, which is what `switchLocalePath` and the hreflang alternates use. Browser detection had a related gap, a cookie or `accept-language` locale the current domain doesn't serve was still adopted and redirected to, landing on a path that renders in the domain's own locale instead.

Both now go through `isLocaleServedOnHost`. A host matching none of the configured domains stays unrestricted and keeps resolving to relative URLs, so `nuxt dev` and staging don't link or redirect to the configured domains. `normalizeDomain` also lowercases now, a configured domain with capitals never matched the request host.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved locale detection for multi-domain setups by restricting browser, cookie, and header locales to those served on the current domain.
  - Prevented redirects to unsupported locales and correctly falls back to the current domain’s locale.
  - Improved domain matching by treating uppercase and lowercase hostnames consistently.
  - Refined cross-domain locale routing and handling for localhost-style addresses.

- **Documentation**
  - Clarified how `detectBrowserLanguage` behaves across domains and how to ensure each domain always uses its configured locale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->