### PR TITLE
feat(domain): restrict locales to a subset of `domains`

### DIFF
--- a/docs/content/docs/02.guide/10.multi-domain-locales.md
+++ b/docs/content/docs/02.guide/10.multi-domain-locales.md
@@ -170,3 +170,46 @@ The same requests when using the `'prefix_except_default'`{lang="ts-type"} strat
 - https://fr.mydomain.com/en -> https://fr.mydomain.com/en (en language)
 
 A locale is only unprefixed on the domains it is the default for, on every other domain it keeps its prefix. This includes the locale set as `defaultLocale`.
+
+## Restricting locales to specific domains
+
+A locale's `domains` doesn't have to list every domain, it only has to list the domains that locale should be served on. A locale configured without `domains` is served on all of them.
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  i18n: {
+    locales: [
+      {
+        code: 'en',
+        domains: ['mydomain.com'],
+        defaultForDomains: ['mydomain.com']
+      },
+      {
+        // shared between both domains
+        code: 'fr',
+        domains: ['mydomain.com', 'es.mydomain.com']
+      },
+      {
+        code: 'es',
+        domains: ['es.mydomain.com'],
+        defaultForDomains: ['es.mydomain.com']
+      }
+    ],
+    defaultLocale: 'en',
+    strategy: 'prefix_except_default',
+    multiDomainLocales: true
+  }
+})
+```
+
+Given the above configuration, following requests will be:
+- https://mydomain.com -> https://mydomain.com (en language)
+- https://mydomain.com/fr -> https://mydomain.com/fr (fr language)
+- https://mydomain.com/es -> https://es.mydomain.com (es language, redirected to the domain serving it)
+- https://es.mydomain.com -> https://es.mydomain.com (es language)
+- https://es.mydomain.com/fr -> https://es.mydomain.com/fr (fr language)
+- https://es.mydomain.com/en -> https://mydomain.com (en language, redirected to the domain serving it)
+
+Locales served on other domains stay available in `locales` and in the locale switcher, `switchLocalePath` links to them on the domain that serves them. Browser language detection only applies locales served on the current domain, so a visitor whose browser or cookie locale isn't available there keeps that domain's own locale.
+
+A request on a host that doesn't match any configured domain, such as a staging domain or a health check by IP, isn't restricted. Every locale is served there and `defaultLocale` is used as the unprefixed default, so it's worth setting even when every domain has its own default through `defaultForDomains`.

--- a/docs/content/docs/04.api/00.options.md
+++ b/docs/content/docs/04.api/00.options.md
@@ -144,6 +144,7 @@ See also [Multiple files lazy loading](/docs/guide/lazy-load-translations#multip
 
 - type: `null | string[]`{lang="ts-type"}
 - An array of `domain`. This property is required when using [`multiDomainLocales`](/docs/api/options#multiDomainLocales) while one or more of the domains having multiple of the same locales
+- This does not have to be the same array for every locale, a locale is only served on the domains listed here. A locale without `domains` is served on all of them. See [Restricting locales to specific domains](/docs/guide/multi-domain-locales#restricting-locales-to-specific-domains)
 
 ### `defaultForDomains`
 

--- a/specs/multi_domains_locales/multi_domains_locales_multi_locales.spec.ts
+++ b/specs/multi_domains_locales/multi_domains_locales_multi_locales.spec.ts
@@ -36,7 +36,8 @@ await setup({
           code: 'ja',
           language: 'jp-JA',
           name: 'Japan',
-          domains: i18nDomains,
+          // restricted to its own domain, the other locales stay on all of them
+          domains: ['ja.nuxt-app.localhost'],
           defaultForDomains: ['ja.nuxt-app.localhost']
         }
       ],
@@ -80,6 +81,49 @@ test('detection locale with x-forwarded-host on server', async () => {
 
   expect(await dom.locator('#lang-switcher-current-locale code').textContent()).toEqual('fr')
   expect(await dom.locator('#home-header').textContent()).toEqual('Accueil')
+})
+
+describe('locales restricted to specific domains', () => {
+  test.each([
+    ['/ja', 'http://ja.nuxt-app.localhost'],
+    ['/ja/parent/child', 'http://ja.nuxt-app.localhost/parent/child'],
+    ['/ja/about?foo=bar', 'http://ja.nuxt-app.localhost/about?foo=bar']
+  ])('%s is relocated to the domain serving it', async (path, location) => {
+    const res = await undiciRequest(path, { headers: { Host: 'nuxt-app.localhost' } })
+
+    expect(res.statusCode).toBe(302)
+    // `ja` is the default on its own domain, so it lands there unprefixed
+    expect(res.headers.location).toEqual(location)
+  })
+
+  test('a restricted locale is served on its own domain', async () => {
+    const res = await undiciRequest('/', { headers: { Host: 'ja.nuxt-app.localhost' } })
+    const dom = await getDom(await res.body.text())
+
+    expect(res.statusCode).toBe(200)
+    expect(await dom.locator('#lang-switcher-current-locale code').textContent()).toEqual('ja')
+  })
+
+  test('a cookie holding a restricted locale does not redirect off the current domain', async () => {
+    const res = await undiciRequest('/', {
+      headers: { Host: 'nuxt-app.localhost', Cookie: 'i18n_redirected=ja' }
+    })
+    const dom = await getDom(await res.body.text())
+
+    expect(res.statusCode).toBe(200)
+    expect(await dom.locator('#lang-switcher-current-locale code').textContent()).toEqual('en')
+  })
+
+  test('a restricted locale stays in the switcher and links to its own domain', async () => {
+    const res = await undiciRequest('/', { headers: { Host: 'nuxt-app.localhost' } })
+    const dom = await getDom(await res.body.text())
+
+    expect(await dom.locator('#switch-locale-path-usages .switch-to-ja a').getAttribute('href')).toEqual(
+      'http://ja.nuxt-app.localhost'
+    )
+    // locales served on the current host keep linking relative
+    expect(await dom.locator('#switch-locale-path-usages .switch-to-no a').getAttribute('href')).toEqual('/no')
+  })
 })
 
 describe('detection locale with child routes', () => {

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -4,7 +4,7 @@ import { defineNitroPlugin, useRuntimeConfig, useStorage } from 'nitropack/runti
 import { initializeI18nContext, tryUseI18nContext, useI18nContext } from './context'
 import { createUserLocaleDetector } from './utils/locale-detector'
 import { pickNested } from './utils/messages-utils'
-import { isSupportedLocale } from '../shared/locales'
+import { getDefaultLocaleForDomain, isSupportedLocale } from '../shared/locales'
 import { setupVueI18nOptions } from '../shared/vue-i18n'
 import { joinURL, parsePath } from 'ufo'
 // @ts-expect-error virtual file
@@ -16,7 +16,7 @@ import { isFunction } from '@intlify/shared'
 import { type H3Event, getRequestURL, sanitizeStatusCode, setCookie } from 'h3'
 import type { CoreOptions } from '@intlify/core'
 import { useDetectors } from '../shared/detection'
-import { domainFromLocale } from '../shared/domain'
+import { domainFromLocale, normalizeDomain } from '../shared/domain'
 import { isExistingNuxtRoute, matchLocalized } from '../shared/matching'
 import { createRedirectResolver } from './utils/redirect'
 
@@ -91,6 +91,22 @@ export default defineNitroPlugin(async (nitro) => {
 
   const baseUrlGetter = createBaseUrlGetter()
 
+  /**
+   * Redirect moving a locale path to the domain that serves it, the target domain has its own
+   * default locale so the path is prefixed for that domain rather than the current one.
+   */
+  const resolveRelocation = (event: H3Event, pathLocale: string, path: string) => {
+    const origin = getDomainFromLocale(event, pathLocale)
+    const host = normalizeDomain(origin)
+    // a target on the current host would redirect to itself
+    if (!origin || host === getRequestURL(event, { xForwardedHost: true }).host) { return }
+
+    const relocated = matchLocalized(path, pathLocale, getDefaultLocaleForDomain(host) || _defaultLocale)
+    if (!relocated) { return }
+
+    return { path: relocated, code: runtimeI18n.redirectStatusCode ?? 302, locale: pathLocale, origin }
+  }
+
   nitro.hooks.hook('request', async (event: H3Event) => {
     await initializeI18nContext(event)
   })
@@ -107,22 +123,29 @@ export default defineNitroPlugin(async (nitro) => {
     // `event.path` is already stripped of `app.baseURL` by Nitro (unlike `url.pathname`), and
     // `parsePath` drops any query string - so `path` stays an absolute, base-free route path.
     const { pathname } = parsePath(event.path)
-    const path = (pathLocale && pathname.slice(pathLocale.length + 1)) ?? pathname
+    // a locale-prefixed root (`/ja`) leaves nothing behind the prefix, its route path is `/`
+    const path = (pathLocale ? pathname.slice(pathLocale.length + 1) || '/' : pathname)
 
     // attempt to only run i18n detection for nuxt pages and i18n server routes
     if (!url.pathname.includes(__I18N_SERVER_ROUTE__) && !isExistingNuxtRoute(path)) {
       return
     }
 
-    const resolved = resolveRedirectPath(event.path, path, pathLocale, ctx.vueI18nOptions!.defaultLocale, detector)
-    if (resolved.path && resolved.path !== pathname) {
+    // a locale restricted to other domains cannot be served here, the request moves to a domain
+    // that does serve it rather than rendering its path in the wrong locale
+    const relocation = (__I18N_ROUTING__ && __I18N_DOMAINS__ && pathLocale && !detector.onHost(pathLocale)
+      && resolveRelocation(event, pathLocale, path)) || undefined
+
+    const resolved = relocation || resolveRedirectPath(event.path, path, pathLocale, ctx.vueI18nOptions!.defaultLocale, detector)
+    if (resolved.path && (relocation || resolved.path !== pathname)) {
       ctx.detectLocale = resolved.locale
-      detection.useCookie && setCookie(event, detection.cookieKey, resolved.locale, cookieOptions)
+      // the origin host would not send the cookie to the domain being redirected to
+      !relocation && detection.useCookie && setCookie(event, detection.cookieKey, resolved.locale, cookieOptions)
       context.response = createRedirectResponse(
         event,
         // the resolved path is base-free (matched against base-free routes), re-add `app.baseURL`
         joinURL(
-          baseUrlGetter(event, ctx.vueI18nOptions!.defaultLocale),
+          relocation?.origin || baseUrlGetter(event, ctx.vueI18nOptions!.defaultLocale),
           useRuntimeConfig(event).app.baseURL,
           resolved.path + url.search,
         ),

--- a/src/runtime/shared/domain.ts
+++ b/src/runtime/shared/domain.ts
@@ -9,7 +9,7 @@ import type { I18nPublicRuntimeConfig, LocaleObject } from '#internal-i18n-types
  * against the request host use the host part only. `ufo` helpers are unsuitable here
  * as they treat the `host:port` shape as a protocol.
  */
-export const normalizeDomain = (domain: string = '') => domain.replace(/^https?:\/\//, '').toLowerCase()
+export const normalizeDomain = (domain: string = '') => domain.replace(/^https?:\/\//i, '').toLowerCase()
 
 /**
  * Whether the locale is served on the given host

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -28,6 +28,7 @@ describe('normalizeDomain', () => {
     expect(normalizeDomain()).toBe('')
     // request hosts are always lowercase, a configured domain may not be
     expect(normalizeDomain('https://EN.Example.com')).toBe('en.example.com')
+    expect(normalizeDomain('HTTPS://EN.Example.com')).toBe('en.example.com')
   })
 })
 


### PR DESCRIPTION
* Related #4080

A locale's `domains` had to list every domain in practice. Listing a subset still served that locale's paths everywhere, but `matchDomainLocale` falls back to the domain's own default, so `https://mydomain.com/es` rendered the Spanish route in English.

A locale path the current domain doesn't serve now redirects to the domain that does, shaped for that domain's own default locale. Route records are left in the router so `switchLocalePath` and the hreflang alternates keep resolving them, and a host matching no configured domain serves every locale as before. Under `differentDomains` every locale already declares a `domain`, so this applies there too, a prefixed path for another domain's locale now redirects rather than rendering in the host's locale.

This also fixes the redirect resolver never running for a locale-prefixed root like `/ja`, where the prefix-free path was empty and treated as a non-route.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for serving locales only on their configured domains via `locales[].domains`.
  * When a locale is requested on an incorrect domain, it redirects to the domain where that locale is available.
  * Locale switcher links now send restricted locales to their designated domains while keeping other links relative to the current host.
  * Browser-language detection is limited to locales available on the current domain, and the redirect cookie is respected to avoid cross-domain redirects.
* **Documentation**
  * Added a guide section and option clarification for “restricting locales to specific domains,” including example outcomes and fallback behavior.
* **Bug Fixes**
  * Improved domain normalization to handle mixed-case hosts and uppercase protocol prefixes correctly.
* **Tests**
  * Expanded multi-domain routing and locale restriction coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->