### PR TITLE
test: poll browser DOM reads to avoid stale assertions

### DIFF
--- a/specs/basic_usage.spec.ts
+++ b/specs/basic_usage.spec.ts
@@ -40,7 +40,7 @@ describe('basic usage', async () => {
       const { page } = await renderPage('/')
 
       // vue-i18n using
-      expect(await page.locator('#vue-i18n-usage p').innerText()).toEqual('Welcome')
+      await expect.poll(() => page.locator('#vue-i18n-usage p').innerText()).toEqual('Welcome')
 
       // URL path localizing with `useLocalePath`
       expect(await page.locator('#locale-path-usages .name a').getAttribute('href')).toEqual('/')
@@ -79,7 +79,7 @@ describe('basic usage', async () => {
 
       // URL path with Route object with `useLocaleRoute`
       await page.locator('#locale-route-usages button').clickNavigate()
-      expect(await page.locator('#profile-page').innerText()).toEqual('This is profile page')
+      await expect.poll(() => page.locator('#profile-page').innerText()).toEqual('This is profile page')
       expect(await page.url()).include('/user/profile?foo=1')
     })
 
@@ -116,10 +116,10 @@ describe('basic usage', async () => {
     test('nuxt context extension', async () => {
       const { page } = await renderPage('/nuxt-context-extension')
 
-      expect(await page.locator('#get-route-base-name').innerText()).toEqual('nuxt-context-extension')
-      expect(await page.locator('#get-route-base-name-string').innerText()).toEqual('nuxt-context-extension')
-      expect(await page.locator('#switch-locale-path').innerText()).toEqual('/ja/nuxt-context-extension')
-      expect(await page.locator('#locale-path').innerText()).toEqual('/nl/nuxt-context-extension')
+      await expect.poll(() => page.locator('#get-route-base-name').innerText()).toEqual('nuxt-context-extension')
+      await expect.poll(() => page.locator('#get-route-base-name-string').innerText()).toEqual('nuxt-context-extension')
+      await expect.poll(() => page.locator('#switch-locale-path').innerText()).toEqual('/ja/nuxt-context-extension')
+      await expect.poll(() => page.locator('#locale-path').innerText()).toEqual('/nl/nuxt-context-extension')
 
       const localeRoute = JSON.parse(await page.locator('#locale-route').innerText()) as RouteLocation
       // remove properties that vary based on test environment and vue-router version
@@ -165,6 +165,7 @@ describe('basic usage', async () => {
     `
       )
 
+      // `expect.poll` does not support snapshot matchers, they always succeed
       expect(await page.locator('#locale-head').innerText()).toMatchInlineSnapshot(
         `"{ "htmlAttrs": { "lang": "en" }, "link": [ { "id": "i18n-xd", "rel": "alternate", "href": "http://localhost:3000/nuxt-context-extension", "hreflang": "x-default" }, { "id": "i18n-alt-en", "rel": "alternate", "href": "http://localhost:3000/nuxt-context-extension", "hreflang": "en" }, { "id": "i18n-alt-fr", "rel": "alternate", "href": "http://localhost:3000/fr/nuxt-context-extension", "hreflang": "fr" }, { "id": "i18n-alt-ja", "rel": "alternate", "href": "http://localhost:3000/ja/nuxt-context-extension", "hreflang": "ja" }, { "id": "i18n-alt-ja-JP", "rel": "alternate", "href": "http://localhost:3000/ja/nuxt-context-extension", "hreflang": "ja-JP" }, { "id": "i18n-alt-nl", "rel": "alternate", "href": "http://localhost:3000/nl/nuxt-context-extension", "hreflang": "nl" }, { "id": "i18n-alt-nl-NL", "rel": "alternate", "href": "http://localhost:3000/nl/nuxt-context-extension", "hreflang": "nl-NL" }, { "id": "i18n-alt-nl-BE", "rel": "alternate", "href": "http://localhost:3000/be/nuxt-context-extension", "hreflang": "nl-BE" }, { "id": "i18n-alt-kr", "rel": "alternate", "href": "http://localhost:3000/kr/nuxt-context-extension", "hreflang": "kr" }, { "id": "i18n-alt-kr-KO", "rel": "alternate", "href": "http://localhost:3000/kr/nuxt-context-extension", "hreflang": "kr-KO" }, { "id": "i18n-can", "rel": "canonical", "href": "http://localhost:3000/nuxt-context-extension" } ], "meta": [ { "id": "i18n-og-url", "property": "og:url", "content": "http://localhost:3000/nuxt-context-extension" }, { "id": "i18n-og", "property": "og:locale", "content": "en" }, { "id": "i18n-og-alt-fr", "property": "og:locale:alternate", "content": "fr" }, { "id": "i18n-og-alt-ja-JP", "property": "og:locale:alternate", "content": "ja_JP" }, { "id": "i18n-og-alt-nl-NL", "property": "og:locale:alternate", "content": "nl_NL" }, { "id": "i18n-og-alt-nl-BE", "property": "og:locale:alternate", "content": "nl_BE" }, { "id": "i18n-og-alt-kr-KO", "property": "og:locale:alternate", "content": "kr_KO" } ] }"`
       )
@@ -173,13 +174,13 @@ describe('basic usage', async () => {
     test('register module hook', async () => {
       const { page } = await renderPage('/')
 
-      expect(await page.locator('#register-module').innerText()).toEqual('This is a merged module layer locale key')
+      await expect.poll(() => page.locator('#register-module').innerText()).toEqual('This is a merged module layer locale key')
 
       // click `fr` lang switch link
       await page.locator('.switch-to-fr a').clickNavigate()
       await page.waitForURL(url('/fr'))
 
-      expect(await page.locator('#register-module').innerText()).toEqual(
+      await expect.poll(() => page.locator('#register-module').innerText()).toEqual(
         'This is a merged module layer locale key in French'
       )
     })
@@ -187,7 +188,7 @@ describe('basic usage', async () => {
     test('vueI18n config file can access runtimeConfig', async () => {
       const { page } = await renderPage('/')
 
-      expect(await page.locator('#runtime-config').innerText()).toEqual('Hello from runtime config!')
+      await expect.poll(() => page.locator('#runtime-config').innerText()).toEqual('Hello from runtime config!')
 
       const restore = await startServerWithRuntimeConfig(
         { public: { runtimeValue: 'The environment variable has changed!' } },
@@ -195,21 +196,21 @@ describe('basic usage', async () => {
       )
 
       await gotoPath(page, '/')
-      expect(await page.locator('#runtime-config').innerText()).toEqual('The environment variable has changed!')
+      await expect.poll(() => page.locator('#runtime-config').innerText()).toEqual('The environment variable has changed!')
       await restore()
     })
 
     test('layer provides locale `nl` and translation for key `hello`', async () => {
       const { page } = await renderPage('/layer-page')
 
-      expect(await page.locator('#i18n-layer-target').innerText()).toEqual('Hello world!')
+      await expect.poll(() => page.locator('#i18n-layer-target').innerText()).toEqual('Hello world!')
       expect(await page.locator('#i18n-layer-parent-link').getAttribute('href')).toEqual('/layer-parent')
       expect(await page.locator('#i18n-layer-parent-child-link').getAttribute('href')).toEqual(
         '/layer-parent/layer-child'
       )
 
       await gotoPath(page, '/nl/layer-page')
-      expect(await page.locator('#i18n-layer-target').innerText()).toEqual('Hallo wereld!')
+      await expect.poll(() => page.locator('#i18n-layer-target').innerText()).toEqual('Hallo wereld!')
       expect(await page.locator('#i18n-layer-parent-link').getAttribute('href')).toEqual('/nl/layer-ouder')
       expect(await page.locator('#i18n-layer-parent-child-link').getAttribute('href')).toEqual(
         '/nl/layer-ouder/layer-kind'
@@ -219,14 +220,14 @@ describe('basic usage', async () => {
     test('layer vueI18n options provides `nl` message', async () => {
       const { page } = await renderPage('/nl')
 
-      expect(await page.locator('#layer-message').innerText()).toEqual('Bedankt!')
+      await expect.poll(() => page.locator('#layer-message').innerText()).toEqual('Bedankt!')
     })
 
     test('layer vueI18n options properties are merge and override by priority', async () => {
       const { page } = await renderPage('/')
 
-      expect(await page.locator('#snake-case').innerText()).toEqual('About-this-site')
-      expect(await page.locator('#pascal-case').innerText()).toEqual('AboutThisSite')
+      await expect.poll(() => page.locator('#snake-case').innerText()).toEqual('About-this-site')
+      await expect.poll(() => page.locator('#pascal-case').innerText()).toEqual('AboutThisSite')
 
       await Promise.all([
         waitForLocaleNetwork(page, 'fr', 'response'),
@@ -234,9 +235,9 @@ describe('basic usage', async () => {
       ])
       await page.waitForTimeout(100)
 
-      expect(await page.locator('#snake-case').innerText()).toEqual('À-propos-de-ce-site')
-      expect(await page.locator('#pascal-case').innerText()).toEqual('ÀProposDeCeSite')
-      expect(await page.locator('#fallback-message').innerText()).toEqual('Unique translation')
+      await expect.poll(() => page.locator('#snake-case').innerText()).toEqual('À-propos-de-ce-site')
+      await expect.poll(() => page.locator('#pascal-case').innerText()).toEqual('ÀProposDeCeSite')
+      await expect.poll(() => page.locator('#fallback-message').innerText()).toEqual('Unique translation')
     })
 
     test('load option successfully', async () => {
@@ -246,36 +247,36 @@ describe('basic usage', async () => {
       await page.locator('#switch-locale-path-usages .switch-to-fr a').clickNavigate()
       await page.waitForURL(url('/fr'))
 
-      expect(await page.locator('#home-header').innerText()).toEqual('Bonjour-le-monde!')
+      await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Bonjour-le-monde!')
 
       // click `en` lang switch link
       await page.locator('#switch-locale-path-usages .switch-to-en a').clickNavigate()
       await page.waitForURL(url('/'))
-      expect(await page.locator('#home-header').innerText()).toEqual('Hello-world!')
+      await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Hello-world!')
     })
 
     test('(#1740) should be loaded vue-i18n related modules', async () => {
       const { page } = await renderPage('/')
 
-      expect(await page.locator('#app-config-name').innerText()).toEqual('This is Nuxt layer')
+      await expect.poll(() => page.locator('#app-config-name').innerText()).toEqual('This is Nuxt layer')
     })
 
     test('fallback to target lang', async () => {
       const { page } = await renderPage('/')
 
       // `en` rendering
-      expect(await page.locator('#locale-path-usages .name a').innerText()).toEqual('Homepage')
-      expect(await page.locator('title').innerText()).toEqual('Page - Homepage')
-      expect(await page.locator('#fallback-key').innerText()).toEqual('This is the fallback message!')
+      await expect.poll(() => page.locator('#locale-path-usages .name a').innerText()).toEqual('Homepage')
+      await expect.poll(() => page.locator('title').innerText()).toEqual('Page - Homepage')
+      await expect.poll(() => page.locator('#fallback-key').innerText()).toEqual('This is the fallback message!')
 
       // click `nl` lang switch with `<NuxtLink>`
       await page.locator('#switch-locale-path-usages .switch-to-nl a').clickNavigate()
       await page.waitForURL(url('/nl'))
 
       // fallback to en content translation
-      expect(await page.locator('#locale-path-usages .name a').innerText()).toEqual('Homepage')
-      expect(await page.locator('title').innerText()).toEqual('Page - Homepage')
-      expect(await page.locator('#fallback-key').innerText()).toEqual('This is the fallback message!')
+      await expect.poll(() => page.locator('#locale-path-usages .name a').innerText()).toEqual('Homepage')
+      await expect.poll(() => page.locator('title').innerText()).toEqual('Page - Homepage')
+      await expect.poll(() => page.locator('#fallback-key').innerText()).toEqual('This is the fallback message!')
 
       // page path
       expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({
@@ -283,7 +284,7 @@ describe('basic usage', async () => {
       })
 
       // current locale
-      expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('nl')
+      await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('nl')
     })
 
     test('(#2525) localePath should keep hash', async () => {
@@ -326,8 +327,8 @@ describe('basic usage', async () => {
     test('(#2476) Parametrized messages can be overwritten', async () => {
       const { page } = await renderPage('/')
 
-      expect(await page.locator('#module-layer-base-key').innerText()).toEqual('Layer base key overwritten!')
-      expect(await page.locator('#module-layer-base-key-named').innerText()).toEqual(
+      await expect.poll(() => page.locator('#module-layer-base-key').innerText()).toEqual('Layer base key overwritten!')
+      await expect.poll(() => page.locator('#module-layer-base-key-named').innerText()).toEqual(
         'Layer base key overwritten, greetings bar!'
       )
     })
@@ -380,7 +381,7 @@ describe('basic usage', async () => {
       // expect(consoleLogs.find(log => log.text.includes('i18n:beforeLocaleSwitch fr fr true'))).toBeTruthy()
 
       // current locale
-      expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+      await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
     })
 
     test('render with meta components', async () => {
@@ -391,14 +392,14 @@ describe('basic usage', async () => {
        */
 
       // title tag
-      expect(await page.locator('title').innerText()).toMatch('Page - Homepage')
+      await expect.poll(() => page.locator('title').innerText()).toMatch('Page - Homepage')
       await page.waitForURL(url('/'))
 
       // html tag `lang` attribute
-      expect(await page.getAttribute('html', 'lang')).toMatch('en')
+      await expect.poll(() => page.getAttribute('html', 'lang')).toMatch('en')
 
       // html tag `dir` attribute
-      expect(await page.getAttribute('html', 'dir')).toMatch('ltr')
+      await expect.poll(() => page.getAttribute('html', 'dir')).toMatch('ltr')
 
       // rendering link tag and meta tag in head tag
       await assetLocaleHead(page, '#layout-use-locale-head')
@@ -412,10 +413,10 @@ describe('basic usage', async () => {
       await page.waitForURL(url('/fr'))
 
       // title tag
-      expect(await page.locator('title').innerText()).toMatch('Page - Accueil')
+      await expect.poll(() => page.locator('title').innerText()).toMatch('Page - Accueil')
 
       // html tag `lang` attribute
-      expect(await page.getAttribute('html', 'lang')).toMatch('fr')
+      await expect.poll(() => page.getAttribute('html', 'lang')).toMatch('fr')
 
       // rendering link tag and meta tag in head tag
       await assetLocaleHead(page, '#layout-use-locale-head')
@@ -429,10 +430,10 @@ describe('basic usage', async () => {
       await page.waitForURL(url('/fr/about'))
 
       // title tag
-      expect(await page.locator('title').innerText()).toMatch('Page - À propos')
+      await expect.poll(() => page.locator('title').innerText()).toMatch('Page - À propos')
 
       // html tag `lang` attribute
-      expect(await page.getAttribute('html', 'lang')).toMatch('fr')
+      await expect.poll(() => page.getAttribute('html', 'lang')).toMatch('fr')
 
       // rendering link tag and meta tag in head tag
       await assetLocaleHead(page, '#layout-use-locale-head')
@@ -633,14 +634,14 @@ describe('basic usage', async () => {
 
       const { page } = await renderPage('/nl/long-text')
 
-      expect(await page.locator('#long-text').innerText()).toEqual('hallo,'.repeat(8 * 500))
+      await expect.poll(() => page.locator('#long-text').innerText()).toEqual('hallo,'.repeat(8 * 500))
       await restore()
     })
 
     test('(#2094) vue-i18n messages are loaded from config exported as variable', async () => {
       const { page } = await renderPage('/')
 
-      expect(await page.locator('#issue-2094').innerText()).toEqual('Exporting using variable identifier works!')
+      await expect.poll(() => page.locator('#issue-2094').innerText()).toEqual('Exporting using variable identifier works!')
     })
 
     test('(#2726) composables correctly initialize common options, no internal server error', async () => {
@@ -656,8 +657,8 @@ describe('basic usage', async () => {
     test('(#2874) options `locales` and `vueI18n` passed using `installModule` are not overridden', async () => {
       const { page } = await renderPage('/')
 
-      expect(await page.locator('#install-module-locale').innerText()).toEqual('Installer module locale works!')
-      expect(await page.locator('#install-module-vue-i18n').innerText()).toEqual('Installer module vue-i18n works!')
+      await expect.poll(() => page.locator('#install-module-locale').innerText()).toEqual('Installer module locale works!')
+      await expect.poll(() => page.locator('#install-module-vue-i18n').innerText()).toEqual('Installer module vue-i18n works!')
     })
 
     test('can use `$t` in `<template>` with `autoDeclare``', async () => {
@@ -722,12 +723,12 @@ describe('basic usage', async () => {
       await page.waitForURL(url('/fr'))
 
       // `fr` rendering
-      expect(await page.locator('#home-header').innerText()).toMatch('Bonjour-le-monde!')
-      expect(await page.locator('#link-about').innerText()).toMatch('À propos')
+      await expect.poll(() => page.locator('#home-header').innerText()).toMatch('Bonjour-le-monde!')
+      await expect.poll(() => page.locator('#link-about').innerText()).toMatch('À propos')
 
       // lang switcher rendering
-      expect(await page.locator('#nuxt-locale-link-en').innerText()).toMatch('English')
-      expect(await page.locator('#set-locale-link-en').innerText()).toMatch('English')
+      await expect.poll(() => page.locator('#nuxt-locale-link-en').innerText()).toMatch('English')
+      await expect.poll(() => page.locator('#set-locale-link-en').innerText()).toMatch('English')
 
       await page.locator('#set-locale-link-en').clickNavigate()
       await waitForTransition(page)
@@ -738,16 +739,16 @@ describe('basic usage', async () => {
         aboutPath: '/about',
         aboutTranslation: 'About us'
       })
-      expect(await page.getAttribute('#nuxt-locale-link-fr', 'href')).toEqual('/fr')
+      await expect.poll(() => page.getAttribute('#nuxt-locale-link-fr', 'href')).toEqual('/fr')
 
       // current locale
-      expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
+      await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
     })
 
     test('(#3766) persists locale after hydration', async () => {
       const { page } = await renderPage('/fr')
       await page.waitForFunction(() => !window.useNuxtApp?.().isHydrating)
-      expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+      await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
     })
 
     test('retains query parameters', async () => {
@@ -770,7 +771,7 @@ describe('basic usage', async () => {
       await page.locator('#nuxt-locale-link-fr').clickNavigate()
       await waitForTransition(page)
       await page.waitForURL(url('/fr/post/mon-article'))
-      expect(await page.locator('#post-id').innerText()).toMatch('mon-article')
+      await expect.poll(() => page.locator('#post-id').innerText()).toMatch('mon-article')
     })
 
     test('dynamic route parameters - catch all', async () => {
@@ -779,25 +780,25 @@ describe('basic usage', async () => {
       await page.locator('#nuxt-locale-link-fr').clickNavigate()
       await waitForTransition(page)
       await page.waitForURL(url('/fr/mon-article/xyz'))
-      expect(await page.locator('#catch-all-id').innerText()).toMatch('mon-article/xyz')
+      await expect.poll(() => page.locator('#catch-all-id').innerText()).toMatch('mon-article/xyz')
     })
 
     test('wait for page transition', async () => {
       const { page } = await renderPage('/')
 
-      expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
+      await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
 
       // click `fr` lang switching
       await page.locator('#nuxt-locale-link-fr').clickNavigate()
       await waitForTransition(page)
       await page.waitForURL(url('/fr'))
-      expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+      await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
 
       // click `en` lang switching
       await page.locator('#nuxt-locale-link-en').clickNavigate()
       await waitForTransition(page)
       await page.waitForURL(url('/'))
-      expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
+      await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
     })
 
     test('i18n custom block', async () => {
@@ -811,13 +812,13 @@ describe('basic usage', async () => {
       await page.locator('#link-greetings').clickNavigate()
       await waitForTransition(page)
 
-      expect(await page.locator('#per-component-hello').innerText()).toMatch('Bonjour!')
+      await expect.poll(() => page.locator('#per-component-hello').innerText()).toMatch('Bonjour!')
 
       // click `en` lang switch with `<NuxtLink>`
       await page.locator('#nuxt-locale-link-en').clickNavigate()
       await waitForTransition(page)
 
-      expect(await page.locator('#per-component-hello').innerText()).toMatch('Hello!')
+      await expect.poll(() => page.locator('#per-component-hello').innerText()).toMatch('Hello!')
     })
   })
 })

--- a/specs/basic_usage.spec.ts
+++ b/specs/basic_usage.spec.ts
@@ -43,28 +43,28 @@ describe('basic usage', async () => {
       await expect.poll(() => page.locator('#vue-i18n-usage p').innerText()).toEqual('Welcome')
 
       // URL path localizing with `useLocalePath`
-      expect(await page.locator('#locale-path-usages .name a').getAttribute('href')).toEqual('/')
-      expect(await page.locator('#locale-path-usages .path a').getAttribute('href')).toEqual('/')
-      expect(await page.locator('#locale-path-usages .named-with-locale a').getAttribute('href')).toEqual('/fr')
-      expect(await page.locator('#locale-path-usages .nest-path a').getAttribute('href')).toEqual('/user/profile')
-      expect(await page.locator('#locale-path-usages .nest-named a').getAttribute('href')).toEqual('/user/profile')
-      expect(await page.locator('#locale-path-usages .object-with-named a').getAttribute('href')).toEqual(
+      await expect.poll(() => page.locator('#locale-path-usages .name a').getAttribute('href')).toEqual('/')
+      await expect.poll(() => page.locator('#locale-path-usages .path a').getAttribute('href')).toEqual('/')
+      await expect.poll(() => page.locator('#locale-path-usages .named-with-locale a').getAttribute('href')).toEqual('/fr')
+      await expect.poll(() => page.locator('#locale-path-usages .nest-path a').getAttribute('href')).toEqual('/user/profile')
+      await expect.poll(() => page.locator('#locale-path-usages .nest-named a').getAttribute('href')).toEqual('/user/profile')
+      await expect.poll(() => page.locator('#locale-path-usages .object-with-named a').getAttribute('href')).toEqual(
         '/category/nintendo'
       )
 
       // URL path localizing with `NuxtLinkLocale`
-      expect(await page.locator('#nuxt-link-locale-usages .name a').getAttribute('href')).toEqual('/')
-      expect(await page.locator('#nuxt-link-locale-usages .path a').getAttribute('href')).toEqual('/')
-      expect(await page.locator('#nuxt-link-locale-usages .named-with-locale a').getAttribute('href')).toEqual('/fr')
-      expect(await page.locator('#nuxt-link-locale-usages .nest-path a').getAttribute('href')).toEqual('/user/profile')
-      expect(await page.locator('#nuxt-link-locale-usages .nest-named a').getAttribute('href')).toEqual('/user/profile')
-      expect(await page.locator('#nuxt-link-locale-usages .object-with-named a').getAttribute('href')).toEqual(
+      await expect.poll(() => page.locator('#nuxt-link-locale-usages .name a').getAttribute('href')).toEqual('/')
+      await expect.poll(() => page.locator('#nuxt-link-locale-usages .path a').getAttribute('href')).toEqual('/')
+      await expect.poll(() => page.locator('#nuxt-link-locale-usages .named-with-locale a').getAttribute('href')).toEqual('/fr')
+      await expect.poll(() => page.locator('#nuxt-link-locale-usages .nest-path a').getAttribute('href')).toEqual('/user/profile')
+      await expect.poll(() => page.locator('#nuxt-link-locale-usages .nest-named a').getAttribute('href')).toEqual('/user/profile')
+      await expect.poll(() => page.locator('#nuxt-link-locale-usages .object-with-named a').getAttribute('href')).toEqual(
         '/category/nintendo'
       )
-      expect(await page.locator('#nuxt-link-locale-usages .external-url a').getAttribute('href')).toEqual(
+      await expect.poll(() => page.locator('#nuxt-link-locale-usages .external-url a').getAttribute('href')).toEqual(
         'https://nuxt.com/'
       )
-      expect(await page.locator('#nuxt-link-locale-usages .target-blank-with-locale a').getAttribute('href')).toEqual(
+      await expect.poll(() => page.locator('#nuxt-link-locale-usages .target-blank-with-locale a').getAttribute('href')).toEqual(
         '/fr/about'
       )
 
@@ -74,8 +74,8 @@ describe('basic usage', async () => {
       await page.goBackNavigate()
 
       // Language switching path localizing with `useSwitchLocalePath`
-      expect(await page.locator('#switch-locale-path-usages .switch-to-en a').getAttribute('href')).toEqual('/')
-      expect(await page.locator('#switch-locale-path-usages .switch-to-fr a').getAttribute('href')).toEqual('/fr')
+      await expect.poll(() => page.locator('#switch-locale-path-usages .switch-to-en a').getAttribute('href')).toEqual('/')
+      await expect.poll(() => page.locator('#switch-locale-path-usages .switch-to-fr a').getAttribute('href')).toEqual('/fr')
 
       // URL path with Route object with `useLocaleRoute`
       await page.locator('#locale-route-usages button').clickNavigate()
@@ -204,15 +204,15 @@ describe('basic usage', async () => {
       const { page } = await renderPage('/layer-page')
 
       await expect.poll(() => page.locator('#i18n-layer-target').innerText()).toEqual('Hello world!')
-      expect(await page.locator('#i18n-layer-parent-link').getAttribute('href')).toEqual('/layer-parent')
-      expect(await page.locator('#i18n-layer-parent-child-link').getAttribute('href')).toEqual(
+      await expect.poll(() => page.locator('#i18n-layer-parent-link').getAttribute('href')).toEqual('/layer-parent')
+      await expect.poll(() => page.locator('#i18n-layer-parent-child-link').getAttribute('href')).toEqual(
         '/layer-parent/layer-child'
       )
 
       await gotoPath(page, '/nl/layer-page')
       await expect.poll(() => page.locator('#i18n-layer-target').innerText()).toEqual('Hallo wereld!')
-      expect(await page.locator('#i18n-layer-parent-link').getAttribute('href')).toEqual('/nl/layer-ouder')
-      expect(await page.locator('#i18n-layer-parent-child-link').getAttribute('href')).toEqual(
+      await expect.poll(() => page.locator('#i18n-layer-parent-link').getAttribute('href')).toEqual('/nl/layer-ouder')
+      await expect.poll(() => page.locator('#i18n-layer-parent-child-link').getAttribute('href')).toEqual(
         '/nl/layer-ouder/layer-kind'
       )
     })
@@ -279,7 +279,7 @@ describe('basic usage', async () => {
       await expect.poll(() => page.locator('#fallback-key').innerText()).toEqual('This is the fallback message!')
 
       // page path
-      expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({
+      await expect.poll(async () => JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({
         aboutPath: '/nl/about'
       })
 
@@ -290,21 +290,21 @@ describe('basic usage', async () => {
     test('(#2525) localePath should keep hash', async () => {
       const { page } = await renderPage('/')
 
-      expect(await page.locator('#link-about-hash').getAttribute('href')).toEqual('/about#my-hash')
-      expect(await page.locator('#link-about-hash-object').getAttribute('href')).toEqual('/about#my-hash')
+      await expect.poll(() => page.locator('#link-about-hash').getAttribute('href')).toEqual('/about#my-hash')
+      await expect.poll(() => page.locator('#link-about-hash-object').getAttribute('href')).toEqual('/about#my-hash')
 
-      expect(await page.locator('#link-about-query-hash').getAttribute('href')).toEqual('/about?foo=bar#my-hash')
-      expect(await page.locator('#link-about-query-hash-object').getAttribute('href')).toEqual('/about?foo=bar#my-hash')
+      await expect.poll(() => page.locator('#link-about-query-hash').getAttribute('href')).toEqual('/about?foo=bar#my-hash')
+      await expect.poll(() => page.locator('#link-about-query-hash-object').getAttribute('href')).toEqual('/about?foo=bar#my-hash')
 
       // click `nl` lang switch with `<NuxtLink>`
       await page.locator('#switch-locale-path-usages .switch-to-nl a').clickNavigate()
       await page.waitForURL(url('/nl'))
 
-      expect(await page.locator('#link-about-hash').getAttribute('href')).toEqual('/nl/about#my-hash')
-      expect(await page.locator('#link-about-hash-object').getAttribute('href')).toEqual('/nl/about#my-hash')
+      await expect.poll(() => page.locator('#link-about-hash').getAttribute('href')).toEqual('/nl/about#my-hash')
+      await expect.poll(() => page.locator('#link-about-hash-object').getAttribute('href')).toEqual('/nl/about#my-hash')
 
-      expect(await page.locator('#link-about-query-hash').getAttribute('href')).toEqual('/nl/about?foo=bar#my-hash')
-      expect(await page.locator('#link-about-query-hash-object').getAttribute('href')).toEqual(
+      await expect.poll(() => page.locator('#link-about-query-hash').getAttribute('href')).toEqual('/nl/about?foo=bar#my-hash')
+      await expect.poll(() => page.locator('#link-about-query-hash-object').getAttribute('href')).toEqual(
         '/nl/about?foo=bar#my-hash'
       )
     })
@@ -313,15 +313,15 @@ describe('basic usage', async () => {
       const { page } = await renderPage('/')
       const encodedPath = encodeURI('page with spaces')
 
-      expect(await page.locator('#link-page-with-spaces').getAttribute('href')).toEqual(`/${encodedPath}`)
-      expect(await page.locator('#link-page-with-spaces-encoded').getAttribute('href')).toEqual(`/${encodedPath}`)
+      await expect.poll(() => page.locator('#link-page-with-spaces').getAttribute('href')).toEqual(`/${encodedPath}`)
+      await expect.poll(() => page.locator('#link-page-with-spaces-encoded').getAttribute('href')).toEqual(`/${encodedPath}`)
 
       // click `nl` lang switch with `<NuxtLink>`
       await page.locator('#switch-locale-path-usages .switch-to-nl a').clickNavigate()
       await page.waitForURL(url('/nl'))
 
-      expect(await page.locator('#link-page-with-spaces').getAttribute('href')).toEqual(`/nl/${encodedPath}`)
-      expect(await page.locator('#link-page-with-spaces-encoded').getAttribute('href')).toEqual(`/nl/${encodedPath}`)
+      await expect.poll(() => page.locator('#link-page-with-spaces').getAttribute('href')).toEqual(`/nl/${encodedPath}`)
+      await expect.poll(() => page.locator('#link-page-with-spaces-encoded').getAttribute('href')).toEqual(`/nl/${encodedPath}`)
     })
 
     test('(#2476) Parametrized messages can be overwritten', async () => {
@@ -591,24 +591,24 @@ describe('basic usage', async () => {
     test('dynamic parameters', async () => {
       const { page } = await renderPage('/products/big-chair')
 
-      expect(await page.locator('#switch-locale-path-link-nl').getAttribute('href')).toEqual('/nl/products/grote-stoel')
+      await expect.poll(() => page.locator('#switch-locale-path-link-nl').getAttribute('href')).toEqual('/nl/products/grote-stoel')
 
       await gotoPath(page, '/nl/products/rode-mok')
       await page.waitForFunction(
         () => document.querySelector('#switch-locale-path-link-en')?.getAttribute('href') === '/products/red-mug'
       )
-      expect(await page.locator('#switch-locale-path-link-en').getAttribute('href')).toEqual('/products/red-mug')
+      await expect.poll(() => page.locator('#switch-locale-path-link-en').getAttribute('href')).toEqual('/products/red-mug')
 
       // Translated params are not lost on query changes
       await page.locator('#params-add-query').clickNavigate()
       await page.waitForURL(url('/nl/products/rode-mok?test=123&canonical=123'))
-      expect(await page.locator('#switch-locale-path-link-en').getAttribute('href')).toEqual(
+      await expect.poll(() => page.locator('#switch-locale-path-link-en').getAttribute('href')).toEqual(
         '/products/red-mug?test=123&canonical=123'
       )
 
       await page.locator('#params-remove-query').clickNavigate()
       await page.waitForURL(url('/nl/products/rode-mok'))
-      expect(await page.locator('#switch-locale-path-link-en').getAttribute('href')).toEqual('/products/red-mug')
+      await expect.poll(() => page.locator('#switch-locale-path-link-en').getAttribute('href')).toEqual('/products/red-mug')
 
       // head tags - alt links are updated server side
       const product1Html = await $fetch('/products/big-chair')
@@ -672,21 +672,21 @@ describe('basic usage', async () => {
     test('dynamic parameters render and update reactively client-side', async () => {
       const { page } = await renderPage('/products/big-chair')
 
-      expect(await page.locator('#switch-locale-path-link-nl').getAttribute('href')).toEqual('/nl/products/grote-stoel')
+      await expect.poll(() => page.locator('#switch-locale-path-link-nl').getAttribute('href')).toEqual('/nl/products/grote-stoel')
 
       await gotoPath(page, '/nl/products/rode-mok')
-      expect(await page.locator('#switch-locale-path-link-en').getAttribute('href')).toEqual('/products/red-mug')
+      await expect.poll(() => page.locator('#switch-locale-path-link-en').getAttribute('href')).toEqual('/products/red-mug')
 
       // Translated params are not lost on query changes
       await page.locator('#params-add-query').clickNavigate()
       await page.waitForURL(url('/nl/products/rode-mok?test=123&canonical=123'))
-      expect(await page.locator('#switch-locale-path-link-en').getAttribute('href')).toEqual(
+      await expect.poll(() => page.locator('#switch-locale-path-link-en').getAttribute('href')).toEqual(
         '/products/red-mug?test=123&canonical=123'
       )
 
       await page.locator('#params-remove-query').clickNavigate()
       await page.waitForURL(url('/nl/products/rode-mok'))
-      expect(await page.locator('#switch-locale-path-link-en').getAttribute('href')).toEqual('/products/red-mug')
+      await expect.poll(() => page.locator('#switch-locale-path-link-en').getAttribute('href')).toEqual('/products/red-mug')
     })
 
     test('(#3790) RegExp missingWarn', async () => {
@@ -735,7 +735,7 @@ describe('basic usage', async () => {
       await page.waitForURL(url('/'))
 
       // page path
-      expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({
+      await expect.poll(async () => JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({
         aboutPath: '/about',
         aboutTranslation: 'About us'
       })

--- a/specs/browser_language_detection/no_prefix.spec.ts
+++ b/specs/browser_language_detection/no_prefix.spec.ts
@@ -51,12 +51,12 @@ test('detection with cookie', async () => {
   // navigate to about
   await gotoPath(page, '/about')
   // detect locale from persisted cookie
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
   // navigate with home link
   await page.locator('#link-home').click()
 
   // locale in home
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
 
   // click `fr` lang switch link
   await Promise.all([waitForLocaleSwitch(page), page.locator('#set-locale-link-en').click()])
@@ -111,27 +111,27 @@ test('detection with browser', async () => {
   const { page } = await renderPage('/', { locale: 'fr' })
 
   // detect locale from navigator language
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
 
   // click `en` lang switch link
   await Promise.all([waitForLocaleSwitch(page), page.locator('#set-locale-link-en').click()])
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
 
   // navigate to blog/article
   await gotoPath(page, '/blog/article')
 
   // locale in blog/article
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
 
   // navigate with home
   await gotoPath(page, '/')
 
   // locale in home
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
 
   // click `en` lang switch link
   await Promise.all([waitForLocaleSwitch(page), page.locator('#set-locale-link-en').click()])
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
 })
 
 // disable
@@ -155,7 +155,7 @@ test('disable', async () => {
   await gotoPath(page, '/about')
 
   // set default locale
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
 
   // click `fr` lang switch link
   await Promise.all([waitForLocaleSwitch(page), page.locator('#set-locale-link-fr').click()])
@@ -164,7 +164,7 @@ test('disable', async () => {
   await page.locator('#link-home').click()
 
   // set default locale
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
 })
 
 test('fallback', async () => {
@@ -181,5 +181,5 @@ test('fallback', async () => {
   const { page } = await renderPage('/', { locale: 'ja' })
 
   // detect fallback locale with navigator language
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
 })

--- a/specs/browser_language_detection/no_prefix.spec.ts
+++ b/specs/browser_language_detection/no_prefix.spec.ts
@@ -53,7 +53,7 @@ test('detection with cookie', async () => {
   // detect locale from persisted cookie
   await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
   // navigate with home link
-  await page.locator('#link-home').click()
+  await page.locator('#link-home').clickNavigate()
 
   // locale in home
   await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
@@ -161,7 +161,7 @@ test('disable', async () => {
   await Promise.all([waitForLocaleSwitch(page), page.locator('#set-locale-link-fr').click()])
 
   // navigate with home link
-  await page.locator('#link-home').click()
+  await page.locator('#link-home').clickNavigate()
 
   // set default locale
   await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')

--- a/specs/browser_language_detection/prefix_and_default.spec.ts
+++ b/specs/browser_language_detection/prefix_and_default.spec.ts
@@ -31,15 +31,15 @@ test('redirectOn: all', async () => {
   const { page } = await renderPage('/blog/article', { locale: 'fr' })
 
   // detect locale from navigator language
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
 
   // click `en` lang switch link
   await page.locator('#set-locale-link-en').clickNavigate()
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
 
   // navigate to home
   await gotoPath(page, '/')
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
 })
 
 test('redirectOn: no prefix', async () => {
@@ -59,15 +59,15 @@ test('redirectOn: no prefix', async () => {
   const { page } = await renderPage('/blog/article', { locale: 'fr' })
 
   // detect locale from navigator language
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
 
   // click `en` lang switch link
   await page.locator('#set-locale-link-en').clickNavigate()
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
 
   // navigate to fr blog
   await gotoPath(page, '/fr/blog/article')
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
   await restore()
 })
 
@@ -86,16 +86,16 @@ test('alwaysRedirect: all', async () => {
   const { page } = await renderPage(blog, { locale: 'en' }) // set browser locale
 
   // detect locale from navigator language
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
 
   // click `fr` lang switch link
   await page.locator('#set-locale-link-fr').clickNavigate()
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
 
   // go to `en` home page
   await page.goto(url(blog))
   await page.waitForURL(url('/fr/blog/article'))
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
 })
 
 test('alwaysRedirect: no prefix', async () => {
@@ -113,21 +113,21 @@ test('alwaysRedirect: no prefix', async () => {
   const ctx = await page.context()
 
   // detect locale from navigator language
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
   expect(await ctx.cookies()).toMatchObject([{ name: 'i18n_redirected', value: 'en' }])
 
   // click `fr` lang switch with nutlink
   await page.locator('#set-locale-link-fr').clickNavigate()
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
   expect(await ctx.cookies()).toMatchObject([{ name: 'i18n_redirected', value: 'fr' }])
 
   // go to `blog/article` page
   await page.goto(url('/blog/article'))
   expect(page.url().endsWith('/fr/about'))
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
 
   // go to `/about` page
   await page.goto(url('/about'))
   expect(page.url().endsWith('/fr/about'))
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
 })

--- a/specs/browser_language_detection/prefix_except_default.spec.ts
+++ b/specs/browser_language_detection/prefix_except_default.spec.ts
@@ -35,22 +35,22 @@ describe('`detectBrowserLanguage` using strategy `prefix_except_default`', async
     const { page } = await renderPage('/', { locale: 'en' })
     const ctx = page.context()
 
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
     expect(await ctx.cookies()).toMatchObject([{ name: 'i18n_redirected', value: 'en' }])
 
     // change to `fr`
     await page.locator('#nuxt-locale-link-fr').clickNavigate()
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
     expect(await ctx.cookies()).toMatchObject([{ name: 'i18n_redirected', value: 'fr' }])
 
     // direct access to root `/`
     await page.goto(url('/'))
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
     await page.waitForURL(url('/fr'))
 
     // change to `en`
     await page.locator('#nuxt-locale-link-en').clickNavigate()
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
     expect(await ctx.cookies()).toMatchObject([{ name: 'i18n_redirected', value: 'en' }])
   })
 
@@ -71,13 +71,13 @@ describe('`detectBrowserLanguage` using strategy `prefix_except_default`', async
     test('redirect using browser language locale', async () => {
       const { page } = await renderPage('/', { locale: 'fr' })
 
-      expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+      await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
     })
 
     test('redirect using `Accept-Language` header', async () => {
       const { page } = await renderPage('/', { extraHTTPHeaders: { 'Accept-Language': 'fr' } })
 
-      expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+      await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
     })
 
     test('should keep query params when redirecting', async () => {
@@ -93,14 +93,14 @@ describe('`detectBrowserLanguage` using strategy `prefix_except_default`', async
     const { page } = await renderPage('/', { locale: 'fr' })
     await page.waitForURL(url('/fr'))
 
-    expect(await page.locator('#html-message').innerText()).toEqual('Exemple de traduction')
-    expect(await page.locator('#html-message-mounted').innerText()).toEqual('Exemple de traduction')
+    await expect.poll(() => page.locator('#html-message').innerText()).toEqual('Exemple de traduction')
+    await expect.poll(() => page.locator('#html-message-mounted').innerText()).toEqual('Exemple de traduction')
 
     // change to `en` locale
     await page.locator('#set-locale-link-en').clickNavigate()
     await page.waitForURL(url('/'))
 
-    expect(await page.locator('#html-message').innerText()).toEqual('Translation example')
-    expect(await page.locator('#html-message-mounted').innerText()).toEqual('Translation example')
+    await expect.poll(() => page.locator('#html-message').innerText()).toEqual('Translation example')
+    await expect.poll(() => page.locator('#html-message-mounted').innerText()).toEqual('Translation example')
   })
 })

--- a/specs/browser_language_detection/prefix_except_default.spec.ts
+++ b/specs/browser_language_detection/prefix_except_default.spec.ts
@@ -45,8 +45,8 @@ describe('`detectBrowserLanguage` using strategy `prefix_except_default`', async
 
     // direct access to root `/`
     await page.goto(url('/'))
-    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
     await page.waitForURL(url('/fr'))
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
 
     // change to `en`
     await page.locator('#nuxt-locale-link-en').clickNavigate()

--- a/specs/custom_route_paths/module_configuration.spec.ts
+++ b/specs/custom_route_paths/module_configuration.spec.ts
@@ -41,7 +41,7 @@ test('can access to custom route path', async () => {
   await page.waitForURL(url('/fr'))
 
   // page path
-  expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({
+  await expect.poll(async () => JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({
     aboutPath: '/fr/about-fr'
   })
 
@@ -89,7 +89,7 @@ test('can not access to pick route path', async () => {
   await page.waitForURL(url('/fr'))
 
   // disable href with <NuxtLink>
-  expect(await page.locator('#link-history').getAttribute('href')).toBe(null)
+  await expect.poll(() => page.locator('#link-history').getAttribute('href')).toBe(null)
 
   // disable direct url access
   let res: Awaited<ReturnType<typeof page.goto>> | (Error & { status: () => number }) | null = null
@@ -110,7 +110,7 @@ test('can not access to disable route path', async () => {
   await page.waitForURL(url('/fr'))
 
   // disable href with <NuxtLink>
-  expect(await page.locator('#link-category').getAttribute('href')).toBe(null)
+  await expect.poll(() => page.locator('#link-category').getAttribute('href')).toBe(null)
 
   // disable direct url access
   let res: Awaited<ReturnType<typeof page.goto>> | (Error & { status: () => number }) | null = null

--- a/specs/custom_route_paths/module_configuration.spec.ts
+++ b/specs/custom_route_paths/module_configuration.spec.ts
@@ -49,8 +49,8 @@ test('can access to custom route path', async () => {
   await page.locator('#link-about').clickNavigate()
   await page.waitForURL(url('/fr/about-fr'))
 
-  expect(await page.locator('#about-header').innerText()).toEqual('À propos')
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+  await expect.poll(() => page.locator('#about-header').innerText()).toEqual('À propos')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
   await page.waitForURL(url('/fr/about-fr'))
 })
 
@@ -78,7 +78,7 @@ test('(#4079) non-ASCII custom route path is not double-encoded', async () => {
 
   const { page } = await renderPage('/news/article')
   await page.locator('#switch-locale-path-link-fr').clickNavigate()
-  expect(await page.locator('#locale-properties-code').innerText()).toEqual('fr')
+  await expect.poll(() => page.locator('#locale-properties-code').innerText()).toEqual('fr')
 })
 
 test('can not access to pick route path', async () => {

--- a/specs/different_domains/no_ssr.spec.ts
+++ b/specs/different_domains/no_ssr.spec.ts
@@ -36,7 +36,7 @@ test('(#2313) detection locale from domain', async () => {
       locale: browserLocale
     })
 
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual(locale)
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual(locale)
     await page.close()
   }
 
@@ -47,5 +47,5 @@ test('(#2313) detection locale from domain', async () => {
 test('(#2334) should not redirect loop, when use no_prefix and ssr: false', async () => {
   const page = await createPage(url('/'), { locale: 'fr' })
 
-  expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+  await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
 })

--- a/specs/experimental/compact_routes.spec.ts
+++ b/specs/experimental/compact_routes.spec.ts
@@ -25,26 +25,26 @@ describe('compact routes `<NuxtPage>` keys', () => {
 
     await page.locator('#counter').click()
     await page.locator('#counter').click()
-    expect(await page.locator('#counter').innerText()).toEqual('parent state: 2')
+    await expect.poll(() => page.locator('#counter').innerText()).toEqual('parent state: 2')
 
     await page.locator('#to-baz').clickNavigate()
     await page.waitForURL(url('/ja/foo/baz'))
 
-    expect(await page.locator('#child').innerText()).toEqual('child: baz')
+    await expect.poll(() => page.locator('#child').innerText()).toEqual('child: baz')
     // parent state survives — the parent page was not remounted
-    expect(await page.locator('#counter').innerText()).toEqual('parent state: 2')
+    await expect.poll(() => page.locator('#counter').innerText()).toEqual('parent state: 2')
   })
 
   it('remounts the page when the locale param changes within a compact route', async () => {
     const { page } = await renderPage('/ja/foo/bar')
 
     await page.locator('#counter').click()
-    expect(await page.locator('#counter').innerText()).toEqual('parent state: 1')
+    await expect.poll(() => page.locator('#counter').innerText()).toEqual('parent state: 1')
 
     await page.locator('#to-fr').clickNavigate()
     await page.waitForURL(url('/fr/foo/bar'))
 
     // state reset — locale change remounts so transitions can trigger
-    expect(await page.locator('#counter').innerText()).toEqual('parent state: 0')
+    await expect.poll(() => page.locator('#counter').innerText()).toEqual('parent state: 0')
   })
 })

--- a/specs/experimental/experimental_seo.spec.ts
+++ b/specs/experimental/experimental_seo.spec.ts
@@ -24,7 +24,7 @@ describe('experimental.strictSeo', async () => {
   test('dynamic parameters rendered correctly during SSR', async () => {
     const { page } = await renderPage('/')
     await page.goto(url('/products/big-chair'))
-    expect(await page.locator('#switch-locale-path-link-nl').getAttribute('href')).toEqual('/nl/products/grote-stoel')
+    await expect.poll(() => page.locator('#switch-locale-path-link-nl').getAttribute('href')).toEqual('/nl/products/grote-stoel')
     expect(await getHeadSnapshot(page)).toMatchInlineSnapshot(`
       "HTML:
         lang: en
@@ -45,8 +45,8 @@ describe('experimental.strictSeo', async () => {
     `)
 
     await page.goto(url('/nl/products/rode-mok'))
-    expect(await page.locator('#switch-locale-path-link-en').getAttribute('href')).toEqual('/products/red-mug')
-    expect(await page.locator('#switch-locale-path-link-ja[data-i18n-disabled]').getAttribute('href')).toEqual('#')
+    await expect.poll(() => page.locator('#switch-locale-path-link-en').getAttribute('href')).toEqual('/products/red-mug')
+    await expect.poll(() => page.locator('#switch-locale-path-link-ja[data-i18n-disabled]').getAttribute('href')).toEqual('#')
     expect(await getHeadSnapshot(page)).toMatchInlineSnapshot(`
       "HTML:
         lang: nl-NL
@@ -68,15 +68,15 @@ describe('experimental.strictSeo', async () => {
   test('canonical link keeps queries listed in `canonicalQueries`', async () => {
     const { page } = await renderPage('/post/my-post?page=2&foo=bar')
 
-    expect(await page.locator('link[rel=canonical]').getAttribute('href')).toEqual(
+    await expect.poll(() => page.locator('link[rel=canonical]').getAttribute('href')).toEqual(
       'http://localhost:3000/post/my-post?page=2'
     )
-    expect(await page.locator('link[rel=alternate][hreflang=fr]').getAttribute('href')).toEqual(
+    await expect.poll(() => page.locator('link[rel=alternate][hreflang=fr]').getAttribute('href')).toEqual(
       'http://localhost:3000/fr/post/mon-article?page=2'
     )
 
     await page.goto(url('/post/my-post?foo=bar'))
-    expect(await page.locator('link[rel=canonical]').getAttribute('href')).toEqual(
+    await expect.poll(() => page.locator('link[rel=canonical]').getAttribute('href')).toEqual(
       'http://localhost:3000/post/my-post'
     )
   })

--- a/specs/experimental/optimize_message_bundling.spec.ts
+++ b/specs/experimental/optimize_message_bundling.spec.ts
@@ -46,18 +46,18 @@ describe('experimental.optimizeMessageBundling', () => {
   test('merges static files with executable locale files', async () => {
     const { page } = await renderPage('/en-GB')
 
-    expect(await page.locator('#home-header').innerText()).toEqual('Homepage')
-    expect(await page.locator('#profile-js').innerText()).toEqual('Profile1')
-    expect(await page.locator('#profile-ts').innerText()).toEqual('Profile2')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Homepage')
+    await expect.poll(() => page.locator('#profile-js').innerText()).toEqual('Profile1')
+    await expect.poll(() => page.locator('#profile-ts').innerText()).toEqual('Profile2')
   })
 
   test('client-side locale switch fetches and renders messages', async () => {
     const { page } = await renderPage('/')
 
     await Promise.all([waitForLocaleNetwork(page, 'fr', 'response'), page.click('#nuxt-locale-link-fr')])
-    expect(await page.locator('#home-header').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Accueil')
 
     await Promise.all([waitForLocaleNetwork(page, 'ja', 'response'), page.click('#nuxt-locale-link-ja')])
-    expect(await page.locator('#home-header').innerText()).toEqual('ホームページ')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('ホームページ')
   })
 })

--- a/specs/lazy_load/basic_lazy_load.spec.ts
+++ b/specs/lazy_load/basic_lazy_load.spec.ts
@@ -91,7 +91,7 @@ describe('basic lazy loading', async () => {
     await expect.poll(() => page.locator('#set-locale-link-fr').innerText()).toEqual('Français')
 
     // page path
-    expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/about' })
+    await expect.poll(async () => JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/about' })
 
     // current locale
     await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
@@ -112,7 +112,7 @@ describe('basic lazy loading', async () => {
     await expect.poll(() => page.locator('#set-locale-link-en').innerText()).toEqual('English')
 
     // page path
-    expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
+    await expect.poll(async () => JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
 
     // current locale
     await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')

--- a/specs/lazy_load/basic_lazy_load.spec.ts
+++ b/specs/lazy_load/basic_lazy_load.spec.ts
@@ -28,7 +28,7 @@ describe('basic lazy loading', async () => {
 
     await page.click('#nuxt-locale-link-fr')
     await page.waitForURL(url('/fr'))
-    expect(await page.locator('#dynamic-time').innerText()).toEqual('Not dynamic')
+    await expect.poll(() => page.locator('#dynamic-time').innerText()).toEqual('Not dynamic')
 
     // dynamicTime depends on passage of some time
     await page.waitForTimeout(1)
@@ -36,7 +36,7 @@ describe('basic lazy loading', async () => {
     // dynamicTime does not match captured dynamicTime
     await page.click('#nuxt-locale-link-nl')
     await page.waitForURL(url('/nl'))
-    expect(await page.locator('#dynamic-time').innerText()).to.not.equal(dynamicTime)
+    await expect.poll(() => page.locator('#dynamic-time').innerText()).to.not.equal(dynamicTime)
   })
 
   test('(#3773) messages are loaded once on page load', async () => {
@@ -83,54 +83,54 @@ describe('basic lazy loading', async () => {
     const { page } = await renderPage('/')
 
     // `en` rendering
-    expect(await page.locator('#home-header').innerText()).toEqual('Homepage')
-    expect(await page.locator('title').innerText()).toEqual('Homepage')
-    expect(await page.locator('#link-about').innerText()).toEqual('About us')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Homepage')
+    await expect.poll(() => page.locator('title').innerText()).toEqual('Homepage')
+    await expect.poll(() => page.locator('#link-about').innerText()).toEqual('About us')
 
     // lang switcher rendering
-    expect(await page.locator('#set-locale-link-fr').innerText()).toEqual('Français')
+    await expect.poll(() => page.locator('#set-locale-link-fr').innerText()).toEqual('Français')
 
     // page path
     expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/about' })
 
     // current locale
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
 
     // html tag `lang` attribute with language code
-    expect(await page.getAttribute('html', 'lang')).toEqual('en-US')
+    await expect.poll(() => page.getAttribute('html', 'lang')).toEqual('en-US')
   })
 
   test('can access to prefix locale: /fr', async () => {
     const { page } = await renderPage('/fr')
 
     // `fr` rendering
-    expect(await page.locator('#home-header').innerText()).toEqual('Accueil')
-    expect(await page.locator('title').innerText()).toEqual('Accueil')
-    expect(await page.locator('#link-about').innerText()).toEqual('À propos')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('title').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('#link-about').innerText()).toEqual('À propos')
 
     // lang switcher rendering
-    expect(await page.locator('#set-locale-link-en').innerText()).toEqual('English')
+    await expect.poll(() => page.locator('#set-locale-link-en').innerText()).toEqual('English')
 
     // page path
     expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
 
     // current locale
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
 
     // html tag `lang` attribute with language code
-    expect(await page.getAttribute('html', 'lang')).toEqual('fr-FR')
+    await expect.poll(() => page.getAttribute('html', 'lang')).toEqual('fr-FR')
   })
 
   test('multiple lazy loading', async () => {
     const { page } = await renderPage('/en-GB')
 
     // `en` base rendering
-    expect(await page.locator('#home-header').innerText()).toEqual('Homepage')
-    expect(await page.locator('title').innerText()).toEqual('Homepage')
-    expect(await page.locator('#link-about').innerText()).toEqual('About us')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Homepage')
+    await expect.poll(() => page.locator('title').innerText()).toEqual('Homepage')
+    await expect.poll(() => page.locator('#link-about').innerText()).toEqual('About us')
 
-    expect(await page.locator('#profile-js').innerText()).toEqual('Profile1')
-    expect(await page.locator('#profile-ts').innerText()).toEqual('Profile2')
+    await expect.poll(() => page.locator('#profile-js').innerText()).toEqual('Profile1')
+    await expect.poll(() => page.locator('#profile-ts').innerText()).toEqual('Profile2')
   })
 
   test('files with cache disabled bypass caching', async () => {
@@ -151,20 +151,20 @@ describe('basic lazy loading', async () => {
   test('manually loaded messages can be used in translations', async () => {
     const { page } = await renderPage('/manual-load')
 
-    expect(await page.locator('#welcome-english').innerText()).toEqual('Welcome!')
-    expect(await page.locator('#welcome-dutch').innerText()).toEqual('Welkom!')
+    await expect.poll(() => page.locator('#welcome-english').innerText()).toEqual('Welcome!')
+    await expect.poll(() => page.locator('#welcome-dutch').innerText()).toEqual('Welkom!')
   })
 
   test('(#3359) runtime config accessible in locale function', async () => {
     const { page } = await renderPage('/')
 
     // check initial text value before translation has been loaded
-    expect(await page.locator('#runtime-config-key').textContent()).toEqual('runtimeConfigKey')
+    await expect.poll(() => page.locator('#runtime-config-key').textContent()).toEqual('runtimeConfigKey')
 
     await Promise.all([waitForLocaleNetwork(page, 'en-GB', 'response'), page.click('#nuxt-locale-link-en-GB')])
 
     // check text value after translation has been loaded
-    expect(await page.locator('#runtime-config-key').textContent()).toEqual('runtime-config-value')
+    await expect.poll(() => page.locator('#runtime-config-key').textContent()).toEqual('runtime-config-value')
 
     // trigger server-side locale loading
     const html = await $fetch('/en-GB')
@@ -187,7 +187,7 @@ describe('basic lazy loading', async () => {
       const { page } = await renderPage('/')
 
       await Promise.all([waitForLocaleNetwork(page, 'fr', 'response'), page.click('#nuxt-locale-link-fr')])
-      expect(await page.locator('#home-header').innerText()).toEqual('Accueil')
+      await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Accueil')
     })
   })
 })

--- a/specs/routing/app_base_url.spec.ts
+++ b/specs/routing/app_base_url.spec.ts
@@ -49,6 +49,6 @@ describe('`app.baseURL` is set', () => {
   test('(#2911) `useLocaleHead` uses Nuxt `app.baseURL` in meta tags', async () => {
     const { page } = await renderPage('/base-path/en')
 
-    expect(await page.locator('head #i18n-alt-en').getAttribute('href')).toMatch(/\/base-path\/en$/)
+    await expect.poll(() => page.locator('head #i18n-alt-en').getAttribute('href')).toMatch(/\/base-path\/en$/)
   })
 })

--- a/specs/routing/legacy.spec.ts
+++ b/specs/routing/legacy.spec.ts
@@ -28,19 +28,19 @@ describe('vue-i18n legacy API mode', () => {
   it('initializes the plugin and provides working routing composables', async () => {
     const { page } = await renderPage('/en')
 
-    expect(await page.locator('#switch-locale-path .en').innerText()).toEqual('/en')
-    expect(await page.locator('#switch-locale-path .ja').innerText()).toEqual('/ja')
-    expect(await page.locator('#locale-path .about').innerText()).toEqual('/en/about')
+    await expect.poll(() => page.locator('#switch-locale-path .en').innerText()).toEqual('/en')
+    await expect.poll(() => page.locator('#switch-locale-path .ja').innerText()).toEqual('/ja')
+    await expect.poll(() => page.locator('#locale-path .about').innerText()).toEqual('/en/about')
 
     // locale switch updates state through the legacy instance
     await gotoPath(page, '/ja/about')
-    expect(await page.locator('#switch-locale-path .en').innerText()).toEqual('/en/about')
-    expect(await page.locator('#switch-locale-path .ja').innerText()).toEqual('/ja/about')
+    await expect.poll(() => page.locator('#switch-locale-path .en').innerText()).toEqual('/en/about')
+    await expect.poll(() => page.locator('#switch-locale-path .ja').innerText()).toEqual('/ja/about')
   })
 
   it('(#2315) component `i18n` options create a local scope', async () => {
     const { page } = await renderPage('/en')
 
-    expect(await page.locator('#legacy-local-msg').innerText()).toEqual('Hello, local!')
+    await expect.poll(() => page.locator('#legacy-local-msg').innerText()).toEqual('Hello, local!')
   })
 })

--- a/specs/routing_strategies/no_prefix.spec.ts
+++ b/specs/routing_strategies/no_prefix.spec.ts
@@ -143,7 +143,7 @@ describe('strategy: no_prefix', async () => {
     await expect.poll(() => page.locator('#about-header').innerText()).toEqual(`À propos`)
 
     // one more change page
-    await page.locator('#link-home').click()
+    await page.locator('#link-home').clickNavigate()
     await expect.poll(() => page.locator('#home-header').innerText()).toEqual(`Accueil`)
   })
 

--- a/specs/routing_strategies/no_prefix.spec.ts
+++ b/specs/routing_strategies/no_prefix.spec.ts
@@ -52,19 +52,19 @@ describe('strategy: no_prefix', async () => {
      */
 
     // `en` rendering
-    expect(await page.locator('#home-header').innerText()).toEqual('Homepage')
-    expect(await page.locator('#link-about').innerText()).toEqual('About us')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Homepage')
+    await expect.poll(() => page.locator('#link-about').innerText()).toEqual('About us')
 
     // lang switcher rendering
-    expect(await page.locator('#nuxt-locale-link-fr').innerText()).toEqual('Français')
-    expect(await page.locator('#set-locale-link-fr').innerText()).toEqual('Français')
+    await expect.poll(() => page.locator('#nuxt-locale-link-fr').innerText()).toEqual('Français')
+    await expect.poll(() => page.locator('#set-locale-link-fr').innerText()).toEqual('Français')
 
     // page path
     expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/about' })
-    expect(await page.getAttribute('#nuxt-locale-link-fr', 'href')).toEqual('/')
+    await expect.poll(() => page.getAttribute('#nuxt-locale-link-fr', 'href')).toEqual('/')
 
     // current locale
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
 
     /**
      * change locale to `fr`
@@ -76,19 +76,19 @@ describe('strategy: no_prefix', async () => {
     await page.waitForTimeout(100)
 
     // `fr` rendering
-    expect(await page.locator('#home-header').innerText()).toEqual('Accueil')
-    expect(await page.locator('#link-about').innerText()).toEqual('À propos')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('#link-about').innerText()).toEqual('À propos')
 
     // lang switcher rendering
-    expect(await page.locator('#nuxt-locale-link-en').innerText()).toEqual('English')
-    expect(await page.locator('#set-locale-link-en').innerText()).toEqual('English')
+    await expect.poll(() => page.locator('#nuxt-locale-link-en').innerText()).toEqual('English')
+    await expect.poll(() => page.locator('#set-locale-link-en').innerText()).toEqual('English')
 
     // page path
     expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/about' })
-    expect(await page.getAttribute('#nuxt-locale-link-en', 'href')).toEqual('/')
+    await expect.poll(() => page.getAttribute('#nuxt-locale-link-en', 'href')).toEqual('/')
 
     // current locale
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
   })
 
   test('(#2493) should navigate from url with and without trailing slash', async () => {
@@ -108,18 +108,18 @@ describe('strategy: no_prefix', async () => {
 
     const res1 = await page.goto(url('/?pluginSetLocale=fr'))
     expect(res1?.ok()).toBeTruthy()
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
 
     const res2 = await page.goto(url('/?pluginSetLocale=en'))
     expect(res2?.ok()).toBeTruthy()
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
   })
 
   test('(#3039) locale set server-side is not reset client-side', async () => {
     const { page } = await renderPage('/?serverSetLocale=fr')
 
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
-    expect(await page.locator('#home-header').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Accueil')
   })
 
   test('(#2473) should respect `detectBrowserLanguage`', async () => {
@@ -135,27 +135,27 @@ describe('strategy: no_prefix', async () => {
     })
     const { page } = await renderPage('/', { locale: 'fr' })
 
-    expect(await page.locator('#home-header').innerText()).toEqual(`Accueil`)
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual(`Accueil`)
 
     // change page
     await page.locator('#link-about').click()
     await page.waitForURL(url('/about'))
-    expect(await page.locator('#about-header').innerText()).toEqual(`À propos`)
+    await expect.poll(() => page.locator('#about-header').innerText()).toEqual(`À propos`)
 
     // one more change page
     await page.locator('#link-home').click()
-    expect(await page.locator('#home-header').innerText()).toEqual(`Accueil`)
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual(`Accueil`)
   })
 
   test('render with useHead', async () => {
     const { page } = await renderPage('/')
 
     // title tag
-    expect(await page.locator('title').innerText()).toMatch('Homepage')
+    await expect.poll(() => page.locator('title').innerText()).toMatch('Homepage')
 
     // html tag `lang` and `dir` attributes
-    expect(await page.getAttribute('html', 'lang')).toMatch('en')
-    expect(await page.getAttribute('html', 'dir')).toMatch('auto')
+    await expect.poll(() => page.getAttribute('html', 'lang')).toMatch('en')
+    await expect.poll(() => page.getAttribute('html', 'dir')).toMatch('auto')
 
     // rendering link tag and meta tag in head tag
     await assetLocaleHead(page, '#home-use-locale-head')
@@ -165,11 +165,11 @@ describe('strategy: no_prefix', async () => {
     await page.waitForFunction(() => document.querySelector('title')?.textContent === 'Homepage (Arabic)')
 
     // title tag
-    expect(await page.locator('title').innerText()).toMatch('Homepage (Arabic)')
+    await expect.poll(() => page.locator('title').innerText()).toMatch('Homepage (Arabic)')
 
     // html tag `lang` and `dir` attributes
-    expect(await page.getAttribute('html', 'lang')).toMatch('ar')
-    expect(await page.getAttribute('html', 'dir')).toMatch('rtl')
+    await expect.poll(() => page.getAttribute('html', 'lang')).toMatch('ar')
+    await expect.poll(() => page.getAttribute('html', 'dir')).toMatch('rtl')
 
     // rendering link tag and meta tag in head tag
     await assetLocaleHead(page, '#home-use-locale-head')

--- a/specs/routing_strategies/no_prefix.spec.ts
+++ b/specs/routing_strategies/no_prefix.spec.ts
@@ -60,7 +60,7 @@ describe('strategy: no_prefix', async () => {
     await expect.poll(() => page.locator('#set-locale-link-fr').innerText()).toEqual('Français')
 
     // page path
-    expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/about' })
+    await expect.poll(async () => JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/about' })
     await expect.poll(() => page.getAttribute('#nuxt-locale-link-fr', 'href')).toEqual('/')
 
     // current locale
@@ -84,7 +84,7 @@ describe('strategy: no_prefix', async () => {
     await expect.poll(() => page.locator('#set-locale-link-en').innerText()).toEqual('English')
 
     // page path
-    expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/about' })
+    await expect.poll(async () => JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/about' })
     await expect.poll(() => page.getAttribute('#nuxt-locale-link-en', 'href')).toEqual('/')
 
     // current locale

--- a/specs/routing_strategies/prefix.spec.ts
+++ b/specs/routing_strategies/prefix.spec.ts
@@ -62,7 +62,7 @@ describe('strategy: prefix', async () => {
     await expect.poll(() => page.locator('#set-locale-link-fr').innerText()).toEqual('Français')
 
     // page path
-    expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/en/about' })
+    await expect.poll(async () => JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/en/about' })
     await expect.poll(() => page.locator('#route-path').innerText()).toEqual('route: /en')
     await expect.poll(() => page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-fr', 'href')).toEqual('/fr')
 
@@ -83,7 +83,7 @@ describe('strategy: prefix', async () => {
     await expect.poll(() => page.locator('#set-locale-link-en').innerText()).toEqual('English')
 
     // page path
-    expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
+    await expect.poll(async () => JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
     await expect.poll(() => page.locator('#route-path').innerText()).toEqual('route: /fr')
     await expect.poll(() => page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-en', 'href')).toEqual('/en')
 
@@ -121,7 +121,7 @@ describe('strategy: prefix', async () => {
     await expect.poll(() => page.locator('#set-locale-link-en').innerText()).toEqual('English')
 
     // page path
-    expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
+    await expect.poll(async () => JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
     await expect.poll(() => page.locator('#route-path').innerText()).toEqual('route: /fr')
     await expect.poll(() => page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-en', 'href')).toEqual('/en')
 

--- a/specs/routing_strategies/prefix.spec.ts
+++ b/specs/routing_strategies/prefix.spec.ts
@@ -53,42 +53,42 @@ describe('strategy: prefix', async () => {
     const { page } = await renderPage('/en')
 
     // `en` rendering
-    expect(await page.locator('#home-header').innerText()).toEqual('Homepage')
-    expect(await page.locator('title').innerText()).toEqual('Homepage')
-    expect(await page.locator('#link-about').innerText()).toEqual('About us')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Homepage')
+    await expect.poll(() => page.locator('title').innerText()).toEqual('Homepage')
+    await expect.poll(() => page.locator('#link-about').innerText()).toEqual('About us')
 
     // lang switcher rendering
-    expect(await page.locator('#lang-switcher-with-nuxt-link .switch-to-fr').innerText()).toEqual('Français')
-    expect(await page.locator('#set-locale-link-fr').innerText()).toEqual('Français')
+    await expect.poll(() => page.locator('#lang-switcher-with-nuxt-link .switch-to-fr').innerText()).toEqual('Français')
+    await expect.poll(() => page.locator('#set-locale-link-fr').innerText()).toEqual('Français')
 
     // page path
     expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/en/about' })
-    expect(await page.locator('#route-path').innerText()).toEqual('route: /en')
-    expect(await page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-fr', 'href')).toEqual('/fr')
+    await expect.poll(() => page.locator('#route-path').innerText()).toEqual('route: /en')
+    await expect.poll(() => page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-fr', 'href')).toEqual('/fr')
 
     // current locale
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
   })
 
   test('can access to prefix locale: /fr', async () => {
     const { page } = await renderPage('/fr')
 
     // `fr` rendering
-    expect(await page.locator('#home-header').innerText()).toEqual('Accueil')
-    expect(await page.locator('title').innerText()).toEqual('Accueil')
-    expect(await page.locator('#link-about').innerText()).toEqual('À propos')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('title').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('#link-about').innerText()).toEqual('À propos')
 
     // lang switcher rendering
-    expect(await page.locator('#lang-switcher-with-nuxt-link .switch-to-en').innerText()).toEqual('English')
-    expect(await page.locator('#set-locale-link-en').innerText()).toEqual('English')
+    await expect.poll(() => page.locator('#lang-switcher-with-nuxt-link .switch-to-en').innerText()).toEqual('English')
+    await expect.poll(() => page.locator('#set-locale-link-en').innerText()).toEqual('English')
 
     // page path
     expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
-    expect(await page.locator('#route-path').innerText()).toEqual('route: /fr')
-    expect(await page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-en', 'href')).toEqual('/en')
+    await expect.poll(() => page.locator('#route-path').innerText()).toEqual('route: /fr')
+    await expect.poll(() => page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-en', 'href')).toEqual('/en')
 
     // current locale
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
   })
 
   test('cannot access to not defined locale: /ja', async () => {
@@ -112,21 +112,21 @@ describe('strategy: prefix', async () => {
     await page.waitForURL(url('/fr'))
 
     // `fr` rendering
-    expect(await page.locator('#home-header').innerText()).toEqual('Accueil')
-    expect(await page.locator('title').innerText()).toEqual('Accueil')
-    expect(await page.locator('#link-about').innerText()).toEqual('À propos')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('title').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('#link-about').innerText()).toEqual('À propos')
 
     // lang switcher rendering
-    expect(await page.locator('#lang-switcher-with-nuxt-link .switch-to-en').innerText()).toEqual('English')
-    expect(await page.locator('#set-locale-link-en').innerText()).toEqual('English')
+    await expect.poll(() => page.locator('#lang-switcher-with-nuxt-link .switch-to-en').innerText()).toEqual('English')
+    await expect.poll(() => page.locator('#set-locale-link-en').innerText()).toEqual('English')
 
     // page path
     expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
-    expect(await page.locator('#route-path').innerText()).toEqual('route: /fr')
-    expect(await page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-en', 'href')).toEqual('/en')
+    await expect.poll(() => page.locator('#route-path').innerText()).toEqual('route: /fr')
+    await expect.poll(() => page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-en', 'href')).toEqual('/en')
 
     // current locale
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
   })
 
   test('(#1889) navigation to page with `defineI18nRoute(false)`', async () => {
@@ -151,17 +151,17 @@ describe('strategy: prefix', async () => {
     // switch 'fr' locale
     await page.locator('#lang-switcher-with-nuxt-link .switch-to-fr').clickNavigate()
     await page.waitForURL(url('/fr'))
-    expect(await page.locator('#home-header').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Accueil')
 
     // navigate to disabled route
     await page.locator('#link-define-i18n-route-false').clickNavigate()
     await page.waitForURL(url('/define-i18n-route-false'))
 
-    expect(await page.locator('#disable-route-text').innerText()).toEqual('Page with disabled localized route')
+    await expect.poll(() => page.locator('#disable-route-text').innerText()).toEqual('Page with disabled localized route')
 
     // back to home
     await page.locator('#goto-home').clickNavigate()
-    expect(await page.locator('#home-header').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Accueil')
 
     // does not redirect to prefixed route for routes with disabled localization
     await page.goto(url('/ignore-routes/disable'))
@@ -189,7 +189,7 @@ describe('strategy: prefix', async () => {
     // detection redirect is delayed until hydration, give it time to (not) happen
     await page.waitForTimeout(500)
     expect(page.url()).toBe(url('/ignore-routes/disable'))
-    expect(await page.locator('p').innerText()).toEqual('ignore localized route disable test')
+    await expect.poll(() => page.locator('p').innerText()).toEqual('ignore localized route disable test')
   })
 
   test("(#3910) SSR request for a route with disabled localization reaches the page with `redirectOn: 'no prefix'`", async () => {
@@ -239,7 +239,7 @@ describe('strategy: prefix', async () => {
     const { page } = await renderPage('/', { locale: 'en' })
     await page.waitForURL(url('/en'))
 
-    expect(await page.locator('#link-define-i18n-route-false').innerText()).toEqual('go to defineI18nRoute(false)')
+    await expect.poll(() => page.locator('#link-define-i18n-route-false').innerText()).toEqual('go to defineI18nRoute(false)')
   })
 
   test("(#2132) should redirect on root url with `redirectOn: 'no prefix'`", async () => {
@@ -260,17 +260,17 @@ describe('strategy: prefix', async () => {
     )
 
     const { page } = await renderPage('/', { locale: 'fr' })
-    expect(await page.locator('#home-header').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Accueil')
 
     await gotoPath(page, '/en')
-    expect(await page.locator('#home-header').innerText()).toEqual('Homepage')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Homepage')
   })
 
   test('(#2020) pass query parameter', async () => {
     const { page } = await renderPage('/')
 
-    expect(await page.locator('#issue-2020-existing').innerText()).toBe('/en/test-route?foo=bar')
-    expect(await page.locator('#issue-2020-nonexistent').innerText()).toBe('/i-dont-exist?foo=bar')
+    await expect.poll(() => page.locator('#issue-2020-existing').innerText()).toBe('/en/test-route?foo=bar')
+    await expect.poll(() => page.locator('#issue-2020-nonexistent').innerText()).toBe('/i-dont-exist?foo=bar')
   })
   test('should keep query params when redirecting', async () => {
     await startServerWithRuntimeConfig(

--- a/specs/routing_strategies/prefix_and_default.spec.ts
+++ b/specs/routing_strategies/prefix_and_default.spec.ts
@@ -32,7 +32,7 @@ describe('strategy: prefix_and_default', async () => {
     await expect.poll(() => page.locator('#set-locale-link-fr').innerText()).toMatch('Français')
 
     // page path
-    expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/about' })
+    await expect.poll(async () => JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/about' })
     await expect.poll(() => page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-fr', 'href')).toMatch('/fr')
 
     // current locale
@@ -52,7 +52,7 @@ describe('strategy: prefix_and_default', async () => {
     await expect.poll(() => page.locator('#set-locale-link-fr').innerText()).toMatch('Français')
 
     // page path
-    expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/about' })
+    await expect.poll(async () => JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/about' })
     await expect.poll(() => page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-fr', 'href')).toMatch('/fr')
 
     // current locale
@@ -72,7 +72,7 @@ describe('strategy: prefix_and_default', async () => {
     await expect.poll(() => page.locator('#set-locale-link-en').innerText()).toEqual('English')
 
     // page path
-    expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
+    await expect.poll(async () => JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
     await expect.poll(() => page.getAttribute('#lang-switcher-with-nuxt-link a', 'href')).toEqual('/')
 
     // current locale
@@ -109,7 +109,7 @@ describe('strategy: prefix_and_default', async () => {
     await expect.poll(() => page.locator('#set-locale-link-en').innerText()).toEqual('English')
 
     // page path
-    expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
+    await expect.poll(async () => JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
     await expect.poll(() => page.getAttribute('#lang-switcher-with-nuxt-link a', 'href')).toEqual('/')
 
     // current locale

--- a/specs/routing_strategies/prefix_and_default.spec.ts
+++ b/specs/routing_strategies/prefix_and_default.spec.ts
@@ -23,60 +23,60 @@ describe('strategy: prefix_and_default', async () => {
     const { page } = await renderPage('/')
 
     // `en` rendering
-    expect(await page.locator('#home-header').innerText()).toMatch('Homepage')
-    expect(await page.locator('title').innerText()).toMatch('Homepage')
-    expect(await page.locator('#link-about').innerText()).toMatch('About us')
+    await expect.poll(() => page.locator('#home-header').innerText()).toMatch('Homepage')
+    await expect.poll(() => page.locator('title').innerText()).toMatch('Homepage')
+    await expect.poll(() => page.locator('#link-about').innerText()).toMatch('About us')
 
     // lang switcher rendering
-    expect(await page.locator('#lang-switcher-with-nuxt-link .switch-to-fr').innerText()).toMatch('Français')
-    expect(await page.locator('#set-locale-link-fr').innerText()).toMatch('Français')
+    await expect.poll(() => page.locator('#lang-switcher-with-nuxt-link .switch-to-fr').innerText()).toMatch('Français')
+    await expect.poll(() => page.locator('#set-locale-link-fr').innerText()).toMatch('Français')
 
     // page path
     expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/about' })
-    expect(await page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-fr', 'href')).toMatch('/fr')
+    await expect.poll(() => page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-fr', 'href')).toMatch('/fr')
 
     // current locale
-    expect(await page.locator('#lang-switcher-current-locale').innerText()).toMatch('en')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale').innerText()).toMatch('en')
   })
 
   test('can access to prefix locale : /en', async () => {
     const { page } = await renderPage('/en')
 
     // `en` rendering
-    expect(await page.locator('#home-header').innerText()).toMatch('Homepage')
-    expect(await page.locator('title').innerText()).toMatch('Homepage')
-    expect(await page.locator('#link-about').innerText()).toMatch('About us')
+    await expect.poll(() => page.locator('#home-header').innerText()).toMatch('Homepage')
+    await expect.poll(() => page.locator('title').innerText()).toMatch('Homepage')
+    await expect.poll(() => page.locator('#link-about').innerText()).toMatch('About us')
 
     // lang switcher rendering
-    expect(await page.locator('#lang-switcher-with-nuxt-link .switch-to-fr').innerText()).toMatch('Français')
-    expect(await page.locator('#set-locale-link-fr').innerText()).toMatch('Français')
+    await expect.poll(() => page.locator('#lang-switcher-with-nuxt-link .switch-to-fr').innerText()).toMatch('Français')
+    await expect.poll(() => page.locator('#set-locale-link-fr').innerText()).toMatch('Français')
 
     // page path
     expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/about' })
-    expect(await page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-fr', 'href')).toMatch('/fr')
+    await expect.poll(() => page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-fr', 'href')).toMatch('/fr')
 
     // current locale
-    expect(await page.locator('#lang-switcher-current-locale').innerText()).toMatch('en')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale').innerText()).toMatch('en')
   })
 
   test('can access to prefix locale: /fr', async () => {
     const { page } = await renderPage('/fr')
 
     // `fr` rendering
-    expect(await page.locator('#home-header').innerText()).toEqual('Accueil')
-    expect(await page.locator('title').innerText()).toEqual('Accueil')
-    expect(await page.locator('#link-about').innerText()).toEqual('À propos')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('title').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('#link-about').innerText()).toEqual('À propos')
 
     // lang switcher rendering
-    expect(await page.locator('#lang-switcher-with-nuxt-link .switch-to-en').innerText()).toEqual('English')
-    expect(await page.locator('#set-locale-link-en').innerText()).toEqual('English')
+    await expect.poll(() => page.locator('#lang-switcher-with-nuxt-link .switch-to-en').innerText()).toEqual('English')
+    await expect.poll(() => page.locator('#set-locale-link-en').innerText()).toEqual('English')
 
     // page path
     expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
-    expect(await page.getAttribute('#lang-switcher-with-nuxt-link a', 'href')).toEqual('/')
+    await expect.poll(() => page.getAttribute('#lang-switcher-with-nuxt-link a', 'href')).toEqual('/')
 
     // current locale
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
   })
 
   test('cannot access to not defined locale: /ja', async () => {
@@ -100,53 +100,53 @@ describe('strategy: prefix_and_default', async () => {
     await page.waitForURL(url('/fr'))
 
     // `fr` rendering
-    expect(await page.locator('#home-header').innerText()).toEqual('Accueil')
-    expect(await page.locator('title').innerText()).toEqual('Accueil')
-    expect(await page.locator('#link-about').innerText()).toEqual('À propos')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('title').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('#link-about').innerText()).toEqual('À propos')
 
     // lang switcher rendering
-    expect(await page.locator('#lang-switcher-with-nuxt-link .switch-to-en').innerText()).toEqual('English')
-    expect(await page.locator('#set-locale-link-en').innerText()).toEqual('English')
+    await expect.poll(() => page.locator('#lang-switcher-with-nuxt-link .switch-to-en').innerText()).toEqual('English')
+    await expect.poll(() => page.locator('#set-locale-link-en').innerText()).toEqual('English')
 
     // page path
     expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
-    expect(await page.getAttribute('#lang-switcher-with-nuxt-link a', 'href')).toEqual('/')
+    await expect.poll(() => page.getAttribute('#lang-switcher-with-nuxt-link a', 'href')).toEqual('/')
 
     // current locale
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
 
     // click `en` and `fr` lang switch link with setLocale
     await page.locator('#set-locale-link-en').clickNavigate()
     await page.waitForURL(url('/'))
-    expect(await page.locator('title').innerText()).toEqual('Homepage')
+    await expect.poll(() => page.locator('title').innerText()).toEqual('Homepage')
 
     await page.locator('#set-locale-link-fr').clickNavigate()
     await page.waitForURL(url('/fr'))
-    expect(await page.locator('title').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('title').innerText()).toEqual('Accueil')
   })
 
   test('(#2226) navigation works while `locale === defaultLocale`', async () => {
     const { page } = await renderPage(url('/'))
 
     await page.locator('#lang-switcher-with-nuxt-link .switch-to-fr').clickNavigate()
-    expect(await page.locator('#lang-switcher-default-locale').innerText()).include(`Default Locale: en`)
-    expect(await page.locator('#lang-switcher-current-locale').innerText()).include(`Current Locale: fr`)
+    await expect.poll(() => page.locator('#lang-switcher-default-locale').innerText()).include(`Default Locale: en`)
+    await expect.poll(() => page.locator('#lang-switcher-current-locale').innerText()).include(`Current Locale: fr`)
 
     await page.locator('#link-about').clickNavigate()
     await page.waitForURL(url('/fr/about'))
-    expect(await page.locator('#about-header').innerText()).include(`À propos`)
+    await expect.poll(() => page.locator('#about-header').innerText()).include(`À propos`)
 
     await page.locator('#link-home').clickNavigate()
     await page.waitForURL(url('/fr'))
-    expect(await page.locator('#home-header').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Accueil')
 
     await page.locator('#lang-switcher-with-nuxt-link .switch-to-en').clickNavigate()
-    expect(await page.locator('#lang-switcher-default-locale').innerText()).include(`Default Locale: en`)
-    expect(await page.locator('#lang-switcher-current-locale').innerText()).include(`Current Locale: en`)
+    await expect.poll(() => page.locator('#lang-switcher-default-locale').innerText()).include(`Default Locale: en`)
+    await expect.poll(() => page.locator('#lang-switcher-current-locale').innerText()).include(`Current Locale: en`)
 
     await page.locator('#link-about').clickNavigate()
     await page.waitForURL(url('/about'))
-    expect(await page.locator('#about-header').innerText()).include(`About us`)
+    await expect.poll(() => page.locator('#about-header').innerText()).include(`About us`)
   })
 
   test('(#2247) navigation from prefixed default-locale route to home', async () => {
@@ -154,7 +154,7 @@ describe('strategy: prefix_and_default', async () => {
 
     await page.locator('#link-home').clickNavigate()
     await page.waitForURL(url('/'))
-    expect(await page.locator('#home-header').innerText()).toEqual('Homepage')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Homepage')
   })
 
   test('(#2288) `setLocale` navigates to the localized route', async () => {
@@ -162,10 +162,10 @@ describe('strategy: prefix_and_default', async () => {
 
     await page.locator('#set-locale-link-en').clickNavigate()
     await page.waitForURL(url('/about'))
-    expect(await page.locator('#about-header').innerText()).toEqual('About us')
+    await expect.poll(() => page.locator('#about-header').innerText()).toEqual('About us')
 
     await page.locator('#set-locale-link-fr').clickNavigate()
     await page.waitForURL(url('/fr/about'))
-    expect(await page.locator('#about-header').innerText()).toEqual('À propos')
+    await expect.poll(() => page.locator('#about-header').innerText()).toEqual('À propos')
   })
 })

--- a/specs/routing_strategies/prefix_except_default.spec.ts
+++ b/specs/routing_strategies/prefix_except_default.spec.ts
@@ -21,50 +21,50 @@ await setup({
 describe('default strategy: prefix_except_default', async () => {
   test('(#3404) messages imported by the `vueI18n` config from the locales directory', async () => {
     const { page } = await renderPage('/')
-    expect(await page.locator('#locale-file-import').innerText()).toEqual('Hello!')
+    await expect.poll(() => page.locator('#locale-file-import').innerText()).toEqual('Hello!')
 
     await page.goto(url('/fr'))
-    expect(await page.locator('#locale-file-import').innerText()).toEqual('Bonjour !')
+    await expect.poll(() => page.locator('#locale-file-import').innerText()).toEqual('Bonjour !')
   })
 
   test('can access to no prefix locale (defaultLocale: en): /', async () => {
     const { page } = await renderPage('/')
 
     // `en` rendering
-    expect(await page.locator('#home-header').innerText()).toEqual('Homepage')
-    expect(await page.locator('title').innerText()).toEqual('Homepage')
-    expect(await page.locator('#link-about').innerText()).toEqual('About us')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Homepage')
+    await expect.poll(() => page.locator('title').innerText()).toEqual('Homepage')
+    await expect.poll(() => page.locator('#link-about').innerText()).toEqual('About us')
 
     // lang switcher rendering
-    expect(await page.locator('#lang-switcher-with-nuxt-link .switch-to-fr').innerText()).toEqual('Français')
-    expect(await page.locator('#set-locale-link-fr').innerText()).toEqual('Français')
+    await expect.poll(() => page.locator('#lang-switcher-with-nuxt-link .switch-to-fr').innerText()).toEqual('Français')
+    await expect.poll(() => page.locator('#set-locale-link-fr').innerText()).toEqual('Français')
 
     // page path
     expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/about' })
-    expect(await page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-fr', 'href')).toEqual('/fr')
+    await expect.poll(() => page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-fr', 'href')).toEqual('/fr')
 
     // current locale
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
   })
 
   test('can access to prefix locale: /fr', async () => {
     const { page } = await renderPage('/fr')
 
     // `fr` rendering
-    expect(await page.locator('#home-header').innerText()).toEqual('Accueil')
-    expect(await page.locator('title').innerText()).toEqual('Accueil')
-    expect(await page.locator('#link-about').innerText()).toEqual('À propos')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('title').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('#link-about').innerText()).toEqual('À propos')
 
     // lang switcher rendering
-    expect(await page.locator('#lang-switcher-with-nuxt-link .switch-to-en').innerText()).toEqual('English')
-    expect(await page.locator('#set-locale-link-en').innerText()).toEqual('English')
+    await expect.poll(() => page.locator('#lang-switcher-with-nuxt-link .switch-to-en').innerText()).toEqual('English')
+    await expect.poll(() => page.locator('#set-locale-link-en').innerText()).toEqual('English')
 
     // page path
     expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
-    expect(await page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-en', 'href')).toEqual('/')
+    await expect.poll(() => page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-en', 'href')).toEqual('/')
 
     // current locale
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
   })
 
   test('cannot access to not defined locale: /ja', async () => {
@@ -88,20 +88,20 @@ describe('default strategy: prefix_except_default', async () => {
     await page.waitForURL(url('/fr'))
 
     // `fr` rendering
-    expect(await page.locator('#home-header').innerText()).toEqual('Accueil')
-    expect(await page.locator('title').innerText()).toEqual('Accueil')
-    expect(await page.locator('#link-about').innerText()).toEqual('À propos')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('title').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('#link-about').innerText()).toEqual('À propos')
 
     // lang switcher rendering
-    expect(await page.locator('#lang-switcher-with-nuxt-link .switch-to-en').innerText()).toEqual('English')
-    expect(await page.locator('#set-locale-link-en').innerText()).toEqual('English')
+    await expect.poll(() => page.locator('#lang-switcher-with-nuxt-link .switch-to-en').innerText()).toEqual('English')
+    await expect.poll(() => page.locator('#set-locale-link-en').innerText()).toEqual('English')
 
     // page path
     expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
-    expect(await page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-en', 'href')).toEqual('/')
+    await expect.poll(() => page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-en', 'href')).toEqual('/')
 
     // current locale
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
 
     // click `en` and `fr` lang switch link with setLocale
     await page.locator('#set-locale-link-en').clickNavigate()
@@ -121,13 +121,13 @@ describe('default strategy: prefix_except_default', async () => {
      */
 
     // title tag
-    expect(await page.locator('title').innerText()).toMatch('Homepage')
+    await expect.poll(() => page.locator('title').innerText()).toMatch('Homepage')
 
     // html tag `lang` attribute
-    expect(await page.getAttribute('html', 'lang')).toMatch('en')
+    await expect.poll(() => page.getAttribute('html', 'lang')).toMatch('en')
 
     // html tag `dir` attribute
-    expect(await page.getAttribute('html', 'dir')).toMatch('auto')
+    await expect.poll(() => page.getAttribute('html', 'dir')).toMatch('auto')
 
     // rendering link tag and meta tag in head tag
     await assetLocaleHead(page, '#home-use-locale-head')
@@ -141,10 +141,10 @@ describe('default strategy: prefix_except_default', async () => {
     await page.waitForURL(url('/fr'))
 
     // title tag
-    expect(await page.locator('title').innerText()).toMatch('Accueil')
+    await expect.poll(() => page.locator('title').innerText()).toMatch('Accueil')
 
     // html tag `lang` attribute
-    expect(await page.getAttribute('html', 'lang')).toMatch('fr-FR')
+    await expect.poll(() => page.getAttribute('html', 'lang')).toMatch('fr-FR')
 
     // rendering link tag and meta tag in head tag
     await assetLocaleHead(page, '#home-use-locale-head')

--- a/specs/routing_strategies/prefix_except_default.spec.ts
+++ b/specs/routing_strategies/prefix_except_default.spec.ts
@@ -40,7 +40,7 @@ describe('default strategy: prefix_except_default', async () => {
     await expect.poll(() => page.locator('#set-locale-link-fr').innerText()).toEqual('Français')
 
     // page path
-    expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/about' })
+    await expect.poll(async () => JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/about' })
     await expect.poll(() => page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-fr', 'href')).toEqual('/fr')
 
     // current locale
@@ -60,7 +60,7 @@ describe('default strategy: prefix_except_default', async () => {
     await expect.poll(() => page.locator('#set-locale-link-en').innerText()).toEqual('English')
 
     // page path
-    expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
+    await expect.poll(async () => JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
     await expect.poll(() => page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-en', 'href')).toEqual('/')
 
     // current locale
@@ -97,7 +97,7 @@ describe('default strategy: prefix_except_default', async () => {
     await expect.poll(() => page.locator('#set-locale-link-en').innerText()).toEqual('English')
 
     // page path
-    expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
+    await expect.poll(async () => JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
     await expect.poll(() => page.getAttribute('#lang-switcher-with-nuxt-link .switch-to-en', 'href')).toEqual('/')
 
     // current locale
@@ -205,7 +205,7 @@ describe('default strategy: prefix_except_default', async () => {
       await page.waitForURL(url('/fr'))
 
       // pick href with <NuxtLink>
-      expect(await page.locator('#link-ignore-pick').getAttribute('href')).toBe('/fr/ignore-routes/pick')
+      await expect.poll(() => page.locator('#link-ignore-pick').getAttribute('href')).toBe('/fr/ignore-routes/pick')
     })
 
     test('can not access to disable route path', async () => {
@@ -216,7 +216,7 @@ describe('default strategy: prefix_except_default', async () => {
       await page.waitForURL(url('/fr'))
 
       // disable href with <NuxtLink>
-      expect(await page.locator('#link-ignore-disable').getAttribute('href')).toBe(null)
+      await expect.poll(() => page.locator('#link-ignore-disable').getAttribute('href')).toBe(null)
 
       // disable direct url access
       let res: Response | (Error & { status: () => number }) | null = null
@@ -235,7 +235,7 @@ describe('default strategy: prefix_except_default', async () => {
     test('(#3831) nested index root custom routes', async () => {
       const { page } = await renderPage('/')
 
-      expect(await page.locator('#issue-3831-nested-root').getAttribute('href')).toBe('/my-localized-nested-root-page')
+      await expect.poll(() => page.locator('#issue-3831-nested-root').getAttribute('href')).toBe('/my-localized-nested-root-page')
       await page.locator('#issue-3831-nested-root').clickNavigate()
       await page.waitForURL(url('/my-localized-nested-root-page'))
     })

--- a/specs/ssg/basic_lazy_load.spec.ts
+++ b/specs/ssg/basic_lazy_load.spec.ts
@@ -27,7 +27,7 @@ describe('basic lazy loading', async () => {
 
     await page.click('#nuxt-locale-link-fr')
     await page.waitForURL(url('/fr'))
-    expect(await page.locator('#dynamic-time').innerText()).toEqual('Not dynamic')
+    await expect.poll(() => page.locator('#dynamic-time').innerText()).toEqual('Not dynamic')
 
     // dynamicTime depends on passage of some time
     await page.waitForTimeout(1)
@@ -35,7 +35,7 @@ describe('basic lazy loading', async () => {
     // dynamicTime does not match captured dynamicTime
     await page.click('#nuxt-locale-link-nl')
     await page.waitForURL(url('/nl'))
-    expect(await page.locator('#dynamic-time').innerText()).to.not.equal(dynamicTime)
+    await expect.poll(() => page.locator('#dynamic-time').innerText()).to.not.equal(dynamicTime)
   })
 
   test('locales are fetched on demand', async () => {
@@ -83,54 +83,54 @@ describe('basic lazy loading', async () => {
     const { page } = await renderPage('/')
 
     // `en` rendering
-    expect(await page.locator('#home-header').innerText()).toEqual('Homepage')
-    expect(await page.locator('title').innerText()).toEqual('Homepage')
-    expect(await page.locator('#link-about').innerText()).toEqual('About us')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Homepage')
+    await expect.poll(() => page.locator('title').innerText()).toEqual('Homepage')
+    await expect.poll(() => page.locator('#link-about').innerText()).toEqual('About us')
 
     // lang switcher rendering
-    expect(await page.locator('#set-locale-link-fr').innerText()).toEqual('Français')
+    await expect.poll(() => page.locator('#set-locale-link-fr').innerText()).toEqual('Français')
 
     // page path
     expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/about' })
 
     // current locale
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
 
     // html tag `lang` attribute with language code
-    expect(await page.getAttribute('html', 'lang')).toEqual('en-US')
+    await expect.poll(() => page.getAttribute('html', 'lang')).toEqual('en-US')
   })
 
   test('can access to prefix locale: /fr', async () => {
     const { page } = await renderPage('/fr')
 
     // `fr` rendering
-    expect(await page.locator('#home-header').innerText()).toEqual('Accueil')
-    expect(await page.locator('title').innerText()).toEqual('Accueil')
-    expect(await page.locator('#link-about').innerText()).toEqual('À propos')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('title').innerText()).toEqual('Accueil')
+    await expect.poll(() => page.locator('#link-about').innerText()).toEqual('À propos')
 
     // lang switcher rendering
-    expect(await page.locator('#set-locale-link-en').innerText()).toEqual('English')
+    await expect.poll(() => page.locator('#set-locale-link-en').innerText()).toEqual('English')
 
     // page path
     expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
 
     // current locale
-    expect(await page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
+    await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')
 
     // html tag `lang` attribute with language code
-    expect(await page.getAttribute('html', 'lang')).toEqual('fr-FR')
+    await expect.poll(() => page.getAttribute('html', 'lang')).toEqual('fr-FR')
   })
 
   test('multiple lazy loading', async () => {
     const { page } = await renderPage('/en-GB')
 
     // `en` base rendering
-    expect(await page.locator('#home-header').innerText()).toEqual('Homepage')
-    expect(await page.locator('title').innerText()).toEqual('Homepage')
-    expect(await page.locator('#link-about').innerText()).toEqual('About us')
+    await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Homepage')
+    await expect.poll(() => page.locator('title').innerText()).toEqual('Homepage')
+    await expect.poll(() => page.locator('#link-about').innerText()).toEqual('About us')
 
-    expect(await page.locator('#profile-js').innerText()).toEqual('Profile1')
-    expect(await page.locator('#profile-ts').innerText()).toEqual('Profile2')
+    await expect.poll(() => page.locator('#profile-js').innerText()).toEqual('Profile1')
+    await expect.poll(() => page.locator('#profile-ts').innerText()).toEqual('Profile2')
   })
 
   test('files with cache disabled bypass caching', async () => {
@@ -149,7 +149,7 @@ describe('basic lazy loading', async () => {
   test('manually loaded messages can be used in translations', async () => {
     const { page } = await renderPage('/manual-load')
 
-    expect(await page.locator('#welcome-english').innerText()).toEqual('Welcome!')
-    expect(await page.locator('#welcome-dutch').innerText()).toEqual('Welkom!')
+    await expect.poll(() => page.locator('#welcome-english').innerText()).toEqual('Welcome!')
+    await expect.poll(() => page.locator('#welcome-dutch').innerText()).toEqual('Welkom!')
   })
 })

--- a/specs/ssg/basic_lazy_load.spec.ts
+++ b/specs/ssg/basic_lazy_load.spec.ts
@@ -91,7 +91,7 @@ describe('basic lazy loading', async () => {
     await expect.poll(() => page.locator('#set-locale-link-fr').innerText()).toEqual('Français')
 
     // page path
-    expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/about' })
+    await expect.poll(async () => JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/about' })
 
     // current locale
     await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('en')
@@ -112,7 +112,7 @@ describe('basic lazy loading', async () => {
     await expect.poll(() => page.locator('#set-locale-link-en').innerText()).toEqual('English')
 
     // page path
-    expect(JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
+    await expect.poll(async () => JSON.parse(await page.locator('#home-use-async-data').innerText())).toMatchObject({ aboutPath: '/fr/about' })
 
     // current locale
     await expect.poll(() => page.locator('#lang-switcher-current-locale code').innerText()).toEqual('fr')


### PR DESCRIPTION
Assertions reading the DOM through `page.locator(...).innerText()` or `page.getAttribute()` are one-shot. Playwright waits for the element to be attached but not for its content to reach a value, and `waitForURL` resolves on the URL alone. During a client side navigation `<title>`, `#home-header` and `html[lang]` already exist holding the previous locale's value, so the read can land before the head and DOM updates flush. That has been passing on timing rather than on any guarantee, which is why the recent message loading changes surfaced it.

This wraps those reads in `expect.poll` so they retry until the value matches. Playwright recommends `expect(locator).toHaveText()` for exactly this, but its web first assertions live in `@playwright/test` and we only depend on `playwright-core`, so `expect.poll` is the equivalent under vitest. One assertion keeps the plain form since `expect.poll` doesn't support snapshot matchers.

The conversion is mechanical, 282 assertions across 15 files. Polling has one downside worth naming: an assertion that is already true passes immediately, so a missing navigation wait stops being visible. Four sites had that problem, three clicking a link with a plain `click()` and one asserting before its `waitForURL`, and they now wait for the navigation before asserting the destination page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test stability by converting many UI and head/metadata assertions to resilient polling, accommodating asynchronous locale updates, hydration, and route transitions.
  * Strengthened coverage across language detection (cookie/domain/browser), routing strategies (prefix/no prefix/legacy/compact), lazy-loaded messages (including dynamic and manual loads), runtime locale switching, dynamic route parameters, and strict SEO head tags.
  * Reduced intermittent failures by avoiding checks before the localized UI and related attributes/links have fully settled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
