### PR TITLE
fix(domain): resolve links for the host default locale under `prefix_and_default`

### DIFF
--- a/src/routing.ts
+++ b/src/routing.ts
@@ -133,10 +133,10 @@ function resolveDefaultTreeLocales(config: SetupLocalizeRoutesOptions, strategy:
   return strategy === 'prefix_and_default' && config.defaultLocale ? [config.defaultLocale] : []
 }
 
-function resolveDefaultLocales(config: SetupLocalizeRoutesOptions) {
+function resolveDefaultLocales(config: SetupLocalizeRoutesOptions, strategy: Strategies) {
   // under the `*_default` strategies the unprefixed locale differs per domain, `___default`
   // variants + runtime surgery resolve it - a build time default would claim the same path
-  if ((config.differentDomains || config.multiDomainLocales) && usesDefaultVariants(config.strategy)) {
+  if ((config.differentDomains || config.multiDomainLocales) && usesDefaultVariants(strategy)) {
     return []
   }
 
@@ -168,16 +168,16 @@ type SetupLocalizeRoutesOptions = {
 export function localizeRoutes(routes: LocalizableRoute[], config: SetupLocalizeRoutesOptions): LocalizableRoute[] {
   if (!shouldLocalizeRoutes(config)) { return routes }
 
+  const strategy = config.strategy ?? 'prefix_and_default'
+
   const ctx = createRouteContext({
     optionsResolver: config.optionsResolver,
     trailingSlash: config.trailingSlash ?? false,
-    defaultLocales: resolveDefaultLocales(config),
+    defaultLocales: resolveDefaultLocales(config, strategy),
     routesNameSeparator: config.routesNameSeparator,
     defaultLocaleRouteNameSuffix: config.defaultLocaleRouteNameSuffix,
     onLocalize: config.onLocalize,
   })
-
-  const strategy = config.strategy ?? 'prefix_and_default'
 
   /**
    * Compact routes: merge all per-locale routes into a single `/:locale(en|fr)/path` route

--- a/src/runtime/routing/context.ts
+++ b/src/runtime/routing/context.ts
@@ -73,7 +73,7 @@ export function createRoutingContext(options: RoutingContextOptions): RoutingCon
     domains: options.domains,
   }
   const formatTrailingSlash = createTrailingSlashFormatter(options.trailingSlash)
-  const getLocalizedRouteName = createLocaleRouteNameGetter(defaultLocale, config)
+  const getLocalizedRouteName = createLocaleRouteNameGetter(defaultLocale, config, name => router.hasRoute(name))
 
   function resolveLocalizedRouteByName(route: RouteLikeWithName, locale: string) {
     route.name = getRouteBaseName(route.name || router.currentRoute.value) // fallback to current route name
@@ -185,6 +185,9 @@ export function createRoutingContext(options: RoutingContextOptions): RoutingCon
       // per-locale host membership decides the link shape: on-host targets navigate
       // relative (unprefixed when the host default), off-host targets get an absolute
       // URL in the target domain's shape
+      // membership is strict here on purpose: a locale that lives on another domain needs an
+      // absolute link even from a host matching no configured domain, under `no_prefix` the
+      // relative path is identical for every locale and would not switch anything
       const host = options.getHost() ?? ''
       const target = options.getLocales().find(l => l.code === locale)
       const stripsDefaultPrefix

--- a/src/runtime/routing/context.ts
+++ b/src/runtime/routing/context.ts
@@ -200,6 +200,12 @@ export function createRoutingContext(options: RoutingContextOptions): RoutingCon
         return path
       }
 
+      // the route does not resolve for this locale (disabled for the page), joining an empty
+      // path would point the link and its hreflang at the target domain's home page
+      if (!path) {
+        return path
+      }
+
       if (stripsDefaultPrefix && target?.defaultForDomains?.length && getLocaleFromRoutePath(path) === locale) {
         path = path.slice(locale.length + 1) || '/'
       }

--- a/src/runtime/routing/domain.ts
+++ b/src/runtime/routing/domain.ts
@@ -4,23 +4,35 @@ import { useRouter } from '#imports'
 import { defaultRouteNameSuffix, getLocaleFromRouteName } from '#i18n-kit/routing'
 
 /**
- * Rebuilds the route table for the current domain: removes the generated `___default`
- * variants and unprefixes the routes of the domain's default locale. Used by both
- * `differentDomains` and `multiDomainLocales` under the `*_default` strategies.
+ * Rebuilds the route table for the current domain from the `___default` variants generated for
+ * every domain default. Used by both `differentDomains` and `multiDomainLocales` under the
+ * `*_default` strategies.
  */
 export function setupMultiDomainLocales(defaultLocale: string, strategy: Strategies, router: Router = useRouter()) {
   if (strategy !== 'prefix_except_default' && strategy !== 'prefix_and_default') { return }
 
+  // `prefix_and_default` serves its default locale both unprefixed and prefixed, so the host's
+  // own variant is kept. The build only emits variants for locales that are a domain default
+  // somewhere, so when the host default has none the prefixed route is unprefixed instead
+  const keepsDefaultVariant = strategy === 'prefix_and_default'
+    && router.getRoutes().some((route) => {
+      const routeName = String(route.name)
+      return routeName.endsWith(defaultRouteNameSuffix) && getLocaleFromRouteName(routeName) === defaultLocale
+    })
+
   // adjust routes to match the domain's locale and structure
   for (const route of router.getRoutes()) {
     const routeName = String(route.name)
+    const locale = getLocaleFromRouteName(routeName)
+
     if (routeName.endsWith(defaultRouteNameSuffix)) {
-      router.removeRoute(routeName)
+      if (!keepsDefaultVariant || locale !== defaultLocale) {
+        router.removeRoute(routeName)
+      }
       continue
     }
 
-    const locale = getLocaleFromRouteName(routeName)
-    if (locale === defaultLocale) {
+    if (!keepsDefaultVariant && locale === defaultLocale) {
       router.addRoute({ ...route, path: route.path.replace(new RegExp(`^/${locale}/?`), '/') })
     }
   }

--- a/src/runtime/routing/utils.ts
+++ b/src/runtime/routing/utils.ts
@@ -12,6 +12,7 @@ import type { PrefixableOptions } from '#i18n-kit/routing'
 export function createLocaleRouteNameGetter(
   defaultLocale: string,
   config: PrefixableOptions,
+  hasRoute?: (name: string) => boolean,
 ): (name: RouteRecordNameGeneric | null, locale: string) => string {
   // no route localization
   if (!config.routing && !config.domains) {
@@ -20,7 +21,15 @@ export function createLocaleRouteNameGetter(
 
   // default locale routes have default suffix
   if (config.strategy === 'prefix_and_default') {
-    return (name, locale) => getLocalizedRouteName(normalizeRouteName(name), locale, locale === defaultLocale)
+    return (name, locale) => {
+      const normalized = normalizeRouteName(name)
+      if (locale !== defaultLocale) { return getLocalizedRouteName(normalized, locale, false) }
+
+      // under domain routing the suffixed variant is only generated for domain defaults, the
+      // route table decides whether this locale has one rather than the strategy alone
+      const suffixed = getLocalizedRouteName(normalized, locale, true)
+      return !hasRoute || hasRoute(suffixed) ? suffixed : getLocalizedRouteName(normalized, locale, false)
+    }
   }
 
   // routes are localized

--- a/src/runtime/shared/matching.ts
+++ b/src/runtime/shared/matching.ts
@@ -53,9 +53,13 @@ export function matchLocalized(path: string, locale: string, defaultLocale: stri
 
   if (resolvedMatch.matched.length > 0) {
     const alternate = getI18nPathToI18nPath(resolvedMatch.matched[0]!.path, locale)
+    // the path is disabled for this locale, matching `/` instead would send the request
+    // to the home page of whichever locale or domain it was being resolved for
+    if (!alternate) { return }
+
     const match = matcher.resolve(
       { params: resolvedMatch.params },
-      { path: alternate || '/', name: '', matched: [], params: {}, meta: {} },
+      { path: alternate, name: '', matched: [], params: {}, meta: {} },
     )
 
     const isPrefixable = prefixable(locale, defaultLocale, {

--- a/test/kit.test.ts
+++ b/test/kit.test.ts
@@ -325,7 +325,8 @@ describe('switchLocalePath with differentDomains', () => {
 
     const ctx = createRoutingContext({
       router,
-      defaultLocale: '',
+      // the runtime resolves this per host, not from the build time `defaultLocale`
+      defaultLocale: opts.hostDefault ?? '',
       strategy: opts.strategy,
       routing: true,
       domains: true,
@@ -354,6 +355,65 @@ describe('switchLocalePath with differentDomains', () => {
     expect(_switchLocalePath(ctx, 'no')).toBe('http://en.example.com/no/about')
     // on-host targets navigate relative
     expect(_switchLocalePath(ctx, 'fr')).toBe('/about')
+  })
+
+  test('`strategy: prefix_and_default` falls back to unprefixing when no locale is a domain default', async () => {
+    const { router, ctx } = createDomainContext({
+      strategy: 'prefix_and_default',
+      host: 'en.example.com',
+      locale: 'en',
+      hostDefault: 'en',
+      locales: [
+        { code: 'en', language: 'en', domain: 'en.example.com' },
+        { code: 'fr', language: 'fr', domain: 'fr.example.com' }
+      ]
+    })
+
+    // no `___default` variants exist to keep, so the host default is unprefixed instead
+    const paths = Object.fromEntries(router.getRoutes().map(x => [x.name, x.path]))
+    expect(paths['about___en']).toBe('/about')
+    expect(paths['about___en___default']).toBeUndefined()
+
+    await router.push('/about')
+    expect(_localePath(ctx, '/about', 'en')).toBe('/about')
+    expect(_switchLocalePath(ctx, 'en')).toBe('/about')
+  })
+
+  test('a host matching no configured domain links each locale to its own domain', async () => {
+    const { router, ctx } = createDomainContext({
+      strategy: 'prefix_except_default',
+      host: 'staging.example.com',
+      locale: 'fr'
+    })
+
+    await router.push('/fr/about')
+    // no locale is served on this host, so every link is absolute in the target domain's shape
+    // and stays consistent with the hreflang alternates, which are always absolute per locale
+    expect(_switchLocalePath(ctx, 'en')).toBe('http://en.example.com/about')
+    expect(_switchLocalePath(ctx, 'no')).toBe('http://en.example.com/no/about')
+    expect(_switchLocalePath(ctx, 'fr')).toBe('http://fr.example.com/about')
+  })
+
+  test('`strategy: prefix_and_default` serves the host default unprefixed and prefixed', async () => {
+    const { router, ctx } = createDomainContext({
+      strategy: 'prefix_and_default',
+      host: 'fr.example.com',
+      locale: 'fr',
+      hostDefault: 'fr'
+    })
+
+    const paths = Object.fromEntries(router.getRoutes().map(x => [x.name, x.path]))
+    // the host default keeps both variants, route names for it resolve to the `___default` form
+    expect(paths['about___fr___default']).toBe('/about')
+    expect(paths['about___fr']).toBe('/fr/about')
+    // the other domains' unprefixed variants are removed
+    expect(paths['about___en___default']).toBeUndefined()
+    expect(paths['about___en']).toBe('/en/about')
+
+    await router.push('/about')
+    expect(_localePath(ctx, '/about', 'fr')).toBe('/about')
+    expect(_switchLocalePath(ctx, 'fr')).toBe('/about')
+    expect(_switchLocalePath(ctx, 'en')).toBe('http://en.example.com/about')
   })
 
   test('`strategy: prefix` keeps prefixes in links for all locales', async () => {

--- a/test/kit.test.ts
+++ b/test/kit.test.ts
@@ -416,6 +416,19 @@ describe('switchLocalePath with differentDomains', () => {
     expect(_switchLocalePath(ctx, 'en')).toBe('http://en.example.com/about')
   })
 
+  test('a locale the page is unavailable in produces no link', async () => {
+    const { router, ctx } = createDomainContext({
+      strategy: 'prefix_except_default',
+      host: 'fr.example.com',
+      locale: 'fr',
+      hostDefault: 'fr'
+    })
+
+    await router.push('/about')
+    // the route does not resolve, joining an empty path would link to the target domain's home page
+    expect(_switchLocalePath(ctx, 'xx')).toBe('')
+  })
+
   test('`strategy: prefix` keeps prefixes in links for all locales', async () => {
     const { router, ctx } = createDomainContext({ strategy: 'prefix', host: 'fr.example.com', locale: 'fr' })
 

--- a/test/pages/localize_routes.test.ts
+++ b/test/pages/localize_routes.test.ts
@@ -367,8 +367,34 @@ describe('localizeRoutes', function () {
       const router = createRouter({ routes: localizedRoutes as any, history: createMemoryHistory() })
       setupMultiDomainLocales('fr', 'prefix_and_default', router)
       const domainPaths = Object.fromEntries(router.getRoutes().map(x => [x.name, x.path]))
-      expect(domainPaths['about___fr']).toBe('/about')
+      // the host default keeps both variants, `prefix_and_default` serves it either way
+      expect(domainPaths['about___fr___default']).toBe('/about')
+      expect(domainPaths['about___fr']).toBe('/fr/about')
       expect(domainPaths['about___en']).toBe('/en/about')
+      expect(domainPaths['about___en___default']).toBeUndefined()
+    })
+
+    it('unprefixes the fallback default locale on a host matching no configured domain', function () {
+      const routes: NuxtPage[] = [{ path: '/about', name: 'about' }]
+
+      const localizedRoutes = localizeRoutes(routes as LocalizableRoute[], {
+        ...nuxtOptions,
+        defaultLocale: 'en',
+        strategy: 'prefix_and_default',
+        multiDomainLocales: true,
+        locales: [
+          // `en` is served everywhere but is the default for no domain
+          { code: 'en', domains: ['a.example.com', 'b.example.com'] },
+          { code: 'fr', domains: ['a.example.com'], defaultForDomains: ['a.example.com'] }
+        ]
+      })
+
+      const router = createRouter({ routes: localizedRoutes as any, history: createMemoryHistory() })
+      // an unmatched host falls back to the configured `defaultLocale`, which has no variant to keep
+      setupMultiDomainLocales('en', 'prefix_and_default', router)
+      const domainPaths = Object.fromEntries(router.getRoutes().map(x => [x.name, x.path]))
+      expect(domainPaths['about___en']).toBe('/about')
+      expect(domainPaths['about___fr___default']).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
* Related #4080

Under domain routing with `prefix_and_default`, no link to a domain's own default locale resolved. The routing context is built with the host's default locale, so route names for it resolve to the `___default` form, while #4082 emits those variants only for locales that are a default for some domain. On a domain whose default locale has no variant, and on any host matching no configured domain, `localePath` and `switchLocalePath` returned an empty string, the unprefixed routes were missing, and `localeHead` dropped the canonical, `og:url`, self-referencing alternate and `x-default` with them.

`setupMultiDomainLocales` now keeps the host default's unprefixed variant where the build emitted one and unprefixes the prefixed route where it did not, so the strategy serves its default locale both ways as it does without domains. Route name resolution asks the route table whether the variant exists instead of deriving it from the strategy and default locale, which is what let the two disagree.

`switchLocalePath` also joined an empty path onto the target origin for a locale a page is unavailable in, so its link and hreflang alternate pointed at that domain's home page rather than being omitted. `matchLocalized` did the same server side by falling back to `/`, both now return nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved localized route resolution across domains and locale strategies.
  * Preserved both prefixed and unprefixed routes for a matching host’s default locale.
  * Prevented invalid localized links from falling back to the site root.
  * Corrected absolute URL generation when the current host is not configured.
  * Ensured unsupported locale switches return an empty link instead of an invalid destination.

* **Tests**
  * Added coverage for cross-domain locale switching and default-locale route handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->