### PR TITLE
fix(seo): emit the same `x-default` on every domain

### DIFF
--- a/specs/different_domains/different_domains_multi_locales_prefix_except_default.spec.ts
+++ b/specs/different_domains/different_domains_multi_locales_prefix_except_default.spec.ts
@@ -101,3 +101,15 @@ test('pass `<NuxtLink> to props', async () => {
   // `fr` is served on the current host and links relative
   expect(await dom.locator('#switch-locale-path-usages .switch-to-fr a').getAttribute('href')).toEqual('/')
 })
+
+test('`x-default` annotates the cluster, so every domain agrees on it', async () => {
+  const hrefs: string[] = []
+  for (const host of ['nuxt-app.localhost', 'fr.nuxt-app.localhost', 'ja.nuxt-app.localhost']) {
+    const res = await undiciRequest('/', { headers: { Host: host } })
+    const dom = await getDom(await res.body.text())
+    hrefs.push((await dom.locator('link[hreflang="x-default"]')?.getAttribute('href')) as string)
+  }
+
+  expect(new Set(hrefs).size).toBe(1)
+  expect(hrefs[0]).toBeTruthy()
+})

--- a/src/runtime/composable-context.ts
+++ b/src/runtime/composable-context.ts
@@ -79,7 +79,9 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
     },
     localePathPayload,
     routingOptions: {
-      defaultLocale: ctx.getDefaultLocale(),
+      // `x-default` annotates the page cluster, so every domain has to agree on it - unlike the
+      // routing `defaultLocale` above, which is the current host's unprefixed locale
+      defaultLocale: ctx.config.defaultLocale || '',
       domains: __I18N_DOMAINS__,
       strictCanonicals: ctx.config.experimental.alternateLinkCanonicalQueries ?? true,
       hreflangLinks: !(!__I18N_ROUTING__ && !__I18N_DOMAINS__),


### PR DESCRIPTION
Every page in an hreflang cluster has to agree on its annotations, but `x-default` was emitted for the routing `defaultLocale`, which domain routing resolves per host. Each domain therefore declared a different `x-default` for the same set of pages, `nuxt-app.localhost` pointing at itself and `fr.nuxt-app.localhost` pointing at itself, so the cluster named two different fallbacks for users whose language matched nothing.

The head context now takes the configured `defaultLocale` for this, the routing context still resolves its own `defaultLocale` per host as before. We emit alternates across domains, which asserts they are one cluster, so one fallback is the consistent choice.

Worth a release note, this one shipped in v10.5.0 unlike the other recent domain fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `x-default` hreflang handling across multiple locale domains.
  * Ensured the default locale reflects the current host’s unprefixed locale, producing consistent annotations across supported domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->