### PR TITLE
fix(domain): resolve domain config the same way at build time and runtime

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -114,7 +114,14 @@ export function getDefineConfig(
     __I18N_PRELOAD__: JSON.stringify(!!options.experimental.preload),
 
     __I18N_ROUTING__: JSON.stringify(nuxt.options.pages.toString() && options.strategy !== 'no_prefix'),
-    __I18N_COMPACT_ROUTES__: String(!!options.experimental?.compactRoutes),
+    // mirrors the build time gate in `localizeRoutes`, an ungated flag makes the runtime take
+    // compact route branches against a table that has none
+    __I18N_COMPACT_ROUTES__: String(
+      !!options.experimental?.compactRoutes
+      && !options.differentDomains
+      && !options.multiDomainLocales
+      && options.strategy !== 'no_prefix',
+    ),
     __I18N_STRICT_SEO__: JSON.stringify(!!options.experimental.strictSeo),
     __I18N_SERVER_ROUTE__: JSON.stringify(options.serverRoutePrefix),
     // SSG already prerenders the messages routes (runtime `prerenderRoutes`), so they exist at the

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -7,6 +7,7 @@ import {
   joinPath,
   localizeSingleRoute,
 } from './kit/gen'
+import { normalizeDomainLocale } from './utils'
 import type { LocaleObject, Strategies } from './types'
 
 export type RouteResources = {
@@ -96,27 +97,30 @@ export function shouldLocalizeRoutes(options: SetupLocalizeRoutesOptions) {
   // check if domains are used multiple times, compared by host as domains may include a protocol
   const domains = new Set<string>()
   for (const locale of options.locales) {
-    if (!locale.domain) { continue }
-    const host = locale.domain.replace(/^https?:\/\//, '')
-    if (domains.has(host)) {
-      console.error(
-        `Cannot use \`strategy: no_prefix\` when using multiple locales on the same domain`
-        + ` - found multiple entries with ${locale.domain}`,
-      )
-      return false
+    for (const domain of locale.domains?.length ? locale.domains : [locale.domain]) {
+      if (!domain) { continue }
+      const host = domain.replace(/^https?:\/\//, '')
+      if (domains.has(host)) {
+        console.error(
+          `Cannot use \`strategy: no_prefix\` when using multiple locales on the same domain`
+          + ` - found multiple entries with ${domain}`,
+        )
+        return false
+      }
+      domains.add(host)
     }
-    domains.add(host)
   }
 
   return true
 }
 
 /**
- * Locales acting as the default (unprefixed) locale for at least one domain,
- * `domainDefault` is read as the unnormalized form of `defaultForDomains`.
+ * Locales acting as the default (unprefixed) locale for at least one domain. Normalizing here
+ * rather than reading `domainDefault` directly keeps this in step with the runtime, which
+ * resolves the domain default from `defaultForDomains` alone.
  */
 function getDomainDefaultLocales(locales: LocaleObject[]): string[] {
-  return locales.filter(locale => locale.defaultForDomains?.length || locale.domainDefault).map(locale => locale.code)
+  return locales.filter(locale => normalizeDomainLocale(locale).defaultForDomains?.length).map(locale => locale.code)
 }
 
 const usesDefaultVariants = (strategy: Strategies | undefined) =>

--- a/src/runtime/shared/domain.ts
+++ b/src/runtime/shared/domain.ts
@@ -97,5 +97,16 @@ export function withRuntimeDomain<T extends string | LocaleObject>(
   }
   const properties = locale as LocaleObject
   const domain = domainLocales[properties.code]?.domain
-  return domain && domain !== properties.domain ? ({ ...properties, domain } as T) : locale
+  if (!domain || domain === properties.domain) {
+    return locale
+  }
+
+  // the override is a single domain, leaving the build time `domains` in place would keep the
+  // locale matching the host it was configured with as well as the one it was moved to
+  return {
+    ...properties,
+    domain,
+    domains: [domain],
+    ...(properties.defaultForDomains?.length ? { defaultForDomains: [domain] } : {}),
+  } as T
 }

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import {
   domainFromLocale,
+  isLocaleOnHost,
   isLocaleServedOnHost,
   matchDomainLocale,
   normalizeDomain,
@@ -161,6 +162,16 @@ describe('withRuntimeDomain', () => {
       code: 'en',
       domain: 'en.staging.example.com'
     })
+  })
+
+  test('an overridden locale stops matching the host it was configured with', () => {
+    const configured = normalizeDomainLocale({ code: 'en', domain: 'en.example.com', domainDefault: true })
+    const patched = withRuntimeDomain(configured, { en: { domain: 'en.staging.example.com' } })
+
+    expect(isLocaleOnHost(patched, 'en.staging.example.com')).toBe(true)
+    expect(isLocaleOnHost(patched, 'en.example.com')).toBe(false)
+    // the locale is still the default, for the domain it was moved to
+    expect(getDefaultLocaleForDomain('en.staging.example.com', [patched])).toBe('en')
   })
 
   test('returns the locale as-is without an override', () => {

--- a/test/pages/__snapshots__/localize_routes.test.ts.snap
+++ b/test/pages/__snapshots__/localize_routes.test.ts.snap
@@ -184,35 +184,6 @@ exports[`localizeRoutes > strategy: "prefix_and_default" + multiDomainLocales > 
   },
   {
     "children": [],
-    "name": "user-profile___en___default",
-    "path": "/user/:id/profile",
-  },
-  {
-    "children": [],
-    "name": "user-posts___en___default",
-    "path": "/user/:id/posts",
-  },
-  {
-    "children": [
-      {
-        "name": "user-profile___en___default",
-        "path": "profile",
-      },
-      {
-        "name": "user-posts___en___default",
-        "path": "posts",
-      },
-    ],
-    "name": "user___en___default",
-    "path": "/user/:id",
-  },
-  {
-    "children": [],
-    "name": "home___en___default",
-    "path": "/",
-  },
-  {
-    "children": [],
     "name": "home___en",
     "path": "/en",
   },
@@ -220,11 +191,6 @@ exports[`localizeRoutes > strategy: "prefix_and_default" + multiDomainLocales > 
     "children": [],
     "name": "home___ja",
     "path": "/ja",
-  },
-  {
-    "children": [],
-    "name": "about___en___default",
-    "path": "/about",
   },
 ]
 `;

--- a/test/pages/localize_routes.test.ts
+++ b/test/pages/localize_routes.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { createMemoryHistory, createRouter } from 'vue-router'
 
 import { getNormalizedLocales, getNuxtOptions } from './utils'
-import { localizeRoutes } from '../../src/routing'
+import { localizeRoutes, shouldLocalizeRoutes } from '../../src/routing'
 import { setupMultiDomainLocales } from '../../src/runtime/routing/domain'
 import type { NuxtPage } from '@nuxt/schema'
 import type { LocaleObject } from '../../src/types'
@@ -341,6 +341,60 @@ describe('localizeRoutes', function () {
       const tree = localizedRoutes.find(r => r.name === 'user___fr___default')
       expect(tree?.children?.map(c => c.name)).toEqual(['user-profile___fr___default'])
     })
+  })
+
+  describe('shouldLocalizeRoutes', function () {
+    it('rejects `no_prefix` with locales sharing a domain, in either option shape', function () {
+      const err = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const shared = 'shared.example.com'
+
+      expect(
+        shouldLocalizeRoutes({
+          ...nuxtOptions,
+          strategy: 'no_prefix',
+          differentDomains: true,
+          locales: [{ code: 'en', domain: shared }, { code: 'fr', domain: shared }]
+        })
+      ).toBe(false)
+
+      expect(
+        shouldLocalizeRoutes({
+          ...nuxtOptions,
+          strategy: 'no_prefix',
+          differentDomains: true,
+          locales: [{ code: 'en', domains: [shared] }, { code: 'fr', domains: [shared] }]
+        })
+      ).toBe(false)
+
+      expect(err).toHaveBeenCalledTimes(2)
+      err.mockRestore()
+    })
+
+    it('allows one locale to serve several domains', function () {
+      expect(
+        shouldLocalizeRoutes({
+          ...nuxtOptions,
+          strategy: 'no_prefix',
+          differentDomains: true,
+          locales: [{ code: 'en', domains: ['a.example.com', 'b.example.com'] }, { code: 'fr', domain: 'c.example.com' }]
+        })
+      ).toBe(true)
+    })
+  })
+
+  it('does not generate an unprefixed variant for `domainDefault` without a domain', function () {
+    const localizedRoutes = localizeRoutes([{ path: '/about', name: 'about' }] as LocalizableRoute[], {
+      ...nuxtOptions,
+      defaultLocale: '',
+      strategy: 'prefix_except_default',
+      differentDomains: true,
+      locales: [{ code: 'en', domainDefault: true }, { code: 'fr', domain: 'fr.example.com', domainDefault: true }]
+    })
+
+    const names = localizedRoutes.map(x => x.name)
+    // `fr` has a domain to be the default for, `en` has none and the runtime resolves no default for it
+    expect(names).toContain('about___fr___default')
+    expect(names).not.toContain('about___en___default')
   })
 
   describe('strategy: "prefix_and_default" + differentDomains', function () {


### PR DESCRIPTION
Four places where a domain fact was derived twice, once at build time and once at runtime, and the two derivations disagreed.

`shouldLocalizeRoutes` read only the singular `domain`, so `no_prefix` accepted two locales sharing a domain when they were configured through `domains` and refused the same setup written as `domain`. `getDomainDefaultLocales` read the raw `domainDefault` while the runtime resolves domain defaults from `defaultForDomains` alone, so a locale carrying `domainDefault` without any domain was given unprefixed `___default` routes the runtime could never select it for. Both now resolve through `normalizeDomainLocale`, which is where that mapping already lives.

`withRuntimeDomain` replaced a locale's `domain` and left `domains` as it was built, so a locale moved with `NUXT_PUBLIC_I18N_DOMAIN_LOCALES_{code}_DOMAIN` matched its new host and the one it was configured with, which host membership now decides navigation and relocation from. It replaces both, and carries `defaultForDomains` over so an overridden locale stays the default for the domain it moved to.

`__I18N_COMPACT_ROUTES__` was set from `experimental.compactRoutes` alone while route generation also requires no domain routing and a prefixing strategy, so an incompatible config left the runtime taking compact branches against a route table that had none, including dropping a `locale` route param. The flag now mirrors the generation gate that `prepare/options.ts` already warns about.

The updated snapshot loses only routes, the `___default` variants that were generated for a locale with no domain to be the default for.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved domain-based locale routing and validation.
  * Prevented unsupported unprefixed routing when multiple locales share a domain.
  * Improved handling of locales configured across multiple domains.
  * Ensured runtime domain overrides keep locale defaults and domain mappings consistent.
  * Corrected route generation for domain-default locales without assigned domains.

* **Tests**
  * Added coverage for runtime domain overrides, shared domains, multi-domain locales, and default route generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->