### PR TITLE
refactor(runtime): resolve route facts from the route table instead of the strategy

### DIFF
--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -7,7 +7,7 @@ import { extendI18n } from '../routing/i18n'
 import { getI18nTarget } from '../compatibility'
 import { _useLocaleHead, localeHead } from '../routing/head'
 import { useLocalePath, useLocaleRoute, useRouteBaseName, useSwitchLocalePath } from '../composables'
-import { createLocaleConfigs, getDefaultLocaleForDomain, resolveSupportedLocale } from '../shared/locales'
+import { createLocaleConfigs, resolveDefaultLocale, resolveSupportedLocale } from '../shared/locales'
 import { setupVueI18nOptions } from '../shared/vue-i18n'
 import { type NuxtI18nContext, createNuxtI18nContext, useLocaleConfigs } from '../context'
 import { useI18nDetection, useRuntimeI18n } from '../shared/utils'
@@ -28,8 +28,7 @@ export default defineNuxtPlugin({
     const nuxt = useNuxtApp(_nuxt._id)
     const runtimeI18n = useRuntimeI18n(nuxt)
     const preloadedOptions = nuxt.ssrContext?.event?.context?.nuxtI18n?.vueI18nOptions
-    const _defaultLocale
-      = getDefaultLocaleForDomain(useRequestURL({ xForwardedHost: true }).host) || runtimeI18n.defaultLocale || ''
+    const _defaultLocale = resolveDefaultLocale(useRequestURL({ xForwardedHost: true }).host, runtimeI18n.defaultLocale)
     const optionsI18n = preloadedOptions || (await setupVueI18nOptions(_defaultLocale))
 
     const localeConfigs = useLocaleConfigs()

--- a/src/runtime/routing/context.ts
+++ b/src/runtime/routing/context.ts
@@ -73,7 +73,7 @@ export function createRoutingContext(options: RoutingContextOptions): RoutingCon
     domains: options.domains,
   }
   const formatTrailingSlash = createTrailingSlashFormatter(options.trailingSlash)
-  const getLocalizedRouteName = createLocaleRouteNameGetter(defaultLocale, config, name => router.hasRoute(name))
+  const getLocalizedRouteName = createLocaleRouteNameGetter(name => router.hasRoute(name), config)
 
   function resolveLocalizedRouteByName(route: RouteLikeWithName, locale: string) {
     route.name = getRouteBaseName(route.name || router.currentRoute.value) // fallback to current route name

--- a/src/runtime/routing/utils.ts
+++ b/src/runtime/routing/utils.ts
@@ -6,34 +6,25 @@ import type { RouteLocationPathRaw, RouteLocationResolvedGeneric, RouteRecordNam
 import type { PrefixableOptions } from '#i18n-kit/routing'
 
 /**
- * Returns a getter function which returns a localized route name for the given route and locale.
- * The returned function can vary based on the strategy and domain configuration.
+ * Returns a getter function which returns a localized route name for the given route and locale,
+ * resolved against the routes that were generated rather than from the strategy.
  */
 export function createLocaleRouteNameGetter(
-  defaultLocale: string,
-  config: PrefixableOptions,
-  hasRoute?: (name: string) => boolean,
+  hasRoute: (name: string) => boolean,
+  config: Pick<PrefixableOptions, 'routing' | 'domains'>,
 ): (name: RouteRecordNameGeneric | null, locale: string) => string {
   // no route localization
   if (!config.routing && !config.domains) {
     return routeName => normalizeRouteName(routeName)
   }
 
-  // default locale routes have default suffix
-  if (config.strategy === 'prefix_and_default') {
-    return (name, locale) => {
-      const normalized = normalizeRouteName(name)
-      if (locale !== defaultLocale) { return getLocalizedRouteName(normalized, locale, false) }
-
-      // under domain routing the suffixed variant is only generated for domain defaults, the
-      // route table decides whether this locale has one rather than the strategy alone
-      const suffixed = getLocalizedRouteName(normalized, locale, true)
-      return !hasRoute || hasRoute(suffixed) ? suffixed : getLocalizedRouteName(normalized, locale, false)
-    }
+  return (name, locale) => {
+    const normalized = normalizeRouteName(name)
+    // which locales get an unprefixed `___default` variant is decided by the strategy at build
+    // time and pruned per host by `setupMultiDomainLocales`, so the route table is the authority
+    const suffixed = getLocalizedRouteName(normalized, locale, true)
+    return hasRoute(suffixed) ? suffixed : getLocalizedRouteName(normalized, locale, false)
   }
-
-  // routes are localized
-  return (name, locale) => getLocalizedRouteName(normalizeRouteName(name), locale, false)
 }
 
 /**

--- a/src/runtime/server/context.ts
+++ b/src/runtime/server/context.ts
@@ -4,7 +4,7 @@ import { deepCopy } from '@intlify/shared'
 import { type H3Event, type H3EventContext, getRequestURL } from 'h3'
 import { type ResolvedI18nOptions, setupVueI18nOptions } from '../shared/vue-i18n'
 import { useRuntimeI18n } from '../shared/utils'
-import { createLocaleConfigs, getDefaultLocaleForDomain } from '../shared/locales'
+import { createLocaleConfigs, resolveDefaultLocale } from '../shared/locales'
 import { cloneDeep } from '../shared/messages'
 import { getMergedMessages } from './utils/messages'
 
@@ -24,7 +24,7 @@ const getHost = (event: H3Event) => getRequestURL(event, { xForwardedHost: true 
 export async function initializeI18nContext(event: H3Event) {
   const runtimeI18n = useRuntimeI18n(undefined, event)
   const defaultLocale: string = runtimeI18n.defaultLocale || ''
-  const options = await setupVueI18nOptions(getDefaultLocaleForDomain(getHost(event)) || defaultLocale)
+  const options = await setupVueI18nOptions(resolveDefaultLocale(getHost(event), defaultLocale))
   const localeConfigs = createLocaleConfigs(options.fallbackLocale)
   const ctx = createI18nContext()
 

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -4,7 +4,7 @@ import { defineNitroPlugin, useRuntimeConfig, useStorage } from 'nitropack/runti
 import { initializeI18nContext, tryUseI18nContext, useI18nContext } from './context'
 import { createUserLocaleDetector } from './utils/locale-detector'
 import { pickNested } from './utils/messages-utils'
-import { getDefaultLocaleForDomain, isSupportedLocale } from '../shared/locales'
+import { isSupportedLocale, resolveDefaultLocale } from '../shared/locales'
 import { setupVueI18nOptions } from '../shared/vue-i18n'
 import { joinURL, parsePath } from 'ufo'
 // @ts-expect-error virtual file
@@ -101,7 +101,7 @@ export default defineNitroPlugin(async (nitro) => {
     // a target on the current host would redirect to itself
     if (!origin || host === getRequestURL(event, { xForwardedHost: true }).host) { return }
 
-    const relocated = matchLocalized(path, pathLocale, getDefaultLocaleForDomain(host) || _defaultLocale)
+    const relocated = matchLocalized(path, pathLocale, resolveDefaultLocale(host, _defaultLocale))
     if (!relocated) { return }
 
     return { path: relocated, code: runtimeI18n.redirectStatusCode ?? 302, locale: pathLocale, origin }

--- a/src/runtime/shared/locales.ts
+++ b/src/runtime/shared/locales.ts
@@ -53,10 +53,23 @@ export function isLocaleWithFallbacksCacheable(locale: string, fallbackLocales: 
 }
 
 /**
- * Returns default locale for the current domain, returns `defaultLocale` by default
+ * The locale configured as the default for `host`, undefined when no locale claims it
  */
 export function getDefaultLocaleForDomain(host: string, locales: LocaleObject[] = normalizedLocales): string | undefined {
   return locales.find(l => l.defaultForDomains?.some(domain => normalizeDomain(domain) === host))?.code
+}
+
+/**
+ * The unprefixed locale for `host`: the locale that domain is the default for, falling back to the
+ * configured `defaultLocale` where the host claims none. Route generation, the routing context and
+ * the server all have to agree on this, so they resolve it here rather than each deriving it.
+ */
+export function resolveDefaultLocale(
+  host: string,
+  defaultLocale: string | undefined,
+  locales: LocaleObject[] = normalizedLocales,
+): string {
+  return getDefaultLocaleForDomain(host, locales) || defaultLocale || ''
 }
 
 export const isSupportedLocale = (locale?: string): boolean => localeCodes.includes(locale || '')

--- a/src/runtime/shared/matching.ts
+++ b/src/runtime/shared/matching.ts
@@ -3,69 +3,88 @@ import { createRouterMatcher } from 'vue-router'
 import { disabledPaths, i18nPathToPath, localizedPaths, pathToI18nConfig } from '#build/i18n-route-resources.mjs'
 import { createTrailingSlashFormatter, prefixable } from '#i18n-kit/routing'
 
-const matcher = createRouterMatcher([], {})
-for (const path of [...localizedPaths, ...Object.keys(i18nPathToPath)]) {
-  matcher.addRoute({ path, component: () => '', meta: {} })
+import type { Strategies } from '#internal-i18n-types'
+import type { RouteResources } from '../../routing'
+
+export type PathMatcherConfig = {
+  strategy: Strategies
+  /** Whether routes are localized (pages enabled and strategy is not `no_prefix`) */
+  routing: boolean
+  trailingSlash: boolean
 }
 
-const disabledI18nMatcher = createRouterMatcher([], {})
-for (const path of disabledPaths) {
-  disabledI18nMatcher.addRoute({ path, component: () => '', meta: {} })
-}
-
-const getI18nPathToI18nPath = (path: string, locale: string) => {
-  if (!path || !locale) { return }
-  const plainPath = i18nPathToPath[path] ?? path
-  const i18nConfig = pathToI18nConfig[plainPath]
-  // locales without an entry use the plain path
-  if (i18nConfig == null || !(locale in i18nConfig)) { return plainPath }
-  return i18nConfig[locale] || undefined
-}
-
-export function isExistingNuxtRoute(path: string) {
-  if (path === '') { return }
-  // TODO: path should not have base url - check if base url is stripped earlier
-  // skip nuxt error route - this path is hardcoded within nitro context code in nuxt
-  if (path.endsWith('/__nuxt_error')) { return }
-
-  // skip disabled i18n routes - this prevent a redirect if there is a catch all route
-  const disabledI18nResolvedMatch = disabledI18nMatcher.resolve({ path }, { path: '/', name: '', matched: [], params: {}, meta: {} })
-  if (disabledI18nResolvedMatch.matched.length > 0) {
-    return
-  }
-
-  const resolvedMatch = matcher.resolve({ path }, { path: '/', name: '', matched: [], params: {}, meta: {} })
-
-  return resolvedMatch.matched.length > 0 ? resolvedMatch : undefined
-}
+const emptyRoute = { path: '/', name: '', matched: [], params: {}, meta: {} }
 
 /**
- * Match a localized path against the resolved path and return the new path if it differs.
- * The passed path can be localized or not but should not include any prefix.
+ * Resolves request paths against the routes the build generated, so path shapes are matched
+ * rather than recomputed. Takes the resources and flags as values, the runtime instance below
+ * composes it from the generated ones.
  */
-export function matchLocalized(path: string, locale: string, defaultLocale: string): string | undefined {
-  if (path === '') { return }
-  const parsed = parsePath(path)
-  const resolvedMatch = matcher.resolve(
-    { path: parsed.pathname || '/' },
-    { path: '/', name: '', matched: [], params: {}, meta: {} },
-  )
+export function createPathMatcher(resources: RouteResources, config: PathMatcherConfig) {
+  const matcher = createRouterMatcher([], {})
+  for (const path of [...resources.localizedPaths, ...Object.keys(resources.i18nPathToPath)]) {
+    matcher.addRoute({ path, component: () => '', meta: {} })
+  }
 
-  if (resolvedMatch.matched.length > 0) {
+  const disabledI18nMatcher = createRouterMatcher([], {})
+  for (const path of resources.disabledPaths) {
+    disabledI18nMatcher.addRoute({ path, component: () => '', meta: {} })
+  }
+
+  const formatTrailingSlash = createTrailingSlashFormatter(config.trailingSlash)
+
+  const getI18nPathToI18nPath = (path: string, locale: string) => {
+    if (!path || !locale) { return }
+    const plainPath = resources.i18nPathToPath[path] ?? path
+    const i18nConfig = resources.pathToI18nConfig[plainPath]
+    // locales without an entry use the plain path
+    if (i18nConfig == null || !(locale in i18nConfig)) { return plainPath }
+    return i18nConfig[locale] || undefined
+  }
+
+  function isExistingNuxtRoute(path: string) {
+    if (path === '') { return }
+    // TODO: path should not have base url - check if base url is stripped earlier
+    // skip nuxt error route - this path is hardcoded within nitro context code in nuxt
+    if (path.endsWith('/__nuxt_error')) { return }
+
+    // skip disabled i18n routes - this prevent a redirect if there is a catch all route
+    if (disabledI18nMatcher.resolve({ path }, emptyRoute).matched.length > 0) {
+      return
+    }
+
+    const resolvedMatch = matcher.resolve({ path }, emptyRoute)
+
+    return resolvedMatch.matched.length > 0 ? resolvedMatch : undefined
+  }
+
+  /**
+   * Match a localized path against the resolved path and return the new path if it differs.
+   * The passed path can be localized or not but should not include any prefix.
+   */
+  function matchLocalized(path: string, locale: string, defaultLocale: string): string | undefined {
+    if (path === '') { return }
+    const parsed = parsePath(path)
+    const resolvedMatch = matcher.resolve({ path: parsed.pathname || '/' }, emptyRoute)
+    if (resolvedMatch.matched.length === 0) { return }
+
     const alternate = getI18nPathToI18nPath(resolvedMatch.matched[0]!.path, locale)
     // the path is disabled for this locale, matching `/` instead would send the request
     // to the home page of whichever locale or domain it was being resolved for
     if (!alternate) { return }
 
-    const match = matcher.resolve(
-      { params: resolvedMatch.params },
-      { path: alternate, name: '', matched: [], params: {}, meta: {} },
-    )
+    const match = matcher.resolve({ params: resolvedMatch.params }, { ...emptyRoute, path: alternate })
+    const isPrefixable = prefixable(locale, defaultLocale, config)
 
-    const isPrefixable = prefixable(locale, defaultLocale, {
-      strategy: __I18N_STRATEGY__,
-      routing: __I18N_ROUTING__,
-    })
-    return createTrailingSlashFormatter(__TRAILING_SLASH__)(withLeadingSlash(joinURL(isPrefixable ? locale : '', match.path)), true)
+    return formatTrailingSlash(withLeadingSlash(joinURL(isPrefixable ? locale : '', match.path)), true)
   }
+
+  return { isExistingNuxtRoute, matchLocalized }
 }
+
+const { isExistingNuxtRoute, matchLocalized } = createPathMatcher(
+  { localizedPaths, i18nPathToPath, pathToI18nConfig, disabledPaths },
+  { strategy: __I18N_STRATEGY__, routing: __I18N_ROUTING__, trailingSlash: __TRAILING_SLASH__ },
+)
+
+export { isExistingNuxtRoute, matchLocalized }

--- a/test/kit.test.ts
+++ b/test/kit.test.ts
@@ -12,6 +12,7 @@ import { resolve } from 'pathe'
 import { localizeRoutes } from '../src/routing'
 import { setupMultiDomainLocales } from '../src/runtime/routing/domain'
 import { getNormalizedLocales } from './pages/utils'
+import { resolveDefaultLocale } from '../src/runtime/shared/locales'
 import type { NuxtPage } from '@nuxt/schema'
 import type { Strategies } from '#internal-i18n-types'
 import { LocalizableRoute } from '../src/kit/gen'
@@ -307,26 +308,25 @@ describe('switchLocalePath with differentDomains', () => {
     host: string
     locale: string
     locales?: typeof DOMAIN_LOCALES
-    /** default locale to rebuild the route table for, mirrors the runtime plugin */
-    hostDefault?: string
+    /** configured `defaultLocale`, the host's own default takes precedence over it */
+    defaultLocale?: string
   }) {
     const locales = opts.locales ?? DOMAIN_LOCALES
     const localized = localizeRoutes([{ path: '/about', name: 'about' }] as LocalizableRoute[], {
       ...routingOptions,
       strategy: opts.strategy,
-      defaultLocale: '',
+      defaultLocale: opts.defaultLocale ?? '',
       differentDomains: true,
       locales
     })
     const router = createRouter({ routes: localized as any, history: createMemoryHistory() })
-    if (opts.hostDefault) {
-      setupMultiDomainLocales(opts.hostDefault, opts.strategy, router)
-    }
+    // resolved the way the runtime does, rather than supplied, so the test cannot drift from it
+    const hostDefault = resolveDefaultLocale(opts.host, opts.defaultLocale, locales)
+    setupMultiDomainLocales(hostDefault, opts.strategy, router)
 
     const ctx = createRoutingContext({
       router,
-      // the runtime resolves this per host, not from the build time `defaultLocale`
-      defaultLocale: opts.hostDefault ?? '',
+      defaultLocale: hostDefault,
       strategy: opts.strategy,
       routing: true,
       domains: true,
@@ -346,7 +346,7 @@ describe('switchLocalePath with differentDomains', () => {
       strategy: 'prefix_except_default',
       host: 'fr.example.com',
       locale: 'fr',
-      hostDefault: 'fr'
+      defaultLocale: 'fr'
     })
 
     await router.push('/about')
@@ -362,7 +362,7 @@ describe('switchLocalePath with differentDomains', () => {
       strategy: 'prefix_and_default',
       host: 'en.example.com',
       locale: 'en',
-      hostDefault: 'en',
+      defaultLocale: 'en',
       locales: [
         { code: 'en', language: 'en', domain: 'en.example.com' },
         { code: 'fr', language: 'fr', domain: 'fr.example.com' }
@@ -399,7 +399,7 @@ describe('switchLocalePath with differentDomains', () => {
       strategy: 'prefix_and_default',
       host: 'fr.example.com',
       locale: 'fr',
-      hostDefault: 'fr'
+      defaultLocale: 'fr'
     })
 
     const paths = Object.fromEntries(router.getRoutes().map(x => [x.name, x.path]))
@@ -421,7 +421,7 @@ describe('switchLocalePath with differentDomains', () => {
       strategy: 'prefix_except_default',
       host: 'fr.example.com',
       locale: 'fr',
-      hostDefault: 'fr'
+      defaultLocale: 'fr'
     })
 
     await router.push('/about')
@@ -464,7 +464,7 @@ describe('switchLocalePath with differentDomains', () => {
       host: 'a.example.com',
       locale: 'en',
       locales,
-      hostDefault: 'en'
+      defaultLocale: 'en'
     })
 
     await router.push('/about')

--- a/test/matching.test.ts
+++ b/test/matching.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'vitest'
+import { createPathMatcher } from '../src/runtime/shared/matching'
+import type { RouteResources } from '../src/routing'
+
+/** `/about` is localized per locale, `/contact` is disabled for `ja`, `/legal` is disabled entirely */
+const resources: RouteResources = {
+  localizedPaths: ['/', '/contact', '/posts/:id'],
+  pathToI18nConfig: {
+    '/about': { en: '/about', fr: '/a-propos' },
+    '/contact': { ja: false }
+  },
+  i18nPathToPath: { '/about': '/about', '/a-propos': '/about' },
+  disabledPaths: ['/legal']
+}
+
+const matcher = (config: Partial<Parameters<typeof createPathMatcher>[1]> = {}) =>
+  createPathMatcher(resources, { strategy: 'prefix_except_default', routing: true, trailingSlash: false, ...config })
+
+describe('isExistingNuxtRoute', () => {
+  test('matches generated routes and ignores the rest', () => {
+    const { isExistingNuxtRoute } = matcher()
+    expect(isExistingNuxtRoute('/about')).toBeTruthy()
+    expect(isExistingNuxtRoute('/posts/1')).toBeTruthy()
+    expect(isExistingNuxtRoute('/nope')).toBeUndefined()
+    expect(isExistingNuxtRoute('')).toBeUndefined()
+    expect(isExistingNuxtRoute('/some/__nuxt_error')).toBeUndefined()
+  })
+
+  test('a path with localization disabled is not treated as a route', () => {
+    expect(matcher().isExistingNuxtRoute('/legal')).toBeUndefined()
+  })
+})
+
+describe('matchLocalized', () => {
+  test('resolves the localized path for the target locale', () => {
+    const { matchLocalized } = matcher()
+    expect(matchLocalized('/about', 'fr', 'en')).toBe('/fr/a-propos')
+    expect(matchLocalized('/a-propos', 'en', 'en')).toBe('/about')
+  })
+
+  test('keeps the default locale unprefixed under `prefix_except_default`', () => {
+    expect(matcher().matchLocalized('/contact', 'en', 'en')).toBe('/contact')
+  })
+
+  test('`prefix` prefixes the default locale too', () => {
+    expect(matcher({ strategy: 'prefix' }).matchLocalized('/contact', 'en', 'en')).toBe('/en/contact')
+  })
+
+  test('a locale the path is disabled for resolves to nothing, not the home page', () => {
+    // matching `/` instead would redirect the request to that locale's home page
+    expect(matcher().matchLocalized('/contact', 'ja', 'en')).toBeUndefined()
+  })
+
+  test('`trailingSlash` is applied to the resolved path', () => {
+    const { matchLocalized } = matcher({ trailingSlash: true })
+    expect(matchLocalized('/about', 'fr', 'en')).toBe('/fr/a-propos/')
+    expect(matchLocalized('/contact', 'en', 'en')).toBe('/contact/')
+  })
+
+  test('dynamic params are carried into the localized path', () => {
+    expect(matcher().matchLocalized('/posts/42', 'fr', 'en')).toBe('/fr/posts/42')
+  })
+
+  test('an unmatched or empty path resolves to nothing', () => {
+    const { matchLocalized } = matcher()
+    expect(matchLocalized('', 'fr', 'en')).toBeUndefined()
+    expect(matchLocalized('/nope', 'fr', 'en')).toBeUndefined()
+  })
+})

--- a/test/mocks/i18n.route-resources.ts
+++ b/test/mocks/i18n.route-resources.ts
@@ -1,0 +1,5 @@
+// the generated resources are build output, unit tests compose their own via `createPathMatcher`
+export const localizedPaths: string[] = []
+export const pathToI18nConfig: Record<string, Record<string, string | false>> = {}
+export const i18nPathToPath: Record<string, string> = {}
+export const disabledPaths: string[] = []

--- a/test/redirect.test.ts
+++ b/test/redirect.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 import { createRedirectResolver } from '../src/runtime/server/utils/redirect'
 import { resolveRootRedirect } from '../src/runtime/shared/utils'
 import { getLocaleFromRoutePath } from '../src/runtime/kit/routing'
+import { createPathMatcher } from '../src/runtime/shared/matching'
 
 import type { RedirectResolverConfig } from '../src/runtime/server/utils/redirect'
 import type { Strategies } from '../src/types'
@@ -20,11 +21,18 @@ const detectors = () => ({
   onHost: (locale: string | null | undefined) => locale,
 })
 
-// mirrors the `matchLocalized` contract for paths that match a route
-const createMatchLocalized = (strategy: Strategies) => (path: string, locale: string, defaultLocale: string) => {
-  const prefixed = strategy === 'prefix' || locale !== defaultLocale
-  return prefixed ? '/' + locale + (path === '/' ? '' : path) : path
-}
+// the real matcher over a small route set, so the resolver is tested against the contract the
+// runtime gives it - including returning nothing for a path with no localized variant
+const createMatchLocalized = (strategy: Strategies) =>
+  createPathMatcher(
+    {
+      localizedPaths: ['/', '/about', '/test-route', '/posts/:id'],
+      pathToI18nConfig: { '/about': { fr: '/a-propos' } },
+      i18nPathToPath: { '/a-propos': '/about' },
+      disabledPaths: [],
+    },
+    { strategy, routing: true, trailingSlash: false },
+  ).matchLocalized
 
 const detection = (overrides: Partial<RedirectResolverConfig['detection']> = {}) =>
   ({ enabled: false, cookieKey: 'i18n_redirected', ...overrides }) as RedirectResolverConfig['detection']
@@ -115,7 +123,8 @@ describe('createRedirectResolver', () => {
       detection: detection({ enabled: true, redirectOn: 'no prefix' }),
     })
     const withCookie = createDetectors({ cookie: () => 'fr' })
-    expect(resolve('/about', '/about', undefined, 'en', withCookie)).toMatchObject({ path: '/fr/about' })
+    // `/about` has a custom `fr` path, the resolver redirects to the localized one
+    expect(resolve('/about', '/about', undefined, 'en', withCookie)).toMatchObject({ path: '/fr/a-propos' })
     expect(resolve('/fr/about', '/about', 'fr', 'en', withCookie).path).toBeUndefined()
   })
 
@@ -137,7 +146,7 @@ describe('createRedirectResolver', () => {
       detection: detection({ enabled: true, redirectOn: 'all' }),
     })
     const withCookie = createDetectors({ cookie: () => 'fr' })
-    expect(resolve('/en/about', '/about', 'en', 'en', withCookie)).toMatchObject({ path: '/fr/about' })
+    expect(resolve('/en/about', '/about', 'en', 'en', withCookie)).toMatchObject({ path: '/fr/a-propos' })
   })
 
   test('detection prefers the cookie locale over the header locale', () => {
@@ -185,4 +194,23 @@ describe('createRedirectResolver', () => {
       expect(resolve('/', '/', undefined, 'en', onHost)).toMatchObject({ path: '/fr', locale: 'fr' })
     })
   })
+})
+
+test('a path with no localized variant for the target locale is not redirected to', () => {
+  const matchLocalized = createPathMatcher(
+    { localizedPaths: ['/', '/about'], pathToI18nConfig: { '/about': { fr: false } }, i18nPathToPath: {}, disabledPaths: [] },
+    { strategy: 'prefix_except_default', routing: true, trailingSlash: false }
+  ).matchLocalized
+
+  const resolve = createRedirectResolver({
+    detection: detection({ enabled: true, redirectOn: 'all' }),
+    matchLocalized,
+    isSupportedLocale: locale => LOCALES.includes(locale || ''),
+    strategy: 'prefix_except_default',
+    routing: true,
+    domains: false
+  })
+
+  // redirecting would have to invent a path, previously the home page
+  expect(resolve('/about', '/about', undefined, 'en', createDetectors({ cookie: () => 'fr' })).path).toBeUndefined()
 })

--- a/test/routing-path-resolver.test.ts
+++ b/test/routing-path-resolver.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test, vi } from 'vitest'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import { createLocalizedRouteByPathResolver } from '../src/runtime/routing/utils'
+import { localizeRoutes } from '../src/routing'
+import type { LocalizableRoute } from '../src/kit/gen'
+import type { Strategies } from '#internal-i18n-types'
+
+const LOCALES = [{ code: 'en', language: 'en' }, { code: 'ja', language: 'ja' }]
+const PAGES = [
+  { path: '/', name: 'index' },
+  { path: '/about', name: 'about' },
+  { path: '/user/:id', name: 'user', children: [{ path: 'profile', name: 'user-profile' }] }
+]
+
+function createResolver(strategy: Strategies) {
+  const localized = localizeRoutes(PAGES as LocalizableRoute[], {
+    strategy,
+    defaultLocale: 'en',
+    locales: LOCALES,
+    routesNameSeparator: '___',
+    defaultLocaleRouteNameSuffix: 'default',
+    trailingSlash: false
+  })
+  const router = createRouter({ routes: localized as never, history: createMemoryHistory() })
+  const resolve = createLocalizedRouteByPathResolver(router, {
+    strategy,
+    routing: strategy !== 'no_prefix',
+    domains: false
+  })
+  return { router, resolve }
+}
+
+describe.each(['prefix', 'prefix_except_default', 'prefix_and_default'] as const)(
+  'createLocalizedRouteByPathResolver (strategy: %s)',
+  strategy => {
+    test('resolves an unprefixed path for a non-default locale without warning', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const { resolve } = createResolver(strategy)
+
+      const resolved = resolve({ path: '/about' }, 'ja')
+      expect(resolved).toBeTruthy()
+      expect(warn.mock.calls.filter(c => String(c[0]).includes('No match'))).toEqual([])
+      warn.mockRestore()
+    })
+
+    test('resolves a nested path without warning', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const { resolve } = createResolver(strategy)
+
+      expect(resolve({ path: '/user/1/profile' }, 'ja')).toBeTruthy()
+      expect(warn.mock.calls.filter(c => String(c[0]).includes('No match'))).toEqual([])
+      warn.mockRestore()
+    })
+
+    test('resolves the root path', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const { resolve } = createResolver(strategy)
+
+      expect(resolve({ path: '/' }, 'ja')).toBeTruthy()
+      expect(warn.mock.calls.filter(c => String(c[0]).includes('No match'))).toEqual([])
+      warn.mockRestore()
+    })
+
+    test('an unknown path does not throw', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const { resolve } = createResolver(strategy)
+
+      expect(() => resolve({ path: '/nope' }, 'ja')).not.toThrow()
+      warn.mockRestore()
+    })
+  }
+)
+
+describe('createLocalizedRouteByPathResolver (no routing)', () => {
+  test('returns the route untouched', () => {
+    const { resolve } = createResolver('no_prefix')
+    const route = { path: '/about' }
+    expect(resolve(route, 'ja')).toBe(route)
+  })
+})

--- a/test/routing-utils.test.ts
+++ b/test/routing-utils.test.ts
@@ -2,17 +2,18 @@ import { describe, it, assert, test } from 'vitest'
 import { createLocaleRouteNameGetter } from '../src/runtime/routing/utils'
 import { findBrowserLocale } from '#i18n-kit/browser'
 
+// the getter reads the route table, so the fixtures are the routes each strategy generates
+const tableFor = (names: string[]) => (name: string) => names.includes(name)
+
 const routeNameGetters = {
-  noPrefix: createLocaleRouteNameGetter('en', { strategy: 'no_prefix', routing: false, differentDomains: false }),
-  prefixAndDefault: createLocaleRouteNameGetter('en', {
-    strategy: 'prefix_and_default',
+  noPrefix: createLocaleRouteNameGetter(tableFor(['route1']), { routing: false, domains: false }),
+  prefixAndDefault: createLocaleRouteNameGetter(tableFor(['route1___en___default', 'route1___en', 'route1___ja']), {
     routing: true,
-    differentDomains: false
+    domains: false
   }),
-  prefixExceptDefault: createLocaleRouteNameGetter('en', {
-    strategy: 'prefix_except_default',
+  prefixExceptDefault: createLocaleRouteNameGetter(tableFor(['route1___en', 'route1___ja']), {
     routing: true,
-    differentDomains: false
+    domains: false
   })
 }
 
@@ -37,8 +38,14 @@ describe('getLocaleRouteName', () => {
 
   describe('irregular', () => {
     describe('route name is null', () => {
-      it('should be ` (null)___en___default`', () => {
-        assert.equal(routeNameGetters.prefixAndDefault(null, 'en'), '___en___default')
+      it('falls back to the plain localized name, which resolves to nothing either way', () => {
+        assert.equal(routeNameGetters.prefixAndDefault(null, 'en'), '___en')
+      })
+    })
+
+    describe('locale has no route in the table', () => {
+      it('returns the plain localized name so resolution fails', () => {
+        assert.equal(routeNameGetters.prefixAndDefault('route1', 'xx'), 'route1___xx')
       })
     })
   })

--- a/vitest.config.test.ts
+++ b/vitest.config.test.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     alias: {
       ...vitestConfig.test?.alias,
       '#build/i18n-options.mjs': resolve('./test/mocks/i18n.options.ts'),
+      '#build/i18n-route-resources.mjs': resolve('./test/mocks/i18n.route-resources.ts'),
       '#app': 'nuxt',
       '#imports': resolve('./test/mocks/imports.ts'),
       // resolve from source - the package `imports` map points at `dist`, which may be stale


### PR DESCRIPTION
The recent domain bugs shared a shape: a fact derived once at build time and again at runtime, from different inputs, with a test helper supplying a third answer. The tests passed because they exercised a derivation production never runs.

`resolveDefaultLocale` replaces the three copies of "the locale this domain is the default for, else the configured one" in the client plugin, the server context and the server redirect, and the domain test helper resolves its default through it instead of taking one as an argument. `createLocaleRouteNameGetter` no longer derives whether a locale has an unprefixed `___default` variant from the strategy, it asks the route table, which is what the build decided and `setupMultiDomainLocales` prunes per host. `strategy` and `defaultLocale` are no longer inputs to route name resolution.

`shared/matching.ts` composes its matcher through `createPathMatcher(resources, flags)` rather than building it from a build import at module scope, so `matchLocalized` is importable. It had no tests before, because it could not be imported without booting a fixture, and `redirect.test.ts` stood in a hand written replacement that could not return `undefined` and knew nothing of custom localized paths. It now resolves against the real matcher, which corrected two expectations that had been asserting paths the runtime never produces.

This also adds the first coverage for `trailingSlash`, for localized path resolution across strategies, and a `#build/i18n-route-resources.mjs` mock so anything downstream of route resources can be unit tested from here on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved default-language resolution across server-side rendering, redirects, and multi-domain routing.
  - Ensured localized route names are used only when matching routes exist, preventing invalid redirects and route names.
  - Improved handling of localized paths, dynamic routes, disabled routes, and trailing slashes.

- **Tests**
  - Added coverage for route matching, localized route resolution, redirects, and multi-domain language precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->