### PR TITLE
refactor(domain): resolve every locale into one domain shape at build time

### DIFF
--- a/internals.d.ts
+++ b/internals.d.ts
@@ -1,5 +1,5 @@
 declare module '#build/i18n-options.mjs' {
-  import type { LocaleObject, VueI18nConfig } from '@nuxtjs/i18n'
+  import type { LocaleObject, NormalizedLocaleObject, VueI18nConfig } from '@nuxtjs/i18n'
 
   export type { LocaleObject }
 
@@ -7,17 +7,17 @@ declare module '#build/i18n-options.mjs' {
   export const localeLoaders: Record<string, LocaleLoader[]>
   export const vueI18nConfigs: VueI18nConfig[]
   export const localeCodes: string[]
-  export const normalizedLocales: LocaleObject[]
+  export const normalizedLocales: NormalizedLocaleObject[]
 }
 
 declare module '#internal/i18n-options.mjs' {
-  import type { LocaleObject, VueI18nConfig } from '@nuxtjs/i18n'
+  import type { NormalizedLocaleObject, VueI18nConfig } from '@nuxtjs/i18n'
 
   type LocaleLoader = { key: string, cache: boolean, load: () => Promise<never> }
   export const localeLoaders: Record<string, LocaleLoader[]>
   export const vueI18nConfigs: VueI18nConfig[]
   export const localeCodes: string[]
-  export const normalizedLocales: LocaleObject[]
+  export const normalizedLocales: NormalizedLocaleObject[]
 }
 
 declare module '#internal/i18n-locale-detector.mjs' {

--- a/src/context.ts
+++ b/src/context.ts
@@ -8,7 +8,7 @@ import { resolveRawResourcePaths } from './resources'
 import { generateLoaderOptions } from './gen'
 
 import type { Resolver } from '@nuxt/kit'
-import type { FileMeta, LocaleInfo, LocaleObject, NuxtI18nOptions } from './types'
+import type { FileMeta, LocaleInfo, NormalizedLocaleObject, NuxtI18nOptions } from './types'
 import type { Nuxt, NuxtConfigLayer } from '@nuxt/schema'
 
 export interface I18nNuxtContext {
@@ -25,7 +25,7 @@ export interface I18nNuxtContext {
  * Locale-derived context, resolved in `modules:done` once all modules have registered locales.
  */
 export interface ResolvedI18nContext extends I18nNuxtContext {
-  normalizedLocales: LocaleObject<string>[]
+  normalizedLocales: NormalizedLocaleObject<string>[]
   localeCodes: string[]
   localeInfo: LocaleInfo[]
   /** flattened `localeInfo` file metas */

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -9,7 +9,7 @@ import type { LocaleObject } from './types'
 import type { ResolvedI18nContext } from './context'
 
 // copy - generators run repeatedly (template re-emits) and must not alter context locales
-function stripLocaleFiles(locale: LocaleObject) {
+function stripLocaleFiles<T extends LocaleObject>(locale: T): T {
   const stripped = assign({}, locale)
   delete stripped.files
   delete stripped.file

--- a/src/prepare/options.ts
+++ b/src/prepare/options.ts
@@ -1,6 +1,6 @@
 import type { I18nNuxtContext } from '../context'
 import type { Nuxt } from '@nuxt/schema'
-import { logger } from '../utils'
+import { logger, normalizeDomainLocale } from '../utils'
 import { checkLayerOptions } from '../layers'
 import { isString } from '@intlify/shared'
 
@@ -33,7 +33,10 @@ export function prepareOptions(ctx: I18nNuxtContext, nuxt: Nuxt) {
   }
 
   if (multiDomainLocales) {
-    const hasDomainLocales = (options.locales || []).some(locale => !isString(locale) && locale.domains?.length)
+    // `domain` normalizes into `domains` and configures the feature just as well
+    const hasDomainLocales = (options.locales || []).some(
+      locale => !isString(locale) && normalizeDomainLocale(locale).domains.length,
+    )
 
     if (!hasDomainLocales) {
       logger.warn(

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -7,8 +7,7 @@ import {
   joinPath,
   localizeSingleRoute,
 } from './kit/gen'
-import { normalizeDomainLocale } from './utils'
-import type { LocaleObject, Strategies } from './types'
+import type { NormalizedLocaleObject, Strategies } from './types'
 
 export type RouteResources = {
   /** plain paths mounted as-is for at least one locale */
@@ -97,8 +96,7 @@ export function shouldLocalizeRoutes(options: SetupLocalizeRoutesOptions) {
   // check if domains are used multiple times, compared by host as domains may include a protocol
   const domains = new Set<string>()
   for (const locale of options.locales) {
-    for (const domain of locale.domains?.length ? locale.domains : [locale.domain]) {
-      if (!domain) { continue }
+    for (const domain of locale.domains) {
       const host = domain.replace(/^https?:\/\//, '')
       if (domains.has(host)) {
         console.error(
@@ -114,13 +112,9 @@ export function shouldLocalizeRoutes(options: SetupLocalizeRoutesOptions) {
   return true
 }
 
-/**
- * Locales acting as the default (unprefixed) locale for at least one domain. Normalizing here
- * rather than reading `domainDefault` directly keeps this in step with the runtime, which
- * resolves the domain default from `defaultForDomains` alone.
- */
-function getDomainDefaultLocales(locales: LocaleObject[]): string[] {
-  return locales.filter(locale => normalizeDomainLocale(locale).defaultForDomains?.length).map(locale => locale.code)
+/** Locales acting as the default (unprefixed) locale for at least one domain */
+function getDomainDefaultLocales(locales: NormalizedLocaleObject[]): string[] {
+  return locales.filter(locale => locale.defaultForDomains.length).map(locale => locale.code)
 }
 
 const usesDefaultVariants = (strategy: Strategies | undefined) =>
@@ -157,7 +151,7 @@ type SetupLocalizeRoutesOptions = {
   trailingSlash?: boolean
   differentDomains?: boolean
   multiDomainLocales?: boolean
-  locales: LocaleObject[]
+  locales: NormalizedLocaleObject[]
   routesNameSeparator: string
   defaultLocaleRouteNameSuffix: string
   defaultLocale?: string

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -18,7 +18,7 @@ import type {
   BaseUrlResolveHandler,
   DetectBrowserLanguageOptions,
   I18nPublicRuntimeConfig,
-  LocaleObject,
+  NormalizedLocaleObject,
 } from '#internal-i18n-types'
 
 export const useLocaleConfigs = () =>
@@ -52,7 +52,7 @@ export interface NuxtI18nContext {
   /** Set locale - suspend if `skipSettingLocaleOnNavigate` is enabled  */
   setLocaleSuspend: (locale: string) => Promise<void>
   /** Get normalized runtime locales */
-  getLocales: () => LocaleObject[]
+  getLocales: () => NormalizedLocaleObject[]
   /** Set locale to locale cookie */
   setCookieLocale: (locale: string) => void
   /** Get current base URL */
@@ -235,7 +235,11 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
         await ctx.vueI18n.__resolvePendingLocalePromise?.()
       }
     },
-    getLocales: () => unref(i18n.locales).map(x => (isString(x) ? { code: x } : (x as LocaleObject<string>))),
+    // string locales carry no domain configuration, they normalize to the empty form
+    getLocales: () =>
+      unref(i18n.locales).map(x =>
+        isString(x) ? { code: x, domains: [], defaultForDomains: [] } : (x as NormalizedLocaleObject<string>),
+      ),
     setCookieLocale: (locale: string) => {
       if (detectConfig.useCookie && isSupportedLocale(locale)) {
         localeCookie.value = locale

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -74,7 +74,8 @@ export default defineNuxtPlugin({
         composer.strategy = __I18N_STRATEGY__
         composer.localeProperties = computed(() =>
           withRuntimeDomain(
-            normalizedLocales.find(l => l.code === composer.locale.value) || { code: composer.locale.value },
+            normalizedLocales.find(l => l.code === composer.locale.value)
+            || { code: composer.locale.value, domains: [], defaultForDomains: [] },
             runtimeI18n.domainLocales,
           ),
         )

--- a/src/runtime/routing/context.ts
+++ b/src/runtime/routing/context.ts
@@ -6,7 +6,7 @@ import { isLocaleOnHost } from '../shared/domain'
 
 import type { RouteLocationPathRaw, RouteRecordNameGeneric, Router } from 'vue-router'
 import type { PrefixableOptions } from '#i18n-kit/routing'
-import type { LocaleObject, Strategies } from '#internal-i18n-types'
+import type { NormalizedLocaleObject, Strategies } from '#internal-i18n-types'
 import type { RouteLike, RouteLikeWithName, RouteLikeWithPath } from './routing'
 import type { I18nRouteMeta, RouteLocationGenericPath } from '../types'
 
@@ -19,7 +19,7 @@ import type { I18nRouteMeta, RouteLocationGenericPath } from '../types'
 export type RoutingContext = {
   router: Router
   getLocale: () => string
-  getLocales: () => LocaleObject[]
+  getLocales: () => NormalizedLocaleObject[]
   getBaseUrl: (locale?: string) => string
   /** Extracts the route base name (without locale suffix) */
   getRouteBaseName: (route: RouteRecordNameGeneric | RouteLocationGenericPath | null) => string | undefined
@@ -43,7 +43,7 @@ export interface RoutingContextOptions {
   router: Router
   defaultLocale: string
   getLocale: () => string
-  getLocales: () => LocaleObject[]
+  getLocales: () => NormalizedLocaleObject[]
   getBaseUrl: (locale?: string) => string
   /** Host of the current request/page, used for domain-based behavior */
   getHost: () => string | undefined
@@ -206,7 +206,7 @@ export function createRoutingContext(options: RoutingContextOptions): RoutingCon
         return path
       }
 
-      if (stripsDefaultPrefix && target?.defaultForDomains?.length && getLocaleFromRoutePath(path) === locale) {
+      if (stripsDefaultPrefix && target?.defaultForDomains.length && getLocaleFromRoutePath(path) === locale) {
         path = path.slice(locale.length + 1) || '/'
       }
       return joinURL(options.getBaseUrl(locale), path)

--- a/src/runtime/routing/head.ts
+++ b/src/runtime/routing/head.ts
@@ -3,7 +3,7 @@ import { joinURL } from 'ufo'
 import { assign } from '@intlify/shared'
 import { type HeadContext, localeHead as _localeHead } from '#i18n-kit/head'
 
-import type { I18nHeadMetaInfo, I18nHeadOptions, SeoAttributesOptions } from '#internal-i18n-types'
+import type { I18nHeadMetaInfo, I18nHeadOptions, LocaleObject, SeoAttributesOptions } from '#internal-i18n-types'
 import type { ComposableContext } from '../composable-context'
 import type { I18nRouteMeta } from '../types'
 import { localeRoute, switchLocalePath } from './routing'
@@ -33,7 +33,7 @@ function createHeadContext(
   // current locale's domain so canonical and og:url self-reference the current host (#2595)
   baseUrl = ctx.routingOptions.domains ? ctx.getBaseUrl(locale) : ctx.getBaseUrl(),
 ): HeadContext {
-  const currentLocale = locales.find(l => l.code === locale) || { code: locale }
+  const currentLocale: LocaleObject = locales.find(l => l.code === locale) || { code: locale }
   // deduplicate, layered configs merge `canonicalQueries` arrays with duplicate entries
   const canonicalQueries = [...new Set((typeof config.seo === 'object' && config.seo?.canonicalQueries) || [])]
 

--- a/src/runtime/shared/detection.ts
+++ b/src/runtime/shared/detection.ts
@@ -9,7 +9,7 @@ import { isLocaleServedOnHost, matchDomainLocale, withRuntimeDomain } from './do
 import { isString } from '@intlify/shared'
 import { isSupportedLocale } from './locales'
 import { type useI18nDetection, useRuntimeI18n } from '../shared/utils'
-import type { I18nPublicRuntimeConfig, LocaleObject } from '../../types'
+import type { I18nPublicRuntimeConfig, NormalizedLocaleObject } from '../../types'
 
 import type { H3Event } from 'h3'
 import type { CompatRoute } from '../types'
@@ -42,7 +42,7 @@ export const useDetectors = (event: H3Event | undefined, config: { cookieKey: st
   const runtimeI18n = useRuntimeI18n(nuxtApp)
   // constant for the lifetime of these detectors, a fresh set is created per request
   let host: string | undefined
-  let locales: LocaleObject[] | undefined
+  let locales: NormalizedLocaleObject[] | undefined
   const getHost = () => (host ??= getRequestHost(event))
   const getLocales = () => (locales ??= getDomainLocales(runtimeI18n.domainLocales))
 

--- a/src/runtime/shared/domain.ts
+++ b/src/runtime/shared/domain.ts
@@ -1,8 +1,7 @@
 import { hasProtocol } from 'ufo'
 import { normalizedLocales } from '#build/i18n-options.mjs'
-import { toArray } from './utils'
 
-import type { I18nPublicRuntimeConfig, LocaleObject } from '#internal-i18n-types'
+import type { I18nPublicRuntimeConfig, NormalizedLocaleObject } from '#internal-i18n-types'
 
 /**
  * Configured domains may include a protocol (used when generating URLs), comparisons
@@ -14,10 +13,8 @@ export const normalizeDomain = (domain: string = '') => domain.replace(/^https?:
 /**
  * Whether the locale is served on the given host
  */
-export function isLocaleOnHost(locale: LocaleObject | undefined, host: string): boolean {
-  return (
-    !!locale && (normalizeDomain(locale.domain) === host || toArray(locale.domains).some(x => normalizeDomain(x) === host))
-  )
+export function isLocaleOnHost(locale: NormalizedLocaleObject | undefined, host: string): boolean {
+  return !!locale?.domains.some(x => normalizeDomain(x) === host)
 }
 
 /**
@@ -25,9 +22,9 @@ export function isLocaleOnHost(locale: LocaleObject | undefined, host: string): 
  * configured without domains qualifies, as does any locale on a host configured for none of
  * them (a staging domain, a health check by IP) so the site keeps working there.
  */
-export function isLocaleServedOnHost(locales: LocaleObject[], host: string, locale: string): boolean {
+export function isLocaleServedOnHost(locales: NormalizedLocaleObject[], host: string, locale: string): boolean {
   const target = locales.find(l => l.code === locale)
-  if (!target?.domain && !target?.domains?.length) { return true }
+  if (!target?.domains.length) { return true }
   return isLocaleOnHost(target, host) || !locales.some(l => isLocaleOnHost(l, host))
 }
 
@@ -36,14 +33,18 @@ export function isLocaleServedOnHost(locales: LocaleObject[], host: string, loca
  * default for. Undefined when the current host can serve it, which keeps hosts that match no
  * configured domain on relative URLs instead of sending them to a configured domain.
  */
-function relocateHostForLocale(host: string, locale: string, locales: LocaleObject[]): string | undefined {
+function relocateHostForLocale(host: string, locale: string, locales: NormalizedLocaleObject[]): string | undefined {
   if (isLocaleServedOnHost(locales, host, locale)) { return }
 
   const target = locales.find(l => l.code === locale)
-  return target?.defaultForDomains?.[0] || target?.domain || target?.domains?.[0]
+  return target?.defaultForDomains[0] || target?.domain || target?.domains[0]
 }
 
-export function matchDomainLocale(locales: LocaleObject[], host: string, pathLocale: string): string | undefined {
+export function matchDomainLocale(
+  locales: NormalizedLocaleObject[],
+  host: string,
+  pathLocale: string,
+): string | undefined {
   const matches = locales.filter(locale => isLocaleOnHost(locale, host))
 
   if (matches.length <= 1) {
@@ -54,7 +55,7 @@ export function matchDomainLocale(locales: LocaleObject[], host: string, pathLoc
     // match by current path locale
     matches.find(l => l.code === pathLocale)?.code
     // fallback to default locale for the domain
-    || matches.find(l => l.defaultForDomains?.some(domain => normalizeDomain(domain) === host) ?? l.domainDefault)?.code
+    || matches.find(l => l.defaultForDomains.some(domain => normalizeDomain(domain) === host))?.code
   )
 }
 
@@ -62,14 +63,14 @@ export function domainFromLocale(
   domainLocales: Record<string, { domain: string | undefined }>,
   url: { host: string, protocol: string },
   locale: string,
-  locales: LocaleObject[] = normalizedLocales,
+  locales: NormalizedLocaleObject[] = normalizedLocales,
 ): string | undefined {
   const lang = locales.find(x => x.code === locale)
   // lookup the `differentDomain` origin associated with given locale
   const domain
     = domainLocales?.[locale]?.domain
       || lang?.domain
-      || lang?.domains?.find(v => normalizeDomain(v) === url.host)
+      || lang?.domains.find(v => normalizeDomain(v) === url.host)
       || relocateHostForLocale(url.host, locale, locales)
 
   if (!domain) {
@@ -88,15 +89,17 @@ export function domainFromLocale(
  * Returns the locale object with the domain overridden by `domainLocales` runtime config (see also `getHostLocale`),
  * a no-op outside domain setups since the override entries are empty.
  */
-export function withRuntimeDomain<T extends string | LocaleObject>(
+export function withRuntimeDomain<T extends string | NormalizedLocaleObject>(
   locale: T,
   domainLocales: I18nPublicRuntimeConfig['domainLocales'],
 ): T {
   if (typeof locale === 'string') {
     return locale
   }
-  const properties = locale as LocaleObject
+  const properties = locale as NormalizedLocaleObject
   const domain = domainLocales[properties.code]?.domain
+  // `domainLocales` is seeded from the configured scalar `domain`, an entry matching it is not an
+  // override - rebuilding on it would drop the locale's other domains
   if (!domain || domain === properties.domain) {
     return locale
   }
@@ -107,6 +110,6 @@ export function withRuntimeDomain<T extends string | LocaleObject>(
     ...properties,
     domain,
     domains: [domain],
-    ...(properties.defaultForDomains?.length ? { defaultForDomains: [domain] } : {}),
+    defaultForDomains: properties.defaultForDomains.length ? [domain] : [],
   } as T
 }

--- a/src/runtime/shared/locales.ts
+++ b/src/runtime/shared/locales.ts
@@ -2,7 +2,7 @@ import { localeCodes, localeLoaders, normalizedLocales } from '#build/i18n-optio
 import { isArray, isString } from '@intlify/shared'
 import { normalizeDomain } from './domain'
 import type { FallbackLocale } from 'vue-i18n'
-import type { LocaleObject } from '#internal-i18n-types'
+import type { NormalizedLocaleObject } from '#internal-i18n-types'
 
 type LocaleConfig = { cacheable: boolean, fallbacks: string[] }
 export function createLocaleConfigs(fallbackLocale: FallbackLocale): Record<string, LocaleConfig> {
@@ -55,8 +55,8 @@ export function isLocaleWithFallbacksCacheable(locale: string, fallbackLocales: 
 /**
  * The locale configured as the default for `host`, undefined when no locale claims it
  */
-export function getDefaultLocaleForDomain(host: string, locales: LocaleObject[] = normalizedLocales): string | undefined {
-  return locales.find(l => l.defaultForDomains?.some(domain => normalizeDomain(domain) === host))?.code
+export function getDefaultLocaleForDomain(host: string, locales: NormalizedLocaleObject[] = normalizedLocales): string | undefined {
+  return locales.find(l => l.defaultForDomains.some(domain => normalizeDomain(domain) === host))?.code
 }
 
 /**
@@ -67,7 +67,7 @@ export function getDefaultLocaleForDomain(host: string, locales: LocaleObject[] 
 export function resolveDefaultLocale(
   host: string,
   defaultLocale: string | undefined,
-  locales: LocaleObject[] = normalizedLocales,
+  locales: NormalizedLocaleObject[] = normalizedLocales,
 ): string {
   return getDefaultLocaleForDomain(host, locales) || defaultLocale || ''
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -558,6 +558,19 @@ export interface LocaleObject<T = Locale> {
 }
 
 /**
+ * A locale passed through `normalizeDomainLocale`: `domains` and `defaultForDomains` are always
+ * set, so domain logic can read them without a fallback. `domainDefault` is fully resolved into
+ * `defaultForDomains` and reading it past normalization means the two can disagree, so the type
+ * takes it away. `domain` is kept: it additionally marks the locale's own domain, which
+ * `domains` cannot express.
+ */
+export type NormalizedLocaleObject<T = Locale> = LocaleObject<T> & {
+  domains: string[]
+  defaultForDomains: string[]
+  domainDefault?: never
+}
+
+/**
  * @public
  * @deprecated Configuring baseUrl as a function is deprecated and will be removed in the v11.
  *
@@ -631,7 +644,7 @@ export interface I18nPublicRuntimeConfig {
   /** Domain locales mapping */
   domainLocales: { [key: Locale]: { domain: string | undefined } }
   /** @internal Overwritten at build time, used to pass generated options to runtime */
-  locales: NonNullable<Required<NuxtI18nOptions<unknown>>['locales']>
+  locales: string[] | NormalizedLocaleObject[]
   /** @internal Overwritten at build time, used to pass generated options to runtime */
   defaultLocale: Required<NuxtI18nOptions>['defaultLocale']
   /** @internal Overwritten at build time, used to pass generated options to runtime */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,15 @@ import { assign, isArray, isString } from '@intlify/shared'
 import { EXECUTABLE_EXT_RE } from './constants'
 import { parseSync } from 'oxc-parser'
 
-import type { FileMeta, LocaleFile, LocaleInfo, LocaleObject, LocaleType, NuxtI18nOptions } from './types'
+import type {
+  FileMeta,
+  LocaleFile,
+  LocaleInfo,
+  LocaleObject,
+  LocaleType,
+  NormalizedLocaleObject,
+  NuxtI18nOptions,
+} from './types'
 import type { NuxtConfigLayer } from '@nuxt/schema'
 import type { IdentifierName, Program, VariableDeclarator } from 'oxc-parser'
 import type { I18nNuxtContext } from './context'
@@ -38,19 +46,17 @@ export function validateLocaleCodes(codes: string[]) {
 }
 
 /**
- * Normalizes the single-domain fields (`domain`/`domainDefault`) into their multi-domain forms
- * (`domains`/`defaultForDomains`) so runtime domain resolution only handles one shape,
- * the scalar fields are kept as-is for compatibility.
+ * Resolves the single-domain fields (`domain`/`domainDefault`) into their multi-domain forms
+ * (`domains`/`defaultForDomains`) so domain logic only handles one shape. Both are always set,
+ * which is what {@link NormalizedLocaleObject} narrows for. The scalar fields stay on the value
+ * for user code reading `locales`.
  */
-export function normalizeDomainLocale(locale: LocaleObject): LocaleObject {
-  const normalized = assign({}, locale)
-  if (locale.domain && !locale.domains) {
-    normalized.domains = [locale.domain]
-  }
-  if (locale.domainDefault && normalized.domains && !locale.defaultForDomains) {
-    normalized.defaultForDomains = normalized.domains
-  }
-  return normalized
+export function normalizeDomainLocale<T extends string>(locale: LocaleObject<T>): NormalizedLocaleObject<T> {
+  const domains = locale.domains?.length ? locale.domains : locale.domain ? [locale.domain] : []
+  return assign({}, locale, {
+    domains,
+    defaultForDomains: locale.defaultForDomains ?? (locale.domainDefault ? domains : []),
+  }) as NormalizedLocaleObject<T>
 }
 
 export function resolveLocales(srcDir: string, locales: LocaleObject[], vfs: Record<string, string>): LocaleInfo[] {

--- a/test/__snapshots__/gen.test.ts.snap
+++ b/test/__snapshots__/gen.test.ts.snap
@@ -40,12 +40,18 @@ exports[`basic 1`] = `
   "normalizedLocales": [
     {
       "code": "en",
+      "defaultForDomains": [],
+      "domains": [],
     },
     {
       "code": "ja",
+      "defaultForDomains": [],
+      "domains": [],
     },
     {
       "code": "fr",
+      "defaultForDomains": [],
+      "domains": [],
     },
   ],
   "vueI18nConfigs": [
@@ -125,18 +131,28 @@ exports[`files with cache configuration 1`] = `
   "normalizedLocales": [
     {
       "code": "en",
+      "defaultForDomains": [],
+      "domains": [],
     },
     {
       "code": "ja",
+      "defaultForDomains": [],
+      "domains": [],
     },
     {
       "code": "fr",
+      "defaultForDomains": [],
+      "domains": [],
     },
     {
       "code": "es",
+      "defaultForDomains": [],
+      "domains": [],
     },
     {
       "code": "es-AR",
+      "defaultForDomains": [],
+      "domains": [],
     },
   ],
   "vueI18nConfigs": [
@@ -189,12 +205,18 @@ exports[`lazy 1`] = `
   "normalizedLocales": [
     {
       "code": "en",
+      "defaultForDomains": [],
+      "domains": [],
     },
     {
       "code": "ja",
+      "defaultForDomains": [],
+      "domains": [],
     },
     {
       "code": "fr",
+      "defaultForDomains": [],
+      "domains": [],
     },
   ],
   "vueI18nConfigs": [
@@ -247,12 +269,18 @@ exports[`locale file in nested 1`] = `
   "normalizedLocales": [
     {
       "code": "en",
+      "defaultForDomains": [],
+      "domains": [],
     },
     {
       "code": "ja",
+      "defaultForDomains": [],
+      "domains": [],
     },
     {
       "code": "fr",
+      "defaultForDomains": [],
+      "domains": [],
     },
   ],
   "vueI18nConfigs": [
@@ -332,18 +360,28 @@ exports[`multiple files 1`] = `
   "normalizedLocales": [
     {
       "code": "en",
+      "defaultForDomains": [],
+      "domains": [],
     },
     {
       "code": "ja",
+      "defaultForDomains": [],
+      "domains": [],
     },
     {
       "code": "fr",
+      "defaultForDomains": [],
+      "domains": [],
     },
     {
       "code": "es",
+      "defaultForDomains": [],
+      "domains": [],
     },
     {
       "code": "es-AR",
+      "defaultForDomains": [],
+      "domains": [],
     },
   ],
   "vueI18nConfigs": [
@@ -393,12 +431,18 @@ exports[`server asset loaders 1`] = `
   "normalizedLocales": [
     {
       "code": "en",
+      "defaultForDomains": [],
+      "domains": [],
     },
     {
       "code": "ja",
+      "defaultForDomains": [],
+      "domains": [],
     },
     {
       "code": "fr",
+      "defaultForDomains": [],
+      "domains": [],
     },
   ],
   "vueI18nConfigs": [],
@@ -445,12 +489,18 @@ exports[`vueI18n option 1`] = `
   "normalizedLocales": [
     {
       "code": "en",
+      "defaultForDomains": [],
+      "domains": [],
     },
     {
       "code": "ja",
+      "defaultForDomains": [],
+      "domains": [],
     },
     {
       "code": "fr",
+      "defaultForDomains": [],
+      "domains": [],
     },
   ],
   "vueI18nConfigs": [

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -10,16 +10,17 @@ import {
 import { getDefaultLocaleForDomain } from '../src/runtime/shared/locales'
 import { createBaseUrlGetter } from '../src/runtime/context'
 import { normalizeDomainLocale } from '../src/utils'
-import type { LocaleObject } from '../src/types'
+import { getNormalizedLocales } from './pages/utils'
 
-const locales: LocaleObject[] = [
+// the runtime only ever sees build-normalized locales, resolve them the same way here
+const locales = getNormalizedLocales([
   { code: 'en', domain: 'en.example.com' },
   { code: 'fr', domain: 'https://fr.example.com' },
   { code: 'nl', domains: ['shared.example.com'], domainDefault: true },
   { code: 'de', domains: ['shared.example.com'] },
   { code: 'es', domains: ['https://shared2.example.com'], defaultForDomains: ['https://shared2.example.com'] },
   { code: 'it', domains: ['shared2.example.com'] },
-]
+])
 
 describe('normalizeDomain', () => {
   test('strips only a leading protocol, `host:port` is kept intact', () => {
@@ -71,7 +72,7 @@ describe('isLocaleServedOnHost', () => {
   })
 
   test('a locale without domains is served everywhere', () => {
-    expect(isLocaleServedOnHost([...locales, { code: 'pl' }], 'en.example.com', 'pl')).toBe(true)
+    expect(isLocaleServedOnHost([...locales, ...getNormalizedLocales(['pl'])], 'en.example.com', 'pl')).toBe(true)
   })
 
   test('an unconfigured host is not restricted', () => {
@@ -85,11 +86,8 @@ describe('isLocaleServedOnHost', () => {
 })
 
 describe('getDefaultLocaleForDomain', () => {
-  // receives build-normalized locales at runtime (`domainDefault` folded into `defaultForDomains`)
-  const normalized = locales.map(normalizeDomainLocale)
-
   test('matches by host', () => {
-    expect(getDefaultLocaleForDomain('shared.example.com', normalized)).toBe('nl')
+    expect(getDefaultLocaleForDomain('shared.example.com', locales)).toBe('nl')
   })
 
   test('(#4064) ignores protocol in `defaultForDomains`', () => {
@@ -97,10 +95,10 @@ describe('getDefaultLocaleForDomain', () => {
   })
 
   test('(#4064) resolves normalized `domain` + `domainDefault` locales per host', () => {
-    const perDomainDefaults = [
+    const perDomainDefaults = getNormalizedLocales([
       { code: 'cs', domain: 'https://www.example.cz', domainDefault: true },
       { code: 'en', domain: 'https://www.example.com', domainDefault: true },
-    ].map(normalizeDomainLocale)
+    ])
     expect(getDefaultLocaleForDomain('www.example.com', perDomainDefaults)).toBe('en')
     expect(getDefaultLocaleForDomain('www.example.cz', perDomainDefaults)).toBe('cs')
   })
@@ -142,12 +140,15 @@ describe('domainFromLocale', () => {
   test('a locale served on none of the current host resolves to the domain it belongs to', () => {
     expect(domainFromLocale({}, url, 'nl', locales)).toBe('http://shared.example.com')
     // the domain the locale is the default for wins over the rest of its `domains`
-    const multi = [...locales, { code: 'pt', domains: ['a.example.com', 'b.example.com'], defaultForDomains: ['b.example.com'] }]
+    const multi = [
+      ...locales,
+      ...getNormalizedLocales([{ code: 'pt', domains: ['a.example.com', 'b.example.com'], defaultForDomains: ['b.example.com'] }]),
+    ]
     expect(domainFromLocale({}, url, 'pt', multi)).toBe('http://b.example.com')
   })
 
   test('returns undefined for a locale without domains', () => {
-    expect(domainFromLocale({}, url, 'pl', [...locales, { code: 'pl' }])).toBeUndefined()
+    expect(domainFromLocale({}, url, 'pl', [...locales, ...getNormalizedLocales(['pl'])])).toBeUndefined()
   })
 
   test('a host matching no configured domain resolves no domain, so URLs stay relative', () => {
@@ -177,6 +178,26 @@ describe('withRuntimeDomain', () => {
   test('returns the locale as-is without an override', () => {
     expect(withRuntimeDomain(locales[0], {})).toBe(locales[0])
     expect(withRuntimeDomain('en', { en: { domain: 'en.staging.example.com' } })).toBe('en')
+  })
+
+  test('an entry matching a configured domain is not an override, the other domains survive', () => {
+    // `domainLocales` is seeded from the scalar `domain` for every locale, so it is populated
+    // without the user setting anything - see `module.ts`
+    const configured = normalizeDomainLocale({
+      code: 'en',
+      domain: 'en.example.com',
+      domains: ['en.example.com', 'www.example.com'],
+    })
+    expect(withRuntimeDomain(configured, { en: { domain: 'en.example.com' } })).toBe(configured)
+  })
+
+  test('a locale that is not configured has no domains to override', () => {
+    // `composer.localeProperties` falls back to a bare locale when the current one is unknown
+    const unknown = { code: 'en', domains: [], defaultForDomains: [] }
+    expect(withRuntimeDomain(unknown, { en: { domain: 'en.staging.example.com' } })).toMatchObject({
+      domains: ['en.staging.example.com'],
+      defaultForDomains: []
+    })
   })
 })
 
@@ -247,8 +268,11 @@ describe('normalizeDomainLocale', () => {
     expect(normalizeDomainLocale(locale)).toEqual(locale)
   })
 
-  test('does not add fields for locales without domains', () => {
-    expect(normalizeDomainLocale({ code: 'en' })).toEqual({ code: 'en' })
-    expect(normalizeDomainLocale({ code: 'en', domainDefault: true })).toEqual({ code: 'en', domainDefault: true })
+  test('both fields are always resolved, a locale without domains gets the empty form', () => {
+    expect(normalizeDomainLocale({ code: 'en' })).toEqual({ code: 'en', domains: [], defaultForDomains: [] })
+  })
+
+  test('`domainDefault` without a domain has nothing to be the default for', () => {
+    expect(normalizeDomainLocale({ code: 'en', domainDefault: true })).toMatchObject({ defaultForDomains: [] })
   })
 })

--- a/test/kit.test.ts
+++ b/test/kit.test.ts
@@ -297,11 +297,11 @@ describe.each(STRATEGIES)('routing context (strategy: %s)', strategy => {
 })
 
 describe('switchLocalePath with differentDomains', () => {
-  const DOMAIN_LOCALES = [
+  const DOMAIN_LOCALES = getNormalizedLocales([
     { code: 'en', language: 'en', domain: 'en.example.com', defaultForDomains: ['en.example.com'] },
     { code: 'no', language: 'no', domain: 'en.example.com' },
     { code: 'fr', language: 'fr', domain: 'fr.example.com', defaultForDomains: ['fr.example.com'] }
-  ]
+  ])
 
   function createDomainContext(opts: {
     strategy: Strategies
@@ -335,7 +335,7 @@ describe('switchLocalePath with differentDomains', () => {
       compactRoutes: false,
       getLocale: () => opts.locale,
       getLocales: () => locales,
-      getBaseUrl: locale => `http://${locales.find(l => l.code === (locale ?? opts.locale))?.domain ?? opts.host}`,
+      getBaseUrl: locale => `http://${locales.find(l => l.code === (locale ?? opts.locale))?.domains[0] ?? opts.host}`,
       getHost: () => opts.host
     })
     return { router, ctx }
@@ -363,10 +363,10 @@ describe('switchLocalePath with differentDomains', () => {
       host: 'en.example.com',
       locale: 'en',
       defaultLocale: 'en',
-      locales: [
+      locales: getNormalizedLocales([
         { code: 'en', language: 'en', domain: 'en.example.com' },
         { code: 'fr', language: 'fr', domain: 'fr.example.com' }
-      ]
+      ])
     })
 
     // no `___default` variants exist to keep, so the host default is unprefixed instead

--- a/test/pages/localize_routes.test.ts
+++ b/test/pages/localize_routes.test.ts
@@ -215,10 +215,10 @@ describe('localizeRoutes', function () {
         defaultLocale: 'en',
         strategy: 'prefix_except_default',
         multiDomainLocales: true,
-        locales: [
+        locales: getNormalizedLocales([
           { code: 'en', iso: 'en-US', domainDefault: true },
           { code: 'ja', iso: 'ja-JP' }
-        ]
+        ])
       })
 
       const router = createRouter({ routes: localizedRoutes as any, history: createMemoryHistory() })
@@ -238,14 +238,14 @@ describe('localizeRoutes', function () {
         defaultLocale: 'en',
         strategy: 'prefix_except_default',
         differentDomains: true,
-        locales: [
+        locales: getNormalizedLocales([
           { code: 'en', domain: 'en.example.com' },
           { code: 'ja', domain: 'ja.example.com' },
           // unnormalized single-domain form
           { code: 'fr', domain: 'fr.example.com', domainDefault: true },
           // multi-domain form
           { code: 'nl', domains: ['nl.example.com'], defaultForDomains: ['nl.example.com'] }
-        ]
+        ])
       })
 
       const paths = Object.fromEntries(localizedRoutes.map(x => [x.name, x.path]))
@@ -281,10 +281,10 @@ describe('localizeRoutes', function () {
         defaultLocale: 'en',
         strategy: 'prefix_except_default',
         differentDomains: true,
-        locales: [
+        locales: getNormalizedLocales([
           { code: 'en', domain: 'en.example.com' },
           { code: 'fr', domain: 'fr.example.com', defaultForDomains: ['fr.example.com'] }
-        ]
+        ])
       })
 
       const router = createRouter({ routes: localizedRoutes as any, history: createMemoryHistory() })
@@ -308,10 +308,10 @@ describe('localizeRoutes', function () {
         strategy: 'prefix_except_default',
         trailingSlash: true,
         differentDomains: true,
-        locales: [
+        locales: getNormalizedLocales([
           { code: 'en', domain: 'en.example.com' },
           { code: 'fr', domain: 'fr.example.com', defaultForDomains: ['fr.example.com'] }
-        ]
+        ])
       })
 
       const router = createRouter({ routes: localizedRoutes as any, history: createMemoryHistory() })
@@ -332,10 +332,10 @@ describe('localizeRoutes', function () {
         defaultLocale: 'en',
         strategy: 'prefix_except_default',
         differentDomains: true,
-        locales: [
+        locales: getNormalizedLocales([
           { code: 'en', domain: 'en.example.com' },
           { code: 'fr', domain: 'fr.example.com', defaultForDomains: ['fr.example.com'] }
-        ]
+        ])
       })
 
       const tree = localizedRoutes.find(r => r.name === 'user___fr___default')
@@ -353,7 +353,7 @@ describe('localizeRoutes', function () {
           ...nuxtOptions,
           strategy: 'no_prefix',
           differentDomains: true,
-          locales: [{ code: 'en', domain: shared }, { code: 'fr', domain: shared }]
+          locales: getNormalizedLocales([{ code: 'en', domain: shared }, { code: 'fr', domain: shared }])
         })
       ).toBe(false)
 
@@ -362,7 +362,7 @@ describe('localizeRoutes', function () {
           ...nuxtOptions,
           strategy: 'no_prefix',
           differentDomains: true,
-          locales: [{ code: 'en', domains: [shared] }, { code: 'fr', domains: [shared] }]
+          locales: getNormalizedLocales([{ code: 'en', domains: [shared] }, { code: 'fr', domains: [shared] }])
         })
       ).toBe(false)
 
@@ -376,7 +376,7 @@ describe('localizeRoutes', function () {
           ...nuxtOptions,
           strategy: 'no_prefix',
           differentDomains: true,
-          locales: [{ code: 'en', domains: ['a.example.com', 'b.example.com'] }, { code: 'fr', domain: 'c.example.com' }]
+          locales: getNormalizedLocales([{ code: 'en', domains: ['a.example.com', 'b.example.com'] }, { code: 'fr', domain: 'c.example.com' }])
         })
       ).toBe(true)
     })
@@ -388,7 +388,7 @@ describe('localizeRoutes', function () {
       defaultLocale: '',
       strategy: 'prefix_except_default',
       differentDomains: true,
-      locales: [{ code: 'en', domainDefault: true }, { code: 'fr', domain: 'fr.example.com', domainDefault: true }]
+      locales: getNormalizedLocales([{ code: 'en', domainDefault: true }, { code: 'fr', domain: 'fr.example.com', domainDefault: true }])
     })
 
     const names = localizedRoutes.map(x => x.name)
@@ -406,10 +406,10 @@ describe('localizeRoutes', function () {
         defaultLocale: 'en',
         strategy: 'prefix_and_default',
         differentDomains: true,
-        locales: [
+        locales: getNormalizedLocales([
           { code: 'en', domain: 'en.example.com' },
           { code: 'fr', domain: 'fr.example.com', defaultForDomains: ['fr.example.com'] }
-        ]
+        ])
       })
 
       const paths = Object.fromEntries(localizedRoutes.map(x => [x.name, x.path]))
@@ -436,11 +436,11 @@ describe('localizeRoutes', function () {
         defaultLocale: 'en',
         strategy: 'prefix_and_default',
         multiDomainLocales: true,
-        locales: [
+        locales: getNormalizedLocales([
           // `en` is served everywhere but is the default for no domain
           { code: 'en', domains: ['a.example.com', 'b.example.com'] },
           { code: 'fr', domains: ['a.example.com'], defaultForDomains: ['a.example.com'] }
-        ]
+        ])
       })
 
       const router = createRouter({ routes: localizedRoutes as any, history: createMemoryHistory() })
@@ -528,10 +528,10 @@ describe('localizeRoutes', function () {
         defaultLocale: 'en',
         strategy: 'no_prefix',
         differentDomains: true,
-        locales: [
+        locales: getNormalizedLocales([
           { code: 'en', domain: 'https://example.com' },
           { code: 'ja', domain: 'example.com' }
-        ]
+        ])
       })
 
       // localization is skipped for multiple locales on the same domain

--- a/test/pages/utils.ts
+++ b/test/pages/utils.ts
@@ -1,11 +1,13 @@
-import type { NuxtI18nOptions, LocaleObject, Strategies } from '../../src/types'
+import type { NuxtI18nOptions, LocaleObject, NormalizedLocaleObject, Strategies } from '../../src/types'
 import type { NuxtPage } from '@nuxt/schema'
 import type { ComputedRouteOptions, LocalizableRoute, RouteOptionsResolver } from '../../src/kit/gen'
 
 import { isString } from '@intlify/shared'
+import { normalizeDomainLocale } from '../../src/utils'
 
-export const getNormalizedLocales = (locales: string[] | LocaleObject[] = []): LocaleObject[] =>
-  locales.map(x => (isString(x) ? { code: x, language: x } : x))
+/** Mirrors how `resolveContext` normalizes configured locales - see `src/context.ts` */
+export const getNormalizedLocales = (locales: string[] | LocaleObject[] = []): NormalizedLocaleObject[] =>
+  locales.map(x => normalizeDomainLocale(isString(x) ? { code: x, language: x } : x))
 
 type MarkRequired<Type, Keys extends keyof Type> = Type extends Type ? Omit<Type, Keys> & Required<Pick<Type, Keys>> : never;
 export function getNuxtOptions(

--- a/test/routing-head.test.ts
+++ b/test/routing-head.test.ts
@@ -7,17 +7,18 @@ import { _useLocaleHead, _useSetI18nParams, localeHead, missesClusterFallback } 
 import { switchLocalePath } from '../src/runtime/routing/routing'
 import { headEntries } from './mocks/imports'
 import { resolveDefaultLocale } from '../src/runtime/shared/locales'
+import { getNormalizedLocales } from './pages/utils'
 
 import type { Router } from 'vue-router'
 import type { ComposableContext } from '../src/runtime/composable-context'
 import type { I18nHeadMetaInfo } from '../src/runtime/kit/head'
 
-const locales = [
+const locales = getNormalizedLocales([
   { code: 'en', language: 'en' },
   { code: 'fr', language: 'fr' },
   { code: 'ja', language: 'ja-JP' },
   { code: 'nl', language: 'nl-NL' },
-]
+])
 
 const component = {}
 const routes = [
@@ -35,11 +36,9 @@ function createTestContext(initialLocale = 'en', strictSeo = false, domains = fa
   let locale = initialLocale
   const router = createRouter({ history: createMemoryHistory(), routes })
   const head = { patches: [] as I18nHeadMetaInfo[], patch(val: I18nHeadMetaInfo) { this.patches.push(val) } }
-  const domainLocales = locales.map(l => ({
-    ...l,
-    domain: `${l.code}.example.com`,
-    defaultForDomains: [`${l.code}.example.com`],
-  }))
+  const domainLocales = getNormalizedLocales(
+    locales.map(l => ({ ...l, domain: `${l.code}.example.com`, defaultForDomains: [`${l.code}.example.com`] })),
+  )
   if (domains) {
     // rebuild the route table for the current host, mirrors the runtime plugin
     setupMultiDomainLocales(initialLocale, 'prefix_except_default', router)


### PR DESCRIPTION
> Based on #4092, the diff will settle once that merges.

The domain bugs fixed in #4090 came from the same place: `domain`/`domainDefault` and `domains`/`defaultForDomains` describe the same thing, and the build and the runtime each picked which pair to read. `normalizeDomainLocale` was meant to settle that but only resolved part of it, so a locale could reach route generation or link resolution with either shape missing.

It's now total, `domains` and `defaultForDomains` are always set, and the result is typed as `NormalizedLocaleObject`. Domain logic reads the array fields without falling back, and `domainDefault` is dropped from that type since it resolves fully into `defaultForDomains` - reading it past normalization is how the two sides came to disagree. `domain` is kept, it additionally marks the locale's own domain and `domains` can't express that.

Behavior is unchanged. `domainFromLocale` still prefers a locale's own `domain`, and a host matching no configured domain still resolves none, so dev and staging keep relative URLs.

The type is applied where locales reach domain logic: the resolved context, the runtime config channel and `localizeRoutes`. The test helpers resolve their locales through the normalizer the way `resolveContext` does, rather than passing a shape the build never produces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added normalized locale configuration types with consistently available domain metadata.
  * Improved support for multi-domain locale routing and runtime domain overrides.
* **Bug Fixes**
  * Corrected domain detection, default-locale resolution, and host matching for normalized configurations.
  * Ensured locale fallbacks consistently include complete domain metadata.
* **Tests**
  * Expanded coverage for domain routing, locale normalization, and runtime domain behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->