### PR TITLE
fix(types): annotate the logger so its declaration stays portable

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,6 +17,7 @@ import type {
   NuxtI18nOptions,
 } from './types'
 import type { NuxtConfigLayer } from '@nuxt/schema'
+import type { ConsolaInstance } from 'consola'
 import type { Node, ObjectExpression, Program, Statement } from 'oxc-parser'
 import type { I18nNuxtContext } from './context'
 
@@ -373,4 +374,5 @@ export function toArray<T>(value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value]
 }
 
-export const logger = useLogger('nuxt-i18n')
+// annotated so the declaration does not have to name consola through its resolved path (TS2742)
+export const logger: ConsolaInstance = useLogger('nuxt-i18n')


### PR DESCRIPTION
Noticed this while building after #4074, though it predates it — `nuxt build` on main before that PR prints the same error. The inferred type of `logger` can't be named without pointing into consola's `.pnpm` path, so declaration emit reports `TS2742`.

This annotates it as `ConsolaInstance`, which is nameable since consola is already a direct devDependency. Nothing changes for consumers, the emitted declarations don't reference consola and `logger` isn't part of the public surface.

The build exits `0` when this happens and `test:types` runs `tsc --noEmit` which skips declaration emit, so it never failed CI — likely why it went unnoticed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal logging type consistency without changing user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->