### PR TITLE
fix(bundler): only precompile locale files the resource transform can re-emit

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -110,20 +110,28 @@ function analyzeResource(path: string, vfs: Record<string, string>) {
 }
 
 // `() => ({ ... })` parses with an explicit `ParenthesizedExpression` node, and TS assertions
-// (`as` / `satisfies` / `!`) nest the runtime expression the same way
-function unwrap(node?: Node | null): Node | undefined {
-  switch (node?.type) {
+// (`as` / `satisfies` / `!`) nest the runtime expression the same way - the resource transform
+// strips both before it reads what they wrap
+function unwrapAssertion(node: Node): Node {
+  switch (node.type) {
     case 'ParenthesizedExpression':
     case 'TSAsExpression':
     case 'TSSatisfiesExpression':
     case 'TSNonNullExpression':
-      return unwrap(node.expression)
-    case 'AwaitExpression':
-      return unwrap(node.argument)
-    case 'SequenceExpression':
-      return unwrap(node.expressions.at(-1))
+      return unwrapAssertion(node.expression)
   }
-  return node ?? undefined
+  return node
+}
+
+function unwrap(node?: Node | null): Node | undefined {
+  const resolved = node != null ? unwrapAssertion(node) : undefined
+  switch (resolved?.type) {
+    case 'AwaitExpression':
+      return unwrap(resolved.argument)
+    case 'SequenceExpression':
+      return unwrap(resolved.expressions.at(-1))
+  }
+  return resolved
 }
 
 type Scope = { declared: Map<string, Node>, exported?: Node }
@@ -164,10 +172,11 @@ function loaderFunction(node: Node | undefined, scope: Scope) {
 }
 
 function localeTypeOf(exported: Node | undefined, scope: Scope): LocaleType {
-  if (exported?.type === 'ObjectExpression') {
-    // a computed key is not readable here, and the bundler's resource transform cannot parse one
-    // either - such a file has to stay a module rather than be treated as a static resource (#3961)
-    return holds(exported, scope, isComputedKey) ? 'unknown' : 'static'
+  // the bundler's resource transform reads the object literal a file exports directly and nothing
+  // else - a locale reaching its messages any other way has to stay a module (#2145)
+  const declared = unwrap(scope.exported)
+  if (declared?.type === 'ObjectExpression') {
+    return isEmittable(declared) ? 'static' : 'unknown'
   }
   return loaderFunction(exported, scope) ? 'dynamic' : 'unknown'
 }
@@ -276,8 +285,37 @@ function holds(node: Node | null | undefined, scope: Scope, test: (node: Node) =
 const isMessageFunction = (node: Node) =>
   node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression'
 
-const isComputedKey = (node: Node) =>
-  node.type === 'ObjectExpression' && node.properties.some(x => x.type === 'Property' && x.computed)
+/**
+ * Whether the resource transform can re-emit a message as written. It reads the literal rather than
+ * the value behind it: an expression it cannot read becomes a reference to the key it was written
+ * under (#3308), a computed key is read as the source text of the key expression (#3961), and an
+ * item it cannot read is dropped - all of them leave the message missing at runtime.
+ */
+function isEmittable(input: Node): boolean {
+  const node = unwrapAssertion(input)
+  switch (node.type) {
+    case 'Literal':
+      // a regex is dropped and a bigint is emitted as a number, neither carries a message anyway
+      return !('regex' in node) && !('bigint' in node)
+    case 'TemplateLiteral':
+      // only the static parts are read, an interpolation is dropped from the message
+      return node.expressions.length === 0
+    case 'ObjectExpression':
+      return node.properties.every(isEmittableProperty)
+    case 'ArrayExpression':
+      return node.elements.every(x => x != null && isEmittable(x))
+  }
+  return false
+}
+
+function isEmittableProperty(node: Node): boolean {
+  // a spread is emitted as `...<name>`, so only a reference survives it
+  if (node.type === 'SpreadElement') { return node.argument.type === 'Identifier' }
+  if (node.type !== 'Property' || node.computed) { return false }
+  // a reference is emitted as written, next to the declaration it points at, a function verbatim
+  const value = unwrapAssertion(node.value)
+  return isEmittable(value) || value.type === 'Identifier' || isMessageFunction(value)
+}
 
 export function resolveVueI18nConfigInfo(path: string, vfs: Record<string, string>) {
   return { path, hash: getHash(path), ...analyzeResource(path, vfs) }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -139,7 +139,7 @@ describe('message source classification', () => {
     resolveLocales('/project', [{ code: 'en', file }] as LocaleObject[], { [`/project/${file}`]: source })[0]!.meta[0]!
 
   test('reads plain data as endpoint deliverable', () => {
-    expect(analyze(`export default { a: 'x', deep: { b: 'y' }, list: ['z'], n: -1, t: \`plain\` }`)).toMatchObject({
+    expect(analyze(`export default { a: 'x', deep: { b: 'y' }, list: ['z'], n: 1, t: \`plain\` }`)).toMatchObject({
       type: 'static',
       serializable: true
     })
@@ -151,7 +151,6 @@ describe('message source classification', () => {
     expect(analyze(`export default { deep: { a: ctx => ctx.named('n') } }`)).toMatchObject({ serializable: false })
     expect(analyze(`export default { a() { return 'x' } }`)).toMatchObject({ serializable: false })
     expect(analyze(`const messages = { a: () => 'x' }\nexport default messages`)).toMatchObject({
-      type: 'static',
       serializable: false
     })
   })
@@ -162,7 +161,6 @@ describe('message source classification', () => {
       serializable: false
     })
     expect(analyze(`const messages = { a: () => 'x' } as const\nexport default messages`)).toMatchObject({
-      type: 'static',
       serializable: false
     })
     expect(analyze(`export default { a: (() => 'x') as unknown }`)).toMatchObject({ serializable: false })
@@ -214,12 +212,13 @@ describe('message source classification', () => {
   })
 
   test('follows variable hops, exported or not', () => {
+    // (#2145) the transform only reads an object exported directly, so a hop keeps the file a module
     expect(analyze(`export const messages = { a: () => 'x' }\nexport default messages`)).toMatchObject({
-      type: 'static',
+      type: 'unknown',
       serializable: false
     })
     expect(analyze(`const a = { x: () => 'y' }\nconst b = a\nexport default b`)).toMatchObject({
-      type: 'static',
+      type: 'unknown',
       serializable: false
     })
     // a self-referential declaration resolves to nothing rather than looping
@@ -261,6 +260,38 @@ describe('message source classification', () => {
     })
     expect(analyze(`export default { [key]: () => 'x' }`)).toMatchObject({ type: 'unknown', serializable: false })
     expect(analyze(`export default { a: 'x' }`)).toMatchObject({ type: 'static' })
+  })
+
+  test('(#3308) a value the resource transform cannot re-emit is not a readable resource', () => {
+    // it would emit `hello: hello` - the message resolves to nothing rather than to its value
+    expect(analyze(`export default { hello: 'Hello' + 'World' }`)).toMatchObject({
+      type: 'unknown',
+      serializable: true
+    })
+    expect(analyze(`export default { a: makeMessage() }`)).toMatchObject({ type: 'unknown' })
+    expect(analyze(`export default { n: -1 }`)).toMatchObject({ type: 'unknown' })
+    expect(analyze(`export default { deep: { a: 'Hello' + 'World' }, b: 'y' }`)).toMatchObject({ type: 'unknown' })
+    // an interpolation is dropped from a template literal, leaving only its static parts
+    expect(analyze('export default { a: `Hello ${name}` }')).toMatchObject({ type: 'unknown' })
+    // an item it cannot read is dropped, shifting the rest of the array up
+    expect(analyze(`export default { list: ['a' + 'b', 'c'] }`)).toMatchObject({ type: 'unknown' })
+    expect(analyze(`export default { list: [ref, 'c'] }`)).toMatchObject({ type: 'unknown' })
+    // a spread of anything but a reference is emitted as `...false`
+    expect(analyze(`export default { ...getBase() }`)).toMatchObject({ type: 'unknown' })
+  })
+
+  test('(#3308) values it re-emits as written stay readable', () => {
+    // the declaration a reference points at is emitted alongside the messages, so it resolves
+    expect(analyze(`const greeting = 'Hello' + 'World'\nexport default { hello: greeting }`)).toMatchObject({
+      type: 'static',
+      serializable: true
+    })
+    expect(analyze(`import en from './en.json'\nexport default { en }`)).toMatchObject({ type: 'static' })
+    expect(analyze(`const nested = { [key]: 'x' }\nexport default { deep: nested }`)).toMatchObject({
+      type: 'static'
+    })
+    expect(analyze(`export default { ...base, a: 'x' }`)).toMatchObject({ type: 'static' })
+    expect(analyze(`export default { list: [{ a: 'x' }, ['y'], 1, true, null] }`)).toMatchObject({ type: 'static' })
   })
 
   test('a shape it cannot read at all is assumed to hold message functions', () => {


### PR DESCRIPTION
* Resolves #3308
* Resolves #2145

Locale files were treated as static resources as long as we could read their exported object, but `@intlify/bundle-utils` only re-emits values it can read as literals. A concatenated message like `{ hello: 'Hello' + 'World' }` was emitted as `{ hello: hello }`, a reference to a variable that doesn't exist, and a file exporting its messages through a variable (`const messages = { ... }; export default messages`) fails the build with `You need to define 'export default' that will return the locale messages.`

These files are now classified as `unknown` so they are left out of the include list and loaded as regular modules instead, values that survive the transform as written (literals, references, functions and spreads of a reference) are still treated as static. The same check covers calls, ternaries, negative numbers, template literals with interpolation and array items it would drop.

Worth mentioning if you want to reproduce this: nitro doesn't run this transform, so the broken output only shows up in the client bundle, an SSR or prerendered page renders the message fine. This also adds unit tests for both directions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of message exports wrapped in TypeScript assertions or parentheses.
  * More accurately identifies when locale messages can be safely re-emitted.
  * Correctly classifies messages containing computed properties or indirect variable references.
  * Expanded coverage for serializable values and values re-emitted as written.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->