### PR TITLE
test: give the prerenderMessages spec its own fixture

### DIFF
--- a/specs/experimental/prerender_messages.spec.ts
+++ b/specs/experimental/prerender_messages.spec.ts
@@ -5,15 +5,10 @@ import { describe, expect, test } from 'vitest'
 
 import { setup, useTestContext } from '../utils'
 
+// its own fixture: this build prerenders, and sharing a rootDir with the specs that run alongside
+// it made the build directory race on windows
 await setup({
-  rootDir: fileURLToPath(new URL(`../fixtures/lazy`, import.meta.url)),
-  nuxtConfig: {
-    i18n: {
-      experimental: { prerenderMessages: true },
-      // `de` holds message functions, the fixture's `en-GB` runs `defineI18nLocale` loaders
-      locales: [{ code: 'de', language: 'de-DE', file: 'lazy-locale-de.ts', name: 'Deutsch' }]
-    }
-  }
+  rootDir: fileURLToPath(new URL(`../fixtures/prerender_messages`, import.meta.url))
 })
 
 describe('experimental.prerenderMessages', () => {
@@ -22,8 +17,8 @@ describe('experimental.prerenderMessages', () => {
     // `_i18n/<hash>/<locale>/messages.json`
     const prerendered = readdirSync(messagesDir).flatMap(hash => readdirSync(join(messagesDir, hash)))
 
-    // `en-GB` and `nl` run loaders (`nl` even returns `new Date()`) so a baked file would freeze
-    // them, and `de` would lose its message functions - all three keep using their loaders
-    expect(prerendered.sort()).toEqual(['en', 'fr'])
+    // `dyn` runs a loader so a baked file would freeze it, and `fn` would lose its message
+    // function - both keep loading through their loaders instead
+    expect(prerendered.sort()).toEqual(['en'])
   })
 })

--- a/specs/fixtures/prerender_messages/app.vue
+++ b/specs/fixtures/prerender_messages/app.vue
@@ -1,0 +1,3 @@
+<template>
+  <NuxtPage />
+</template>

--- a/specs/fixtures/prerender_messages/i18n/locales/dyn.ts
+++ b/specs/fixtures/prerender_messages/i18n/locales/dyn.ts
@@ -1,0 +1,2 @@
+// resolved per request, a baked file would freeze whatever the build happened to produce
+export default defineI18nLocale(() => ({ heading: 'Dynamic' }))

--- a/specs/fixtures/prerender_messages/i18n/locales/en.json
+++ b/specs/fixtures/prerender_messages/i18n/locales/en.json
@@ -1,0 +1,3 @@
+{
+  "heading": "Homepage"
+}

--- a/specs/fixtures/prerender_messages/i18n/locales/fn.ts
+++ b/specs/fixtures/prerender_messages/i18n/locales/fn.ts
@@ -1,0 +1,4 @@
+// a message function, which JSON cannot carry
+export default {
+  heading: () => 'Function'
+}

--- a/specs/fixtures/prerender_messages/nuxt.config.ts
+++ b/specs/fixtures/prerender_messages/nuxt.config.ts
@@ -1,0 +1,18 @@
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/i18n'],
+
+  i18n: {
+    defaultLocale: 'en',
+    detectBrowserLanguage: false,
+    experimental: {
+      prerenderMessages: true
+    },
+    locales: [
+      { code: 'en', language: 'en-US', name: 'English', file: 'en.json' },
+      { code: 'dyn', language: 'dy-DY', name: 'Dynamic', file: 'dyn.ts' },
+      { code: 'fn', language: 'fn-FN', name: 'Function', file: 'fn.ts' }
+    ]
+  },
+
+  compatibilityDate: '2025-03-30'
+})

--- a/specs/fixtures/prerender_messages/pages/index.vue
+++ b/specs/fixtures/prerender_messages/pages/index.vue
@@ -1,0 +1,3 @@
+<template>
+  <h1 id="heading">{{ $t('heading') }}</h1>
+</template>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
Should fix the flakiness associated with this spec, the underlying issue is likely that its build directory is being cleaned up by a different test. Will probably look into fixing that so we can clean up this fixture and reuse the lazy fixture again.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prerendered internationalization message handling.
  * Ensured static locale messages are prerendered correctly while dynamic and function-based messages continue loading at request time.
  * Added coverage for locale-specific translation rendering across supported message formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->