### PR TITLE
fix(routing): re-escape '#' and '?' left over from localePath's path normalization

### DIFF
--- a/src/runtime/routing/routing.ts
+++ b/src/runtime/routing/routing.ts
@@ -57,17 +57,37 @@ function normalizeRawLocation(route: RouteLocationRaw): RouteLike {
 }
 
 /**
+ * `resolveLocalizedRouteObject` may return an already-resolved route (its `path`
+ * decoded for readability, e.g. `%20` becomes a literal space — see `context.ts`
+ * `resolveLocalizedRouteByPath`). Resolving that object a second time below re-parses
+ * `path` as a fresh location string, so a literal '#' or '?' left over from decoding is
+ * read as an actual fragment/query delimiter instead of path text, silently truncating
+ * the path — `query`/`hash` are unaffected, populated separately and not re-parsed.
+ * Only `path` (and the `fullPath` built from it) needs the fix; re-escape both.
+ */
+function sanitizeResolvedPath<T extends { path: string, fullPath: string }>(resolved: T): T {
+  if (!/[#?]/.test(resolved.path)) {
+    return resolved
+  }
+
+  const suffix = resolved.fullPath.slice(resolved.path.length)
+  resolved.path = resolved.path.replace(/#/g, '%23').replace(/\?/g, '%3F')
+  resolved.fullPath = resolved.path + suffix
+  return resolved
+}
+
+/**
  * Try resolving route and throw on failure
  */
 function resolveRoute(ctx: RoutingContext, route: RouteLocationRaw, locale: Locale) {
   const normalized = normalizeRawLocation(route)
   const resolved = ctx.router.resolve(ctx.resolveLocalizedRouteObject(normalized, locale))
   if (resolved.name) {
-    return resolved
+    return sanitizeResolvedPath(resolved)
   }
 
   // if unable to resolve route try resolving route based on original input
-  return ctx.router.resolve(route)
+  return sanitizeResolvedPath(ctx.router.resolve(route))
 }
 
 /**

--- a/src/runtime/routing/routing.ts
+++ b/src/runtime/routing/routing.ts
@@ -63,9 +63,13 @@ function normalizeRawLocation(route: RouteLocationRaw): RouteLike {
  * `path` as a fresh location string, so a literal '#' or '?' left over from decoding is
  * read as an actual fragment/query delimiter instead of path text, silently truncating
  * the path — `query`/`hash` are unaffected, populated separately and not re-parsed.
- * Only `path` (and the `fullPath` built from it) needs the fix; re-escape both.
+ * Only `path` (and the `fullPath`/`href` strings built from it) need the fix; re-escape
+ * both characters and recompute `href` the same way vue-router derives it from `fullPath`.
  */
-function sanitizeResolvedPath<T extends { path: string, fullPath: string }>(resolved: T): T {
+function sanitizeResolvedPath<T extends { path: string, fullPath: string, href?: string }>(
+  ctx: RoutingContext,
+  resolved: T,
+): T {
   if (!/[#?]/.test(resolved.path)) {
     return resolved
   }
@@ -73,6 +77,9 @@ function sanitizeResolvedPath<T extends { path: string, fullPath: string }>(reso
   const suffix = resolved.fullPath.slice(resolved.path.length)
   resolved.path = resolved.path.replace(/#/g, '%23').replace(/\?/g, '%3F')
   resolved.fullPath = resolved.path + suffix
+  if (resolved.href !== undefined) {
+    resolved.href = ctx.router.options.history.createHref(resolved.fullPath)
+  }
   return resolved
 }
 
@@ -83,11 +90,11 @@ function resolveRoute(ctx: RoutingContext, route: RouteLocationRaw, locale: Loca
   const normalized = normalizeRawLocation(route)
   const resolved = ctx.router.resolve(ctx.resolveLocalizedRouteObject(normalized, locale))
   if (resolved.name) {
-    return sanitizeResolvedPath(resolved)
+    return sanitizeResolvedPath(ctx, resolved)
   }
 
   // if unable to resolve route try resolving route based on original input
-  return sanitizeResolvedPath(ctx.router.resolve(route))
+  return sanitizeResolvedPath(ctx, ctx.router.resolve(route))
 }
 
 /**

--- a/test/kit.test.ts
+++ b/test/kit.test.ts
@@ -162,6 +162,13 @@ describe.each(STRATEGIES)('routing context (strategy: %s)', strategy => {
       normalizesEncoding ? pp('/path/as a test?foo=bar+sentence') : pp('/path/as%20a%20test?foo=bar+sentence')
     )
 
+    // (#4098) '#' and '?' must stay escaped even when normalizesEncoding decodes the
+    // rest of the path — left literal, they'd be misread as an actual fragment/query
+    // delimiter by the second `router.resolve()` call in `resolveRoute`, truncating the path
+    expect(localePath('/path/as%20a%20test%23one?foo=bar')).toEqual(
+      normalizesEncoding ? pp('/path/as a test%23one?foo=bar') : pp('/path/as%20a%20test%23one?foo=bar')
+    )
+
     // preserve hash
     expect(localePath({ path: '/about', hash: '#foo=bar' })).toEqual(pp('/about#foo=bar'))
 

--- a/test/kit.test.ts
+++ b/test/kit.test.ts
@@ -168,6 +168,11 @@ describe.each(STRATEGIES)('routing context (strategy: %s)', strategy => {
     expect(localePath('/path/as%20a%20test%23one?foo=bar')).toEqual(
       normalizesEncoding ? pp('/path/as a test%23one?foo=bar') : pp('/path/as%20a%20test%23one?foo=bar')
     )
+    // same for an encoded '?' within the path itself, distinct from the real '?foo=bar'
+    // query delimiter that follows it — only the former must stay percent-encoded
+    expect(localePath('/path/as%20a%20test%3Fone?foo=bar')).toEqual(
+      normalizesEncoding ? pp('/path/as a test%3Fone?foo=bar') : pp('/path/as%20a%20test%3Fone?foo=bar')
+    )
 
     // preserve hash
     expect(localePath({ path: '/about', hash: '#foo=bar' })).toEqual(pp('/about#foo=bar'))
@@ -246,6 +251,15 @@ describe.each(STRATEGIES)('routing context (strategy: %s)', strategy => {
 
     // undefined name
     expect(localeRoute('vue-i18n', 'ja')).toBeUndefined()
+
+    // (#4098) href must reflect the same '#'/'?' escaping fix as fullPath/path — true for
+    // every strategy: normalizesEncoding strategies re-escape it after decoding, the others
+    // never decoded it in the first place
+    expect(localeRoute('/blog%23one', 'ja')).toMatchObject({
+      fullPath: pp('/blog%23one', 'ja'),
+      href: pp('/blog%23one', 'ja'),
+      name: rn('pathMatch', 'ja')
+    })
   })
 
   test('switchLocalePath', async () => {


### PR DESCRIPTION
Resolves #4098

## Summary

`resolveRoute()` (used by `localePath`, `localeRoute`, and `switchLocalePath`) resolves an already-resolved route object a second time to attach the localized route name (`ctx.router.resolve(ctx.resolveLocalizedRouteObject(normalized, locale))`). For the `prefix_except_default`/`prefix_and_default` strategies, `resolveLocalizedRouteObject`'s path-based branch has already gone through one `router.resolve()` call (`createLocalizedRouteByPathResolver`), which decodes percent-encoded characters — kept intentionally, for readable URLs (`%20` → literal space, already covered by an existing test in `test/kit.test.ts`).

The second `router.resolve()` call re-parses that decoded `path` as a fresh location string. A literal `#` or `?` left over from decoding is read as an actual fragment/query delimiter rather than path text — confirmed directly against vue-router alone, no i18n module involved:

```ts
const router = createRouter({ history: createMemoryHistory(), routes: [{ path: '/blog/:slug(.*)*', name: 'blog', component: {} }] })
const first = router.resolve('/blog/my%20post%20%231')
console.log(first.fullPath)                  // /blog/my%20post%20%231  (correct)
console.log(router.resolve(first).fullPath)  // /blog/my post #1        (decoded, '#' now a literal fragment delimiter)
```

`query`/`hash` are populated separately during resolution and are unaffected by this — verified they stay structurally correct (`{"foo":"bar"}`, not swallowed into the corrupted path) even while `path`/`fullPath` are wrong. Any caller that uses the `localePath()`/`switchLocalePath()` output directly as a navigation target — `navigateTo(...)` (SSR redirects), `router.replace({ path })`, `<NuxtLink :to>` — ends up navigating to a silently truncated path with a bogus fragment attached.

This is the same underlying double-resolve pattern #4079 fixed for `switchLocalePath`'s `routeCopy` (by omitting `path` so the second resolve takes the name+params branch, which does correctly re-encode via `encodeParam`). That approach doesn't work here without regressing the "readable URL" behavior `test/kit.test.ts` already covers (`localePath('/path/as%20a%20test...')` decoding to `/path/as a test...`) — using name+params always fully re-encodes via `encodeURI`, including turning spaces into `%20`. So rather than avoiding the second resolve, this re-escapes only the two characters that are genuinely unsafe to leave literal in a path string (`#` → `%23`, `?` → `%3F`) on the already-resolved object, after both resolves, right before the caller gets it.

## Fix

Added `sanitizeResolvedPath()` in `src/runtime/routing/routing.ts`, applied at both return points of `resolveRoute()` (the shared function `localePath`/`localeRoute`/`switchLocalePath` all funnel through). No-ops when `path` doesn't contain `#`/`?` (the common case).

## Test plan

- [x] Added a regression case to the existing `localePath` test in `test/kit.test.ts`, covering all four strategies, alongside the existing "readable URL" assertion it must not regress
- [x] `pnpm lint` — clean
- [x] `tsc --noEmit` — clean
- [x] `pnpm test:unit` — 407 passed, 1 skipped (unchanged from main + the 1 new assertion)
- [x] `pnpm build` — clean
- [x] `pnpm test:e2e` — 201 passed (33 files)

`pnpm test:types`'s `specs/fixtures/typed_routes` sub-check fails in my local sandbox with unrelated `Cannot find module '#app'`/`__I18N_*__` errors — reproduces identically on a clean, unmodified `main` checkout (verified via `git stash`), so it's a pre-existing local environment issue, not something this change introduces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed localized route resolution to keep percent-encoded reserved delimiters inside path segments (including `%23` and `%3F`) from being treated as fragment/query separators on subsequent resolutions.
  * Ensured `fullPath`/`href` are correctly recomputed to preserve the expected escaping behavior.
* **Tests**
  * Added regression tests verifying `%23` and `%3F` remain encoded for both path-based and route-based localization resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->