### PR TITLE
feat: add multiDomainLocales: { isolate: true } for regional brand domains

### DIFF
--- a/docs/content/docs/02.guide/10.multi-domain-locales.md
+++ b/docs/content/docs/02.guide/10.multi-domain-locales.md
@@ -223,6 +223,38 @@ Locales served on other domains stay available in `locales` and in the locale sw
 
 A request on a host that doesn't match any configured domain, such as a staging domain or a health check by IP, isn't restricted. Every locale is served there and `defaultLocale` is used as the unprefixed default, so it's worth setting even when every domain has its own default through `defaultForDomains`. Redirects on such a host stay relative, they never send a visitor to one of the configured domains.
 
+## Isolating domains with their own regional brand name
+
+The behavior above assumes every domain is the same brand shown in a different language, so a locale not served on the current domain still belongs to the same site and is worth redirecting to and worth linking to from the switcher. Some products are sold under a different brand name per market instead, on the same build, without sharing a single public identity. Each domain should feel like its own self-contained site for that market's brand name rather than a variant of another domain's. Set `multiDomainLocales` to `{ isolate: true }`{lang="ts"} for this case:
+
+- A locale-prefixed path not served on the current domain 404s instead of being redirected to the domain that serves it.
+- The locale switcher and hreflang/canonical alternates only list locales served on the current domain.
+- Browser-language detection never crosses domains either. A first visit whose detected language belongs to another domain stays on the current domain in its own locale, and a `detectBrowserLanguage.cookieDomain` spanning the domains no longer follows the cookie across them.
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  i18n: {
+    locales: [
+      {
+        code: 'en',
+        domains: ['brand-a.com'],
+        defaultForDomains: ['brand-a.com']
+      },
+      {
+        code: 'fr',
+        domains: ['brand-b.com'],
+        defaultForDomains: ['brand-b.com']
+      }
+    ],
+    defaultLocale: 'en',
+    strategy: 'prefix_except_default',
+    multiDomainLocales: { isolate: true }
+  }
+})
+```
+
+Given the above configuration, `https://brand-a.com/fr` 404s rather than redirecting to `brand-b.com`, and `brand-a.com`'s switcher and hreflang alternates only mention `en`. A host matching no configured domain is unaffected by `isolate`. It still serves every locale, per the staging/health-check exception described above.
+
 ## `defaultLocale` and `x-default`
 
 The domains are annotated as one cluster, each page links to its alternates on the other domains. A cluster has a single fallback for unmatched languages, so the `x-default` alternate is taken from `defaultLocale` rather than from the locale a domain happens to default to - otherwise every domain would name a different one.

--- a/docs/content/docs/04.api/00.options.md
+++ b/docs/content/docs/04.api/00.options.md
@@ -350,10 +350,12 @@ Set this to `true`{lang="ts"} when using different domains for each locale, with
 
 ## multiDomainLocales
 
-- type: `boolean`{lang="ts-type"}
+- type: `boolean | { isolate?: boolean }`{lang="ts-type"}
 - default: `false`{lang="ts"}
 
 Set this to `true` when using different domains with different locales. If enabled, you MUST configure locales as an array of objects, each containing a `domains` and `defaultForDomains` key. Refer to the [Multi Domain Locales](/docs/guide/multi-domain-locales) for more information.
+
+Pass `{ isolate: true }` instead of `true` when each domain has its own regional brand name for the same product: a locale not served on the current domain 404s instead of being cross-domain redirected there, and the locale switcher/hreflang alternates only include locales served on the current domain. See [Isolating domains with their own regional brand name](/docs/guide/multi-domain-locales#isolating-domains-with-their-own-regional-brand-name).
 
 ## compilation
 

--- a/specs/fixtures/multi_domains_locales/pages/index.vue
+++ b/specs/fixtures/multi_domains_locales/pages/index.vue
@@ -2,7 +2,7 @@
 import { useHead } from '#imports'
 import { useI18n, useLocalePath, useLocaleHead } from '#i18n'
 
-const { t, locale } = useI18n()
+const { t, locale, localeCodes, getBrowserLocale, getLocaleCookie } = useI18n()
 const localePath = useLocalePath()
 const i18nHead = useLocaleHead({ seo: { canonicalQueries: ['page'] } })
 
@@ -30,6 +30,13 @@ useHead(() => ({
     </section>
     <section>
       <code id="extend-message">{{ t('my-module-exemple.hello') }}</code>
+    </section>
+    <section>
+      <code id="locale-codes">{{ localeCodes }}</code>
+    </section>
+    <section>
+      <code id="browser-locale">{{ getBrowserLocale() }}</code>
+      <code id="cookie-locale">{{ getLocaleCookie() }}</code>
     </section>
     <NuxtLink id="link-about" exact :to="localePath('about')">{{ $t('about') }}</NuxtLink>
     <NuxtLink id="link-blog" :to="localePath('blog')">{{ $t('blog') }}</NuxtLink>

--- a/specs/multi_domains_locales/multi_domains_locales_isolate.spec.ts
+++ b/specs/multi_domains_locales/multi_domains_locales_isolate.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, undiciRequest } from '../utils'
+import { getDom, getDataFromDom } from '../helper'
+
+// `brand-a` and `brand-b` are the same product under two different regional brand names -
+// `isolate: true` keeps them from ever redirecting or cross-linking into each other's locale
+await setup({
+  rootDir: fileURLToPath(new URL(`../fixtures/multi_domains_locales`, import.meta.url)),
+  nuxtConfig: {
+    i18n: {
+      baseUrl: 'http://localhost:3000',
+      defaultLocale: 'en',
+      locales: [
+        {
+          code: 'en',
+          language: 'en',
+          name: 'English',
+          domains: ['brand-a.nuxt-app.localhost'],
+          defaultForDomains: ['brand-a.nuxt-app.localhost']
+        },
+        {
+          code: 'fr',
+          language: 'fr',
+          name: 'Français',
+          domains: ['brand-b.nuxt-app.localhost'],
+          defaultForDomains: ['brand-b.nuxt-app.localhost']
+        }
+      ],
+      multiDomainLocales: { isolate: true },
+      strategy: 'prefix_except_default',
+      detectBrowserLanguage: {
+        useCookie: true,
+        cookieDomain: '.nuxt-app.localhost'
+      }
+    }
+  }
+})
+
+test('a domain still serves and links its own locale normally', async () => {
+  const res = await undiciRequest('/', { headers: { Host: 'brand-a.nuxt-app.localhost' } })
+  expect(res.statusCode).toBe(200)
+  const dom = await getDom(await res.body.text())
+  expect(await dom.locator('#home-header').textContent()).toEqual('Homepage')
+})
+
+test('a locale not served on this domain 404s instead of relocating there', async () => {
+  const res = await undiciRequest('/fr', { headers: { Host: 'brand-a.nuxt-app.localhost' } })
+
+  expect(res.statusCode).toBe(404)
+  expect(res.headers.location).toBeUndefined()
+})
+
+test('a browser-detected off-host locale does not redirect off the current domain', async () => {
+  const res = await undiciRequest('/', {
+    headers: { Host: 'brand-a.nuxt-app.localhost', 'Accept-Language': 'fr' }
+  })
+
+  expect(res.statusCode).toBe(200)
+  expect(res.headers.location).toBeUndefined()
+  const dom = await getDom(await res.body.text())
+  expect(await dom.locator('#lang-switcher-current-locale code').textContent()).toEqual('en')
+})
+
+test('a cookie spanning the domains still keeps the other brand off-host', async () => {
+  // without isolate, a `cookieDomain` spanning both domains would follow this cookie to brand-b
+  const res = await undiciRequest('/', {
+    headers: { Host: 'brand-a.nuxt-app.localhost', Cookie: 'i18n_redirected=fr' }
+  })
+
+  expect(res.statusCode).toBe(200)
+  const dom = await getDom(await res.body.text())
+  expect(await dom.locator('#lang-switcher-current-locale code').textContent()).toEqual('en')
+})
+
+test('the switcher only lists the locale served on this domain', async () => {
+  const res = await undiciRequest('/', { headers: { Host: 'brand-a.nuxt-app.localhost' } })
+  const dom = await getDom(await res.body.text())
+
+  expect(await dom.locator('#switch-locale-path-usages .switch-to-en').count()).toBe(1)
+  expect(await dom.locator('#switch-locale-path-usages .switch-to-fr').count()).toBe(0)
+})
+
+test('hreflang alternates only list the locale served on this domain', async () => {
+  const res = await undiciRequest('/', { headers: { Host: 'brand-a.nuxt-app.localhost' } })
+  const dom = await getDom(await res.body.text())
+  const localeHead = await getDataFromDom(dom, '#home-use-locale-head')
+
+  const hreflangs = (localeHead.link as { rel: string; hreflang?: string }[])
+    .filter(l => l.rel === 'alternate' && l.hreflang)
+    .map(l => l.hreflang)
+  expect(hreflangs).not.toContain('fr')
+})
+
+test('the other brand serves and links its own locale the same way', async () => {
+  const res = await undiciRequest('/', { headers: { Host: 'brand-b.nuxt-app.localhost' } })
+  expect(res.statusCode).toBe(200)
+  const dom = await getDom(await res.body.text())
+
+  expect(await dom.locator('#home-header').textContent()).toEqual('Accueil')
+  expect(await dom.locator('#switch-locale-path-usages .switch-to-fr').count()).toBe(1)
+  expect(await dom.locator('#switch-locale-path-usages .switch-to-en').count()).toBe(0)
+})
+
+test('a path for the other brand 404s there too', async () => {
+  const res = await undiciRequest('/en', { headers: { Host: 'brand-b.nuxt-app.localhost' } })
+
+  expect(res.statusCode).toBe(404)
+  expect(res.headers.location).toBeUndefined()
+})

--- a/specs/multi_domains_locales/multi_domains_locales_isolate.spec.ts
+++ b/specs/multi_domains_locales/multi_domains_locales_isolate.spec.ts
@@ -62,6 +62,15 @@ test('a browser-detected off-host locale does not redirect off the current domai
   expect(await dom.locator('#lang-switcher-current-locale code').textContent()).toEqual('en')
 })
 
+test('getBrowserLocale does not report a locale pruned off this domain', async () => {
+  const res = await undiciRequest('/', {
+    headers: { Host: 'brand-a.nuxt-app.localhost', 'Accept-Language': 'fr' }
+  })
+
+  const dom = await getDom(await res.body.text())
+  expect(await dom.locator('#browser-locale').textContent()).toEqual('')
+})
+
 test('a cookie spanning the domains still keeps the other brand off-host', async () => {
   // without isolate, a `cookieDomain` spanning both domains would follow this cookie to brand-b
   const res = await undiciRequest('/', {
@@ -73,12 +82,28 @@ test('a cookie spanning the domains still keeps the other brand off-host', async
   expect(await dom.locator('#lang-switcher-current-locale code').textContent()).toEqual('en')
 })
 
+test('getLocaleCookie does not report a locale pruned off this domain', async () => {
+  const res = await undiciRequest('/', {
+    headers: { Host: 'brand-a.nuxt-app.localhost', Cookie: 'i18n_redirected=fr' }
+  })
+
+  const dom = await getDom(await res.body.text())
+  expect(await dom.locator('#cookie-locale').textContent()).toEqual('')
+})
+
 test('the switcher only lists the locale served on this domain', async () => {
   const res = await undiciRequest('/', { headers: { Host: 'brand-a.nuxt-app.localhost' } })
   const dom = await getDom(await res.body.text())
 
   expect(await dom.locator('#switch-locale-path-usages .switch-to-en').count()).toBe(1)
   expect(await dom.locator('#switch-locale-path-usages .switch-to-fr').count()).toBe(0)
+})
+
+test('composer.localeCodes excludes the locale pruned off this domain', async () => {
+  const res = await undiciRequest('/', { headers: { Host: 'brand-a.nuxt-app.localhost' } })
+  const dom = await getDom(await res.body.text())
+
+  expect(JSON.parse(await dom.locator('#locale-codes').textContent())).toEqual(['en'])
 })
 
 test('hreflang alternates only list the locale served on this domain', async () => {

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -109,7 +109,10 @@ export function getDefineConfig(
     __SWITCH_LOCALE_PATH_LINK_IDENTIFIER__: JSON.stringify(SWITCH_LOCALE_PATH_LINK_IDENTIFIER),
     __I18N_STRATEGY__: JSON.stringify(options.strategy),
     // gate for domain-based locale resolution
-    __I18N_DOMAINS__: String(options.differentDomains || options.multiDomainLocales),
+    __I18N_DOMAINS__: String(!!(options.differentDomains || options.multiDomainLocales)),
+    __I18N_ISOLATE_MULTIDOMAINLOCALES__: String(
+      typeof options.multiDomainLocales === 'object' && !!options.multiDomainLocales.isolate,
+    ),
     __ROUTE_NAME_SEPARATOR__: JSON.stringify(options.routesNameSeparator),
     __ROUTE_NAME_DEFAULT_SUFFIX__: JSON.stringify(options.defaultLocaleRouteNameSuffix),
     __TRAILING_SLASH__: String(options.trailingSlash),

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -9,6 +9,8 @@ declare let __IS_SSR__: boolean
 declare let __TRAILING_SLASH__: boolean
 declare let __PARALLEL_PLUGIN__: boolean
 declare let __I18N_DOMAINS__: boolean
+/** `multiDomainLocales: { isolate: true }` blocks cross-domain relocation and prunes off-host routes and locales */
+declare let __I18N_ISOLATE_MULTIDOMAINLOCALES__: boolean
 
 declare let __DYNAMIC_PARAMS_KEY__: string
 declare let __DEFAULT_COOKIE_KEY__: string

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -112,6 +112,7 @@ export const disabledPaths = ${JSON.stringify(routeResources.disabledPaths, null
         locales: normalizedLocales,
         optionsResolver: resolver,
         compactRoutes: !!options.experimental?.compactRoutes,
+        multiDomainLocales: !!options.multiDomainLocales,
         onLocalize: resources.collect,
       }
 

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -77,7 +77,10 @@ export default defineNuxtPlugin({
           const normalized = locales.map(normalizeLocale)
           return locales.filter((_, i) => isLocaleServedOnHost(normalized, host, normalized[i]!.code))
         })
-        composer.localeCodes = computed(() => localeCodes)
+        composer.localeCodes = computed(() => {
+          if (!__I18N_ISOLATE_MULTIDOMAINLOCALES__) { return localeCodes }
+          return composer.locales.value.map(l => normalizeLocale(l).code)
+        })
 
         const _baseUrl = ref(ctx.getBaseUrl())
         composer.baseUrl = computed(() => _baseUrl.value)
@@ -103,12 +106,21 @@ export default defineNuxtPlugin({
         composer.differentDomains = __I18N_DOMAINS__
         composer.defaultLocale = optionsI18n.defaultLocale
 
+        // `resolveSupportedLocale` only checks the locale is configured at all, under isolate a
+        // locale off this host is still "supported" globally, so it needs its own host gate
+        const resolveOnHostLocale = (locale: string | undefined) => {
+          const resolved = resolveSupportedLocale(locale)
+          return resolved && __I18N_ISOLATE_MULTIDOMAINLOCALES__ && !composer.localeCodes.value.includes(resolved)
+            ? undefined
+            : resolved
+        }
+
         composer.getBrowserLocale = () =>
           import.meta.client
-            ? resolveSupportedLocale(detectors.navigator())
-            : resolveSupportedLocale(detectors.header())
+            ? resolveOnHostLocale(detectors.navigator())
+            : resolveOnHostLocale(detectors.header())
 
-        composer.getLocaleCookie = () => resolveSupportedLocale(detectors.cookie())
+        composer.getLocaleCookie = () => resolveOnHostLocale(detectors.cookie())
         composer.setLocaleCookie = ctx.setCookieLocale
 
         composer.finalizePendingLocaleChange = async () => {

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -12,11 +12,15 @@ import { setupVueI18nOptions } from '../shared/vue-i18n'
 import { type NuxtI18nContext, createNuxtI18nContext, isPrerenderable, useLocaleConfigs } from '../context'
 import { useI18nDetection, useRuntimeI18n } from '../shared/utils'
 import { useDetectors } from '../shared/detection'
-import { setupMultiDomainLocales } from '../routing/domain'
-import { withRuntimeDomain } from '../shared/domain'
+import { pruneOffHostRoutes, setupMultiDomainLocales } from '../routing/domain'
+import { isLocaleServedOnHost, withRuntimeDomain } from '../shared/domain'
 
 import type { Composer, TranslateOptions } from 'vue-i18n'
-import type { I18nHeadOptions } from '#internal-i18n-types'
+import type { I18nHeadOptions, NormalizedLocaleObject } from '#internal-i18n-types'
+
+// string locales carry no domain configuration, they normalize to the empty form (mirrors `getLocales` in `context.ts`)
+const normalizeLocale = (l: string | NormalizedLocaleObject): NormalizedLocaleObject =>
+  typeof l === 'string' ? { code: l, domains: [], defaultForDomains: [] } : l
 
 export default defineNuxtPlugin({
   name: 'i18n:plugin',
@@ -28,7 +32,8 @@ export default defineNuxtPlugin({
     const nuxt = useNuxtApp(_nuxt._id)
     const runtimeI18n = useRuntimeI18n(nuxt)
     const preloadedOptions = nuxt.ssrContext?.event?.context?.nuxtI18n?.vueI18nOptions
-    const _defaultLocale = resolveDefaultLocale(useRequestURL({ xForwardedHost: true }).host, runtimeI18n.defaultLocale)
+    const host = useRequestURL({ xForwardedHost: true }).host
+    const _defaultLocale = resolveDefaultLocale(host, runtimeI18n.defaultLocale)
     const optionsI18n = preloadedOptions || (await setupVueI18nOptions(_defaultLocale))
 
     const localeConfigs = useLocaleConfigs()
@@ -41,6 +46,9 @@ export default defineNuxtPlugin({
 
     if (__I18N_DOMAINS__) {
       setupMultiDomainLocales(optionsI18n.defaultLocale, __I18N_STRATEGY__)
+      if (__I18N_ISOLATE_MULTIDOMAINLOCALES__) {
+        pruneOffHostRoutes(runtimeI18n.locales.map(l => normalizeLocale(withRuntimeDomain(l, runtimeI18n.domainLocales))), host)
+      }
     }
 
     prerenderRoutes(
@@ -63,9 +71,12 @@ export default defineNuxtPlugin({
     // extend i18n instance
     extendI18n(i18n, {
       extendComposer(composer) {
-        composer.locales = computed(() =>
-          runtimeI18n.locales.map(locale => withRuntimeDomain(locale, runtimeI18n.domainLocales)),
-        )
+        composer.locales = computed(() => {
+          const locales = runtimeI18n.locales.map(locale => withRuntimeDomain(locale, runtimeI18n.domainLocales))
+          if (!__I18N_ISOLATE_MULTIDOMAINLOCALES__) { return locales }
+          const normalized = locales.map(normalizeLocale)
+          return locales.filter((_, i) => isLocaleServedOnHost(normalized, host, normalized[i]!.code))
+        })
         composer.localeCodes = computed(() => localeCodes)
 
         const _baseUrl = ref(ctx.getBaseUrl())

--- a/src/runtime/routing/domain.ts
+++ b/src/runtime/routing/domain.ts
@@ -1,7 +1,8 @@
 import type { Router } from 'vue-router'
-import type { Strategies } from '#internal-i18n-types'
+import type { NormalizedLocaleObject, Strategies } from '#internal-i18n-types'
 import { useRouter } from '#imports'
 import { defaultRouteNameSuffix, getLocaleFromRouteName } from '#i18n-kit/routing'
+import { isLocaleServedOnHost } from '../shared/domain'
 
 /**
  * Rebuilds the route table for the current domain from the `___default` variants generated for
@@ -34,6 +35,23 @@ export function setupMultiDomainLocales(defaultLocale: string, strategy: Strateg
 
     if (!keepsDefaultVariant && locale === defaultLocale) {
       router.addRoute({ ...route, path: route.path.replace(new RegExp(`^/${locale}/?`), '/') })
+    }
+  }
+}
+
+/**
+ * Removes every route whose locale isn't served on `host`. Kept separate from
+ * `setupMultiDomainLocales` since that only adjusts routes for the `*_default` strategies, and
+ * this has to run for every strategy. Used by `multiDomainLocales: { isolate: true }`: an off-host
+ * route becomes unmatchable, so both the initial SSR request and any later client-side navigation
+ * to it resolve as a 404 instead of ever being reachable on this host.
+ */
+export function pruneOffHostRoutes(locales: NormalizedLocaleObject[], host: string, router: Router = useRouter()) {
+  for (const route of router.getRoutes()) {
+    const routeName = String(route.name)
+    const locale = getLocaleFromRouteName(routeName)
+    if (locale && !isLocaleServedOnHost(locales, host, locale)) {
+      router.removeRoute(routeName)
     }
   }
 }

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -79,6 +79,7 @@ export default defineNitroPlugin(async (nitro) => {
     strategy: __I18N_STRATEGY__,
     routing: __I18N_ROUTING__,
     domains: __I18N_DOMAINS__,
+    isolate: __I18N_ISOLATE_MULTIDOMAINLOCALES__,
   })
 
   /**
@@ -128,7 +129,7 @@ export default defineNitroPlugin(async (nitro) => {
       pathLocale,
       ctx.vueI18nOptions!.defaultLocale,
       detector,
-      __I18N_DOMAINS__ ? locale => resolveRelocation(event, locale, path) : undefined,
+      __I18N_DOMAINS__ && !__I18N_ISOLATE_MULTIDOMAINLOCALES__ ? locale => resolveRelocation(event, locale, path) : undefined,
     )
     if (resolved.path && (resolved.origin || resolved.path !== pathname)) {
       ctx.detectLocale = resolved.locale

--- a/src/runtime/server/utils/redirect.ts
+++ b/src/runtime/server/utils/redirect.ts
@@ -21,15 +21,17 @@ export type RedirectResolverConfig = {
   routing: boolean
   /** Whether locales are resolved from domains */
   domains: boolean
+  /** `multiDomainLocales: { isolate: true }`, forwarded to `createLocaleDetector` */
+  isolate?: boolean
 }
 
 /** `origin` is set when the redirect moves to another domain, a relative redirect otherwise */
 export type ResolvedRedirect = { path: string | undefined, code: number, locale: string, origin?: string }
 
 export function createRedirectResolver(config: RedirectResolverConfig) {
-  const { detection, rootRedirect, matchLocalized, strategy, routing, domains } = config
+  const { detection, rootRedirect, matchLocalized, strategy, routing, domains, isolate } = config
   const isSupported = config.isSupportedLocale ?? isSupportedLocale
-  const detectLocale = createLocaleDetector({ detection, isSupportedLocale: isSupported, routing, domains })
+  const detectLocale = createLocaleDetector({ detection, isSupportedLocale: isSupported, routing, domains, isolate })
 
   /**
    * Resolves the redirect for a request, `fullPath` may contain a query string while
@@ -45,8 +47,9 @@ export function createRedirectResolver(config: RedirectResolverConfig) {
     relocate?: (locale: string) => ResolvedRedirect | undefined,
   ): ResolvedRedirect {
     // a path locale restricted to other domains moves to a domain serving it before detection
-    // gets to strip the prefix and keep the request here in another locale
-    if (routing && domains && pathLocale && !detectors.onHost(pathLocale)) {
+    // gets to strip the prefix and keep the request here in another locale. Isolated domains
+    // never relocate, an unmatchable route 404s instead (see `pruneOffHostRoutes`)
+    if (routing && domains && !isolate && pathLocale && !detectors.onHost(pathLocale)) {
       const relocated = relocate?.(pathLocale)
       if (relocated) { return relocated }
     }
@@ -94,7 +97,7 @@ export function createRedirectResolver(config: RedirectResolverConfig) {
 
     // a detected locale served by another domain redirects there directly, shaped for that
     // domain's default locale, instead of localizing here and relocating again
-    if (domains && !detectors.onHost(locale)) {
+    if (domains && !isolate && !detectors.onHost(locale)) {
       const relocated = relocate?.(locale)
       if (relocated) { return relocated }
     }

--- a/src/runtime/shared/detection.ts
+++ b/src/runtime/shared/detection.ts
@@ -86,10 +86,12 @@ export type LocaleDetectorConfig = {
   routing: boolean
   /** Whether locales are resolved from domains */
   domains: boolean
+  /** `multiDomainLocales: { isolate: true }` never lets an external arrival's cookie or browser signal cross to another domain's locale */
+  isolate?: boolean
 }
 
 export function createLocaleDetector(config: LocaleDetectorConfig) {
-  const { detection, routing, domains } = config
+  const { detection, routing, domains, isolate } = config
   const isSupported = config.isSupportedLocale ?? isSupportedLocale
 
   /**
@@ -133,7 +135,7 @@ export function createLocaleDetector(config: LocaleDetectorConfig) {
         // only an external arrival may follow a source off-host (an internal one already chose
         // its destination), and only sources reading the same on every domain - per-host cookies
         // can disagree and would have two hosts redirect at each other indefinitely
-        const external = domains && !detectors.fromOwnDomain()
+        const external = domains && !isolate && !detectors.fromOwnDomain()
         const cookie = external && detectors.cookieSpans() ? pass : onHost
         const browser = external ? pass : onHost
         yield cookie(detectors.cookie())

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -46,6 +46,7 @@ export function detectLocale(nuxtApp: NuxtApp, route: string | CompatRoute): str
     detection: detectConfig,
     routing: __I18N_ROUTING__,
     domains: __I18N_DOMAINS__,
+    isolate: __I18N_ISOLATE_MULTIDOMAINLOCALES__,
   })
 
   return detect(detectors, route, ctx.initial) || ctx.getLocale() || ctx.getDefaultLocale() || ''
@@ -59,7 +60,7 @@ export function navigate(nuxtApp: NuxtApp, to: CompatRoute, locale: string) {
   const detectors = useDetectors(useRequestEvent(), useI18nDetection(nuxtApp), nuxtApp)
   const host = __I18N_DOMAINS__ ? useRequestURL({ xForwardedHost: true }).host : ''
   const resolve = createNavigationResolver({
-    localeReach: __I18N_DOMAINS__
+    localeReach: __I18N_DOMAINS__ && !__I18N_ISOLATE_MULTIDOMAINLOCALES__
       ? locale => resolveLocaleReach(_ctx.getLocales(), host, locale)
       : undefined,
     rootRedirect: ctx.rootRedirect,

--- a/src/types.ts
+++ b/src/types.ts
@@ -297,9 +297,14 @@ export type NuxtI18nOptions<
    * Enable when using different domains with different locales
    *
    * If enabled, `locales` must be configured as an array of `LocaleObject` objects with the `domains` and `defaultForDomains` property set.
+   *
+   * Set to `{ isolate: true }` when each domain sells the same product under its own regional
+   * brand name rather than one brand serving every region under the same name: a locale not
+   * served on the current domain 404s instead of being cross-domain redirected there, and the
+   * locale switcher/hreflang alternates only include locales served on the current domain.
    * @default false
    */
-  multiDomainLocales?: boolean
+  multiDomainLocales?: boolean | { isolate?: boolean }
   /**
    * Enables browser language detection to automatically redirect visitors to their preferred locale as they visit your site for the first time.
    *

--- a/test/detection.test.ts
+++ b/test/detection.test.ts
@@ -118,6 +118,19 @@ describe('createLocaleDetector', () => {
     expect(detect(detectors({ cookie: () => 'en', host: () => 'fr', onHost, cookieSpans: () => true }), '/', true)).toBe('en')
   })
 
+  test('domains: isolate keeps a browser locale off-host even from an external arrival', () => {
+    const detect = createDetector({ domains: true, isolate: true })
+    const onHost = servedExcept('en')
+    expect(detect(detectors({ header: () => 'en', host: () => 'fr', onHost }), '/', true)).toBe('fr')
+    expect(detect(detectors({ navigator: () => 'en', host: () => 'fr', onHost }), '/', true)).toBe('fr')
+  })
+
+  test('domains: isolate keeps a spanning cookie locale off-host too', () => {
+    const detect = createDetector({ domains: true, isolate: true })
+    const onHost = servedExcept('en')
+    expect(detect(detectors({ cookie: () => 'en', host: () => 'fr', onHost, cookieSpans: () => true }), '/', true)).toBe('fr')
+  })
+
   test('domains: a `cookieDomain` not covering every domain keeps the cookie on-host', () => {
     // following it would bounce the visitor between hosts that cannot read each other's cookie
     const detect = createDetector({ domains: true, detection: detection({ cookieDomain: '.mysite.com' }) })

--- a/test/kit.test.ts
+++ b/test/kit.test.ts
@@ -10,7 +10,7 @@ import { ref, unref } from 'vue'
 import { buildNuxt, loadNuxt } from '@nuxt/kit'
 import { resolve } from 'pathe'
 import { localizeRoutes } from '../src/routing'
-import { setupMultiDomainLocales } from '../src/runtime/routing/domain'
+import { pruneOffHostRoutes, setupMultiDomainLocales } from '../src/runtime/routing/domain'
 import { createTestBaseUrls, getNormalizedLocales } from './pages/utils'
 import { resolveDefaultLocale } from '../src/runtime/shared/locales'
 import type { NuxtPage } from '@nuxt/schema'
@@ -479,5 +479,68 @@ describe('switchLocalePath with differentDomains', () => {
     expect(_switchLocalePath(ctx, 'no')).toBe('/no/about')
     // domain defaults of other hosts stay reachable through their prefixed paths
     expect(_switchLocalePath(ctx, 'fr')).toBe('/fr/about')
+  })
+})
+
+describe('pruneOffHostRoutes', () => {
+  function createIsolatedRouter(strategy: Strategies, locales = ISOLATE_LOCALES) {
+    const localized = localizeRoutes([{ path: '/about', name: 'about' }] as LocalizableRoute[], {
+      ...routingOptions,
+      strategy,
+      defaultLocale: 'en',
+      differentDomains: false,
+      multiDomainLocales: true,
+      locales
+    })
+    const router = createRouter({ routes: localized as any, history: createMemoryHistory() })
+    setupMultiDomainLocales('en', strategy, router)
+    return router
+  }
+
+  const ISOLATE_LOCALES = getNormalizedLocales([
+    { code: 'en', language: 'en', domains: ['en.example.com'], defaultForDomains: ['en.example.com'] },
+    { code: 'fr', language: 'fr', domains: ['fr.example.com'], defaultForDomains: ['fr.example.com'] }
+  ])
+
+  test('removes routes for a locale restricted to another domain', () => {
+    const router = createIsolatedRouter('prefix_except_default')
+    pruneOffHostRoutes(ISOLATE_LOCALES, 'en.example.com', router)
+
+    const names = router.getRoutes().map(x => String(x.name))
+    expect(names).toContain('about___en')
+    expect(names).not.toContain('about___fr')
+  })
+
+  test('runs for every strategy, not only the `*_default` ones', () => {
+    const router = createIsolatedRouter('prefix')
+    pruneOffHostRoutes(ISOLATE_LOCALES, 'en.example.com', router)
+
+    const names = router.getRoutes().map(x => String(x.name))
+    expect(names).toContain('about___en')
+    expect(names).not.toContain('about___fr')
+  })
+
+  test('a host matching no configured domain keeps every locale', () => {
+    const router = createIsolatedRouter('prefix_except_default')
+    pruneOffHostRoutes(ISOLATE_LOCALES, 'staging.example.com', router)
+
+    const names = router.getRoutes().map(x => String(x.name))
+    expect(names).toContain('about___en')
+    expect(names).toContain('about___fr')
+  })
+
+  test('a locale configuring no domains is kept on every host', () => {
+    const locales = getNormalizedLocales([
+      { code: 'en', language: 'en', domains: ['en.example.com'], defaultForDomains: ['en.example.com'] },
+      { code: 'fr', language: 'fr', domains: ['fr.example.com'], defaultForDomains: ['fr.example.com'] },
+      { code: 'de', language: 'de' }
+    ])
+    const router = createIsolatedRouter('prefix_except_default', locales)
+    pruneOffHostRoutes(locales, 'en.example.com', router)
+
+    const names = router.getRoutes().map(x => String(x.name))
+    expect(names).toContain('about___en')
+    expect(names).not.toContain('about___fr')
+    expect(names).toContain('about___de')
   })
 })

--- a/test/redirect.test.ts
+++ b/test/redirect.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { createRedirectResolver } from '../src/runtime/server/utils/redirect'
 import { resolveRootRedirect } from '../src/runtime/shared/utils'
 import { getLocaleFromRoutePath } from '../src/runtime/kit/routing'
@@ -223,6 +223,37 @@ describe('createRedirectResolver', () => {
         locale: 'fr',
         origin: 'http://fr.example.com',
       })
+    })
+
+    test('isolate: a path locale served on another domain never relocates', () => {
+      const resolve = createResolver({
+        strategy: 'prefix_except_default',
+        domains: true,
+        isolate: true,
+        detection: detection({ enabled: true, redirectOn: 'root' }),
+      })
+      const offHost = createDetectors({ host: () => 'en', onHost: l => (l === 'fr' ? undefined : l) })
+      const relocateSpy = vi.fn(relocate)
+      expect(resolve('/fr/about', '/about', 'fr', 'en', offHost, relocateSpy)).toMatchObject({ path: undefined, locale: 'en' })
+      expect(relocateSpy).not.toHaveBeenCalled()
+    })
+
+    test('isolate: a detected locale served on another domain never relocates either', () => {
+      const resolve = createResolver({
+        strategy: 'prefix_except_default',
+        domains: true,
+        isolate: true,
+        detection: detection({ enabled: true, redirectOn: 'root' }),
+      })
+      const offHost = createDetectors({
+        cookie: () => 'fr',
+        host: () => 'en',
+        onHost: l => (l === 'fr' ? undefined : l),
+        cookieSpans: () => true,
+      })
+      const relocateSpy = vi.fn(relocate)
+      expect(resolve('/', '/', undefined, 'en', offHost, relocateSpy)).toMatchObject({ path: undefined, locale: 'en' })
+      expect(relocateSpy).not.toHaveBeenCalled()
     })
 
     test('a failed relocation falls back to resolving on the current host', () => {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -9,6 +9,7 @@ vi.stubGlobal('__PARALLEL_PLUGIN__', false)
 
 vi.stubGlobal('__TRAILING_SLASH__', false)
 vi.stubGlobal('__I18N_DOMAINS__', false)
+vi.stubGlobal('__I18N_ISOLATE_MULTIDOMAINLOCALES__', false)
 
 vi.stubGlobal('__ROUTE_NAME_SEPARATOR__', '___')
 vi.stubGlobal('__ROUTE_NAME_DEFAULT_SUFFIX__', 'default')


### PR DESCRIPTION
## Summary
Adds `multiDomainLocales: { isolate: true }` for the case where each domain sells the same product under its own regional brand rather than one brand serving every region. Each domain should
  behave like a fully self-contained site. It should never redirect to or link into another domain's locale.

  With `isolate: true`:
  - A locale-prefixed path not served on the current domain **404s** instead of being redirected to the domain that serves it.
  - The locale switcher and hreflang/canonical alternates **only list locales served on the current domain**.
  - Browser-language detection and a `detectBrowserLanguage.cookieDomain` spanning multiple domains **never cross domains**. A first visit detected as another domain's locale stays on the current
  domain in its own locale instead of relocating.
  - A host matching no configured domain (staging, health checks) is unaffected. It still serves every locale, per the existing non-isolated fallback.

@BobbieGoede, feel free to accept this or not, and make any changes you see fit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added isolated multi-domain locale support with `multiDomainLocales: { isolate: true }`.
  * Unsupported locale paths now return 404 instead of redirecting to another domain.
  * Locale switchers and SEO alternate links show only locales available on the current domain.
  * Browser-language detection and locale cookies remain within the current domain.

* **Documentation**
  * Updated configuration and guide documentation with isolation behavior and usage details.

* **Tests**
  * Added coverage for domain-specific routing, detection, redirects, and SEO locale links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## ~~Summary~~
- ~~Add `multiDomainLocales: { isolate: true }` for hosting genuinely unrelated brands on one shared build. A locale not served on the current domain now 404s instead of redirecting cross-domain, and the locale switcher and hreflang alternates only list locales actually served on the current domain.~~
- ~~Revert part of upstream #4083, which made `detectBrowserLanguage` unconditionally stay within the current domain for every domain setup. That's the right call for `{ isolate: true }`, since unrelated brands must never reveal a connection, but it was wrong for plain `multiDomainLocales`/`differentDomains`. The entire point of `differentDomains` is one product spanning several regional domains, so a detected locale should be able to send a visitor to the domain that actually serves it, exactly like an explicit locale-prefixed path already does. #4083's actual bug was narrower than that: an adopted off-host locale built a broken path on the current domain instead of relocating anywhere. This restores the intended cross-domain behavior for `differentDomains` and plain `multiDomainLocales` without reintroducing that original bug, and keeps `{ isolate: true }` exactly as strict as before.~~ 

This is an older summary from before I force-pushed the changes. I’m just keeping it here for reference.