### PR TITLE
fix(domain): resolve the current origin from the host

### DIFF
--- a/docs/content/docs/02.guide/10.multi-domain-locales.md
+++ b/docs/content/docs/02.guide/10.multi-domain-locales.md
@@ -214,7 +214,7 @@ Given the above configuration, following requests will be:
 
 Locales served on other domains stay available in `locales` and in the locale switcher, `switchLocalePath` links to them on the domain that serves them. Browser language detection only applies locales served on the current domain, so a visitor whose browser or cookie locale isn't available there keeps that domain's own locale.
 
-A request on a host that doesn't match any configured domain, such as a staging domain or a health check by IP, isn't restricted. Every locale is served there and `defaultLocale` is used as the unprefixed default, so it's worth setting even when every domain has its own default through `defaultForDomains`.
+A request on a host that doesn't match any configured domain, such as a staging domain or a health check by IP, isn't restricted. Every locale is served there and `defaultLocale` is used as the unprefixed default, so it's worth setting even when every domain has its own default through `defaultForDomains`. Redirects on such a host stay relative, they never send a visitor to one of the configured domains.
 
 ## `defaultLocale` and `x-default`
 

--- a/specs/multi_domains_locales/multi_domains_locales_redirect_origin.spec.ts
+++ b/specs/multi_domains_locales/multi_domains_locales_redirect_origin.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, undiciRequest } from '../utils'
+
+// `brand-c` serves `ja` and `ko` but neither claims it through `defaultForDomains`, so the host
+// resolves the configured `defaultLocale` instead, which is served on `brand-a`. Redirect origins
+// are resolved from the host rather than that locale, otherwise the visitor leaves the domain
+// they asked for (reported in #4101)
+await setup({
+  rootDir: fileURLToPath(new URL(`../fixtures/multi_domains_locales`, import.meta.url)),
+  nuxtConfig: {
+    i18n: {
+      baseUrl: 'http://localhost:3000',
+      defaultLocale: 'en',
+      locales: [
+        {
+          code: 'en',
+          language: 'en',
+          name: 'English',
+          domains: ['brand-a.nuxt-app.localhost'],
+          defaultForDomains: ['brand-a.nuxt-app.localhost']
+        },
+        {
+          code: 'ja',
+          language: 'ja-JA',
+          name: 'Japan',
+          domains: ['brand-c.nuxt-app.localhost']
+        },
+        {
+          code: 'ko',
+          language: 'ko-KO',
+          name: 'Korea',
+          domains: ['brand-c.nuxt-app.localhost']
+        }
+      ],
+      multiDomainLocales: true,
+      strategy: 'prefix',
+      detectBrowserLanguage: {
+        useCookie: true
+      }
+    }
+  }
+})
+
+test('a host claiming no default locale keeps its own origin', async () => {
+  const res = await undiciRequest('/', { headers: { Host: 'brand-c.nuxt-app.localhost' } })
+
+  expect(res.statusCode).toBe(302)
+  expect(res.headers.location).toBe('http://brand-c.nuxt-app.localhost/en')
+})
+
+// the host still resolves a locale it does not serve, so following the redirect relocates once
+// more, `resolveDefaultLocale` picking a served locale is the open half of this (see #4101)
+test('the locale it lands on is still the cluster default, which relocates from there', async () => {
+  const res = await undiciRequest('/en', { headers: { Host: 'brand-c.nuxt-app.localhost' } })
+
+  expect(res.statusCode).toBe(302)
+  expect(res.headers.location).toBe('http://brand-a.nuxt-app.localhost/en')
+})
+
+test('a host claiming a default locale keeps resolving its own origin', async () => {
+  const res = await undiciRequest('/', { headers: { Host: 'brand-a.nuxt-app.localhost' } })
+
+  expect(res.statusCode).toBe(302)
+  expect(res.headers.location).toBe('http://brand-a.nuxt-app.localhost/en')
+})

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -6,7 +6,7 @@ import { cloneDeep, fillMissing, getLocaleMessagesMergedCached, warnMissedMessag
 import { createPrerenderablePredicate, createRuntimeLoaderPredicate } from './shared/delivery'
 import { createComposableContext } from './composable-context'
 import { getComposer, getI18nTarget } from './compatibility'
-import { domainFromLocale } from './shared/domain'
+import { domainForHost, domainFromLocale } from './shared/domain'
 import { isSupportedLocale } from './shared/locales'
 import { resolveRootRedirect, useI18nDetection, useRuntimeI18n } from './shared/utils'
 import { joinURL } from 'ufo'
@@ -70,13 +70,13 @@ export function createBaseUrlGetter(opts: {
   baseUrl: string | (() => string) | undefined
   appBase: string
   domains: boolean
-  defaultLocale: string
+  getDomainForHost: () => string | undefined
   getDomainFromLocale: (locale: string) => string | undefined
 }): (locale?: string) => string {
-  const { baseUrl, appBase, domains, defaultLocale, getDomainFromLocale } = opts
+  const { baseUrl, appBase, domains, getDomainForHost, getDomainFromLocale } = opts
   const base = isFunction(baseUrl)
     ? baseUrl
-    : () => (domains && defaultLocale && getDomainFromLocale(defaultLocale)) || baseUrl || ''
+    : () => (domains && getDomainForHost()) || baseUrl || ''
   return locale => joinURL((locale && getDomainFromLocale(locale)) || base(), appBase)
 }
 
@@ -162,7 +162,7 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
     baseUrl: isFunction(runtimeI18n.baseUrl) ? () => (runtimeI18n.baseUrl as BaseUrlResolveHandler<unknown>)(nuxt) : runtimeI18n.baseUrl,
     appBase: nuxt.$config.app.baseURL,
     domains: __I18N_DOMAINS__,
-    defaultLocale,
+    getDomainForHost: () => domainForHost(runtimeI18n.domainLocales, useRequestURL({ xForwardedHost: true })),
     getDomainFromLocale,
   })
   const resolvedLocale = useResolvedLocale()

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -16,7 +16,7 @@ import { isFunction } from '@intlify/shared'
 import { type H3Event, getRequestURL, sanitizeStatusCode, setCookie } from 'h3'
 import type { CoreOptions } from '@intlify/core'
 import { useDetectors } from '../shared/detection'
-import { domainFromLocale, normalizeDomain } from '../shared/domain'
+import { domainForHost, domainFromLocale, normalizeDomain } from '../shared/domain'
 import { isExistingNuxtRoute, matchLocalized } from '../shared/matching'
 import { createRedirectResolver } from './utils/redirect'
 
@@ -69,9 +69,11 @@ export default defineNitroPlugin(async (nitro) => {
       return (): string => ''
     }
 
-    return (event: H3Event, defaultLocale: string): string => {
-      if (__I18N_DOMAINS__ && defaultLocale) {
-        return getDomainFromLocale(event, defaultLocale) || baseUrl
+    return (event: H3Event): string => {
+      if (__I18N_DOMAINS__) {
+        // the origin of the current host, resolving it from `defaultLocale` would send a host
+        // that serves no default locale to whichever domain that locale lives on
+        return domainForHost(runtimeI18n.domainLocales, getRequestURL(event, { xForwardedHost: true })) || baseUrl
       }
 
       // if baseUrl is not determined by domain then prefer relative URL from server-side
@@ -145,7 +147,7 @@ export default defineNitroPlugin(async (nitro) => {
         event,
         // the resolved path is base-free (matched against base-free routes), re-add `app.baseURL`
         joinURL(
-          relocation?.origin || baseUrlGetter(event, ctx.vueI18nOptions!.defaultLocale),
+          relocation?.origin || baseUrlGetter(event),
           useRuntimeConfig(event).app.baseURL,
           resolved.path + url.search,
         ),

--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -62,23 +62,17 @@ export default defineNitroPlugin(async (nitro) => {
   }
 
   const createBaseUrlGetter = () => {
-    const baseUrl: string = isFunction(runtimeI18n.baseUrl) ? '' : runtimeI18n.baseUrl || ''
     if (isFunction(runtimeI18n.baseUrl)) {
       import.meta.dev
         && console.warn('[nuxt-i18n] Configuring baseUrl as a function is deprecated and will be removed in v11.')
       return (): string => ''
     }
 
-    return (event: H3Event): string => {
-      if (__I18N_DOMAINS__) {
-        // the origin of the current host, resolving it from `defaultLocale` would send a host
-        // that serves no default locale to whichever domain that locale lives on
-        return domainForHost(runtimeI18n.domainLocales, getRequestURL(event, { xForwardedHost: true })) || baseUrl
-      }
-
-      // if baseUrl is not determined by domain then prefer relative URL from server-side
-      return ''
-    }
+    // a redirect stays on the host it was requested on: the configured origin of the current host
+    // under domains, relative otherwise. Resolving it from `defaultLocale` sent a host serving no
+    // default locale to that locale's domain, and `baseUrl` would send staging to production
+    return (event: H3Event): string =>
+      (__I18N_DOMAINS__ && domainForHost(runtimeI18n.domainLocales, getRequestURL(event, { xForwardedHost: true }))) || ''
   }
 
   const resolveRedirectPath = createRedirectResolver({

--- a/src/runtime/shared/domain.ts
+++ b/src/runtime/shared/domain.ts
@@ -59,6 +59,9 @@ export function matchDomainLocale(
   )
 }
 
+const withProtocol = (domain: string, url: { protocol: string }) =>
+  hasProtocol(domain, { strict: true }) ? domain : url.protocol + '//' + domain
+
 export function domainFromLocale(
   domainLocales: Record<string, { domain: string | undefined }>,
   url: { host: string, protocol: string },
@@ -78,11 +81,31 @@ export function domainFromLocale(
     return
   }
 
-  if (hasProtocol(domain, { strict: true })) {
-    return domain
+  return withProtocol(domain, url)
+}
+
+/**
+ * The configured domain matching the request host, keeping the protocol it was configured with.
+ * This answers "where am I", unlike {@link domainFromLocale} which answers "where is this locale
+ * served" and may resolve to another domain - deriving the current origin from a locale sends
+ * hosts that serve no default locale to whichever domain `defaultLocale` happens to live on.
+ */
+export function domainForHost(
+  domainLocales: I18nPublicRuntimeConfig['domainLocales'],
+  url: { host: string, protocol: string },
+  locales: NormalizedLocaleObject[] = normalizedLocales,
+): string | undefined {
+  let match: string | undefined
+  for (const locale of locales) {
+    const domain = withRuntimeDomain(locale, domainLocales).domains.find(v => normalizeDomain(v) === url.host)
+    // locales sharing a host may not all configure it with a protocol, prefer the one that does
+    // so the origin does not depend on the order the locales are configured in
+    if (domain && (!match || hasProtocol(domain, { strict: true }))) {
+      match = domain
+    }
   }
 
-  return url.protocol + '//' + domain
+  return match && withProtocol(match, url)
 }
 
 /**

--- a/src/runtime/shared/domain.ts
+++ b/src/runtime/shared/domain.ts
@@ -97,11 +97,15 @@ export function domainForHost(
 ): string | undefined {
   let match: string | undefined
   for (const locale of locales) {
-    const domain = withRuntimeDomain(locale, domainLocales).domains.find(v => normalizeDomain(v) === url.host)
-    // locales sharing a host may not all configure it with a protocol, prefer the one that does
-    // so the origin does not depend on the order the locales are configured in
-    if (domain && (!match || hasProtocol(domain, { strict: true }))) {
-      match = domain
+    const patched = withRuntimeDomain(locale, domainLocales)
+    // a locale configuring both keeps `domain` outside `domains`, `domainFromLocale` reads it too
+    for (const candidate of [patched.domain, ...patched.domains]) {
+      if (!candidate || normalizeDomain(candidate) !== url.host) { continue }
+      // locales sharing a host may not all configure it with a protocol, take the first match but
+      // let one carrying a protocol replace it so `https` is not lost to configuration order
+      if (!match || (!hasProtocol(match, { strict: true }) && hasProtocol(candidate, { strict: true }))) {
+        match = candidate
+      }
     }
   }
 

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import {
+  domainForHost,
   domainFromLocale,
   isLocaleOnHost,
   isLocaleServedOnHost,
@@ -157,6 +158,54 @@ describe('domainFromLocale', () => {
   })
 })
 
+describe('domainForHost', () => {
+  test('resolves the current host with the request protocol', () => {
+    expect(domainForHost({}, { host: 'en.example.com', protocol: 'http:' }, locales)).toBe('http://en.example.com')
+  })
+
+  test('keeps the protocol of the configured domain', () => {
+    expect(domainForHost({}, { host: 'fr.example.com', protocol: 'http:' }, locales)).toBe('https://fr.example.com')
+  })
+
+  test('a host shared by several locales resolves once, the configured protocol wins over order', () => {
+    expect(domainForHost({}, { host: 'shared.example.com', protocol: 'http:' }, locales)).toBe(
+      'http://shared.example.com'
+    )
+    // `es` configures it with a protocol, `it` without - the result cannot depend on which comes first
+    expect(domainForHost({}, { host: 'shared2.example.com', protocol: 'http:' }, locales)).toBe(
+      'https://shared2.example.com'
+    )
+    expect(domainForHost({}, { host: 'shared2.example.com', protocol: 'http:' }, [...locales].reverse())).toBe(
+      'https://shared2.example.com'
+    )
+  })
+
+  test('a host serving locales but no default resolves to itself, not to `defaultLocale`', () => {
+    const brands = getNormalizedLocales([
+      { code: 'en', domains: ['brand-a.example.com'], defaultForDomains: ['brand-a.example.com'] },
+      { code: 'ja', domains: ['brand-c.example.com'] },
+    ])
+    const url = { host: 'brand-c.example.com', protocol: 'http:' }
+
+    expect(domainForHost({}, url, brands)).toBe('http://brand-c.example.com')
+    // the locale lookup resolves where `en` is served, which is what made the redirect leave the host
+    expect(domainFromLocale({}, url, 'en', brands)).toBe('http://brand-a.example.com')
+  })
+
+  test('a host matching no configured domain resolves no domain, so URLs stay relative', () => {
+    expect(domainForHost({}, { host: 'localhost:3000', protocol: 'http:' }, locales)).toBeUndefined()
+  })
+
+  test('(#3988) resolves a host the locale was moved to by `domainLocales`', () => {
+    const url = { host: 'en.staging.example.com', protocol: 'http:' }
+
+    expect(domainForHost({ en: { domain: 'en.staging.example.com' } }, url, locales)).toBe(
+      'http://en.staging.example.com'
+    )
+    expect(domainForHost({}, url, locales)).toBeUndefined()
+  })
+})
+
 describe('withRuntimeDomain', () => {
   test('(#3988) overrides the locale domain from runtime config', () => {
     expect(withRuntimeDomain(locales[0], { en: { domain: 'en.staging.example.com' } })).toMatchObject({
@@ -208,7 +257,7 @@ describe('createBaseUrlGetter', () => {
       baseUrl: 'http://localhost:3000',
       appBase: '/',
       domains: false,
-      defaultLocale: 'en',
+      getDomainForHost: () => 'http://en.example.com',
       getDomainFromLocale: locale => domains[locale],
       ...overrides
     })
@@ -217,7 +266,7 @@ describe('createBaseUrlGetter', () => {
     expect(getBaseUrl()()).toBe('http://localhost:3000')
   })
 
-  test('domains: resolves the default locale domain', () => {
+  test('domains: resolves the current host domain', () => {
     expect(getBaseUrl({ domains: true })()).toBe('http://en.example.com')
   })
 
@@ -225,9 +274,16 @@ describe('createBaseUrlGetter', () => {
     expect(getBaseUrl({ domains: true })('fr')).toBe('http://fr.example.com')
   })
 
-  test('falls back to the default locale domain, then `baseUrl`', () => {
+  test('falls back to the current host domain, then `baseUrl`', () => {
     expect(getBaseUrl({ domains: true })('nl')).toBe('http://en.example.com')
-    expect(getBaseUrl({ domains: true, getDomainFromLocale: () => undefined })('nl')).toBe('http://localhost:3000')
+    expect(getBaseUrl({ domains: true, getDomainForHost: () => undefined })('nl')).toBe('http://localhost:3000')
+  })
+
+  test('a host serving no default locale keeps its own origin', () => {
+    // resolving the base from `defaultLocale` sent it to that locale's domain instead
+    expect(getBaseUrl({ domains: true, getDomainForHost: () => 'http://shared.example.com' })()).toBe(
+      'http://shared.example.com'
+    )
   })
 
   test('(#3628, #3887) joins `app.baseURL` after the locale domain', () => {

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -167,6 +167,14 @@ describe('domainForHost', () => {
     expect(domainForHost({}, { host: 'fr.example.com', protocol: 'http:' }, locales)).toBe('https://fr.example.com')
   })
 
+  test('matches the scalar `domain` of a locale that also configures `domains`', () => {
+    // `normalizeDomainLocale` only folds `domain` into `domains` when `domains` is empty
+    const both = getNormalizedLocales([
+      { code: 'en', domain: 'en.example.com', domains: ['shared.example.com'], defaultForDomains: ['shared.example.com'] },
+    ])
+    expect(domainForHost({}, { host: 'en.example.com', protocol: 'http:' }, both)).toBe('http://en.example.com')
+  })
+
   test('a host shared by several locales resolves once, the configured protocol wins over order', () => {
     expect(domainForHost({}, { host: 'shared.example.com', protocol: 'http:' }, locales)).toBe(
       'http://shared.example.com'
@@ -178,6 +186,18 @@ describe('domainForHost', () => {
     expect(domainForHost({}, { host: 'shared2.example.com', protocol: 'http:' }, [...locales].reverse())).toBe(
       'https://shared2.example.com'
     )
+  })
+
+  test('two locales configuring the same host with different protocols keep the first', () => {
+    // nothing disambiguates this, the result at least does not depend on which locale is asked
+    const conflicting = getNormalizedLocales([
+      { code: 'en', domains: ['https://shared.example.com'] },
+      { code: 'fr', domains: ['http://shared.example.com'] },
+    ])
+    const url = { host: 'shared.example.com', protocol: 'http:' }
+
+    expect(domainForHost({}, url, conflicting)).toBe('https://shared.example.com')
+    expect(domainForHost({}, url, [...conflicting].reverse())).toBe('http://shared.example.com')
   })
 
   test('a host serving locales but no default resolves to itself, not to `defaultLocale`', () => {


### PR DESCRIPTION
* Related #4101
* Related #4083

#4083 gave `domainFromLocale` a fallback resolving the domain a locale is served on, which is what `switchLocalePath` and the hreflang alternates need. Both base URL getters also used it to resolve the current site's own origin, through `defaultLocale`, so a domain serving no default locale resolved the origin of whichever domain that locale lives on and redirects left the host the visitor asked for.

`domainForHost` resolves that from the request host instead, it matches the configured domains and never resolves another one. A host matching none of them (staging, a health check by IP, a dev port) now stays relative rather than falling back to `baseUrl`, which is the production origin. An explicitly requested locale still resolves through `domainFromLocale`, so canonical, `og:url` and the alternates are unchanged. There's an e2e pinning the redirect origin per host shape and the guide mentions the relative redirects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multi-domain locale redirects to preserve the request’s current origin when appropriate.
  - Redirects now correctly resolve the domain associated with the requesting host and locale.
  - Requests from hosts not configured for a specific domain serve all locales, use the default locale appropriately, and remain on the same host during redirects.

- **Documentation**
  - Clarified behavior for unmatched hosts, including staging environments and IP-based health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
