### PR TITLE
fix: keep params encoded when resolving a localized route by path

### DIFF
--- a/src/runtime/routing/routing.ts
+++ b/src/runtime/routing/routing.ts
@@ -61,7 +61,14 @@ function normalizeRawLocation(route: RouteLocationRaw): RouteLike {
  */
 function resolveRoute(ctx: RoutingContext, route: RouteLocationRaw, locale: Locale) {
   const normalized = normalizeRawLocation(route)
-  const resolved = ctx.router.resolve(ctx.resolveLocalizedRouteObject(normalized, locale))
+  const localized = ctx.resolveLocalizedRouteObject(normalized, locale)
+  // the matcher ignores `path` whenever `name` is set, but its presence makes `router.resolve()`
+  // take its path branch, which skips `encodeParams()` and returns the params decoded — turning
+  // an escape such as `%23` back into a `#` delimiter (#4079, #4098)
+  if (localized.name) {
+    localized.path = undefined
+  }
+  const resolved = ctx.router.resolve(localized)
   if (resolved.name) {
     return resolved
   }
@@ -87,11 +94,7 @@ export function switchLocalePath(
   /**
    * Nuxt route uses a proxy with getters for performance reasons (https://github.com/nuxt/nuxt/pull/21957).
    * Spreading will result in an empty object, so we make a copy of the route by accessing each getter property by name.
-   * We skip the `matched` and `redirectedFrom` properties.
-   *
-   * `path` is deliberately omitted: the route matcher ignores it whenever `name` is set, but its
-   * presence makes `router.resolve()` take its path branch, which skips `encodeParams()` and returns
-   * a path with unencoded params (#4079).
+   * We skip the `matched`, `redirectedFrom` and `path` properties.
    */
   const routeCopy = {
     name,

--- a/test/kit.test.ts
+++ b/test/kit.test.ts
@@ -153,14 +153,17 @@ describe.each(STRATEGIES)('routing context (strategy: %s)', strategy => {
     expect(localePath('/?foo=1')).toEqual(pp('?foo=1'))
     expect(localePath('/about?foo=1')).toEqual(pp('/about?foo=1'))
     expect(localePath('/about?foo=1&test=2')).toEqual(pp('/about?foo=1&test=2'))
-    expect(localePath('/path/as a test?foo=bar sentence')).toEqual(pp('/path/as a test?foo=bar+sentence'))
-    // encoded path input is normalized (decoded) only when the path resolver matches a route
-    // record and re-resolves it by name; `prefix` (exact-path lookup misses param routes) and
-    // `no_prefix` (no path resolver) pass the raw path through and keep its encoding
-    const normalizesEncoding = strategy === 'prefix_and_default' || strategy === 'prefix_except_default'
-    expect(localePath('/path/as%20a%20test?foo=bar%20sentence')).toEqual(
-      normalizesEncoding ? pp('/path/as a test?foo=bar+sentence') : pp('/path/as%20a%20test?foo=bar+sentence')
+    // params are re-encoded only when the path resolver matches a route record and re-resolves
+    // it by name; `prefix` (exact-path lookup misses param routes) and `no_prefix` (no path
+    // resolver) pass the raw path through
+    const encodesParams = strategy === 'prefix_and_default' || strategy === 'prefix_except_default'
+    expect(localePath('/path/as a test?foo=bar sentence')).toEqual(
+      pp(encodesParams ? '/path/as%20a%20test?foo=bar+sentence' : '/path/as a test?foo=bar+sentence')
     )
+    expect(localePath('/path/as%20a%20test?foo=bar%20sentence')).toEqual(pp('/path/as%20a%20test?foo=bar+sentence'))
+    // (#4098) escapes in a param survive resolution instead of decoding into delimiters
+    expect(localePath('/path/a%23b%3Fc%2Fd%25e')).toEqual(pp('/path/a%23b%3Fc%2Fd%25e'))
+    expect(localePath('/blog/my%20post%20%231')).toEqual(pp('/blog/my%20post%20%231'))
 
     // preserve hash
     expect(localePath({ path: '/about', hash: '#foo=bar' })).toEqual(pp('/about#foo=bar'))


### PR DESCRIPTION
* Resolves #4098
* Related #4079, #4099

`localePath()` decoded percent-encoded characters in dynamic path segments, so `/blog/my%20post%20%231` came back as `/blog/my post #1` and anything passing that to `navigateTo` or `<NuxtLink>` silently lost everything after the `#`. The route object passed to the second `router.resolve()` in `resolveRoute` carries both a name and a path, which makes vue-router take its path branch and skip `encodeParams()` while the matcher resolves by name.

This omits `path` once a name resolved, the same fix #4079 made for `switchLocalePath`. Only `prefix_except_default` and `prefix_and_default` were affected, the other two resolve param routes by path and pass their encoding through unchanged.

Params of a matched route are now encoded by vue-router in those two strategies, so a path passed in with literal characters comes back encoded (`/path/as a test` gives `/path/as%20a%20test`). This doesn't cover a hand-written non-repeatable catch-all like `:slug(.*)` - its param value holds the segment separators, which get escaped to `%2F` when the route resolves by name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved localized route resolution when switching locales.
  * Preserved encoded characters in route parameters and paths.
  * Corrected query-string space encoding during locale path generation.
  * Prevented escaped characters from being incorrectly converted into route delimiters.

* **Documentation**
  * Clarified which route properties are omitted when copying proxy routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->