### PR TITLE
fix(seo): resolve alternate and canonical links from one domain per locale

### DIFF
--- a/docs/content/docs/02.guide/10.multi-domain-locales.md
+++ b/docs/content/docs/02.guide/10.multi-domain-locales.md
@@ -225,7 +225,9 @@ A request on a host that doesn't match any configured domain, such as a staging 
 
 The domains are annotated as one cluster, each page links to its alternates on the other domains. A cluster has a single fallback for unmatched languages, so the `x-default` alternate is taken from `defaultLocale` rather than from the locale a domain happens to default to - otherwise every domain would name a different one.
 
-A locale served on several domains is annotated on one of them: the first entry of its `defaultForDomains`, or of its `domains` otherwise. Every domain that serves the locale emits that same URL for it, keeping the cluster reciprocal - annotating the current domain instead would make each domain claim the language for itself. A locale configured without any domain has none to name and is still annotated on the current domain.
+A locale served on several domains is annotated on one of them: the first entry of its `defaultForDomains`, or of its `domains` otherwise. Every domain that serves the locale emits that same URL for it, keeping the cluster reciprocal - annotating the current domain instead would make each domain claim the language for itself. A locale configured without any domain is served on all of them and has none of its own to be annotated on, so it takes the domain serving `defaultLocale`.
+
+The canonical link follows the same rule, so a page reachable on several domains points at the URL its language is advertised on rather than claiming itself. A locale served on a single domain canonicalises to that domain, as before.
 
 This means a locale you list on several domains is advertised at one of them while remaining reachable at the others, so restrict a locale to the domain it belongs on unless you deliberately want it served in several places.
 

--- a/docs/content/docs/02.guide/10.multi-domain-locales.md
+++ b/docs/content/docs/02.guide/10.multi-domain-locales.md
@@ -178,6 +178,10 @@ A locale is only unprefixed on the domains it is the default for, on every other
 
 A locale's `domains` doesn't have to list every domain, it only has to list the domains that locale should be served on. A locale configured without `domains` is served on all of them.
 
+Restricting locales is what keeps each page reachable at a single address: a locale listed on one domain is served there and relocated there from the others. Listing a locale on several domains serves it on each of them, so the same page becomes reachable at several URLs - see [`defaultLocale` and `x-default`](#defaultlocale-and-x-default) for how those are annotated.
+
+Restricting every locale to a domain of its own is also what makes `strategy: 'no_prefix'`{lang="ts"} usable here: with no prefix in the path, the domain is the only thing naming a locale, so each domain has to serve exactly one. Two locales sharing a domain under `'no_prefix'`{lang="ts-type"} leaves routes unlocalized and is reported at build time.
+
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   i18n: {
@@ -220,5 +224,9 @@ A request on a host that doesn't match any configured domain, such as a staging 
 ## `defaultLocale` and `x-default`
 
 The domains are annotated as one cluster, each page links to its alternates on the other domains. A cluster has a single fallback for unmatched languages, so the `x-default` alternate is taken from `defaultLocale` rather than from the locale a domain happens to default to - otherwise every domain would name a different one.
+
+A locale served on several domains is annotated on one of them: the first entry of its `defaultForDomains`, or of its `domains` otherwise. Every domain that serves the locale emits that same URL for it, keeping the cluster reciprocal - annotating the current domain instead would make each domain claim the language for itself. A locale configured without any domain has none to name and is still annotated on the current domain.
+
+This means a locale you list on several domains is advertised at one of them while remaining reachable at the others, so restrict a locale to the domain it belongs on unless you deliberately want it served in several places.
 
 `defaultLocale` is optional here, since each domain resolves its own unprefixed locale through `defaultForDomains`. Leaving it out means no `x-default` is annotated at all, which is allowed but drops a signal for visitors whose language matches none of your locales. A warning is logged when it isn't set.

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -91,10 +91,11 @@ function createShouldPrefix(opts: SetupLocalizeRoutesOptions, ctx: RouteContext)
 export function shouldLocalizeRoutes(options: SetupLocalizeRoutesOptions) {
   if (options.strategy !== 'no_prefix') { return true }
 
-  // without a prefix the host is the only thing naming a locale, so `no_prefix` localizes routes
-  // exactly when each locale has a domain of its own. The locale data decides that, not which
-  // option turned domains on - `differentDomains` and `multiDomainLocales` qualify alike
-  // domains are compared by host as they may include a protocol
+  // without a prefix the host is all that names a locale, and only these options make the runtime
+  // resolve one from it (`__I18N_DOMAINS__`) - localizing routes without it leaves them unreachable
+  if (!options.differentDomains && !options.multiDomainLocales) { return false }
+
+  // compared by host, as configured domains may include a protocol
   const domains = new Set<string>()
   for (const locale of options.locales) {
     for (const domain of locale.domains) {
@@ -111,7 +112,7 @@ export function shouldLocalizeRoutes(options: SetupLocalizeRoutesOptions) {
     }
   }
 
-  // no domains at all is a plain `no_prefix` site, where routes are meant to stay unlocalized
+  // one domain per locale is the requirement, so a domain setup configuring none localizes nothing
   return domains.size > 0
 }
 

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -90,10 +90,11 @@ function createShouldPrefix(opts: SetupLocalizeRoutesOptions, ctx: RouteContext)
 
 export function shouldLocalizeRoutes(options: SetupLocalizeRoutesOptions) {
   if (options.strategy !== 'no_prefix') { return true }
-  // no_prefix is only supported when using a separate domain per locale
-  if (!options.differentDomains) { return false }
 
-  // check if domains are used multiple times, compared by host as domains may include a protocol
+  // without a prefix the host is the only thing naming a locale, so `no_prefix` localizes routes
+  // exactly when each locale has a domain of its own. The locale data decides that, not which
+  // option turned domains on - `differentDomains` and `multiDomainLocales` qualify alike
+  // domains are compared by host as they may include a protocol
   const domains = new Set<string>()
   for (const locale of options.locales) {
     for (const domain of locale.domains) {
@@ -101,7 +102,8 @@ export function shouldLocalizeRoutes(options: SetupLocalizeRoutesOptions) {
       if (domains.has(host)) {
         console.error(
           `Cannot use \`strategy: no_prefix\` when using multiple locales on the same domain`
-          + ` - found multiple entries with ${domain}`,
+          + ` - found multiple entries with ${domain}.`
+          + ` Routes stay unlocalized, so \`switchLocalePath\` and the \`hreflang\`/\`canonical\` tags resolve to nothing.`,
         )
         return false
       }
@@ -109,7 +111,8 @@ export function shouldLocalizeRoutes(options: SetupLocalizeRoutesOptions) {
     }
   }
 
-  return true
+  // no domains at all is a plain `no_prefix` site, where routes are meant to stay unlocalized
+  return domains.size > 0
 }
 
 /** Locales acting as the default (unprefixed) locale for at least one domain */

--- a/src/runtime/composable-context.ts
+++ b/src/runtime/composable-context.ts
@@ -48,9 +48,11 @@ export function createComposableContext(ctx: NuxtI18nContext, nuxtApp: NuxtApp =
   const routingCtx = createRoutingContext({
     router: useRouter(),
     defaultLocale: ctx.getDefaultLocale(),
+    configuredDefaultLocale: ctx.config.defaultLocale || '',
     getLocale: ctx.getLocale,
     getLocales: ctx.getLocales,
     getBaseUrl: ctx.getBaseUrl,
+    getCanonicalBaseUrl: ctx.getCanonicalBaseUrl,
     getHost: () => useRequestURL({ xForwardedHost: true }).host,
     getLocalePathPayload: () => __I18N_STRICT_SEO__ && import.meta.client && nuxtApp.isHydrating && localePathPayload,
     strategy: __I18N_STRATEGY__,

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -65,6 +65,20 @@ export interface NuxtI18nContext {
 }
 
 /**
+ * The request URL with the scheme `baseUrl` was configured with, used to complete domains
+ * configured without one. `useRequestURL` reports the scheme the server was reached on, which is
+ * `http` behind a proxy terminating TLS and during prerender, where there is no request at all.
+ * @internal exported for testing
+ */
+export function withConfiguredProtocol(
+  url: { host: string, protocol: string },
+  baseUrl: string | BaseUrlResolveHandler<unknown> | undefined,
+): { host: string, protocol: string } {
+  const protocol = !isFunction(baseUrl) && baseUrl?.match(/^(https?:)\/\//)?.[1]
+  return protocol ? { host: url.host, protocol } : url
+}
+
+/**
  * Returns a getter resolving the base URL for a locale, joined with `app.baseURL` exactly
  * once - locale domains and `baseUrl` are configured without it (#3628, #3887).
  */
@@ -158,13 +172,14 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
   if (import.meta.dev && isFunction(runtimeI18n.baseUrl)) {
     console.warn('[nuxt-i18n] Configuring baseUrl as a function is deprecated and will be removed in v11.')
   }
+  const requestUrl = () => withConfiguredProtocol(useRequestURL({ xForwardedHost: true }), runtimeI18n.baseUrl)
   const getDomainFromLocale = (locale: string) =>
-    domainFromLocale(runtimeI18n.domainLocales, useRequestURL({ xForwardedHost: true }), locale)
+    domainFromLocale(runtimeI18n.domainLocales, requestUrl(), locale)
   const baseUrlOptions = {
     baseUrl: isFunction(runtimeI18n.baseUrl) ? () => (runtimeI18n.baseUrl as BaseUrlResolveHandler<unknown>)(nuxt) : runtimeI18n.baseUrl,
     appBase: nuxt.$config.app.baseURL,
     domains: __I18N_DOMAINS__,
-    getDomainForHost: () => domainForHost(runtimeI18n.domainLocales, useRequestURL({ xForwardedHost: true })),
+    getDomainForHost: () => domainForHost(runtimeI18n.domainLocales, requestUrl()),
   }
   const getBaseUrl = createBaseUrlGetter({ ...baseUrlOptions, getDomainFromLocale })
   const getCanonicalBaseUrl = createBaseUrlGetter({
@@ -173,7 +188,7 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
     // domain serving `defaultLocale` - the cluster has no domain with a better claim, and leaving
     // it to the current host would advertise that one locale differently from each of them
     getDomainFromLocale: (locale) => {
-      const url = useRequestURL({ xForwardedHost: true })
+      const url = requestUrl()
       return canonicalDomainFromLocale(runtimeI18n.domainLocales, url, locale)
         || canonicalDomainFromLocale(runtimeI18n.domainLocales, url, runtimeI18n.defaultLocale)
     },

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -6,7 +6,7 @@ import { cloneDeep, fillMissing, getLocaleMessagesMergedCached, warnMissedMessag
 import { createPrerenderablePredicate, createRuntimeLoaderPredicate } from './shared/delivery'
 import { createComposableContext } from './composable-context'
 import { getComposer, getI18nTarget } from './compatibility'
-import { domainForHost, domainFromLocale } from './shared/domain'
+import { canonicalDomainFromLocale, domainForHost, domainFromLocale } from './shared/domain'
 import { isSupportedLocale } from './shared/locales'
 import { resolveRootRedirect, useI18nDetection, useRuntimeI18n } from './shared/utils'
 import { joinURL } from 'ufo'
@@ -57,6 +57,8 @@ export interface NuxtI18nContext {
   setCookieLocale: (locale: string) => void
   /** Get current base URL */
   getBaseUrl: (locale?: string) => string
+  /** Get the base URL canonically naming a locale (alternate links), without current-host preference */
+  getCanonicalBaseUrl: (locale: string) => string
   /** Load locale messages */
   loadMessages: (locale: Locale) => Promise<void>
   composableCtx: ComposableContext
@@ -158,12 +160,17 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
   if (import.meta.dev && isFunction(runtimeI18n.baseUrl)) {
     console.warn('[nuxt-i18n] Configuring baseUrl as a function is deprecated and will be removed in v11.')
   }
-  const getBaseUrl = createBaseUrlGetter({
+  const baseUrlOptions = {
     baseUrl: isFunction(runtimeI18n.baseUrl) ? () => (runtimeI18n.baseUrl as BaseUrlResolveHandler<unknown>)(nuxt) : runtimeI18n.baseUrl,
     appBase: nuxt.$config.app.baseURL,
     domains: __I18N_DOMAINS__,
     getDomainForHost: () => domainForHost(runtimeI18n.domainLocales, useRequestURL({ xForwardedHost: true })),
-    getDomainFromLocale,
+  }
+  const getBaseUrl = createBaseUrlGetter({ ...baseUrlOptions, getDomainFromLocale })
+  const getCanonicalBaseUrl = createBaseUrlGetter({
+    ...baseUrlOptions,
+    getDomainFromLocale: locale =>
+      canonicalDomainFromLocale(runtimeI18n.domainLocales, useRequestURL({ xForwardedHost: true }), locale),
   })
   const resolvedLocale = useResolvedLocale()
   if (__I18N_SERVER_REDIRECT__ && import.meta.server && nuxt.ssrContext?.event?.context?.nuxtI18n?.detectLocale) {
@@ -280,6 +287,7 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
       }
     },
     getBaseUrl,
+    getCanonicalBaseUrl,
     loadMessages: async (locale: string) => {
       // prevent multiple loads during hydration
       if (nuxt.isHydrating && loadMap.has(locale)) { return }

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -9,7 +9,7 @@ import { getComposer, getI18nTarget } from './compatibility'
 import { canonicalDomainFromLocale, domainForHost, domainFromLocale } from './shared/domain'
 import { isSupportedLocale } from './shared/locales'
 import { resolveRootRedirect, useI18nDetection, useRuntimeI18n } from './shared/utils'
-import { joinURL } from 'ufo'
+import { joinURL, parseURL } from 'ufo'
 import { isFunction, isString } from '@intlify/shared'
 
 import type { NuxtApp } from '#app'
@@ -57,7 +57,7 @@ export interface NuxtI18nContext {
   setCookieLocale: (locale: string) => void
   /** Get current base URL */
   getBaseUrl: (locale?: string) => string
-  /** Get the base URL canonically naming a locale (alternate links), without current-host preference */
+  /** Base URL for a locale, ignoring the current host (alternate links) */
   getCanonicalBaseUrl: (locale: string) => string
   /** Load locale messages */
   loadMessages: (locale: Locale) => Promise<void>
@@ -65,16 +65,15 @@ export interface NuxtI18nContext {
 }
 
 /**
- * The request URL with the scheme `baseUrl` was configured with, used to complete domains
- * configured without one. `useRequestURL` reports the scheme the server was reached on, which is
- * `http` behind a proxy terminating TLS and during prerender, where there is no request at all.
+ * `useRequestURL` reports the scheme the server was reached on: `http` behind a TLS-terminating
+ * proxy, and nothing meaningful while prerendering. A configured `baseUrl` names the real one.
  * @internal exported for testing
  */
 export function withConfiguredProtocol(
   url: { host: string, protocol: string },
   baseUrl: string | BaseUrlResolveHandler<unknown> | undefined,
 ): { host: string, protocol: string } {
-  const protocol = !isFunction(baseUrl) && baseUrl?.match(/^(https?:)\/\//)?.[1]
+  const protocol = !isFunction(baseUrl) && parseURL(baseUrl).protocol
   return protocol ? { host: url.host, protocol } : url
 }
 
@@ -172,7 +171,10 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
   if (import.meta.dev && isFunction(runtimeI18n.baseUrl)) {
     console.warn('[nuxt-i18n] Configuring baseUrl as a function is deprecated and will be removed in v11.')
   }
-  const requestUrl = () => withConfiguredProtocol(useRequestURL({ xForwardedHost: true }), runtimeI18n.baseUrl)
+  // host and protocol cannot change while a context lives - one per request on the server, one per
+  // app on the client - and every link and head tag resolves through here
+  let url: { host: string, protocol: string } | undefined
+  const requestUrl = () => (url ??= withConfiguredProtocol(useRequestURL({ xForwardedHost: true }), runtimeI18n.baseUrl))
   const getDomainFromLocale = (locale: string) =>
     domainFromLocale(runtimeI18n.domainLocales, requestUrl(), locale)
   const baseUrlOptions = {
@@ -182,17 +184,13 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
     getDomainForHost: () => domainForHost(runtimeI18n.domainLocales, requestUrl()),
   }
   const getBaseUrl = createBaseUrlGetter({ ...baseUrlOptions, getDomainFromLocale })
-  const getCanonicalBaseUrl = createBaseUrlGetter({
-    ...baseUrlOptions,
-    // a locale served on every domain has none of its own to be annotated on, so it takes the
-    // domain serving `defaultLocale` - the cluster has no domain with a better claim, and leaving
-    // it to the current host would advertise that one locale differently from each of them
-    getDomainFromLocale: (locale) => {
-      const url = requestUrl()
-      return canonicalDomainFromLocale(runtimeI18n.domainLocales, url, locale)
-        || canonicalDomainFromLocale(runtimeI18n.domainLocales, url, runtimeI18n.defaultLocale)
-    },
-  })
+  const getCanonicalBaseUrl = __I18N_DOMAINS__
+    ? createBaseUrlGetter({
+        ...baseUrlOptions,
+        getDomainFromLocale: locale =>
+          canonicalDomainFromLocale(runtimeI18n.domainLocales, requestUrl(), locale, runtimeI18n.defaultLocale),
+      })
+    : getBaseUrl
   const resolvedLocale = useResolvedLocale()
   if (__I18N_SERVER_REDIRECT__ && import.meta.server && nuxt.ssrContext?.event?.context?.nuxtI18n?.detectLocale) {
     resolvedLocale.value = nuxt.ssrContext.event.context.nuxtI18n.detectLocale

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -155,11 +155,11 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
 
   /** Get computed config for locale */
   const getLocaleConfig = (locale: string) => serverLocaleConfigs.value![locale]
-  const getDomainFromLocale = (locale: string) =>
-    domainFromLocale(runtimeI18n.domainLocales, useRequestURL({ xForwardedHost: true }), locale)
   if (import.meta.dev && isFunction(runtimeI18n.baseUrl)) {
     console.warn('[nuxt-i18n] Configuring baseUrl as a function is deprecated and will be removed in v11.')
   }
+  const getDomainFromLocale = (locale: string) =>
+    domainFromLocale(runtimeI18n.domainLocales, useRequestURL({ xForwardedHost: true }), locale)
   const baseUrlOptions = {
     baseUrl: isFunction(runtimeI18n.baseUrl) ? () => (runtimeI18n.baseUrl as BaseUrlResolveHandler<unknown>)(nuxt) : runtimeI18n.baseUrl,
     appBase: nuxt.$config.app.baseURL,
@@ -169,8 +169,14 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
   const getBaseUrl = createBaseUrlGetter({ ...baseUrlOptions, getDomainFromLocale })
   const getCanonicalBaseUrl = createBaseUrlGetter({
     ...baseUrlOptions,
-    getDomainFromLocale: locale =>
-      canonicalDomainFromLocale(runtimeI18n.domainLocales, useRequestURL({ xForwardedHost: true }), locale),
+    // a locale served on every domain has none of its own to be annotated on, so it takes the
+    // domain serving `defaultLocale` - the cluster has no domain with a better claim, and leaving
+    // it to the current host would advertise that one locale differently from each of them
+    getDomainFromLocale: (locale) => {
+      const url = useRequestURL({ xForwardedHost: true })
+      return canonicalDomainFromLocale(runtimeI18n.domainLocales, url, locale)
+        || canonicalDomainFromLocale(runtimeI18n.domainLocales, url, runtimeI18n.defaultLocale)
+    },
   })
   const resolvedLocale = useResolvedLocale()
   if (__I18N_SERVER_REDIRECT__ && import.meta.server && nuxt.ssrContext?.event?.context?.nuxtI18n?.detectLocale) {

--- a/src/runtime/kit/head.ts
+++ b/src/runtime/kit/head.ts
@@ -35,6 +35,7 @@ export type HeadContext = {
   seo: boolean | SeoAttributesOptions | undefined
   baseUrl: string
   locales: HeadLocale[]
+  currentLocale: string
   defaultLocale: string | undefined
   hreflangLinks: boolean
   strictCanonicals: boolean
@@ -133,6 +134,15 @@ function getHreflangLinks(options: HeadContext) {
   return links
 }
 
+/**
+ * A resolved locale path is already absolute under domain setups. `joinURL` collapses a root path
+ * against an empty base, so a site without `baseUrl` keeps the path as-is.
+ */
+function absolutize(options: HeadContext, path: string) {
+  if (hasProtocol(path) || !options.baseUrl) { return path }
+  return joinURL(options.baseUrl, path)
+}
+
 function getHreflangLink(
   language: string,
   locale: HeadLocale,
@@ -143,7 +153,7 @@ function getHreflangLink(
   if (!localePath) { return undefined }
 
   const href = withQuery(
-    hasProtocol(localePath) ? localePath : joinURL(options.baseUrl, localePath),
+    absolutize(options, localePath),
     options.strictCanonicals ? getCanonicalQueryParams(options) : {},
   )
   return options.strictSeo
@@ -151,13 +161,18 @@ function getHreflangLink(
     : { [options.key]: `i18n-alt-${language}`, rel: 'alternate', href, hreflang: language }
 }
 
-function getCanonicalUrl(options: HeadContext, route = options.getCurrentRoute()) {
-  const currentRoute = options.getLocaleRoute(
-    Object.assign({}, route, { path: undefined, name: options.getRouteBaseName(route) }),
-  )
-
-  if (!currentRoute) { return '' }
-  return withQuery(joinURL(options.baseUrl, currentRoute.path), getCanonicalQueryParams(options))
+/**
+ * The current locale's own alternate link, so the canonical is by construction a member of the
+ * hreflang set it is emitted with. Under domains that means the locale's canonical domain rather
+ * than the host being served, which is what makes a page reachable on several domains name one URL.
+ */
+function getCanonicalUrl(
+  options: HeadContext,
+  routeWithoutQuery = options.strictCanonicals ? options.getRouteWithoutQuery() : undefined,
+) {
+  const localePath = options.getLocalizedRoute(options.currentLocale, routeWithoutQuery)
+  if (!localePath) { return '' }
+  return withQuery(absolutize(options, localePath), getCanonicalQueryParams(options))
 }
 
 function getCanonicalLink(options: HeadContext, href = getCanonicalUrl(options)): CanonicalLink[] {

--- a/src/runtime/kit/head.ts
+++ b/src/runtime/kit/head.ts
@@ -1,4 +1,4 @@
-import { hasProtocol, joinURL, withQuery } from 'ufo'
+import { withBase, withQuery } from 'ufo'
 
 import type { QueryValue } from 'ufo'
 import type { RouteLocationNormalizedLoadedGeneric, RouteLocationResolvedGeneric } from 'vue-router'
@@ -74,14 +74,17 @@ export function localeHead(
 
   // Adding SEO Meta
   if (options.seo) {
-    const alternateLinks = getHreflangLinks(options)
+    const routeWithoutQuery = options.strictCanonicals ? options.getRouteWithoutQuery() : undefined
+    const alternateLinks = getHreflangLinks(options, routeWithoutQuery)
+    // `og:url` is the canonical by definition, resolving it twice lets the two disagree
+    const canonical = getCanonicalUrl(options, routeWithoutQuery)
     metaObject.link = metaObject.link.concat(
       alternateLinks,
-      getCanonicalLink(options),
+      getCanonicalLink(options, canonical),
     )
 
     metaObject.meta = metaObject.meta.concat(
-      getOgUrl(options),
+      getOgUrl(options, canonical),
       getCurrentOgLocale(options),
       getAlternateOgLocales(options, getAlternateOgLanguages(options, alternateLinks)),
     )
@@ -112,21 +115,31 @@ function createLocaleMap(locales: HeadLocale[]) {
   return localeMap
 }
 
-function getHreflangLinks(options: HeadContext) {
+function getHreflangLinks(
+  options: HeadContext,
+  routeWithoutQuery = options.strictCanonicals ? options.getRouteWithoutQuery() : undefined,
+) {
   if (!options.hreflangLinks) { return [] }
 
   const links: AlternateLanguageLink[] = []
   const localeMap = createLocaleMap(options.locales)
+  // a region-tagged locale holds two entries (`en` and `en-US`) resolving to the same href
+  const hrefs = new Map<string, string>()
   for (const [language, locale] of localeMap.entries()) {
-    const link = getHreflangLink(language, locale, options)
-    if (!link) { continue }
+    const href = hrefs.get(locale.code) ?? resolveAlternateHref(locale.code, options, routeWithoutQuery)
+    if (!href) { continue }
+    hrefs.set(locale.code, href)
+
+    const link: AlternateLanguageLink = options.strictSeo
+      ? { rel: 'alternate', href, hreflang: language }
+      : { [options.key]: `i18n-alt-${language}`, rel: 'alternate', href, hreflang: language }
 
     links.push(link)
     if (options.defaultLocale && options.defaultLocale === locale.code && links[0]!.hreflang !== 'x-default') {
       links.unshift(
         options.strictSeo
-          ? { rel: 'alternate', href: link.href!, hreflang: 'x-default' }
-          : { [options.key]: 'i18n-xd', rel: 'alternate', href: link.href!, hreflang: 'x-default' },
+          ? { rel: 'alternate', href, hreflang: 'x-default' }
+          : { [options.key]: 'i18n-xd', rel: 'alternate', href, hreflang: 'x-default' },
       )
     }
   }
@@ -134,45 +147,28 @@ function getHreflangLinks(options: HeadContext) {
   return links
 }
 
-/**
- * A resolved locale path is already absolute under domain setups. `joinURL` collapses a root path
- * against an empty base, so a site without `baseUrl` keeps the path as-is.
- */
-function absolutize(options: HeadContext, path: string) {
-  if (hasProtocol(path) || !options.baseUrl) { return path }
-  return joinURL(options.baseUrl, path)
-}
-
-function getHreflangLink(
-  language: string,
-  locale: HeadLocale,
+function resolveAlternateHref(
+  locale: string,
   options: HeadContext,
   routeWithoutQuery = options.strictCanonicals ? options.getRouteWithoutQuery() : undefined,
-): AlternateLanguageLink | undefined {
-  const localePath = options.getLocalizedRoute(locale.code, routeWithoutQuery)
+): string | undefined {
+  const localePath = options.getLocalizedRoute(locale, routeWithoutQuery)
   if (!localePath) { return undefined }
 
-  const href = withQuery(
-    absolutize(options, localePath),
+  return withQuery(
+    withBase(localePath, options.baseUrl),
     options.strictCanonicals ? getCanonicalQueryParams(options) : {},
   )
-  return options.strictSeo
-    ? { rel: 'alternate', href, hreflang: language }
-    : { [options.key]: `i18n-alt-${language}`, rel: 'alternate', href, hreflang: language }
 }
 
-/**
- * The current locale's own alternate link, so the canonical is by construction a member of the
- * hreflang set it is emitted with. Under domains that means the locale's canonical domain rather
- * than the host being served, which is what makes a page reachable on several domains name one URL.
- */
+/** the current locale's own alternate, so the canonical is always a member of the set it ships with */
 function getCanonicalUrl(
   options: HeadContext,
   routeWithoutQuery = options.strictCanonicals ? options.getRouteWithoutQuery() : undefined,
 ) {
   const localePath = options.getLocalizedRoute(options.currentLocale, routeWithoutQuery)
   if (!localePath) { return '' }
-  return withQuery(absolutize(options, localePath), getCanonicalQueryParams(options))
+  return withQuery(withBase(localePath, options.baseUrl), getCanonicalQueryParams(options))
 }
 
 function getCanonicalLink(options: HeadContext, href = getCanonicalUrl(options)): CanonicalLink[] {
@@ -181,6 +177,8 @@ function getCanonicalLink(options: HeadContext, href = getCanonicalUrl(options))
 }
 
 function getCanonicalQueryParams(options: HeadContext, route = options.getCurrentRoute()) {
+  if (!options.canonicalQueries.length) { return {} }
+
   const currentRoute = options.getLocaleRoute(
     Object.assign({}, route, { path: undefined, name: options.getRouteBaseName(route) }),
   )

--- a/src/runtime/routing/context.ts
+++ b/src/runtime/routing/context.ts
@@ -1,8 +1,8 @@
 import { joinURL } from 'ufo'
 import { createLocaleRouteNameGetter, createLocalizedRouteByPathResolver } from './utils'
 import { createTrailingSlashFormatter, getLocaleFromRoutePath, getRouteBaseName, prefixable } from '#i18n-kit/routing'
-import { getDefaultLocaleForDomain, isSupportedLocale } from '../shared/locales'
-import { isLocaleOnHost } from '../shared/domain'
+import { getDefaultLocaleForDomain, isSupportedLocale, resolveDefaultLocale } from '../shared/locales'
+import { canonicalDomain, isLocaleOnHost, normalizeDomain } from '../shared/domain'
 
 import type { RouteLocationPathRaw, RouteRecordNameGeneric, Router } from 'vue-router'
 import type { PrefixableOptions } from '#i18n-kit/routing'
@@ -25,6 +25,11 @@ export type RoutingContext = {
   getRouteBaseName: (route: RouteRecordNameGeneric | RouteLocationGenericPath | null) => string | undefined
   /** Modifies the resolved localized path. Middleware for `switchLocalePath` */
   afterSwitchLocalePath: (path: string, locale: string) => string
+  /**
+   * `afterSwitchLocalePath` for alternate links: the path is shaped for the locale's canonical
+   * domain instead of the current host, so every host in the cluster emits the same href
+   */
+  getAlternatePath: (path: string, locale: string) => string
   /** Provides localized dynamic parameters for the current route */
   getLocalizedDynamicParams: (locale: string) => Record<string, unknown> | false | undefined
   /** Prepares a route object to be resolved as a localized route */
@@ -41,10 +46,18 @@ export type RoutingContext = {
  */
 export interface RoutingContextOptions {
   router: Router
+  /** The current host's unprefixed locale */
   defaultLocale: string
+  /**
+   * The configured `defaultLocale`, which a domain claiming none of its own falls back to. Needed to
+   * shape a link for another domain, where the current host's `defaultLocale` says nothing.
+   */
+  configuredDefaultLocale: string
   getLocale: () => string
   getLocales: () => NormalizedLocaleObject[]
   getBaseUrl: (locale?: string) => string
+  /** Base URL canonically naming a locale (alternate links), without current-host preference */
+  getCanonicalBaseUrl: (locale: string) => string
   /** Host of the current request/page, used for domain-based behavior */
   getHost: () => string | undefined
   /**
@@ -158,6 +171,40 @@ export function createRoutingContext(options: RoutingContextOptions): RoutingCon
   const getRouteLocalizedParams = () =>
     (router.currentRoute.value.meta[__DYNAMIC_PARAMS_KEY__] ?? {}) as Partial<I18nRouteMeta>
 
+  // a route carrying localized params it misses for `locale` is unavailable there (strict SEO)
+  const missesLocalizedParams = (locale: string, params = getRouteLocalizedParams()) =>
+    strictSeo && !!locale && Object.keys(params).length > 0 && !params[locale]
+
+  const stripsDefaultPrefix
+    = config.strategy === 'prefix_except_default' || config.strategy === 'prefix_and_default'
+
+  // whether `locale` is served unprefixed on `domain`. `defaultForDomains` alone is not the answer:
+  // a domain claiming no default of its own serves the configured `defaultLocale` unprefixed, and
+  // emitting a prefixed URL for it links to a route that domain never generated
+  const unprefixesLocale = (domain: string | undefined, locale: string) =>
+    !!domain && resolveDefaultLocale(normalizeDomain(domain), options.configuredDefaultLocale, options.getLocales()) === locale
+
+  // shapes `path` for the domain `getBase` resolves the locale to. Without a base the path stays
+  // relative to the current host, which prefixes the locale - stripping would link to whichever
+  // locale is unprefixed here (`joinURL('', '/')` collapses to an empty href)
+  const toDomainUrl = (getBase: (locale: string) => string) =>
+    (path: string, locale: string, target: NormalizedLocaleObject | undefined) => {
+      const base = getBase(locale)
+      if (!base) {
+        return path
+      }
+      if (stripsDefaultPrefix && unprefixesLocale(canonicalDomain(target), locale) && getLocaleFromRoutePath(path) === locale) {
+        path = path.slice(locale.length + 1) || '/'
+      }
+      return joinURL(base, path)
+    }
+
+  // navigation relocates to where the locale is SERVED, which stays relative on a host matching no
+  // configured domain so dev and staging never link to production; hreflang instead names one
+  // canonical domain per locale, identical from every host in the cluster
+  const toServingUrl = toDomainUrl(options.getBaseUrl)
+  const toCanonicalUrl = toDomainUrl(options.getCanonicalBaseUrl)
+
   return {
     router,
     getLocale: options.getLocale,
@@ -173,8 +220,7 @@ export function createRoutingContext(options: RoutingContextOptions): RoutingCon
       return getRouteLocalizedParams()?.[locale]
     },
     afterSwitchLocalePath: (path, locale) => {
-      const params = getRouteLocalizedParams()
-      if (strictSeo && locale && Object.keys(params).length && !params[locale]) {
+      if (missesLocalizedParams(locale)) {
         return ''
       }
 
@@ -190,8 +236,6 @@ export function createRoutingContext(options: RoutingContextOptions): RoutingCon
       // relative path is identical for every locale and would not switch anything
       const host = options.getHost() ?? ''
       const target = options.getLocales().find(l => l.code === locale)
-      const stripsDefaultPrefix
-        = config.strategy === 'prefix_except_default' || config.strategy === 'prefix_and_default'
 
       if (isLocaleOnHost(target, host)) {
         if (stripsDefaultPrefix && locale === getDefaultLocaleForDomain(host, options.getLocales()) && getLocaleFromRoutePath(path) === locale) {
@@ -206,10 +250,19 @@ export function createRoutingContext(options: RoutingContextOptions): RoutingCon
         return path
       }
 
-      if (stripsDefaultPrefix && target?.defaultForDomains.length && getLocaleFromRoutePath(path) === locale) {
-        path = path.slice(locale.length + 1) || '/'
+      return toServingUrl(path, locale, target)
+    },
+    getAlternatePath: (path, locale) => {
+      // the page being rendered has a URL of its own even when the params map omits its locale, and
+      // its canonical is resolved through here - a set that excluded the page itself is worse than
+      // one advertising a locale the author did not list
+      if (locale !== options.getLocale() && missesLocalizedParams(locale)) {
+        return ''
       }
-      return joinURL(options.getBaseUrl(locale), path)
+      if (!config.domains || !path) {
+        return path
+      }
+      return toCanonicalUrl(path, locale, options.getLocales().find(l => l.code === locale))
     },
     resolveLocalizedRouteObject: (route, locale) => {
       return isRouteLocationPathRaw(route)

--- a/src/runtime/routing/context.ts
+++ b/src/runtime/routing/context.ts
@@ -25,10 +25,7 @@ export type RoutingContext = {
   getRouteBaseName: (route: RouteRecordNameGeneric | RouteLocationGenericPath | null) => string | undefined
   /** Modifies the resolved localized path. Middleware for `switchLocalePath` */
   afterSwitchLocalePath: (path: string, locale: string) => string
-  /**
-   * `afterSwitchLocalePath` for alternate links: the path is shaped for the locale's canonical
-   * domain instead of the current host, so every host in the cluster emits the same href
-   */
+  /** `afterSwitchLocalePath` for alternate links, shaped for the locale's canonical domain */
   getAlternatePath: (path: string, locale: string) => string
   /** Provides localized dynamic parameters for the current route */
   getLocalizedDynamicParams: (locale: string) => Record<string, unknown> | false | undefined
@@ -48,15 +45,11 @@ export interface RoutingContextOptions {
   router: Router
   /** The current host's unprefixed locale */
   defaultLocale: string
-  /**
-   * The configured `defaultLocale`, which a domain claiming none of its own falls back to. Needed to
-   * shape a link for another domain, where the current host's `defaultLocale` says nothing.
-   */
+  /** Needed to shape a link for another domain, where the current host's `defaultLocale` says nothing */
   configuredDefaultLocale: string
   getLocale: () => string
   getLocales: () => NormalizedLocaleObject[]
   getBaseUrl: (locale?: string) => string
-  /** Base URL canonically naming a locale (alternate links), without current-host preference */
   getCanonicalBaseUrl: (locale: string) => string
   /** Host of the current request/page, used for domain-based behavior */
   getHost: () => string | undefined
@@ -178,30 +171,24 @@ export function createRoutingContext(options: RoutingContextOptions): RoutingCon
   const stripsDefaultPrefix
     = config.strategy === 'prefix_except_default' || config.strategy === 'prefix_and_default'
 
-  // whether `locale` is served unprefixed on `domain`. `defaultForDomains` alone is not the answer:
-  // a domain claiming no default of its own serves the configured `defaultLocale` unprefixed, and
-  // emitting a prefixed URL for it links to a route that domain never generated
-  const unprefixesLocale = (domain: string | undefined, locale: string) =>
-    !!domain && resolveDefaultLocale(normalizeDomain(domain), options.configuredDefaultLocale, options.getLocales()) === locale
+  const unprefixesLocale = (domain: string | undefined, locale: string, locales: NormalizedLocaleObject[]) =>
+    !!domain && resolveDefaultLocale(normalizeDomain(domain), options.configuredDefaultLocale, locales) === locale
 
-  // shapes `path` for the domain `getBase` resolves the locale to. Without a base the path stays
-  // relative to the current host, which prefixes the locale - stripping would link to whichever
-  // locale is unprefixed here (`joinURL('', '/')` collapses to an empty href)
+  // without a base the path stays relative to the current host, which prefixes the locale - and
+  // `joinURL('', '/')` collapses to an empty href
   const toDomainUrl = (getBase: (locale: string) => string) =>
-    (path: string, locale: string, target: NormalizedLocaleObject | undefined) => {
+    (path: string, locale: string, target: NormalizedLocaleObject | undefined, locales: NormalizedLocaleObject[]) => {
       const base = getBase(locale)
       if (!base) {
         return path
       }
-      if (stripsDefaultPrefix && unprefixesLocale(canonicalDomain(target), locale) && getLocaleFromRoutePath(path) === locale) {
+      if (stripsDefaultPrefix && unprefixesLocale(canonicalDomain(target), locale, locales) && getLocaleFromRoutePath(path) === locale) {
         path = path.slice(locale.length + 1) || '/'
       }
       return joinURL(base, path)
     }
 
-  // navigation relocates to where the locale is SERVED, which stays relative on a host matching no
-  // configured domain so dev and staging never link to production; hreflang instead names one
-  // canonical domain per locale, identical from every host in the cluster
+  // serving URLs stay relative on an unconfigured host, so dev and staging never link to production
   const toServingUrl = toDomainUrl(options.getBaseUrl)
   const toCanonicalUrl = toDomainUrl(options.getCanonicalBaseUrl)
 
@@ -228,17 +215,14 @@ export function createRoutingContext(options: RoutingContextOptions): RoutingCon
         return path
       }
 
-      // per-locale host membership decides the link shape: on-host targets navigate
-      // relative (unprefixed when the host default), off-host targets get an absolute
-      // URL in the target domain's shape
-      // membership is strict here on purpose: a locale that lives on another domain needs an
-      // absolute link even from a host matching no configured domain, under `no_prefix` the
-      // relative path is identical for every locale and would not switch anything
+      // membership is strict on purpose: a locale living on another domain needs an absolute link
+      // even from an unconfigured host, and under `no_prefix` a relative path switches nothing
       const host = options.getHost() ?? ''
-      const target = options.getLocales().find(l => l.code === locale)
+      const locales = options.getLocales()
+      const target = locales.find(l => l.code === locale)
 
       if (isLocaleOnHost(target, host)) {
-        if (stripsDefaultPrefix && locale === getDefaultLocaleForDomain(host, options.getLocales()) && getLocaleFromRoutePath(path) === locale) {
+        if (stripsDefaultPrefix && locale === getDefaultLocaleForDomain(host, locales) && getLocaleFromRoutePath(path) === locale) {
           return path.slice(locale.length + 1) || '/'
         }
         return path
@@ -250,19 +234,19 @@ export function createRoutingContext(options: RoutingContextOptions): RoutingCon
         return path
       }
 
-      return toServingUrl(path, locale, target)
+      return toServingUrl(path, locale, target, locales)
     },
     getAlternatePath: (path, locale) => {
-      // the page being rendered has a URL of its own even when the params map omits its locale, and
-      // its canonical is resolved through here - a set that excluded the page itself is worse than
-      // one advertising a locale the author did not list
+      // the current page has a URL even when the params map omits its locale, and its canonical
+      // resolves through here - excluding the page itself is worse than advertising an unlisted one
       if (locale !== options.getLocale() && missesLocalizedParams(locale)) {
         return ''
       }
       if (!config.domains || !path) {
         return path
       }
-      return toCanonicalUrl(path, locale, options.getLocales().find(l => l.code === locale))
+      const locales = options.getLocales()
+      return toCanonicalUrl(path, locale, locales.find(l => l.code === locale), locales)
     },
     resolveLocalizedRouteObject: (route, locale) => {
       return isRouteLocationPathRaw(route)

--- a/src/runtime/routing/head.ts
+++ b/src/runtime/routing/head.ts
@@ -28,8 +28,7 @@ function createHeadContext(
   config: Required<I18nHeadOptions>,
   locale = ctx.getLocale(),
   locales = ctx.getLocales(),
-  // the default base URL under domain setups is the default locale's domain, resolve the
-  // current locale's domain so canonical and og:url self-reference the current host (#2595)
+  // only reached for a relative path, which under domains means a host matching none of them
   baseUrl = ctx.routingOptions.domains ? ctx.getBaseUrl(locale) : ctx.getBaseUrl(),
 ): HeadContext {
   const currentLocale: LocaleObject = locales.find(l => l.code === locale) || { code: locale }
@@ -40,6 +39,9 @@ function createHeadContext(
     warnedClusterFallback = true
     console.warn('[nuxt-i18n] Set `defaultLocale` to annotate an `x-default` alternate for your domains.')
   }
+
+  // alternate links resolve through the same routing as navigation, shaped for the canonical domain
+  const alternateCtx = { ...ctx, afterSwitchLocalePath: ctx.getAlternatePath }
 
   if (!baseUrl && !ctx.routingOptions.domains) {
     if (ctx.strictSeo) {
@@ -64,10 +66,7 @@ function createHeadContext(
     getCurrentLanguage: () => currentLocale.language,
     getCurrentDirection: () => currentLocale.dir || __DEFAULT_DIRECTION__,
     getLocaleRoute: route => localeRoute(ctx, route),
-    // alternate links name the locale's canonical domain rather than the current host, so hosts
-    // sharing a locale agree on its href. A locale configuring no domain has none to name and
-    // still resolves per host
-    getLocalizedRoute: (locale, route) => switchLocalePath(ctx, locale, route, ctx.getAlternatePath),
+    getLocalizedRoute: (locale, route) => switchLocalePath(alternateCtx, locale, route),
     getRouteWithoutQuery: () => {
       try {
         return assign({}, ctx.router.resolve({ query: {} }), { meta: ctx.router.currentRoute.value.meta })

--- a/src/runtime/routing/head.ts
+++ b/src/runtime/routing/head.ts
@@ -1,5 +1,4 @@
 import { type Ref, computed, getCurrentScope, onScopeDispose, ref, useHead, useRequestEvent, watch } from '#imports'
-import { joinURL } from 'ufo'
 import { assign } from '@intlify/shared'
 import { type HeadContext, localeHead as _localeHead } from '#i18n-kit/head'
 
@@ -54,6 +53,7 @@ function createHeadContext(
     key: ctx.strictSeo ? 'key' : 'id',
     strictSeo: ctx.strictSeo,
     locales,
+    currentLocale: locale,
     baseUrl,
     canonicalQueries,
     hreflangLinks: ctx.routingOptions.hreflangLinks,
@@ -64,14 +64,10 @@ function createHeadContext(
     getCurrentLanguage: () => currentLocale.language,
     getCurrentDirection: () => currentLocale.dir || __DEFAULT_DIRECTION__,
     getLocaleRoute: route => localeRoute(ctx, route),
-    getLocalizedRoute: (locale, route) => {
-      const path = switchLocalePath(ctx, locale, route)
-      // head links are absolute per locale under domain setups, navigation links may be host-relative
-      if (ctx.routingOptions.domains && path && path[0] === '/') {
-        return joinURL(ctx.getBaseUrl(locale), path)
-      }
-      return path
-    },
+    // alternate links name the locale's canonical domain rather than the current host, so hosts
+    // sharing a locale agree on its href. A locale configuring no domain has none to name and
+    // still resolves per host
+    getLocalizedRoute: (locale, route) => switchLocalePath(ctx, locale, route, ctx.getAlternatePath),
     getRouteWithoutQuery: () => {
       try {
         return assign({}, ctx.router.resolve({ query: {} }), { meta: ctx.router.currentRoute.value.meta })

--- a/src/runtime/routing/routing.ts
+++ b/src/runtime/routing/routing.ts
@@ -83,7 +83,6 @@ export function switchLocalePath(
   ctx: RoutingContext,
   locale: Locale,
   route: CompatRoute = ctx.router.currentRoute.value,
-  shapePath: (path: string, locale: string) => string = ctx.afterSwitchLocalePath,
 ): string {
   const name = ctx.getRouteBaseName(route)
   // unable to localize nameless path
@@ -111,5 +110,5 @@ export function switchLocalePath(
 
   const path = localePath(ctx, routeCopy, locale)
   // custom locale path for domains
-  return shapePath(path, locale)
+  return ctx.afterSwitchLocalePath(path, locale)
 }

--- a/src/runtime/routing/routing.ts
+++ b/src/runtime/routing/routing.ts
@@ -83,6 +83,7 @@ export function switchLocalePath(
   ctx: RoutingContext,
   locale: Locale,
   route: CompatRoute = ctx.router.currentRoute.value,
+  shapePath: (path: string, locale: string) => string = ctx.afterSwitchLocalePath,
 ): string {
   const name = ctx.getRouteBaseName(route)
   // unable to localize nameless path
@@ -110,5 +111,5 @@ export function switchLocalePath(
 
   const path = localePath(ctx, routeCopy, locale)
   // custom locale path for domains
-  return ctx.afterSwitchLocalePath(path, locale)
+  return shapePath(path, locale)
 }

--- a/src/runtime/shared/domain.ts
+++ b/src/runtime/shared/domain.ts
@@ -29,15 +29,21 @@ export function isLocaleServedOnHost(locales: NormalizedLocaleObject[], host: st
 }
 
 /**
- * The domain that should serve `locale` when `host` does not, preferring the one it is the
- * default for. Undefined when the current host can serve it, which keeps hosts that match no
- * configured domain on relative URLs instead of sending them to a configured domain.
+ * The domain canonically naming `locale`. `defaultForDomains` leads so the domain agrees with the
+ * unprefixed shape callers derive from that same field.
+ */
+export const canonicalDomain = (target: NormalizedLocaleObject | undefined) =>
+  target?.defaultForDomains[0] || target?.domain || target?.domains[0]
+
+/**
+ * The domain that should serve `locale` when `host` does not. Undefined when the current host
+ * can serve it, which keeps hosts that match no configured domain on relative URLs instead of
+ * sending them to a configured domain.
  */
 function relocateHostForLocale(host: string, locale: string, locales: NormalizedLocaleObject[]): string | undefined {
   if (isLocaleServedOnHost(locales, host, locale)) { return }
 
-  const target = locales.find(l => l.code === locale)
-  return target?.defaultForDomains[0] || target?.domain || target?.domains[0]
+  return canonicalDomain(locales.find(l => l.code === locale))
 }
 
 export function matchDomainLocale(
@@ -94,6 +100,22 @@ export function domainFromLocale(
   }
 
   return withProtocol(domain, url)
+}
+
+/**
+ * Resolves {@link canonicalDomain} for `locale`, unlike {@link domainFromLocale} without a
+ * current-host preference: alternate links must name one URL for a locale served on several
+ * domains, identical from every host in the cluster, or the hreflang set is non-reciprocal.
+ * Undefined for a locale without domains, which is served wherever it is asked for.
+ */
+export function canonicalDomainFromLocale(
+  domainLocales: Record<string, { domain: string | undefined }>,
+  url: { host: string, protocol: string },
+  locale: string,
+  locales: NormalizedLocaleObject[] = normalizedLocales,
+): string | undefined {
+  const domain = domainLocales?.[locale]?.domain || canonicalDomain(locales.find(x => x.code === locale))
+  return domain ? withProtocol(domain, url) : undefined
 }
 
 /**

--- a/src/runtime/shared/domain.ts
+++ b/src/runtime/shared/domain.ts
@@ -106,7 +106,8 @@ export function domainFromLocale(
  * Resolves {@link canonicalDomain} for `locale`, unlike {@link domainFromLocale} without a
  * current-host preference: alternate links must name one URL for a locale served on several
  * domains, identical from every host in the cluster, or the hreflang set is non-reciprocal.
- * Undefined for a locale without domains, which is served wherever it is asked for.
+ * Undefined for a locale configuring no domain, which is served on all of them - callers resolve
+ * the cluster's own domain by asking for `defaultLocale` instead.
  */
 export function canonicalDomainFromLocale(
   domainLocales: Record<string, { domain: string | undefined }>,

--- a/src/runtime/shared/domain.ts
+++ b/src/runtime/shared/domain.ts
@@ -28,10 +28,7 @@ export function isLocaleServedOnHost(locales: NormalizedLocaleObject[], host: st
   return isLocaleOnHost(target, host) || !locales.some(l => isLocaleOnHost(l, host))
 }
 
-/**
- * The domain canonically naming `locale`. `defaultForDomains` leads so the domain agrees with the
- * unprefixed shape callers derive from that same field.
- */
+/** `defaultForDomains` leads so the domain agrees with the unprefixed shape derived from it */
 export const canonicalDomain = (target: NormalizedLocaleObject | undefined) =>
   target?.defaultForDomains[0] || target?.domain || target?.domains[0]
 
@@ -104,18 +101,19 @@ export function domainFromLocale(
 
 /**
  * Resolves {@link canonicalDomain} for `locale`, unlike {@link domainFromLocale} without a
- * current-host preference: alternate links must name one URL for a locale served on several
- * domains, identical from every host in the cluster, or the hreflang set is non-reciprocal.
- * Undefined for a locale configuring no domain, which is served on all of them - callers resolve
- * the cluster's own domain by asking for `defaultLocale` instead.
+ * current-host preference - alternate links naming a different URL per host are non-reciprocal.
+ * A locale configuring no domain is served on all of them, so it falls back to `fallbackLocale`'s
+ * domain (the cluster's own) rather than to whichever host is answering.
  */
 export function canonicalDomainFromLocale(
   domainLocales: Record<string, { domain: string | undefined }>,
   url: { host: string, protocol: string },
   locale: string,
+  fallbackLocale?: string,
   locales: NormalizedLocaleObject[] = normalizedLocales,
 ): string | undefined {
-  const domain = domainLocales?.[locale]?.domain || canonicalDomain(locales.find(x => x.code === locale))
+  const forLocale = (code: string) => domainLocales?.[code]?.domain || canonicalDomain(locales.find(x => x.code === code))
+  const domain = forLocale(locale) || (fallbackLocale ? forLocale(fallbackLocale) : undefined)
   return domain ? withProtocol(domain, url) : undefined
 }
 

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -11,7 +11,7 @@ import {
   withRuntimeDomain,
 } from '../src/runtime/shared/domain'
 import { getDefaultLocaleForDomain } from '../src/runtime/shared/locales'
-import { createBaseUrlGetter } from '../src/runtime/context'
+import { createBaseUrlGetter, withConfiguredProtocol } from '../src/runtime/context'
 import { normalizeDomainLocale } from '../src/utils'
 import { getNormalizedLocales } from './pages/utils'
 
@@ -340,6 +340,23 @@ describe('withRuntimeDomain', () => {
       domains: ['en.staging.example.com'],
       defaultForDomains: []
     })
+  })
+})
+
+describe('withConfiguredProtocol', () => {
+  const url = { host: 'en.example.com', protocol: 'http:' }
+
+  test('takes the scheme from `baseUrl`, which the request cannot be trusted for', () => {
+    // prerender has no request, and a proxy terminating TLS reports `http` for an https site
+    expect(withConfiguredProtocol(url, 'https://example.com')).toEqual({ host: 'en.example.com', protocol: 'https:' })
+    expect(withConfiguredProtocol(url, 'http://example.com')).toEqual({ host: 'en.example.com', protocol: 'http:' })
+  })
+
+  test('keeps the request URL when `baseUrl` names no scheme', () => {
+    expect(withConfiguredProtocol(url, '')).toBe(url)
+    expect(withConfiguredProtocol(url, undefined)).toBe(url)
+    expect(withConfiguredProtocol(url, '/base-path')).toBe(url)
+    expect(withConfiguredProtocol(url, () => 'https://example.com')).toBe(url)
   })
 })
 

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import {
+  canonicalDomainFromLocale,
   cookieSpansDomains,
   domainForHost,
   domainFromLocale,
@@ -183,6 +184,50 @@ describe('domainFromLocale', () => {
   test('a host matching no configured domain resolves no domain, so URLs stay relative', () => {
     // otherwise `nuxt dev` and staging would link and redirect to the configured domains
     expect(domainFromLocale({}, { host: 'localhost:3000', protocol: 'http:' }, 'nl', locales)).toBeUndefined()
+  })
+})
+
+describe('canonicalDomainFromLocale', () => {
+  const url = { host: 'en.example.com', protocol: 'http:' }
+  const multi = [
+    ...locales,
+    ...getNormalizedLocales([
+      { code: 'pt', domains: ['a.example.com', 'b.example.com'], defaultForDomains: ['b.example.com'] },
+    ]),
+  ]
+
+  test('resolves the same domain from every host for a locale served on several', () => {
+    for (const host of ['a.example.com', 'b.example.com', 'en.example.com', 'localhost:3000']) {
+      expect(canonicalDomainFromLocale({}, { host, protocol: 'http:' }, 'pt', multi)).toBe('http://b.example.com')
+    }
+    // `domainFromLocale` prefers the current host, which made hreflang links non-reciprocal
+    expect(domainFromLocale({}, { host: 'a.example.com', protocol: 'http:' }, 'pt', multi)).toBe(
+      'http://a.example.com'
+    )
+  })
+
+  test('the domain the locale is the default for wins over its own `domain`', () => {
+    // the unprefixed shape is derived from `defaultForDomains` too, resolving `domain` here would
+    // emit an unprefixed path for a domain that prefixes the locale
+    const own = getNormalizedLocales([
+      { code: 'en', domain: 'own.example.com', domains: ['shared.example.com'], defaultForDomains: ['shared.example.com'] },
+    ])
+    expect(canonicalDomainFromLocale({}, url, 'en', own)).toBe('http://shared.example.com')
+    expect(canonicalDomainFromLocale({}, url, 'nl', locales)).toBe('http://shared.example.com')
+  })
+
+  test('keeps the protocol of the configured domain', () => {
+    expect(canonicalDomainFromLocale({}, url, 'es', locales)).toBe('https://shared2.example.com')
+  })
+
+  test('`domainLocales` runtime config overrides the configured domain', () => {
+    expect(canonicalDomainFromLocale({ pt: { domain: 'pt.staging.example.com' } }, url, 'pt', multi)).toBe(
+      'http://pt.staging.example.com'
+    )
+  })
+
+  test('returns undefined for a locale without domains', () => {
+    expect(canonicalDomainFromLocale({}, url, 'pl', [...locales, ...getNormalizedLocales(['pl'])])).toBeUndefined()
   })
 })
 

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -198,7 +198,7 @@ describe('canonicalDomainFromLocale', () => {
 
   test('resolves the same domain from every host for a locale served on several', () => {
     for (const host of ['a.example.com', 'b.example.com', 'en.example.com', 'localhost:3000']) {
-      expect(canonicalDomainFromLocale({}, { host, protocol: 'http:' }, 'pt', multi)).toBe('http://b.example.com')
+      expect(canonicalDomainFromLocale({}, { host, protocol: 'http:' }, 'pt', undefined, multi)).toBe('http://b.example.com')
     }
     // `domainFromLocale` prefers the current host, which made hreflang links non-reciprocal
     expect(domainFromLocale({}, { host: 'a.example.com', protocol: 'http:' }, 'pt', multi)).toBe(
@@ -212,22 +212,26 @@ describe('canonicalDomainFromLocale', () => {
     const own = getNormalizedLocales([
       { code: 'en', domain: 'own.example.com', domains: ['shared.example.com'], defaultForDomains: ['shared.example.com'] },
     ])
-    expect(canonicalDomainFromLocale({}, url, 'en', own)).toBe('http://shared.example.com')
-    expect(canonicalDomainFromLocale({}, url, 'nl', locales)).toBe('http://shared.example.com')
+    expect(canonicalDomainFromLocale({}, url, 'en', undefined, own)).toBe('http://shared.example.com')
+    expect(canonicalDomainFromLocale({}, url, 'nl', undefined, locales)).toBe('http://shared.example.com')
   })
 
   test('keeps the protocol of the configured domain', () => {
-    expect(canonicalDomainFromLocale({}, url, 'es', locales)).toBe('https://shared2.example.com')
+    expect(canonicalDomainFromLocale({}, url, 'es', undefined, locales)).toBe('https://shared2.example.com')
   })
 
   test('`domainLocales` runtime config overrides the configured domain', () => {
-    expect(canonicalDomainFromLocale({ pt: { domain: 'pt.staging.example.com' } }, url, 'pt', multi)).toBe(
+    expect(canonicalDomainFromLocale({ pt: { domain: 'pt.staging.example.com' } }, url, 'pt', undefined, multi)).toBe(
       'http://pt.staging.example.com'
     )
   })
 
-  test('returns undefined for a locale without domains', () => {
-    expect(canonicalDomainFromLocale({}, url, 'pl', [...locales, ...getNormalizedLocales(['pl'])])).toBeUndefined()
+  test('a locale without domains falls back to the domain naming `fallbackLocale`', () => {
+    const withPlain = [...locales, ...getNormalizedLocales(['pl'])]
+    expect(canonicalDomainFromLocale({}, url, 'pl', 'nl', withPlain)).toBe('http://shared.example.com')
+    // nothing to fall back to leaves the caller on its own base
+    expect(canonicalDomainFromLocale({}, url, 'pl', undefined, withPlain)).toBeUndefined()
+    expect(canonicalDomainFromLocale({}, url, 'pl', 'pl', withPlain)).toBeUndefined()
   })
 })
 
@@ -347,7 +351,6 @@ describe('withConfiguredProtocol', () => {
   const url = { host: 'en.example.com', protocol: 'http:' }
 
   test('takes the scheme from `baseUrl`, which the request cannot be trusted for', () => {
-    // prerender has no request, and a proxy terminating TLS reports `http` for an https site
     expect(withConfiguredProtocol(url, 'https://example.com')).toEqual({ host: 'en.example.com', protocol: 'https:' })
     expect(withConfiguredProtocol(url, 'http://example.com')).toEqual({ host: 'en.example.com', protocol: 'http:' })
   })

--- a/test/kit-head.test.ts
+++ b/test/kit-head.test.ts
@@ -19,6 +19,7 @@ function createHeadContext(overrides: Partial<HeadContext> = {}): HeadContext {
     seo: true,
     baseUrl: 'https://example.com',
     locales,
+    currentLocale: 'en',
     defaultLocale: 'en',
     hreflangLinks: true,
     strictCanonicals: true,
@@ -111,7 +112,8 @@ describe('canonical link', () => {
   })
 
   test('omits canonical when the route cannot be resolved', () => {
-    const head = localeHead(createHeadContext({ getLocaleRoute: () => undefined }))
+    // the canonical is the current locale's own alternate, so it goes when that cannot be resolved
+    const head = localeHead(createHeadContext({ getLocalizedRoute: () => '' }))
     expect(head.link.find(x => x.rel === 'canonical')).toBeUndefined()
     expect(head.meta.find(x => x.property === 'og:url')).toBeUndefined()
   })

--- a/test/kit.test.ts
+++ b/test/kit.test.ts
@@ -13,6 +13,8 @@ import { localizeRoutes } from '../src/routing'
 import { setupMultiDomainLocales } from '../src/runtime/routing/domain'
 import { getNormalizedLocales } from './pages/utils'
 import { resolveDefaultLocale } from '../src/runtime/shared/locales'
+import { canonicalDomainFromLocale, domainForHost, domainFromLocale } from '../src/runtime/shared/domain'
+import { createBaseUrlGetter } from '../src/runtime/context'
 import type { NuxtPage } from '@nuxt/schema'
 import type { Strategies } from '#internal-i18n-types'
 import { LocalizableRoute } from '../src/kit/gen'
@@ -30,10 +32,10 @@ const routingOptions = {
 
 const i18nMock = {
   locale: ref('en'),
-  locales: ref([
+  locales: ref(getNormalizedLocales([
     { code: 'en', language: 'en-US' },
     { code: 'ja', language: 'ja-JP' }
-  ]),
+  ])),
   baseUrl: ref('http://localhost')
 }
 
@@ -48,7 +50,8 @@ async function loadFixtureAndRoutes() {
   })
   const locales = getNormalizedLocales(nuxt.options.i18n.locales)
   i18nMock.locale.value = locales[0].code
-  i18nMock.locales.value = locales.map(x => ({ code: x.code, language: x.language ?? x.code }))
+  // kept normalized - `localizeRoutes` and the routing context both read the domain fields
+  i18nMock.locales.value = locales.map(x => ({ ...x, language: x.language ?? x.code }))
   i18nMock.baseUrl.value = String(nuxt.options.i18n.baseUrl)
   try {
     return await new Promise<NuxtPage[]>(res => {
@@ -107,6 +110,7 @@ describe.each(STRATEGIES)('routing context (strategy: %s)', strategy => {
     ctx = createRoutingContext({
       router,
       defaultLocale: DEFAULT_LOCALE,
+      configuredDefaultLocale: DEFAULT_LOCALE,
       strategy,
       routing: strategy !== 'no_prefix',
       domains: false,
@@ -116,6 +120,7 @@ describe.each(STRATEGIES)('routing context (strategy: %s)', strategy => {
       getLocale: () => unref(i18nMock.locale),
       getLocales: () => unref(i18nMock.locales),
       getBaseUrl: () => unref(i18nMock.baseUrl),
+      getCanonicalBaseUrl: () => unref(i18nMock.baseUrl),
       getHost: () => 'localhost'
     })
   })
@@ -327,9 +332,19 @@ describe('switchLocalePath with differentDomains', () => {
     const hostDefault = resolveDefaultLocale(opts.host, opts.defaultLocale, locales)
     setupMultiDomainLocales(hostDefault, opts.strategy, router)
 
+    // base URLs derived through the runtime getters, seeded like `module.ts` seeds `domainLocales`
+    const url = { host: opts.host, protocol: 'http:' }
+    const domainLocales = Object.fromEntries(locales.map(l => [l.code, { domain: l.domain ?? '' }]))
+    const baseUrlOptions = {
+      baseUrl: undefined,
+      appBase: '/',
+      domains: true,
+      getDomainForHost: () => domainForHost(domainLocales, url, locales)
+    }
     const ctx = createRoutingContext({
       router,
       defaultLocale: hostDefault,
+      configuredDefaultLocale: opts.defaultLocale ?? '',
       strategy: opts.strategy,
       routing: true,
       domains: true,
@@ -338,7 +353,14 @@ describe('switchLocalePath with differentDomains', () => {
       compactRoutes: false,
       getLocale: () => opts.locale,
       getLocales: () => locales,
-      getBaseUrl: locale => `http://${locales.find(l => l.code === (locale ?? opts.locale))?.domains[0] ?? opts.host}`,
+      getBaseUrl: createBaseUrlGetter({
+        ...baseUrlOptions,
+        getDomainFromLocale: l => domainFromLocale(domainLocales, url, l, locales)
+      }),
+      getCanonicalBaseUrl: createBaseUrlGetter({
+        ...baseUrlOptions,
+        getDomainFromLocale: l => canonicalDomainFromLocale(domainLocales, url, l, locales)
+      }),
       getHost: () => opts.host
     })
     return { router, ctx }

--- a/test/kit.test.ts
+++ b/test/kit.test.ts
@@ -11,10 +11,8 @@ import { buildNuxt, loadNuxt } from '@nuxt/kit'
 import { resolve } from 'pathe'
 import { localizeRoutes } from '../src/routing'
 import { setupMultiDomainLocales } from '../src/runtime/routing/domain'
-import { getNormalizedLocales } from './pages/utils'
+import { createTestBaseUrls, getNormalizedLocales } from './pages/utils'
 import { resolveDefaultLocale } from '../src/runtime/shared/locales'
-import { canonicalDomainFromLocale, domainForHost, domainFromLocale } from '../src/runtime/shared/domain'
-import { createBaseUrlGetter } from '../src/runtime/context'
 import type { NuxtPage } from '@nuxt/schema'
 import type { Strategies } from '#internal-i18n-types'
 import { LocalizableRoute } from '../src/kit/gen'
@@ -332,15 +330,6 @@ describe('switchLocalePath with differentDomains', () => {
     const hostDefault = resolveDefaultLocale(opts.host, opts.defaultLocale, locales)
     setupMultiDomainLocales(hostDefault, opts.strategy, router)
 
-    // base URLs derived through the runtime getters, seeded like `module.ts` seeds `domainLocales`
-    const url = { host: opts.host, protocol: 'http:' }
-    const domainLocales = Object.fromEntries(locales.map(l => [l.code, { domain: l.domain ?? '' }]))
-    const baseUrlOptions = {
-      baseUrl: undefined,
-      appBase: '/',
-      domains: true,
-      getDomainForHost: () => domainForHost(domainLocales, url, locales)
-    }
     const ctx = createRoutingContext({
       router,
       defaultLocale: hostDefault,
@@ -353,14 +342,7 @@ describe('switchLocalePath with differentDomains', () => {
       compactRoutes: false,
       getLocale: () => opts.locale,
       getLocales: () => locales,
-      getBaseUrl: createBaseUrlGetter({
-        ...baseUrlOptions,
-        getDomainFromLocale: l => domainFromLocale(domainLocales, url, l, locales)
-      }),
-      getCanonicalBaseUrl: createBaseUrlGetter({
-        ...baseUrlOptions,
-        getDomainFromLocale: l => canonicalDomainFromLocale(domainLocales, url, l, locales)
-      }),
+      ...createTestBaseUrls({ locales, host: opts.host, protocol: 'http:', defaultLocale: opts.defaultLocale }),
       getHost: () => opts.host
     })
     return { router, ctx }

--- a/test/pages/localize_routes.test.ts
+++ b/test/pages/localize_routes.test.ts
@@ -380,6 +380,35 @@ describe('localizeRoutes', function () {
         })
       ).toBe(true)
     })
+
+    it('accepts `no_prefix` under `multiDomainLocales` when each locale has its own domain', function () {
+      // the locale data decides, not which option turned domains on
+      expect(
+        shouldLocalizeRoutes({
+          ...nuxtOptions,
+          strategy: 'no_prefix',
+          multiDomainLocales: true,
+          locales: getNormalizedLocales([
+            { code: 'en', domains: ['en.example.com'] },
+            { code: 'fr', domains: ['fr.example.com'] }
+          ])
+        })
+      ).toBe(true)
+    })
+
+    it('rejects `no_prefix` without any domain, so a plain site keeps unlocalized routes', function () {
+      expect(
+        shouldLocalizeRoutes({ ...nuxtOptions, strategy: 'no_prefix', locales: getNormalizedLocales(['en', 'fr']) })
+      ).toBe(false)
+      // domains alone qualify, with neither option set (the v11 direction)
+      expect(
+        shouldLocalizeRoutes({
+          ...nuxtOptions,
+          strategy: 'no_prefix',
+          locales: getNormalizedLocales([{ code: 'en', domains: ['en.example.com'] }, { code: 'fr', domains: ['fr.example.com'] }])
+        })
+      ).toBe(true)
+    })
   })
 
   it('does not generate an unprefixed variant for `domainDefault` without a domain', function () {

--- a/test/pages/localize_routes.test.ts
+++ b/test/pages/localize_routes.test.ts
@@ -382,7 +382,6 @@ describe('localizeRoutes', function () {
     })
 
     it('accepts `no_prefix` under `multiDomainLocales` when each locale has its own domain', function () {
-      // the locale data decides, not which option turned domains on
       expect(
         shouldLocalizeRoutes({
           ...nuxtOptions,
@@ -396,18 +395,26 @@ describe('localizeRoutes', function () {
       ).toBe(true)
     })
 
-    it('rejects `no_prefix` without any domain, so a plain site keeps unlocalized routes', function () {
+    it('rejects `no_prefix` without domains, and without an option making the runtime use them', function () {
+      const perLocaleDomains = getNormalizedLocales([
+        { code: 'en', domains: ['en.example.com'] },
+        { code: 'fr', domains: ['fr.example.com'] }
+      ])
+      // a plain `no_prefix` site keeps unlocalized routes
       expect(
         shouldLocalizeRoutes({ ...nuxtOptions, strategy: 'no_prefix', locales: getNormalizedLocales(['en', 'fr']) })
       ).toBe(false)
-      // domains alone qualify, with neither option set (the v11 direction)
+      // domains alone leave `__I18N_DOMAINS__` off, so nothing would resolve a locale from the host
+      expect(shouldLocalizeRoutes({ ...nuxtOptions, strategy: 'no_prefix', locales: perLocaleDomains })).toBe(false)
+      // a domain setup configuring no domains has nothing to localize by
       expect(
         shouldLocalizeRoutes({
           ...nuxtOptions,
           strategy: 'no_prefix',
-          locales: getNormalizedLocales([{ code: 'en', domains: ['en.example.com'] }, { code: 'fr', domains: ['fr.example.com'] }])
+          multiDomainLocales: true,
+          locales: getNormalizedLocales(['en', 'fr'])
         })
-      ).toBe(true)
+      ).toBe(false)
     })
   })
 

--- a/test/pages/utils.ts
+++ b/test/pages/utils.ts
@@ -4,6 +4,8 @@ import type { ComputedRouteOptions, LocalizableRoute, RouteOptionsResolver } fro
 
 import { isString } from '@intlify/shared'
 import { normalizeDomainLocale } from '../../src/utils'
+import { canonicalDomainFromLocale, domainForHost, domainFromLocale } from '../../src/runtime/shared/domain'
+import { createBaseUrlGetter } from '../../src/runtime/context'
 
 /** Mirrors how `resolveContext` normalizes configured locales - see `src/context.ts` */
 export const getNormalizedLocales = (locales: string[] | LocaleObject[] = []): NormalizedLocaleObject[] =>
@@ -103,5 +105,42 @@ export function createTestConfig(opts: {
     differentDomains: opts.differentDomains,
     multiDomainLocales: opts.multiDomainLocales,
     compactRoutes: opts.compactRoutes,
+  }
+}
+
+/**
+ * Mirrors how `createNuxtI18nContext` builds the base URL getters - see `src/runtime/context.ts`.
+ * Derived through the real resolvers rather than stubbed per suite: a hand-written getter cannot
+ * expose a current-host preference, which is what let #4106's hreflang bug through.
+ */
+export function createTestBaseUrls(opts: {
+  locales: NormalizedLocaleObject[]
+  host: string
+  protocol?: string
+  baseUrl?: string
+  appBase?: string
+  domains?: boolean
+  defaultLocale?: string
+}) {
+  const url = { host: opts.host, protocol: opts.protocol ?? 'https:' }
+  // `module.ts` seeds an entry per locale from the scalar `domain`
+  const domainLocales = Object.fromEntries(opts.locales.map(l => [l.code, { domain: l.domain ?? '' }]))
+  const shared = {
+    baseUrl: opts.baseUrl,
+    appBase: opts.appBase ?? '/',
+    domains: opts.domains ?? true,
+    getDomainForHost: () => domainForHost(domainLocales, url, opts.locales),
+  }
+
+  return {
+    getBaseUrl: createBaseUrlGetter({
+      ...shared,
+      getDomainFromLocale: l => domainFromLocale(domainLocales, url, l, opts.locales),
+    }),
+    getCanonicalBaseUrl: createBaseUrlGetter({
+      ...shared,
+      getDomainFromLocale: l =>
+        canonicalDomainFromLocale(domainLocales, url, l, opts.defaultLocale, opts.locales),
+    }),
   }
 }

--- a/test/routing-head.test.ts
+++ b/test/routing-head.test.ts
@@ -7,9 +7,7 @@ import { _useLocaleHead, _useSetI18nParams, localeHead, missesClusterFallback } 
 import { switchLocalePath } from '../src/runtime/routing/routing'
 import { headEntries } from './mocks/imports'
 import { resolveDefaultLocale } from '../src/runtime/shared/locales'
-import { canonicalDomainFromLocale, domainForHost, domainFromLocale } from '../src/runtime/shared/domain'
-import { createBaseUrlGetter } from '../src/runtime/context'
-import { getNormalizedLocales } from './pages/utils'
+import { createTestBaseUrls, getNormalizedLocales } from './pages/utils'
 
 import type { Router } from 'vue-router'
 import type { ComposableContext } from '../src/runtime/composable-context'
@@ -41,8 +39,7 @@ const clusterLocales = getNormalizedLocales([
   { code: 'fr', language: 'fr', domains: ['example.nl', 'example.be'], defaultForDomains: ['example.be'] },
 ])
 
-// mirrors the build output: every locale prefixed, `___default` variants for domain defaults,
-// `setupMultiDomainLocales` rebuilds them per host
+// mirrors the build output: every locale prefixed, `___default` variants for domain defaults
 const clusterRoutesFor = (cluster: typeof clusterLocales) => [
   ...cluster.map(l => ({ name: `index___${l.code}`, path: `/${l.code}`, component })),
   ...cluster
@@ -50,12 +47,15 @@ const clusterRoutesFor = (cluster: typeof clusterLocales) => [
     .map(l => ({ name: `index___${l.code}___default`, path: '/', component })),
 ]
 
-function createTestContext(
-  initialLocale = 'en',
-  strictSeo = false,
-  domains: boolean | { host: string, locales?: typeof clusterLocales } = false,
-  configuredDefault = 'en',
-) {
+type TestContextOptions = {
+  strictSeo?: boolean
+  /** `true` gives every locale its own domain, an object selects the shared-domain cluster */
+  domains?: boolean | { host: string, locales?: typeof clusterLocales }
+  defaultLocale?: string
+}
+
+function createTestContext(initialLocale = 'en', opts: TestContextOptions = {}) {
+  const { strictSeo = false, domains = false, defaultLocale: configuredDefault = 'en' } = opts
   let locale = initialLocale
   const cluster = typeof domains === 'object' ? (domains.locales ?? clusterLocales) : undefined
   const router = createRouter({
@@ -76,15 +76,6 @@ function createTestContext(
     // rebuild the route table for the current host, mirrors the runtime plugin
     setupMultiDomainLocales(hostDefault, 'prefix_except_default', router)
   }
-  // base URLs derived through the runtime getters, seeded like `module.ts` seeds `domainLocales`
-  const url = { host, protocol: 'https:' }
-  const domainLocalesMap = Object.fromEntries(testLocales.map(l => [l.code, { domain: l.domain ?? '' }]))
-  const baseUrlOptions = {
-    baseUrl: domains ? undefined : 'https://example.com',
-    appBase: '/',
-    domains: !!domains,
-    getDomainForHost: () => domainForHost(domainLocalesMap, url, testLocales),
-  }
   const ctx = {
     ...createRoutingContext({
       router,
@@ -98,16 +89,12 @@ function createTestContext(
       compactRoutes: false,
       getLocale: () => locale,
       getLocales: () => testLocales,
-      getBaseUrl: createBaseUrlGetter({
-        ...baseUrlOptions,
-        getDomainFromLocale: l => domainFromLocale(domainLocalesMap, url, l, testLocales),
-      }),
-      getCanonicalBaseUrl: createBaseUrlGetter({
-        ...baseUrlOptions,
-        // composed the way `createNuxtI18nContext` does, including the cluster fallback
-        getDomainFromLocale: l =>
-          canonicalDomainFromLocale(domainLocalesMap, url, l, testLocales)
-          || canonicalDomainFromLocale(domainLocalesMap, url, configuredDefault, testLocales),
+      ...createTestBaseUrls({
+        locales: testLocales,
+        host,
+        baseUrl: domains ? undefined : 'https://example.com',
+        domains: !!domains,
+        defaultLocale: configuredDefault,
       }),
       getHost: () => host,
     }),
@@ -182,7 +169,7 @@ describe('localeHead', () => {
 
 describe('localeHead with domains', () => {
   test('(#2595) alternate and canonical links are absolute in each locale domain', async () => {
-    const { router, ctx } = createTestContext('fr', false, true)
+    const { router, ctx } = createTestContext('fr', { domains: true })
     await router.push('/')
 
     const head = localeHead(ctx, {})
@@ -208,7 +195,7 @@ describe('localeHead with domains', () => {
 
   test('every domain annotates the same `x-default`', async () => {
     for (const host of ['en', 'fr', 'nl']) {
-      const { router, ctx } = createTestContext(host, false, true)
+      const { router, ctx } = createTestContext(host, { domains: true })
       await router.push('/')
 
       const xDefault = localeHead(ctx, {}).link.find(x => x.hreflang === 'x-default')
@@ -218,7 +205,7 @@ describe('localeHead with domains', () => {
 
   test('a missing cluster fallback is only worth reporting where alternates are emitted', () => {
     const seo = { dir: true, lang: true, seo: true }
-    const withDomains = (configuredDefault: string) => createTestContext('fr', false, true, configuredDefault).ctx
+    const withDomains = (configuredDefault: string) => createTestContext('fr', { domains: true, defaultLocale: configuredDefault }).ctx
 
     expect(missesClusterFallback(withDomains(''), seo)).toBe(true)
     // `defaultLocale` names the fallback
@@ -226,13 +213,13 @@ describe('localeHead with domains', () => {
     // no alternate links to annotate
     expect(missesClusterFallback(withDomains(''), { ...seo, seo: false })).toBe(false)
     // a single domain cluster resolves `x-default` from the routing default as before
-    expect(missesClusterFallback(createTestContext('fr', false, false, '').ctx, seo)).toBe(false)
+    expect(missesClusterFallback(createTestContext('fr', { defaultLocale: '' }).ctx, seo)).toBe(false)
   })
 
   test('no configured `defaultLocale` annotates no fallback, rather than one per domain', async () => {
     // the domain default is host-resolved and would disagree across the cluster, `prepareOptions`
     // warns instead - a locale has no way to claim the cluster fallback on its own
-    const { router, ctx } = createTestContext('fr', false, true, '')
+    const { router, ctx } = createTestContext('fr', { domains: true, defaultLocale: '' })
     await router.push('/')
 
     const links = localeHead(ctx, {}).link
@@ -250,7 +237,7 @@ describe('localeHead with locales served on several domains', () => {
   test('every host emits the same alternate links, shaped for each locale`s canonical domain', async () => {
     const alternates = []
     for (const [host, currentLocale] of clusterHosts) {
-      const { router, ctx } = createTestContext(currentLocale, false, { host })
+      const { router, ctx } = createTestContext(currentLocale, { domains: { host } })
       await router.push('/')
       alternates.push(localeHead(ctx, {}).link.filter(x => x.rel === 'alternate').map(x => [x.hreflang, x.href]))
     }
@@ -269,7 +256,7 @@ describe('localeHead with locales served on several domains', () => {
 
   test('(#2595) the canonical keeps self-referencing the host serving the locale', async () => {
     for (const [host, currentLocale] of clusterHosts) {
-      const { router, ctx } = createTestContext(currentLocale, false, { host })
+      const { router, ctx } = createTestContext(currentLocale, { domains: { host } })
       await router.push('/')
 
       expect(localeHead(ctx, {}).link.find(x => x.rel === 'canonical')!.href).toBe(`https://${host}`)
@@ -279,7 +266,7 @@ describe('localeHead with locales served on several domains', () => {
   test('a page served off its locale`s canonical domain canonicalises to it', async () => {
     // `example.be` serves `nl` too, but the cluster advertises `nl` on `example.nl` - the duplicate
     // has to point there instead of claiming itself, or it competes with the URL it is a copy of
-    const { router, ctx } = createTestContext('nl', false, { host: 'example.be' })
+    const { router, ctx } = createTestContext('nl', { domains: { host: 'example.be' } })
     await router.push('/nl')
 
     const head = localeHead(ctx, {})
@@ -291,7 +278,7 @@ describe('localeHead with locales served on several domains', () => {
   })
 
   test('navigation links stay on the current host for the locales it serves', async () => {
-    const { router, ctx } = createTestContext('nl', false, { host: 'example.nl' })
+    const { router, ctx } = createTestContext('nl', { domains: { host: 'example.nl' } })
     await router.push('/')
 
     expect(switchLocalePath(ctx, 'fr')).toBe('/fr')
@@ -305,7 +292,7 @@ describe('localeHead with locales served on several domains', () => {
       { code: 'nl', language: 'nl-NL', domains: ['example.nl', 'example.be'] },
       { code: 'fr', language: 'fr', domains: ['example.nl', 'example.be'], defaultForDomains: ['example.be'] },
     ])
-    const { router, ctx } = createTestContext('fr', false, { host: 'example.be', locales }, 'nl')
+    const { router, ctx } = createTestContext('fr', { domains: { host: 'example.be', locales }, defaultLocale: 'nl' })
     await router.push('/')
 
     const links = localeHead(ctx, {}).link.filter(x => x.rel === 'alternate').map(x => [x.hreflang, x.href])
@@ -323,7 +310,7 @@ describe('localeHead with locales served on several domains', () => {
     const withPlain = [...clusterLocales, ...getNormalizedLocales([{ code: 'de', language: 'de' }])]
     const hrefs = []
     for (const [host, currentLocale] of clusterHosts) {
-      const { router, ctx } = createTestContext(currentLocale, false, { host, locales: withPlain }, 'nl')
+      const { router, ctx } = createTestContext(currentLocale, { domains: { host, locales: withPlain }, defaultLocale: 'nl' })
       await router.push('/')
       hrefs.push(localeHead(ctx, {}).link.find(x => x.hreflang === 'de')!.href)
     }
@@ -339,7 +326,7 @@ describe('localeHead with locales served on several domains', () => {
       { code: 'nl', language: 'nl-NL', domains: ['example.nl'], defaultForDomains: ['example.nl'] },
       { code: 'be', language: 'nl-BE', domains: ['example.nl'], defaultForDomains: ['example.nl'] },
     ])
-    const { router, ctx } = createTestContext('nl', false, { host: 'example.nl', locales }, 'nl')
+    const { router, ctx } = createTestContext('nl', { domains: { host: 'example.nl', locales }, defaultLocale: 'nl' })
     await router.push('/')
 
     const hrefs = localeHead(ctx, {}).link.filter(x => x.rel === 'alternate').map(x => [x.hreflang, x.href])
@@ -352,9 +339,8 @@ describe('localeHead with locales served on several domains', () => {
   })
 
   test('an unconfigured host keeps navigation relative while alternates stay canonical', async () => {
-    // dev and staging must never link to the configured domains, but their alternates still
-    // annotate the cluster - the two resolve through different base URLs
-    const { router, ctx } = createTestContext('nl', false, { host: 'localhost:3000' })
+    // the two resolve through different base URLs
+    const { router, ctx } = createTestContext('nl', { domains: { host: 'localhost:3000' } })
     await router.push('/nl')
 
     // relative paths resolve against this host's own table, where `en` is unprefixed (it is the
@@ -388,7 +374,7 @@ describe('switchLocalePath', () => {
 
 describe('strict seo mode', () => {
   test('disables locales without localized dynamic params', async () => {
-    const { router, ctx, setLocale } = createTestContext('en', true)
+    const { router, ctx, setLocale } = createTestContext('en', { strictSeo: true })
     await router.push('/nl/products/rode-mok')
     setLocale('nl')
     // no ja params - route should be treated as unavailable in ja
@@ -416,7 +402,7 @@ describe('strict seo mode', () => {
   })
 
   test('omits tag identity keys', async () => {
-    const { router, ctx } = createTestContext('en', true)
+    const { router, ctx } = createTestContext('en', { strictSeo: true })
     await router.push('/products/big-chair')
     setDynamicParams(router, chairParams)
 
@@ -443,7 +429,7 @@ describe('_useLocaleHead', () => {
   })
 
   test('patches shared head state on updates in strict seo mode', async () => {
-    const { router, ctx, head } = createTestContext('en', true)
+    const { router, ctx, head } = createTestContext('en', { strictSeo: true })
     await router.push('/')
 
     const metaObject = _useLocaleHead(ctx, { dir: true, lang: true, seo: true })
@@ -485,7 +471,7 @@ describe('_useSetI18nParams', () => {
   })
 
   test('seo attributes override global canonicalQueries in strict seo mode', async () => {
-    const { router, ctx, head } = createTestContext('en', true)
+    const { router, ctx, head } = createTestContext('en', { strictSeo: true })
     ctx.seoSettings.seo = { canonicalQueries: ['page'] }
     await router.push('/products/big-chair?page=2&canonical=1')
 

--- a/test/routing-head.test.ts
+++ b/test/routing-head.test.ts
@@ -7,6 +7,8 @@ import { _useLocaleHead, _useSetI18nParams, localeHead, missesClusterFallback } 
 import { switchLocalePath } from '../src/runtime/routing/routing'
 import { headEntries } from './mocks/imports'
 import { resolveDefaultLocale } from '../src/runtime/shared/locales'
+import { canonicalDomainFromLocale, domainForHost, domainFromLocale } from '../src/runtime/shared/domain'
+import { createBaseUrlGetter } from '../src/runtime/context'
 import { getNormalizedLocales } from './pages/utils'
 
 import type { Router } from 'vue-router'
@@ -32,34 +34,79 @@ const routes = [
   })),
 )
 
-function createTestContext(initialLocale = 'en', strictSeo = false, domains = false, configuredDefault = 'en') {
+// one cluster of two hosts sharing every locale, with per-host defaults (`multiDomainLocales`)
+const clusterLocales = getNormalizedLocales([
+  { code: 'en', language: 'en', domains: ['example.nl', 'example.be'] },
+  { code: 'nl', language: 'nl-NL', domains: ['example.nl', 'example.be'], defaultForDomains: ['example.nl'] },
+  { code: 'fr', language: 'fr', domains: ['example.nl', 'example.be'], defaultForDomains: ['example.be'] },
+])
+
+// mirrors the build output: every locale prefixed, `___default` variants for domain defaults,
+// `setupMultiDomainLocales` rebuilds them per host
+const clusterRoutesFor = (cluster: typeof clusterLocales) => [
+  ...cluster.map(l => ({ name: `index___${l.code}`, path: `/${l.code}`, component })),
+  ...cluster
+    .filter(l => l.defaultForDomains.length)
+    .map(l => ({ name: `index___${l.code}___default`, path: '/', component })),
+]
+
+function createTestContext(
+  initialLocale = 'en',
+  strictSeo = false,
+  domains: boolean | { host: string, locales?: typeof clusterLocales } = false,
+  configuredDefault = 'en',
+) {
   let locale = initialLocale
-  const router = createRouter({ history: createMemoryHistory(), routes })
+  const cluster = typeof domains === 'object' ? (domains.locales ?? clusterLocales) : undefined
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: cluster ? clusterRoutesFor(cluster) : routes,
+  })
   const head = { patches: [] as I18nHeadMetaInfo[], patch(val: I18nHeadMetaInfo) { this.patches.push(val) } }
   const domainLocales = getNormalizedLocales(
     locales.map(l => ({ ...l, domain: `${l.code}.example.com`, defaultForDomains: [`${l.code}.example.com`] })),
   )
+  const testLocales = cluster ?? (domains ? domainLocales : locales)
+  const host = typeof domains === 'object'
+    ? domains.host
+    : domains ? `${initialLocale}.example.com` : 'example.com'
+  // resolved the way the runtime plugin does, rather than supplied
+  const hostDefault = resolveDefaultLocale(host, configuredDefault, testLocales)
   if (domains) {
     // rebuild the route table for the current host, mirrors the runtime plugin
-    setupMultiDomainLocales(initialLocale, 'prefix_except_default', router)
+    setupMultiDomainLocales(hostDefault, 'prefix_except_default', router)
   }
-  const host = domains ? `${initialLocale}.example.com` : 'example.com'
+  // base URLs derived through the runtime getters, seeded like `module.ts` seeds `domainLocales`
+  const url = { host, protocol: 'https:' }
+  const domainLocalesMap = Object.fromEntries(testLocales.map(l => [l.code, { domain: l.domain ?? '' }]))
+  const baseUrlOptions = {
+    baseUrl: domains ? undefined : 'https://example.com',
+    appBase: '/',
+    domains: !!domains,
+    getDomainForHost: () => domainForHost(domainLocalesMap, url, testLocales),
+  }
   const ctx = {
     ...createRoutingContext({
       router,
-      // resolved the way the runtime plugin does, rather than supplied
-      defaultLocale: resolveDefaultLocale(host, configuredDefault, domains ? domainLocales : locales),
+      defaultLocale: hostDefault,
+      configuredDefaultLocale: configuredDefault || '',
       strategy: 'prefix_except_default',
       routing: true,
-      domains,
+      domains: !!domains,
       trailingSlash: false,
       strictSeo,
       compactRoutes: false,
       getLocale: () => locale,
-      getLocales: () => (domains ? domainLocales : locales),
-      // the default (no-locale) base URL under domains is the default locale's domain
-      getBaseUrl: l => (domains ? `https://${l ?? 'en'}.example.com` : 'https://example.com'),
-      getHost: () => (domains ? `${locale}.example.com` : 'example.com'),
+      getLocales: () => testLocales,
+      getBaseUrl: createBaseUrlGetter({
+        ...baseUrlOptions,
+        getDomainFromLocale: l => domainFromLocale(domainLocalesMap, url, l, testLocales),
+      }),
+      getCanonicalBaseUrl: createBaseUrlGetter({
+        ...baseUrlOptions,
+        getDomainFromLocale: l => canonicalDomainFromLocale(domainLocalesMap, url, l, testLocales),
+      }),
+      getHost: () => host,
     }),
     _head: undefined,
     head,
@@ -72,7 +119,7 @@ function createTestContext(initialLocale = 'en', strictSeo = false, domains = fa
       defaultLocale: configuredDefault || '',
       strictCanonicals: true,
       hreflangLinks: true,
-      domains,
+      domains: !!domains,
     },
   } as unknown as ComposableContext
   return { router, ctx, head, setLocale: (l: string) => (locale = l) }
@@ -188,6 +235,96 @@ describe('localeHead with domains', () => {
     const links = localeHead(ctx, {}).link
     expect(links.filter(x => x.hreflang === 'x-default')).toEqual([])
     expect(links.map(x => x.hreflang ?? x.rel)).toContain('fr')
+  })
+})
+
+describe('localeHead with locales served on several domains', () => {
+  const clusterHosts = [
+    ['example.nl', 'nl'],
+    ['example.be', 'fr'],
+  ] as const
+
+  test('every host emits the same alternate links, shaped for each locale`s canonical domain', async () => {
+    const alternates = []
+    for (const [host, currentLocale] of clusterHosts) {
+      const { router, ctx } = createTestContext(currentLocale, false, { host })
+      await router.push('/')
+      alternates.push(localeHead(ctx, {}).link.filter(x => x.rel === 'alternate').map(x => [x.hreflang, x.href]))
+    }
+
+    // `nl` and `fr` resolve to the domain they are the default for (unprefixed there), `en` is
+    // no host's default and resolves prefixed to its first domain - including `x-default`
+    expect(alternates[0]).toEqual([
+      ['x-default', 'https://example.nl/en'],
+      ['en', 'https://example.nl/en'],
+      ['nl', 'https://example.nl'],
+      ['nl-NL', 'https://example.nl'],
+      ['fr', 'https://example.be'],
+    ])
+    expect(alternates[1]).toEqual(alternates[0])
+  })
+
+  test('(#2595) the canonical keeps self-referencing the host serving the locale', async () => {
+    for (const [host, currentLocale] of clusterHosts) {
+      const { router, ctx } = createTestContext(currentLocale, false, { host })
+      await router.push('/')
+
+      expect(localeHead(ctx, {}).link.find(x => x.rel === 'canonical')!.href).toBe(`https://${host}`)
+    }
+  })
+
+  test('a page served off its locale`s canonical domain canonicalises to it', async () => {
+    // `example.be` serves `nl` too, but the cluster advertises `nl` on `example.nl` - the duplicate
+    // has to point there instead of claiming itself, or it competes with the URL it is a copy of
+    const { router, ctx } = createTestContext('nl', false, { host: 'example.be' })
+    await router.push('/nl')
+
+    const head = localeHead(ctx, {})
+    const canonical = head.link.find(x => x.rel === 'canonical')!.href
+    expect(canonical).toBe('https://example.nl')
+    expect(head.meta.find(x => x.property === 'og:url')!.content).toBe('https://example.nl')
+    // the canonical is a member of the set emitted alongside it
+    expect(head.link.filter(x => x.rel === 'alternate').map(x => x.href)).toContain(canonical)
+  })
+
+  test('navigation links stay on the current host for the locales it serves', async () => {
+    const { router, ctx } = createTestContext('nl', false, { host: 'example.nl' })
+    await router.push('/')
+
+    expect(switchLocalePath(ctx, 'fr')).toBe('/fr')
+    expect(switchLocalePath(ctx, 'en')).toBe('/en')
+  })
+
+  test('a locale unprefixed on its canonical domain only through `defaultLocale` is not linked prefixed', async () => {
+    // `nl` claims no `defaultForDomains`, so example.nl serves it unprefixed by falling back to the
+    // configured `defaultLocale` - annotating `example.nl/nl` would name a route that host never got
+    const locales = getNormalizedLocales([
+      { code: 'nl', language: 'nl-NL', domains: ['example.nl', 'example.be'] },
+      { code: 'fr', language: 'fr', domains: ['example.nl', 'example.be'], defaultForDomains: ['example.be'] },
+    ])
+    const { router, ctx } = createTestContext('fr', false, { host: 'example.be', locales }, 'nl')
+    await router.push('/')
+
+    const links = localeHead(ctx, {}).link.filter(x => x.rel === 'alternate').map(x => [x.hreflang, x.href])
+    expect(links).toEqual([
+      ['x-default', 'https://example.nl'],
+      ['nl', 'https://example.nl'],
+      ['nl-NL', 'https://example.nl'],
+      ['fr', 'https://example.be'],
+    ])
+  })
+
+  test('an unconfigured host keeps navigation relative while alternates stay canonical', async () => {
+    // dev and staging must never link to the configured domains, but their alternates still
+    // annotate the cluster - the two resolve through different base URLs
+    const { router, ctx } = createTestContext('nl', false, { host: 'localhost:3000' })
+    await router.push('/nl')
+
+    // relative paths resolve against this host's own table, where `en` is unprefixed (it is the
+    // configured `defaultLocale`) and every other locale keeps its prefix
+    expect(switchLocalePath(ctx, 'fr')).toBe('/fr')
+    expect(switchLocalePath(ctx, 'en')).toBe('/')
+    expect(ctx.getAlternatePath('/fr', 'fr')).toBe('https://example.be')
   })
 })
 

--- a/test/routing-head.test.ts
+++ b/test/routing-head.test.ts
@@ -104,7 +104,10 @@ function createTestContext(
       }),
       getCanonicalBaseUrl: createBaseUrlGetter({
         ...baseUrlOptions,
-        getDomainFromLocale: l => canonicalDomainFromLocale(domainLocalesMap, url, l, testLocales),
+        // composed the way `createNuxtI18nContext` does, including the cluster fallback
+        getDomainFromLocale: l =>
+          canonicalDomainFromLocale(domainLocalesMap, url, l, testLocales)
+          || canonicalDomainFromLocale(domainLocalesMap, url, configuredDefault, testLocales),
       }),
       getHost: () => host,
     }),
@@ -311,6 +314,40 @@ describe('localeHead with locales served on several domains', () => {
       ['nl', 'https://example.nl'],
       ['nl-NL', 'https://example.nl'],
       ['fr', 'https://example.be'],
+    ])
+  })
+
+  test('a locale served on every domain is annotated on the one serving `defaultLocale`', async () => {
+    // it has no domain of its own, and annotating the answering host would give the cluster a
+    // different URL for this one locale from each domain
+    const withPlain = [...clusterLocales, ...getNormalizedLocales([{ code: 'de', language: 'de' }])]
+    const hrefs = []
+    for (const [host, currentLocale] of clusterHosts) {
+      const { router, ctx } = createTestContext(currentLocale, false, { host, locales: withPlain }, 'nl')
+      await router.push('/')
+      hrefs.push(localeHead(ctx, {}).link.find(x => x.hreflang === 'de')!.href)
+    }
+
+    // `nl` is the configured `defaultLocale` and is served unprefixed on example.nl
+    expect(hrefs).toEqual(['https://example.nl/de', 'https://example.nl/de'])
+  })
+
+  test('only the locale that wins a shared `defaultForDomains` entry is linked unprefixed', async () => {
+    // both claim example.nl but the route table can only unprefix one of them, so the other has to
+    // keep its prefix or the two would advertise the same URL for different languages
+    const locales = getNormalizedLocales([
+      { code: 'nl', language: 'nl-NL', domains: ['example.nl'], defaultForDomains: ['example.nl'] },
+      { code: 'be', language: 'nl-BE', domains: ['example.nl'], defaultForDomains: ['example.nl'] },
+    ])
+    const { router, ctx } = createTestContext('nl', false, { host: 'example.nl', locales }, 'nl')
+    await router.push('/')
+
+    const hrefs = localeHead(ctx, {}).link.filter(x => x.rel === 'alternate').map(x => [x.hreflang, x.href])
+    expect(hrefs).toEqual([
+      ['x-default', 'https://example.nl'],
+      ['nl', 'https://example.nl'],
+      ['nl-NL', 'https://example.nl'],
+      ['nl-BE', 'https://example.nl/be'],
     ])
   })
 

--- a/test/routing-path-resolver.test.ts
+++ b/test/routing-path-resolver.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, test, vi } from 'vitest'
 import { createMemoryHistory, createRouter } from 'vue-router'
 import { createLocalizedRouteByPathResolver } from '../src/runtime/routing/utils'
 import { localizeRoutes } from '../src/routing'
+import { getNormalizedLocales } from './pages/utils'
 import type { LocalizableRoute } from '../src/kit/gen'
 import type { Strategies } from '#internal-i18n-types'
 
-const LOCALES = [{ code: 'en', language: 'en' }, { code: 'ja', language: 'ja' }]
+// normalized the way `resolveContext` does - `localizeRoutes` reads the domain fields
+const LOCALES = getNormalizedLocales([{ code: 'en', language: 'en' }, { code: 'ja', language: 'ja' }])
 const PAGES = [
   { path: '/', name: 'index' },
   { path: '/about', name: 'about' },


### PR DESCRIPTION
* Related #3374
* Related #4089

Alternate links resolved each locale to the current host whenever it serves that locale, so a locale served on more than one domain got a different URL from each of them and the pages never listed each other. `x-default` had the same problem whenever the default locale wasn't limited to a single domain. Each locale is now annotated on one domain, the first entry of its `defaultForDomains` or of its `domains` otherwise, so every domain emits the same set. The canonical link is now the current locale's own alternate link, which keeps it a member of the set it's emitted with: a page reachable on several domains points at the URL its language is advertised on instead of claiming itself, and a locale served on a single domain still canonicalises to that domain (#2595).

`strategy: 'no_prefix'` was gated on `differentDomains`, while the check right after it (no two locales sharing a domain) is the actual requirement, since without a prefix the host is the only thing naming a locale. This decides it from the locale domains instead, so `no_prefix` also works with `multiDomainLocales` when each locale has a domain of its own, and locale domains alone qualify without either option set.

A few smaller things came out of this: a locale configured without `domains` takes the domain serving `defaultLocale` rather than the host answering the request, domains configured without a protocol are completed from `baseUrl` (the request protocol is `http` behind a proxy terminating TLS and while prerendering), and an empty base URL collapsed to an empty href, which returned dead switcher links and dropped `canonical`/`og:url` on a host matching no configured domain. This also updates the multi domain guide and adds tests for each case.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-domain locale routing and validation, including clearer handling of conflicting or missing domain configurations.
  * Corrected canonical and alternate URL generation across domains, hosts, and locale configurations.
  * Improved strict SEO behavior when localized route parameters are unavailable.
  * Ensured canonical links, alternate links, and social URLs consistently use the correct locale and domain.

* **Documentation**
  * Added guidance explaining locale relocation, reciprocal domain reachability, `no_prefix` restrictions, and canonical URL behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->