### PR TITLE
fix(domain): resolve a domain serving a single locale as its default

### DIFF
--- a/specs/different_domains/different_domains_implicit_domain_default.spec.ts
+++ b/specs/different_domains/different_domains_implicit_domain_default.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect, describe } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, undiciRequest } from '../utils'
+import { getDom } from '../helper'
+
+// the documented `differentDomains` shape: a scalar `domain` per locale and no `domainDefault`
+await setup({
+  rootDir: fileURLToPath(new URL(`../fixtures/different_domains`, import.meta.url)),
+})
+
+const hosts = [
+  ['en', 'en.nuxt-app.localhost'],
+  ['no', 'no.nuxt-app.localhost'],
+  ['fr', 'fr.nuxt-app.localhost'],
+] as const
+
+describe('a domain serving one locale is its default without `domainDefault`', () => {
+  test.each(hosts)('%s host serves its locale unprefixed at the root', async (locale, host) => {
+    const res = await undiciRequest('/', { headers: { Host: host } })
+
+    // asserting the status matters as much as the content: the regression this covers answered
+    // every root with a 302 to `/{locale}` while still rendering the right locale after the hop
+    expect(res.statusCode).toBe(200)
+    const dom = await getDom(await res.body.text())
+    expect(await dom.locator('#lang-switcher-current-locale code').textContent()).toEqual(locale)
+  })
+
+  test.each(hosts)('%s host serves an unprefixed path', async (locale, host) => {
+    const res = await undiciRequest('/about', { headers: { Host: host } })
+
+    expect(res.statusCode).toBe(200)
+    const dom = await getDom(await res.body.text())
+    expect(await dom.locator('#lang-switcher-current-locale code').textContent()).toEqual(locale)
+  })
+
+  test.each(hosts)('%s host does not serve its own locale prefixed', async (locale, host) => {
+    const res = await undiciRequest(`/${locale}/about`, { headers: { Host: host } })
+
+    expect(res.statusCode).toBe(404)
+  })
+
+  test('links and canonical use the unprefixed URL on the domain serving the locale', async () => {
+    const res = await undiciRequest('/', { headers: { Host: 'fr.nuxt-app.localhost' } })
+    const body = await res.body.text()
+    const dom = await getDom(body)
+
+    expect(await dom.locator('#switch-locale-path-usages .switch-to-fr a').getAttribute('href')).toEqual('/')
+    expect(body).toContain('rel="canonical" href="http://fr.nuxt-app.localhost"')
+  })
+})

--- a/src/context.ts
+++ b/src/context.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'pathe'
 import { assign, isString } from '@intlify/shared'
 import { applyLayerOptions, resolveLayerVueI18nConfigInfo } from './layers'
-import { computeLocaleHashes, filterLocales, getLayerI18n, normalizeDomainLocale, resolveLocales, validateLocaleCodes } from './utils'
+import { computeLocaleHashes, filterLocales, getLayerI18n, normalizeDomainLocale, resolveLocales, validateLocaleCodes, withImplicitDomainDefaults } from './utils'
 import { resolveRawResourcePaths } from './resources'
 import { generateLoaderOptions } from './gen'
 // takes its facts as config and reads no `__FLAG__` defines, so the build can share it
@@ -94,8 +94,8 @@ export async function resolveContext(ctx: I18nNuxtContext, nuxt: Nuxt): Promise<
   ctx.options.locales = await applyLayerOptions(ctx, nuxt)
   ctx.options.locales = filterLocales(ctx)
 
-  const normalizedLocales = ctx.options.locales.map(x =>
-    normalizeDomainLocale(isString(x) ? { code: x, language: x } : x),
+  const normalizedLocales = withImplicitDomainDefaults(
+    ctx.options.locales.map(x => normalizeDomainLocale(isString(x) ? { code: x, language: x } : x)),
   )
   const localeCodes = normalizedLocales.map(locale => locale.code)
   validateLocaleCodes(localeCodes)

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -2,7 +2,7 @@ import { assign, isString } from '@intlify/shared'
 import { genDynamicImport, genImport, genSafeVariableName, genString } from 'knitwork'
 import { basename, join, relative, resolve } from 'pathe'
 import { asI18nVirtual } from './transform/utils'
-import { normalizeDomainLocale } from './utils'
+import { normalizeDomainLocale, withImplicitDomainDefaults } from './utils'
 
 import type { Nuxt } from '@nuxt/schema'
 import type { LocaleObject } from './types'
@@ -18,9 +18,12 @@ function stripLocaleFiles<T extends LocaleObject>(locale: T): T {
 
 export function simplifyLocaleOptions(ctx: ResolvedI18nContext, _nuxt: Nuxt) {
   const locales = (ctx.options.locales ?? []) as LocaleObject[]
-  const hasLocaleObjects = locales?.some(x => !isString(x))
-  // normalize so runtime locale consumers (e.g. `defaultForDomains` reads) only handle one shape
-  return locales.map(locale => (!hasLocaleObjects ? locale.code : stripLocaleFiles(normalizeDomainLocale(locale))))
+  if (!locales.some(x => !isString(x))) {
+    return locales.map(locale => locale.code)
+  }
+  // normalize so runtime locale consumers (e.g. `defaultForDomains` reads) only handle one shape,
+  // through the same passes as `ctx.normalizedLocales` so both channels agree on route shape
+  return withImplicitDomainDefaults(locales.map(normalizeDomainLocale)).map(stripLocaleFiles)
 }
 
 type LocaleLoaderData = {

--- a/src/gen.ts
+++ b/src/gen.ts
@@ -17,13 +17,18 @@ function stripLocaleFiles<T extends LocaleObject>(locale: T): T {
 }
 
 export function simplifyLocaleOptions(ctx: ResolvedI18nContext, _nuxt: Nuxt) {
-  const locales = (ctx.options.locales ?? []) as LocaleObject[]
+  const locales = ctx.options.locales ?? []
+  // codes alone carry no domain configuration, and keeping them saves shipping empty objects.
+  // `mergeConfigLocales` resolves every locale into an object before this runs, so this is only
+  // reached for an empty list - spreading a string here yields a character-indexed object
   if (!locales.some(x => !isString(x))) {
-    return locales.map(locale => locale.code)
+    return locales
   }
   // normalize so runtime locale consumers (e.g. `defaultForDomains` reads) only handle one shape,
   // through the same passes as `ctx.normalizedLocales` so both channels agree on route shape
-  return withImplicitDomainDefaults(locales.map(normalizeDomainLocale)).map(stripLocaleFiles)
+  return withImplicitDomainDefaults(
+    locales.map(locale => normalizeDomainLocale(isString(locale) ? { code: locale, language: locale } : locale)),
+  ).map(stripLocaleFiles)
 }
 
 type LocaleLoaderData = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,6 +61,49 @@ export function normalizeDomainLocale<T extends string>(locale: LocaleObject<T>)
   }) as NormalizedLocaleObject<T>
 }
 
+/**
+ * A domain served by exactly one locale is that locale's default. The documented `differentDomains`
+ * shape names a `domain` per locale and never sets `domainDefault`, and since #4042 the unprefixed
+ * route for a domain comes from `defaultForDomains` alone - without this those sites prefix every
+ * locale and serve nothing at `/`. Domains shared by several locales stay ambiguous, they need an
+ * explicit `defaultForDomains`.
+ *
+ * Runs across all locales, so it cannot live in {@link normalizeDomainLocale}. Both locale channels
+ * (`ctx.normalizedLocales` and the runtime config) must apply it or they disagree on route shape.
+ */
+export function withImplicitDomainDefaults<T extends string>(
+  locales: NormalizedLocaleObject<T>[],
+): NormalizedLocaleObject<T>[] {
+  // mirrors `normalizeDomain`, which reads compile-time defines and so cannot be imported here
+  const toHost = (domain: string) => domain.replace(/^https?:\/\//i, '').toLowerCase()
+  const claimed = new Set(locales.flatMap(l => l.defaultForDomains.map(toHost)))
+  const servedBy = new Map<string, { locale: NormalizedLocaleObject<T>, domain: string }[]>()
+  for (const locale of locales) {
+    for (const domain of locale.domains) {
+      const host = toHost(domain)
+      if (claimed.has(host)) { continue }
+      const entries = servedBy.get(host) ?? []
+      entries.push({ locale, domain })
+      servedBy.set(host, entries)
+    }
+  }
+
+  // keep the configured spelling - `defaultForDomains` entries are also read as URL origins
+  const implicit = new Map<NormalizedLocaleObject<T>, string[]>()
+  for (const entries of servedBy.values()) {
+    if (entries.length !== 1) { continue }
+    const { locale, domain } = entries[0]!
+    implicit.set(locale, [...(implicit.get(locale) ?? []), domain])
+  }
+  if (!implicit.size) { return locales }
+
+  return locales.map(locale =>
+    implicit.has(locale)
+      ? { ...locale, defaultForDomains: [...locale.defaultForDomains, ...implicit.get(locale)!] }
+      : locale,
+  )
+}
+
 export function resolveLocales(srcDir: string, locales: LocaleObject[], vfs: Record<string, string>): LocaleInfo[] {
   const localesResolved: LocaleInfo[] = []
   for (const locale of locales) {

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -12,7 +12,7 @@ import {
 } from '../src/runtime/shared/domain'
 import { getDefaultLocaleForDomain } from '../src/runtime/shared/locales'
 import { createBaseUrlGetter, withConfiguredProtocol } from '../src/runtime/context'
-import { normalizeDomainLocale } from '../src/utils'
+import { normalizeDomainLocale, withImplicitDomainDefaults } from '../src/utils'
 import { getNormalizedLocales } from './pages/utils'
 
 // the runtime only ever sees build-normalized locales, resolve them the same way here
@@ -443,5 +443,53 @@ describe('normalizeDomainLocale', () => {
 
   test('`domainDefault` without a domain has nothing to be the default for', () => {
     expect(normalizeDomainLocale({ code: 'en', domainDefault: true })).toMatchObject({ defaultForDomains: [] })
+  })
+})
+
+describe('withImplicitDomainDefaults', () => {
+  const defaultsFor = (locales: Parameters<typeof getNormalizedLocales>[0]) =>
+    withImplicitDomainDefaults(getNormalizedLocales(locales)).map(l => [l.code, l.defaultForDomains])
+
+  test('a domain serving one locale makes it the default, keeping the configured spelling', () => {
+    // the documented `differentDomains` shape, which never sets `domainDefault`
+    expect(defaultsFor([
+      { code: 'en', domain: 'en.example.com' },
+      { code: 'fr', domain: 'https://fr.example.com' },
+    ])).toEqual([['en', ['en.example.com']], ['fr', ['https://fr.example.com']]])
+  })
+
+  test('a domain serving several locales stays ambiguous', () => {
+    expect(defaultsFor([
+      { code: 'en', domains: ['shared.example.com'] },
+      { code: 'de', domains: ['shared.example.com'] },
+    ])).toEqual([['en', []], ['de', []]])
+  })
+
+  test('an explicit claim on a domain is never overridden or duplicated', () => {
+    expect(defaultsFor([
+      { code: 'en', domains: ['a.example.com'], defaultForDomains: ['a.example.com'] },
+      // `b` is served only by `fr`, so it is claimed implicitly alongside the explicit `a`
+      { code: 'fr', domains: ['a.example.com', 'b.example.com'] },
+    ])).toEqual([['en', ['a.example.com']], ['fr', ['b.example.com']]])
+  })
+
+  test('a claim by another locale, in any spelling, blocks the implicit default', () => {
+    expect(defaultsFor([
+      { code: 'en', domains: ['https://shared.example.com'], defaultForDomains: ['https://shared.example.com'] },
+      { code: 'fr', domains: ['shared.example.com'] },
+    ])).toEqual([['en', ['https://shared.example.com']], ['fr', []]])
+  })
+
+  test('the multi-domain shape is untouched, every domain serves every locale', () => {
+    const all = ['a.example.com', 'b.example.com']
+    expect(defaultsFor([
+      { code: 'en', domains: all, defaultForDomains: ['a.example.com'] },
+      { code: 'fr', domains: all, defaultForDomains: ['b.example.com'] },
+      { code: 'de', domains: all },
+    ])).toEqual([['en', ['a.example.com']], ['fr', ['b.example.com']], ['de', []]])
+  })
+
+  test('locales without domains are left alone', () => {
+    expect(defaultsFor(['en', 'fr'])).toEqual([['en', []], ['fr', []]])
   })
 })

--- a/test/gen.test.ts
+++ b/test/gen.test.ts
@@ -1,4 +1,4 @@
-import { generateLoaderOptions } from '../src/gen'
+import { generateLoaderOptions, simplifyLocaleOptions } from '../src/gen'
 import { getNormalizedLocales } from './pages/utils'
 import { resolveLocales, resolveRelativeLocales, resolveVueI18nConfigInfo } from '../src/utils'
 import { vi, beforeEach, afterEach, test, expect } from 'vitest'
@@ -245,4 +245,19 @@ test('server asset loaders', async () => {
   )
 
   expect(code).toMatchSnapshot()
+})
+
+test('simplifyLocaleOptions keeps locale codes and resolves objects through the domain passes', () => {
+  const run = (locales: unknown) =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    simplifyLocaleOptions({ options: { locales } } as any, {} as any)
+
+  // `mergeConfigLocales` objectifies every locale before this runs, so a string only reaches it
+  // through a direct call - it must still not be spread into a character-indexed object
+  expect(run(['en', 'fr'])).toEqual(['en', 'fr'])
+  expect(run([])).toEqual([])
+  expect(run(['en', { code: 'fr', domain: 'fr.example.com' }])).toEqual([
+    { code: 'en', language: 'en', domains: [], defaultForDomains: [] },
+    { code: 'fr', domain: 'fr.example.com', domains: ['fr.example.com'], defaultForDomains: ['fr.example.com'] },
+  ])
 })


### PR DESCRIPTION
Sites using the documented `differentDomains` shape - a scalar `domain` per locale and no `domainDefault` - stopped serving anything at the root. On `fr.mydomain.com` the root answered `302 → /fr`, `/about` answered `404`, and only the prefixed paths worked. #4042 made the unprefixed route for a domain come from `defaultForDomains`, which those configs never set, so every locale kept its prefix. With `defaultLocale` naming a locale that isn't configured, every host redirected its root; with it naming a real locale, that one locale became unprefixed on *every* domain, so the other domains served the wrong language at `/`.

A domain served by exactly one locale is now that locale's default, which is what `09.different-domains.md` already describes - `domainDefault` is only needed when a domain hosts several languages. Domains shared by several locales stay ambiguous and still need it. The pass runs across all locales so it can't live in `normalizeDomainLocale`, and it's applied to both locale channels (`ctx.normalizedLocales` and the runtime config) since they have to agree on route shape.

The existing domain specs assert the rendered locale after following redirects, so they passed throughout - this adds a spec asserting status codes and URL shape instead, which is what the regression actually broke.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic default-domain handling when a domain maps unambiguously to a single locale.
  * Locale switch links and canonical URLs now prefer unprefixed paths on the domain that serves the default locale.
* **Bug Fixes**
  * Prevented locale-prefixed URLs from incorrectly rendering content when that locale does not match the request host.
* **Tests**
  * Expanded coverage for implicit default-domain inference, ambiguous domains, explicit overrides, and correct locale routing/link generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->