### PR TITLE
fix(domain): serve every locale on a host matching no configured domain

### DIFF
--- a/specs/different_domains/different_domains_unconfigured_host.spec.ts
+++ b/specs/different_domains/different_domains_unconfigured_host.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect, describe } from 'vitest'
+import { fileURLToPath } from 'node:url'
+import { setup, undiciRequest } from '../utils'
+import { getDom } from '../helper'
+
+// domains without `defaultLocale`, which is optional under domains - see the `x-default` guide
+await setup({
+  rootDir: fileURLToPath(new URL(`../fixtures/different_domains`, import.meta.url)),
+  nuxtConfig: {
+    i18n: {
+      defaultLocale: '',
+    },
+  },
+})
+
+describe('a host matching no configured domain', () => {
+  test.each([
+    ['/', 'staging.nuxt-app.localhost'],
+    ['/about', 'staging.nuxt-app.localhost'],
+    ['/', '127.0.0.1'],
+  ])('serves %s on %s instead of 404ing', async (path, host) => {
+    const res = await undiciRequest(path, { headers: { Host: host } })
+
+    // without an unprefixed locale the route table has nothing at `/` and every unprefixed path 404s
+    expect(res.statusCode).toBe(200)
+  })
+
+  test('serves every locale there, prefixed, and keeps links relative', async () => {
+    const res = await undiciRequest('/fr/about', { headers: { Host: 'staging.nuxt-app.localhost' } })
+    expect(res.statusCode).toBe(200)
+
+    const dom = await getDom(await res.body.text())
+    expect(await dom.locator('#lang-switcher-current-locale code').textContent()).toEqual('fr')
+  })
+})

--- a/specs/fixtures/different_domains/nuxt.config.ts
+++ b/specs/fixtures/different_domains/nuxt.config.ts
@@ -25,6 +25,6 @@ export default defineNuxtConfig({
       }
     ],
     differentDomains: true,
-    defaultLocale: 'ja'
+    defaultLocale: 'en'
   }
 })

--- a/src/context.ts
+++ b/src/context.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url'
 import { dirname, resolve } from 'pathe'
 import { assign, isString } from '@intlify/shared'
 import { applyLayerOptions, resolveLayerVueI18nConfigInfo } from './layers'
-import { computeLocaleHashes, filterLocales, getLayerI18n, normalizeDomainLocale, resolveLocales, validateLocaleCodes, withImplicitDomainDefaults } from './utils'
+import { computeLocaleHashes, filterLocales, getLayerI18n, normalizeDomainLocale, resolveLocales, validateDefaultLocale, validateLocaleCodes, withImplicitDomainDefaults } from './utils'
 import { resolveRawResourcePaths } from './resources'
 import { generateLoaderOptions } from './gen'
 // takes its facts as config and reads no `__FLAG__` defines, so the build can share it
@@ -99,6 +99,7 @@ export async function resolveContext(ctx: I18nNuxtContext, nuxt: Nuxt): Promise<
   )
   const localeCodes = normalizedLocales.map(locale => locale.code)
   validateLocaleCodes(localeCodes)
+  validateDefaultLocale(ctx.options.defaultLocale, localeCodes)
 
   const localeInfo = resolveLocales(nuxt.options.srcDir, normalizedLocales, nuxt.vfs)
   const localeFileMetas = localeInfo.flatMap(x => x.meta)

--- a/src/runtime/routing/navigation.ts
+++ b/src/runtime/routing/navigation.ts
@@ -15,10 +15,8 @@ export type NavigationResolverConfig = {
   routeLocale: (to: CompatRoute) => string | undefined
   hasRoute: (name: string) => boolean
   getLocaleCodes: () => string[]
-  /** Whether the locale is served on the current host, set under domain setups */
-  isLocaleOnHost?: (locale: string) => boolean
-  /** Whether the locale can be served on the current host (see `isLocaleServedOnHost`), set under domain setups */
-  isLocaleServed?: (locale: string) => boolean
+  /** How the current host can reach a locale (see `resolveLocaleReach`), set under domain setups */
+  localeReach?: (locale: string) => 'here' | 'other-domain' | 'off-host'
   strategy: Strategies
   compactRoutes: boolean
 }
@@ -42,10 +40,15 @@ export function createNavigationResolver(config: NavigationResolverConfig) {
   }
 
   return function resolveNavigation(to: CompatRoute, locale: string, pendingLocale = false): ResolvedNavigation | undefined {
-    // a locale restricted to other domains relocates to its absolute `switchLocalePath` URL,
-    // while a host matching no configured domain (e.g. staging) serves every locale in place
-    if (config.isLocaleOnHost && !config.isLocaleOnHost(locale)) {
-      if (config.isLocaleServed?.(locale) || isUnlocalizedRoute(to) || pendingLocale) { return }
+    const reach = config.localeReach?.(locale)
+
+    // an unconfigured host serves every locale in place, and must not send a visitor to a domain
+    if (reach === 'off-host') { return }
+
+    // vue-router cannot cross origins, so a locale belonging to other domains needs a full load of
+    // its absolute `switchLocalePath` URL
+    if (reach === 'other-domain') {
+      if (isUnlocalizedRoute(to) || pendingLocale) { return }
       const destination = config.switchLocalePath(locale, to)
       if (!destination || !hasProtocol(destination, { strict: true })) { return }
       return { path: destination, code: config.redirectStatusCode, external: true }

--- a/src/runtime/shared/domain.ts
+++ b/src/runtime/shared/domain.ts
@@ -18,14 +18,29 @@ export function isLocaleOnHost(locale: NormalizedLocaleObject | undefined, host:
 }
 
 /**
- * Whether the locale can be served on the given host. Unlike {@link isLocaleOnHost} a locale
- * configured without domains qualifies, as does any locale on a host configured for none of
- * them (a staging domain, a health check by IP) so the site keeps working there.
+ * How `host` can reach `locale`:
+ * - `here` - served on this host, either because it is one of the locale's domains or because the
+ *   locale configures none and is served on all of them
+ * - `other-domain` - the locale belongs to domains this host is not one of
+ * - `off-host` - same, but this host matches no configured domain at all (a staging domain, a health
+ *   check by IP), where the site keeps serving every locale and never sends a visitor to a domain
+ */
+export function resolveLocaleReach(
+  locales: NormalizedLocaleObject[],
+  host: string,
+  locale: string,
+): 'here' | 'other-domain' | 'off-host' {
+  const target = locales.find(l => l.code === locale)
+  if (!target?.domains.length || isLocaleOnHost(target, host)) { return 'here' }
+  return locales.some(l => isLocaleOnHost(l, host)) ? 'other-domain' : 'off-host'
+}
+
+/**
+ * Whether the locale can be served on the given host - every {@link resolveLocaleReach} answer but
+ * `other-domain`. Shares that resolution so the two cannot disagree.
  */
 export function isLocaleServedOnHost(locales: NormalizedLocaleObject[], host: string, locale: string): boolean {
-  const target = locales.find(l => l.code === locale)
-  if (!target?.domains.length) { return true }
-  return isLocaleOnHost(target, host) || !locales.some(l => isLocaleOnHost(l, host))
+  return resolveLocaleReach(locales, host, locale) !== 'other-domain'
 }
 
 /** `defaultForDomains` leads so the domain agrees with the unprefixed shape derived from it */

--- a/src/runtime/shared/locales.ts
+++ b/src/runtime/shared/locales.ts
@@ -69,7 +69,14 @@ export function resolveDefaultLocale(
   defaultLocale: string | undefined,
   locales: NormalizedLocaleObject[] = normalizedLocales,
 ): string {
-  return getDefaultLocaleForDomain(host, locales) || defaultLocale || ''
+  const resolved = getDefaultLocaleForDomain(host, locales) || defaultLocale
+  if (resolved) { return resolved }
+
+  // under domains `defaultLocale` is optional, so a host claiming none of them can end up with no
+  // unprefixed locale at all - the route table then has nothing at `/` and every unprefixed path
+  // 404s. Serving the first locale there keeps such a host (dev, staging, a health check by IP)
+  // usable, matching the promise that every locale is served on it
+  return (locales.some(l => l.domains.length) ? locales[0]?.code : '') || ''
 }
 
 export const isSupportedLocale = (locale?: string): boolean => localeCodes.includes(locale || '')

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -6,7 +6,7 @@ import { useComposableContext } from './composable-context'
 import { isSupportedLocale } from './shared/locales'
 import { createLocaleDetector, useDetectors } from './shared/detection'
 import { useI18nDetection } from './shared/utils'
-import { isLocaleOnHost, isLocaleServedOnHost } from './shared/domain'
+import { resolveLocaleReach } from './shared/domain'
 
 import type { Locale } from 'vue-i18n'
 import type { NuxtApp } from '#app'
@@ -59,11 +59,8 @@ export function navigate(nuxtApp: NuxtApp, to: CompatRoute, locale: string) {
   const detectors = useDetectors(useRequestEvent(), useI18nDetection(nuxtApp), nuxtApp)
   const host = __I18N_DOMAINS__ ? useRequestURL({ xForwardedHost: true }).host : ''
   const resolve = createNavigationResolver({
-    isLocaleOnHost: __I18N_DOMAINS__
-      ? locale => isLocaleOnHost(_ctx.getLocales().find(l => l.code === locale), host)
-      : undefined,
-    isLocaleServed: __I18N_DOMAINS__
-      ? locale => isLocaleServedOnHost(_ctx.getLocales(), host, locale)
+    localeReach: __I18N_DOMAINS__
+      ? locale => resolveLocaleReach(_ctx.getLocales(), host, locale)
       : undefined,
     rootRedirect: ctx.rootRedirect,
     redirectStatusCode: ctx.redirectStatusCode,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,6 +37,20 @@ export function filterLocales(ctx: I18nNuxtContext) {
 // locale codes are used as single URL path segments (route prefixes, messages endpoint), in route names and in cookies (#4036)
 const INVALID_LOCALE_CODE_CHAR_RE = /[/\\?#%:\s]/
 
+/**
+ * A `defaultLocale` naming no configured locale cannot be the unprefixed locale, so a host relying
+ * on it (one matching no configured domain, or any host without domains) resolves none and serves
+ * nothing at `/`. Only checkable once layers have contributed their locales.
+ */
+export function validateDefaultLocale(defaultLocale: string | undefined, codes: string[]) {
+  if (defaultLocale && !codes.includes(defaultLocale)) {
+    logger.warn(
+      `\`defaultLocale: ${JSON.stringify(defaultLocale)}\` is not one of the configured locales (${codes.join(', ')}),`
+      + ` so it cannot be served as the unprefixed locale.`,
+    )
+  }
+}
+
 export function validateLocaleCodes(codes: string[]) {
   const invalid = codes.filter(code => !code || INVALID_LOCALE_CODE_CHAR_RE.test(code))
   if (invalid.length) {

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -8,9 +8,10 @@ import {
   isLocaleServedOnHost,
   matchDomainLocale,
   normalizeDomain,
+  resolveLocaleReach,
   withRuntimeDomain,
 } from '../src/runtime/shared/domain'
-import { getDefaultLocaleForDomain } from '../src/runtime/shared/locales'
+import { getDefaultLocaleForDomain, resolveDefaultLocale } from '../src/runtime/shared/locales'
 import { createBaseUrlGetter, withConfiguredProtocol } from '../src/runtime/context'
 import { normalizeDomainLocale, withImplicitDomainDefaults } from '../src/utils'
 import { getNormalizedLocales } from './pages/utils'
@@ -112,6 +113,40 @@ describe('isLocaleServedOnHost', () => {
 
   test('an unknown locale is not restricted', () => {
     expect(isLocaleServedOnHost(locales, 'en.example.com', 'xx')).toBe(true)
+  })
+})
+
+describe('resolveLocaleReach', () => {
+  test('distinguishes the two reasons a locale is not on this host', () => {
+    // `isLocaleServedOnHost` answers `true` for both, which is why they were conflated
+    expect(resolveLocaleReach(locales, 'en.example.com', 'de')).toBe('other-domain')
+    expect(resolveLocaleReach(locales, 'staging.example.com', 'de')).toBe('off-host')
+  })
+
+  test('a locale on this host, and one configuring no domain, are both served here', () => {
+    expect(resolveLocaleReach(locales, 'shared.example.com', 'de')).toBe('here')
+    expect(resolveLocaleReach([...locales, ...getNormalizedLocales(['pl'])], 'en.example.com', 'pl')).toBe('here')
+  })
+})
+
+describe('resolveDefaultLocale', () => {
+  test('the host it is the default for wins over the configured `defaultLocale`', () => {
+    expect(resolveDefaultLocale('shared.example.com', 'en', locales)).toBe('nl')
+  })
+
+  test('a host claiming no default falls back to the configured `defaultLocale`', () => {
+    expect(resolveDefaultLocale('staging.example.com', 'fr', locales)).toBe('fr')
+  })
+
+  test('under domains a host claiming none serves the first locale rather than nothing', () => {
+    // `defaultLocale` is optional under domains, and with no unprefixed locale the route table has
+    // nothing at `/` - every unprefixed path on such a host 404s
+    expect(resolveDefaultLocale('staging.example.com', undefined, locales)).toBe('en')
+    expect(resolveDefaultLocale('staging.example.com', '', locales)).toBe('en')
+  })
+
+  test('without domains nothing is invented, an unset `defaultLocale` stays unset', () => {
+    expect(resolveDefaultLocale('example.com', undefined, getNormalizedLocales(['en', 'fr']))).toBe('')
   })
 })
 

--- a/test/navigation.test.ts
+++ b/test/navigation.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from 'vitest'
 import { createNavigationResolver } from '../src/runtime/routing/navigation'
 import { getLocaleFromRoutePath } from '../src/runtime/kit/routing'
+import { resolveLocaleReach } from '../src/runtime/shared/domain'
+import { getNormalizedLocales } from './pages/utils'
 
 import type { NavigationResolverConfig } from '../src/runtime/routing/navigation'
 import type { CompatRoute } from '../src/runtime/types'
@@ -12,6 +14,15 @@ const route = (overrides: Partial<CompatRoute> = {}): CompatRoute =>
   ({ path: '/about', fullPath: '/about', name: 'about___en', matched: [], meta: {}, ...overrides }) as any
 
 const ROUTES = new Set(['index___en', 'index___fr', 'about___en', 'about___fr', 'test-route___en', 'test-route___fr'])
+
+const DOMAIN_LOCALES = getNormalizedLocales([
+  { code: 'en', domains: ['en.example.com'], defaultForDomains: ['en.example.com'] },
+  { code: 'fr', domains: ['fr.example.com'], defaultForDomains: ['fr.example.com'] },
+])
+
+// derived through the real predicate, so the harness cannot describe a host the runtime never sees
+const reachFrom = (host: string, locales = DOMAIN_LOCALES) => (locale: string) =>
+  resolveLocaleReach(locales, host, locale)
 
 // mirrors `localePath`/`switchLocalePath` for existing routes with `strategy: prefix_except_default`
 const localizePath = (path: string, locale: string) =>
@@ -79,7 +90,7 @@ describe('createNavigationResolver', () => {
   })
 
   test('domains: locales served on the current host navigate through the router', () => {
-    const resolve = createResolver({ isLocaleOnHost: locale => locale !== 'fr' })
+    const resolve = createResolver({ localeReach: reachFrom('en.example.com') })
     expect(resolve(route({ path: '/fr/about', fullPath: '/fr/about', name: 'about___fr' }), 'en')).toEqual({
       path: '/about',
       code: undefined,
@@ -88,7 +99,7 @@ describe('createNavigationResolver', () => {
 
   test('domains: a locale served on another domain relocates to its absolute URL', () => {
     const resolve = createResolver({
-      isLocaleOnHost: locale => locale !== 'fr',
+      localeReach: reachFrom('en.example.com'),
       switchLocalePath: (locale, to) => 'http://fr.example.com' + unprefixedPath(String(to.fullPath)),
     })
     expect(resolve(route(), 'fr')).toEqual({ path: 'http://fr.example.com/about', code: undefined, external: true })
@@ -96,8 +107,7 @@ describe('createNavigationResolver', () => {
 
   test('domains: a locale served on an unconfigured host stays put', () => {
     const resolve = createResolver({
-      isLocaleOnHost: locale => locale !== 'fr',
-      isLocaleServed: () => true,
+      localeReach: reachFrom('staging.example.com'),
       switchLocalePath: () => 'http://fr.example.com/about',
     })
     expect(resolve(route(), 'fr')).toBeUndefined()
@@ -105,7 +115,18 @@ describe('createNavigationResolver', () => {
 
   test('domains: an off-host locale without an absolute destination stays put', () => {
     // the default mock resolves a relative path - only an absolute URL can navigate externally
-    const resolve = createResolver({ isLocaleOnHost: locale => locale !== 'fr' })
+    const resolve = createResolver({ localeReach: reachFrom('en.example.com') })
     expect(resolve(route(), 'fr')).toBeUndefined()
+  })
+
+  test('domains: a locale configuring no domain navigates in place', () => {
+    // it is served on every domain, so it has nowhere to be relocated to - resolving it as off-host
+    // left `setLocale` setting the locale and its cookie while the URL never changed
+    const withPlain = [...DOMAIN_LOCALES, ...getNormalizedLocales([{ code: 'de' }])]
+    const resolve = createResolver({
+      localeReach: reachFrom('en.example.com', withPlain),
+      getLocaleCodes: () => ['en', 'fr', 'de'],
+    })
+    expect(resolve(route(), 'de')).toEqual({ path: '/de/about', code: undefined })
   })
 })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,4 +1,4 @@
-import { filterLocales, resolveLocales, validateLocaleCodes } from '../src/utils'
+import { filterLocales, logger, resolveLocales, validateDefaultLocale, validateLocaleCodes } from '../src/utils'
 import type { NuxtI18nOptions } from '../src/types'
 import type { I18nNuxtContext } from '../src/context'
 import { vi, describe, test, expect } from 'vitest'
@@ -336,5 +336,24 @@ describe('message source classification', () => {
       serializable: false
     })
     expect(analyze(`export { default } from './en'`)).toMatchObject({ type: 'unknown', serializable: false })
+  })
+})
+
+describe('validateDefaultLocale', () => {
+  test('warns when `defaultLocale` names no configured locale', () => {
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+
+    validateDefaultLocale('ja', ['en', 'fr'])
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn.mock.calls[0]![0]).toContain('"ja"')
+
+    warn.mockClear()
+    // a layer may contribute the locale, so this is only checkable after they are merged
+    validateDefaultLocale('ja', ['en', 'fr', 'ja'])
+    validateDefaultLocale('', ['en', 'fr'])
+    validateDefaultLocale(undefined, ['en', 'fr'])
+    expect(warn).not.toHaveBeenCalled()
+
+    warn.mockRestore()
   })
 })


### PR DESCRIPTION
Two domain setups left a locale unreachable.

`setLocale` on a locale configuring no `domains` set the locale and its cookie but never changed the URL, so a reload reverted it. Such a locale is served on every domain, so it has nowhere to be relocated to, but it was resolved as off-host and treated like one that had to be reached elsewhere. `isLocaleServedOnHost` answered `true` for two unrelated reasons - the locale configures no domains, or the host matches none of them - while navigation read it as "serves every locale in place", which only follows from the second. This replaces it with `resolveLocaleReach`, returning `here`, `other-domain` or `off-host`, and defines the old predicate in terms of it so the two can't drift apart.

A host matching none of the configured domains also 404s on every unprefixed path when `defaultLocale` isn't set, which is allowed under domains: nothing claims the unprefixed route, so the table has nothing at `/`. Such a host now serves the first locale unprefixed. That fallback is gated on locales actually carrying domains, so a site without them still resolves to no default exactly as before.

A `defaultLocale` naming no configured locale hits the same dead end without saying why, so it warns now. The check runs after layers have contributed their locales, since a layer may be what declares it - which the `different_domains` fixture was relying on, pointing at a `ja` locale it stopped configuring in 2023.

The domain specs assert the rendered locale rather than the response, so this adds one for an unconfigured `Host`, and swaps the hand-written host predicates in `test/navigation.test.ts` for the real one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale routing for requests from unconfigured hosts, preventing unexpected 404 responses.
  * Enhanced language switching across domains, including correct redirects to absolute locale URLs.
  * Improved fallback handling when a default locale is unavailable or domain mappings are incomplete.
  * Added warnings when the configured default locale is not supported.

* **Tests**
  * Added coverage for cross-domain routing, unconfigured hosts, locale fallbacks, and language-switcher behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->