### PR TITLE
test: poll message counts instead of reading them once after a locale fetch

### DIFF
--- a/specs/lazy_load/basic_lazy_load.spec.ts
+++ b/specs/lazy_load/basic_lazy_load.spec.ts
@@ -49,34 +49,20 @@ describe('basic lazy loading', async () => {
     const { page } = await renderPage(home)
 
     // `en` present on initial load
-    expect(await getLocalesMessageKeyCount(page)).toMatchInlineSnapshot(`
-      {
-        "en": 8,
-      }
-    `)
+    await expect.poll(() => getLocalesMessageKeyCount(page)).toEqual({ en: 8 })
 
     // navigate and wait for locale file request
     await Promise.all([waitForLocaleNetwork(page, 'fr', 'response'), page.click('#nuxt-locale-link-fr')])
 
-    // `fr` locale has been fetched
-    expect(await getLocalesMessageKeyCount(page)).toMatchInlineSnapshot(`
-      {
-        "en": 8,
-        "fr": 5,
-      }
-    `)
+    // `fr` locale has been fetched. Polled rather than read once: the network wait resolves when the
+    // response arrives, the messages are only installed once the client has merged it
+    await expect.poll(() => getLocalesMessageKeyCount(page)).toEqual({ en: 8, fr: 5 })
 
     // navigate and wait for locale file request
     await Promise.all([waitForLocaleNetwork(page, 'nl', 'response'), page.click('#nuxt-locale-link-nl')])
 
     // `nl` (module) locale has been fetched
-    expect(await getLocalesMessageKeyCount(page)).toMatchInlineSnapshot(`
-      {
-        "en": 8,
-        "fr": 5,
-        "nl": 3,
-      }
-    `)
+    await expect.poll(() => getLocalesMessageKeyCount(page)).toEqual({ en: 8, fr: 5, nl: 3 })
   })
 
   test('can access to no prefix locale (en): /', async () => {

--- a/specs/ssg/basic_lazy_load.spec.ts
+++ b/specs/ssg/basic_lazy_load.spec.ts
@@ -49,22 +49,14 @@ describe('basic lazy loading', async () => {
     const { page } = await renderPage(home)
 
     // `en` present on initial load
-    expect(await getLocalesMessageKeyCount(page)).toMatchInlineSnapshot(`
-      {
-        "en": 8,
-      }
-    `)
+    await expect.poll(() => getLocalesMessageKeyCount(page)).toEqual({ en: 8 })
 
     // `fr` messages are static, so they come from the prerendered endpoint instead of a chunk
     await Promise.all([waitForLocaleNetwork(page, 'fr', 'response'), page.click('#nuxt-locale-link-fr')])
 
-    // `fr` locale has been fetched
-    expect(await getLocalesMessageKeyCount(page)).toMatchInlineSnapshot(`
-      {
-        "en": 8,
-        "fr": 5,
-      }
-    `)
+    // `fr` locale has been fetched. Polled rather than read once: the network wait resolves when the
+    // response arrives, the messages are only installed once the client has merged it
+    await expect.poll(() => getLocalesMessageKeyCount(page)).toEqual({ en: 8, fr: 5 })
 
     // navigate and wait for locale file request
     await Promise.all([
@@ -73,13 +65,7 @@ describe('basic lazy loading', async () => {
     ])
 
     // `nl` (module) locale has been fetched
-    expect(await getLocalesMessageKeyCount(page)).toMatchInlineSnapshot(`
-      {
-        "en": 8,
-        "fr": 5,
-        "nl": 3,
-      }
-    `)
+    await expect.poll(() => getLocalesMessageKeyCount(page)).toEqual({ en: 8, fr: 5, nl: 3 })
   })
 
   test('can access to no prefix locale (en): /', async () => {


### PR DESCRIPTION
`specs/ssg/basic_lazy_load.spec.ts` [failed on CI](https://github.com/nuxt-modules/i18n/actions/runs/30502548227/job/90745231588?pr=4106) with `{ "en": 8 }` where it also expected `fr`, and passed on a rerun. `waitForLocaleNetwork(page, locale, 'response')` resolves when the response arrives, while the messages only reach `$i18n.messages` once the client has merged it, so reading the count right after can land in between.

This polls those reads in both lazy-load specs instead. `expect.poll` doesn't take snapshot matchers, so the inline snapshots become plain objects - less convenient to update, but the assertion no longer depends on timing. Anything else reading browser state directly after a network wait has the same hole.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for on-demand locale loading in lazy-load and static-generation scenarios.
  * Tests now reliably wait for locale messages to become available after switching languages, including French and Dutch locales.
  * Updated assertions to better reflect asynchronous locale installation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->