### PR TITLE
docs: describe what the domain override cannot change and which links cross origins

### DIFF
--- a/docs/content/docs/02.guide/09.different-domains.md
+++ b/docs/content/docs/02.guide/09.different-domains.md
@@ -44,7 +44,7 @@ export default defineNuxtConfig({
 })
 ```
 
-When using different domain names, your lang switcher should use regular `<a>`{lang="html"} tags:
+When using different domain names, your lang switcher links to another origin. Prefer `<SwitchLocalePathLink>`{lang="html"}, which also writes the locale cookie so the choice survives the switch where `detectBrowserLanguage.cookieDomain` spans your domains. Regular `<a>`{lang="html"} tags work as well - unlike `<NuxtLink>`{lang="html"}, which adds `rel="noreferrer"`{lang="html"} to an external link, so detection cannot recognize the arrival as one of your own and redirects it away again:
 
 ```vue
 <script setup>
@@ -114,6 +114,8 @@ NUXT_PUBLIC_I18N_DOMAIN_LOCALES_FR_DOMAIN=fr.example.test
 NUXT_PUBLIC_I18N_DOMAIN_LOCALES_UK_DOMAIN=uk.staging.example.test
 NUXT_PUBLIC_I18N_DOMAIN_LOCALES_FR_DOMAIN=fr.staging.example.test
 ```
+
+The override changes which domain serves a locale, it can't make a locale the default for a domain it wasn't already the default for. Which locale a domain serves unprefixed is decided by the routes generated at build time, so each locale needs a `domain` (and `domainDefault`, where a domain serves several locales) in `nuxt.config.ts` for the override to re-point. A locale left without one - because the build ran with `DOMAIN_FR` unset, for example - keeps its prefix on the domain it is overridden onto, and that domain serves whichever locale the build did resolve as its default. The `'no_prefix'`{lang="ts-type"} strategy is unaffected, no route shape depends on the domain there.
 
 ## Using different domains for only some of the languages
 

--- a/docs/content/docs/02.guide/10.multi-domain-locales.md
+++ b/docs/content/docs/02.guide/10.multi-domain-locales.md
@@ -99,6 +99,8 @@ export default defineNuxtConfig({
 
 With the above config, a build would have to be run for staging and production with different .env files that specify `DOMAIN_UK` and `DOMAIN_FR`.
 
+A single build can also serve different domains by overriding them with `NUXT_PUBLIC_I18N_DOMAIN_LOCALES_{code}_DOMAIN` at runtime - see [runtime environment variables](/docs/guide/different-domains#runtime-environment-variables) in the `differentDomains` guide, including what the override cannot change.
+
 ## Using different domains for only some of the languages
 
 If multiple domains share the same default language, you can specify them all using `defaultForDomains`, which supports multiple domains.

--- a/docs/content/docs/06.composables/01.use-locale-path.md
+++ b/docs/content/docs/06.composables/01.use-locale-path.md
@@ -4,6 +4,8 @@ title: useLocalePath
 
 The `useLocalePath()`{lang="ts"} composable returns a function that resolves a path according to the current locale.
 
+It always resolves a path on the current domain, it doesn't consider which domain serves a locale. Under [`differentDomains`](/docs/guide/different-domains) or [`multiDomainLocales`](/docs/guide/multi-domain-locales) a path it returns for a locale served elsewhere is redirected to that domain when the URL is loaded, so link to another locale with [`useSwitchLocalePath()`](/docs/composables/use-switch-locale-path) or `<SwitchLocalePathLink>`{lang="html"} instead - those resolve the domain serving the locale.
+
 ## Type
 
 ```ts


### PR DESCRIPTION

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
The runtime `NUXT_PUBLIC_I18N_DOMAIN_LOCALES_*` override changes which domain serves a locale, but it can't make a locale the default for a domain it wasn't already the default for, since the unprefixed routes are generated at build time. A locale whose domain is unset at build keeps its prefix on the domain it's moved onto, and that domain serves whichever locale the build resolved as its default. This documents that, and cross-references it from the multi domain guide, which only covered the build-time approach.

`useLocalePath()` resolves on the current domain and doesn't consider which domain serves a locale, so a path it returns for a locale served elsewhere is redirected away when loaded. Documented alongside a pointer to `switchLocalePath`.

The differentDomains switcher example predates `<SwitchLocalePathLink>` and recommended plain <a> tags — those still work, but the component is the better default, and `<NuxtLink>` specifically is the wrong choice because the `rel="noreferrer"` it adds to external links defeats referer-based detection.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how to create cross-domain locale switcher links while preserving locale detection.
  * Documented limitations when overriding locale domains at runtime.
  * Explained how `useLocalePath()` behaves across domains and recommended locale-switching utilities for cross-domain links.
  * Added guidance on serving multiple domains from a single build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->