### PR TITLE
refactor(routing): drop the unreachable on-host prefix strip

### DIFF
--- a/src/runtime/routing/context.ts
+++ b/src/runtime/routing/context.ts
@@ -1,7 +1,7 @@
 import { joinURL } from 'ufo'
 import { createLocaleRouteNameGetter, createLocalizedRouteByPathResolver } from './utils'
 import { createTrailingSlashFormatter, getLocaleFromRoutePath, getRouteBaseName, prefixable } from '#i18n-kit/routing'
-import { getDefaultLocaleForDomain, isSupportedLocale, resolveDefaultLocale } from '../shared/locales'
+import { isSupportedLocale, resolveDefaultLocale } from '../shared/locales'
 import { canonicalDomain, isLocaleOnHost, normalizeDomain } from '../shared/domain'
 
 import type { RouteLocationPathRaw, RouteRecordNameGeneric, Router } from 'vue-router'
@@ -221,10 +221,9 @@ export function createRoutingContext(options: RoutingContextOptions): RoutingCon
       const locales = options.getLocales()
       const target = locales.find(l => l.code === locale)
 
+      // `setupMultiDomainLocales` already unprefixed this host's own default locale in the route
+      // table, so a path resolved here needs no reshaping
       if (isLocaleOnHost(target, host)) {
-        if (stripsDefaultPrefix && locale === getDefaultLocaleForDomain(host, locales) && getLocaleFromRoutePath(path) === locale) {
-          return path.slice(locale.length + 1) || '/'
-        }
         return path
       }
 


### PR DESCRIPTION
`afterSwitchLocalePath` stripped the locale prefix for the host's own default locale, using `getDefaultLocaleForDomain` where the surrounding code resolves the same question through `resolveDefaultLocale` - two answers to "is this locale unprefixed here" that disagree on a host claiming no default of its own.

Neither answer is needed. `setupMultiDomainLocales` already rewrites that locale's route to its unprefixed path, so `localePath` returns an unprefixed path and the strip's own `getLocaleFromRoutePath(path) === locale` check can never be true; under `prefix_and_default` the `___default` variant wins name resolution and gets there first. I confirmed it by making the branch throw: 464 unit and 232 e2e tests, all four strategies and both domain option shapes, never reached it.

Removing it drops the disagreement with no behaviour change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved locale path prefixes when switching locales on the current host.
  * Prevented valid default-locale paths from being unintentionally shortened or altered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->