### PR TITLE
fix: skip the messages route cache when caching is disabled

### DIFF
--- a/src/runtime/server/routes/messages.ts
+++ b/src/runtime/server/routes/messages.ts
@@ -61,8 +61,8 @@ const _messagesHandlerCached = defineCachedEventHandler(_cachedMessageLoader, {
 
 /**
  * Load messages for the specified locale event parameter
- * - uses `messagesHandler` in development
+ * - uses `messagesHandler` in development or when caching is disabled
  * - uses `cachedMessagesHandler` in production
  */
 // export default _messagesHandler
-export default import.meta.dev ? _messagesHandler : _messagesHandlerCached
+export default import.meta.dev || !__I18N_CACHE__ ? _messagesHandler : _messagesHandlerCached

--- a/test/messages-route.test.ts
+++ b/test/messages-route.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, expect, test, vi } from 'vitest'
+
+// nitro turns a cache handler's `maxAge` into an `EX <ttl>` on the storage write, and a redis driver
+// rejects a non-positive expiry, so mimic a cached handler that writes with `ttl: maxAge` and a store
+// that throws like redis does on an invalid ttl
+const { writes, ctx } = vi.hoisted(() => ({
+  writes: [] as number[],
+  ctx: {
+    loadMessages: vi.fn(async (locale: string) => ({ [locale]: { hello: 'world' } })),
+    localeConfigs: { en: { cacheable: true } } as Record<string, { cacheable: boolean }>,
+  },
+}))
+
+vi.mock('nitropack/runtime', () => {
+  const cached = (fn: (...args: unknown[]) => unknown, opts: any) => async (...args: unknown[]) => {
+    if (await opts.shouldBypassCache?.(...args)) {
+      return fn(...args)
+    }
+    const value = await fn(...args)
+    if (opts.maxAge && opts.swr === false) {
+      if (opts.maxAge <= 0) {
+        throw new Error('ERR invalid expire time in set')
+      }
+      writes.push(opts.maxAge)
+    }
+    return value
+  }
+  return { defineCachedFunction: cached, defineCachedEventHandler: cached }
+})
+
+vi.mock('../src/runtime/server/context', () => ({
+  useI18nContext: () => ctx,
+  tryUseI18nContext: () => ctx,
+  initializeI18nContext: async () => ctx,
+}))
+vi.mock('../src/runtime/shared/messages', () => ({ warnMissedMessageFunctions: () => {} }))
+
+async function importMessagesHandler() {
+  return (await import('../src/runtime/server/routes/messages')).default
+}
+
+function createEvent() {
+  return { context: { params: { locale: 'en' } }, node: { req: { headers: {} } }, path: '/_i18n/en/messages.json' }
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  writes.length = 0
+  ctx.loadMessages.mockClear()
+})
+
+test('serves messages without a cache expiry when caching is disabled', async () => {
+  const handler = await importMessagesHandler()
+
+  await expect(handler(createEvent() as never)).resolves.toEqual({ en: { hello: 'world' } })
+  expect(writes).toEqual([])
+})


### PR DESCRIPTION
* Resolves #4112

When message caching is disabled, the production route still runs through Nitro's cached event handler, and the module passes `maxAge: -1` there to mean "do not cache". Nitro treats that as a real expiry and writes the response to storage with a negative TTL, which a Redis driver rejects with `ERR invalid expire time in set`. The route already serves uncached in development, so this now does the same whenever caching is off, keeping the negative TTL from ever reaching the store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Message responses now correctly bypass caching when caching is disabled, preventing unintended cache writes.

* **Tests**
  * Added coverage to verify that disabled caching returns messages without attempting to write cache entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->