### PR TITLE
fix: reject a messages.json hash that doesn't match the build's own hash (CWE-770)

### DIFF
--- a/specs/helper.ts
+++ b/specs/helper.ts
@@ -1,6 +1,8 @@
 // @ts-ignore
 import { getBrowser, startServer, TestContext, url, useTestContext } from './utils'
 import { onTestFinished } from 'vitest'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
 
 import type { BrowserContextOptions, Page } from 'playwright-core'
 
@@ -392,4 +394,22 @@ export async function getHeadSnapshot(page: Page): Promise<string> {
   }
 
   return formattedOutput.join('\n')
+}
+
+/**
+ * The messages endpoint rejects any `:hash` that isn't the build's own content hash for the
+ * locale, so read the real one straight out of the built server instead of hardcoding it, which
+ * would go stale the moment a fixture's locale files change.
+ */
+export function findLocaleHash(locale: string) {
+  const chunksDir = join(useTestContext().nuxt!.options.nitro!.output!.dir!, 'server/chunks')
+  const pattern = new RegExp(`"${locale}":\\s*"([a-f0-9]+)"`)
+
+  for (const name of readdirSync(chunksDir, { recursive: true }) as string[]) {
+    if (!name.endsWith('.mjs')) continue
+    const match = pattern.exec(readFileSync(join(chunksDir, name), 'utf-8'))
+    if (match) return match[1]!
+  }
+
+  throw new Error(`Could not find the build's content hash for locale '${locale}'`)
 }

--- a/specs/lazy_load/app_context_locale.spec.ts
+++ b/specs/lazy_load/app_context_locale.spec.ts
@@ -1,7 +1,9 @@
 import { fileURLToPath } from 'node:url'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
 import { describe, expect, test } from 'vitest'
 
-import { setup, $fetch } from '../utils'
+import { setup, $fetch, useTestContext } from '../utils'
 
 await setup({
   rootDir: fileURLToPath(new URL(`../fixtures/lazy`, import.meta.url)),
@@ -19,6 +21,22 @@ await setup({
   }
 })
 
+// the endpoint rejects any `:hash` that isn't the build's own content hash for the locale (see
+// `computeLocaleHashes` in `src/utils.ts`), so read the real one straight out of the built server
+// instead of hardcoding it, which would go stale the moment the fixture's locale files change
+function findLocaleHash(locale: string) {
+  const chunksDir = join(useTestContext().nuxt!.options.nitro!.output!.dir!, 'server/chunks')
+  const pattern = new RegExp(`"${locale}":\\s*"([a-f0-9]+)"`)
+
+  for (const name of readdirSync(chunksDir, { recursive: true }) as string[]) {
+    if (!name.endsWith('.mjs')) continue
+    const match = pattern.exec(readFileSync(join(chunksDir, name), 'utf-8'))
+    if (match) return match[1]!
+  }
+
+  throw new Error(`Could not find the build's content hash for locale '${locale}'`)
+}
+
 describe('(#3940) a locale file that needs the Nuxt app', () => {
   test('produces its messages during SSR instead of failing in nitro', async () => {
     const html = await $fetch('/ap')
@@ -26,8 +44,9 @@ describe('(#3940) a locale file that needs the Nuxt app', () => {
   })
 
   test('is not among the loaders the messages endpoint runs', async () => {
-    // the handler resolves the locale from the route, any `:hash` segment reaches it
-    const messages = await $fetch<Record<string, Record<string, unknown>>>('/_i18n/test/ap/messages.json')
+    const messages = await $fetch<Record<string, Record<string, unknown>>>(
+      `/_i18n/${findLocaleHash('ap')}/ap/messages.json`
+    )
 
     // the locale's other file is still served from there, the one needing the app is left out
     expect(messages.ap).toHaveProperty('home', 'Homepage')

--- a/specs/lazy_load/app_context_locale.spec.ts
+++ b/specs/lazy_load/app_context_locale.spec.ts
@@ -1,9 +1,8 @@
 import { fileURLToPath } from 'node:url'
-import { readFileSync, readdirSync } from 'node:fs'
-import { join } from 'node:path'
 import { describe, expect, test } from 'vitest'
 
-import { setup, $fetch, useTestContext } from '../utils'
+import { setup, $fetch } from '../utils'
+import { findLocaleHash } from '../helper'
 
 await setup({
   rootDir: fileURLToPath(new URL(`../fixtures/lazy`, import.meta.url)),
@@ -20,22 +19,6 @@ await setup({
     }
   }
 })
-
-// the endpoint rejects any `:hash` that isn't the build's own content hash for the locale (see
-// `computeLocaleHashes` in `src/utils.ts`), so read the real one straight out of the built server
-// instead of hardcoding it, which would go stale the moment the fixture's locale files change
-function findLocaleHash(locale: string) {
-  const chunksDir = join(useTestContext().nuxt!.options.nitro!.output!.dir!, 'server/chunks')
-  const pattern = new RegExp(`"${locale}":\\s*"([a-f0-9]+)"`)
-
-  for (const name of readdirSync(chunksDir, { recursive: true }) as string[]) {
-    if (!name.endsWith('.mjs')) continue
-    const match = pattern.exec(readFileSync(join(chunksDir, name), 'utf-8'))
-    if (match) return match[1]!
-  }
-
-  throw new Error(`Could not find the build's content hash for locale '${locale}'`)
-}
 
 describe('(#3940) a locale file that needs the Nuxt app', () => {
   test('produces its messages during SSR instead of failing in nitro', async () => {

--- a/specs/lazy_load/messages_hash_collision.spec.ts
+++ b/specs/lazy_load/messages_hash_collision.spec.ts
@@ -1,9 +1,8 @@
 import { fileURLToPath } from 'node:url'
-import { readFileSync, readdirSync } from 'node:fs'
-import { join } from 'node:path'
 import { describe, expect, test } from 'vitest'
 
-import { setup, fetch, useTestContext } from '../utils'
+import { setup, fetch } from '../utils'
+import { findLocaleHash } from '../helper'
 
 // `cacheLifetime` enables the messages.json HTTP cache (`__I18N_CACHE__`, see `isCacheEnabled`
 // in src/bundler.ts). `locales` is overridden (arrays replace rather than merge) to a plain
@@ -22,22 +21,6 @@ await setup({
     }
   }
 })
-
-// the endpoint rejects any `:hash` that isn't the build's own content hash for the locale, so
-// read the real one straight out of the built server instead of hardcoding it, which would go
-// stale the moment the fixture's locale files change
-function findLocaleHash(locale: string) {
-  const chunksDir = join(useTestContext().nuxt!.options.nitro!.output!.dir!, 'server/chunks')
-  const pattern = new RegExp(`"${locale}":\\s*"([a-f0-9]+)"`)
-
-  for (const name of readdirSync(chunksDir, { recursive: true }) as string[]) {
-    if (!name.endsWith('.mjs')) continue
-    const match = pattern.exec(readFileSync(join(chunksDir, name), 'utf-8'))
-    if (match) return match[1]!
-  }
-
-  throw new Error(`Could not find the build's content hash for locale '${locale}'`)
-}
 
 describe('(security) messages.json cache key collision', () => {
   test('a hash colliding across the locale/hash join cannot read another locale\'s cache entry', async () => {

--- a/specs/lazy_load/messages_hash_collision.spec.ts
+++ b/specs/lazy_load/messages_hash_collision.spec.ts
@@ -1,0 +1,69 @@
+import { fileURLToPath } from 'node:url'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, test } from 'vitest'
+
+import { setup, fetch, useTestContext } from '../utils'
+
+// `cacheLifetime` enables the messages.json HTTP cache (`__I18N_CACHE__`, see `isCacheEnabled`
+// in src/bundler.ts). `locales` is overridden (arrays replace rather than merge) to a plain
+// `en`/`en-US` pair - see the cacheability comment in the test body for why
+await setup({
+  rootDir: fileURLToPath(new URL(`../fixtures/lazy`, import.meta.url)),
+  nuxtConfig: {
+    i18n: {
+      experimental: {
+        cacheLifetime: 60
+      },
+      locales: [
+        { code: 'en', file: 'lazy-locale-en.json' },
+        { code: 'en-US', file: 'lazy-locale-en.json' }
+      ]
+    }
+  }
+})
+
+// the endpoint rejects any `:hash` that isn't the build's own content hash for the locale, so
+// read the real one straight out of the built server instead of hardcoding it, which would go
+// stale the moment the fixture's locale files change
+function findLocaleHash(locale: string) {
+  const chunksDir = join(useTestContext().nuxt!.options.nitro!.output!.dir!, 'server/chunks')
+  const pattern = new RegExp(`"${locale}":\\s*"([a-f0-9]+)"`)
+
+  for (const name of readdirSync(chunksDir, { recursive: true }) as string[]) {
+    if (!name.endsWith('.mjs')) continue
+    const match = pattern.exec(readFileSync(join(chunksDir, name), 'utf-8'))
+    if (match) return match[1]!
+  }
+
+  throw new Error(`Could not find the build's content hash for locale '${locale}'`)
+}
+
+describe('(security) messages.json cache key collision', () => {
+  test('a hash colliding across the locale/hash join cannot read another locale\'s cache entry', async () => {
+    const hash = findLocaleHash('en-US')
+
+    // populate the `en-US` cache entry with a legitimate request
+    const legit = await fetch(`/_i18n/${hash}/en-US/messages.json`)
+    expect(legit.status).toBe(200)
+
+    // guard against a vacuous test: if `__I18N_CACHE__` were compiled out, `maxAge` would be `-1`
+    // (see `_messagesHandlerCached`) and every request would hit validation directly regardless of
+    // whether the fix's reordering is in place. A positive `max-age` confirms it's compiled in
+    const maxAge = Number(/max-age=(-?\d+)/.exec(legit.headers.get('cache-control') ?? '')?.[1])
+    expect(maxAge).toBeGreaterThan(0)
+
+    // the other way this could be vacuous: `shouldBypassCache` (routes/messages.ts) skips the
+    // cache per locale, so an uncacheable locale can never populate an entry either. `en`/`en-US`
+    // above are plain single-file locales with no `cache: false` (unlike the fixture's own
+    // `en-GB`, which shares a file with `runtime-config-translation.js` and the module marks
+    // uncacheable), so both are cacheable by construction - confirmed by running this exact
+    // assertion against the pre-fix handler, where it fails with 200 instead of 404, proving the
+    // collision really does read a cache entry rather than reaching validation on its own
+
+    // `en` is a prefix of `en-US` followed by `-`, so this request computes the exact same cache
+    // key as the legitimate one above: ['en', `US-${hash}`].join('-') === ['en-US', hash].join('-')
+    const colliding = await fetch(`/_i18n/US-${hash}/en/messages.json`)
+    expect(colliding.status).toBe(404)
+  })
+})

--- a/src/runtime/server/routes/messages.ts
+++ b/src/runtime/server/routes/messages.ts
@@ -18,7 +18,7 @@ const _messagesHandler = defineEventHandler(async (event: H3Event) => {
   const ctx = useI18nContext(event)
   if (
     // reject a locale the build doesn't know about
-    (ctx.localeConfigs && locale in ctx.localeConfigs === false) ||
+    (ctx.localeConfigs && !Object.hasOwn(ctx.localeConfigs, locale)) ||
     // reject any hash that isn't the build's own for this locale, so an arbitrary path segment
     // can't mint unbounded cache entries (24h, per miss)
     getRouterParam(event, 'hash') !== __I18N_LOCALE_HASHES__[locale]

--- a/src/runtime/server/routes/messages.ts
+++ b/src/runtime/server/routes/messages.ts
@@ -16,7 +16,13 @@ const _messagesHandler = defineEventHandler(async (event: H3Event) => {
   }
 
   const ctx = useI18nContext(event)
-  if (ctx.localeConfigs && locale in ctx.localeConfigs === false) {
+  if (
+    // reject a locale the build doesn't know about
+    (ctx.localeConfigs && locale in ctx.localeConfigs === false) ||
+    // reject any hash that isn't the build's own for this locale, so an arbitrary path segment
+    // can't mint unbounded cache entries (24h, per miss)
+    getRouterParam(event, 'hash') !== __I18N_LOCALE_HASHES__[locale]
+  ) {
     throw createError({ status: 404, message: `Locale '${locale}' not found.` })
   }
 

--- a/src/runtime/server/routes/messages.ts
+++ b/src/runtime/server/routes/messages.ts
@@ -5,6 +5,9 @@ import { warnMissedMessageFunctions } from '../../shared/messages'
 
 import type { H3Event } from 'h3'
 
+// prerendering may require initializing context
+const getOrInitContext = async (event: H3Event) => tryUseI18nContext(event) || await initializeI18nContext(event)
+
 /**
  * Reject a bad locale/hash pair before either cache layer computes a key or does a
  * lookup, so a colliding hash for one locale can never read another locale's cache entry.
@@ -16,8 +19,7 @@ async function validateLocaleRequest(event: H3Event) {
     throw createError({ status: 400, message: 'Locale not specified.' })
   }
 
-  // prerendering may require initializing context
-  const ctx = tryUseI18nContext(event) || await initializeI18nContext(event)
+  const ctx = await getOrInitContext(event)
   if (
     // reject a locale the build doesn't know about
     (ctx.localeConfigs && !Object.hasOwn(ctx.localeConfigs, locale)) ||
@@ -51,8 +53,7 @@ const getCacheKey = (event: H3Event) =>
 async function shouldBypassCache(event: H3Event) {
   const locale = getRouterParam(event, 'locale')
   if (locale == null) { return false }
-  // prerendering may require initializing context
-  const ctx = tryUseI18nContext(event) || await initializeI18nContext(event)
+  const ctx = await getOrInitContext(event)
   return !ctx.localeConfigs?.[locale]?.cacheable
 }
 

--- a/src/runtime/server/routes/messages.ts
+++ b/src/runtime/server/routes/messages.ts
@@ -6,16 +6,18 @@ import { warnMissedMessageFunctions } from '../../shared/messages'
 import type { H3Event } from 'h3'
 
 /**
- * Load messages for the specified locale event parameter
+ * Reject a bad locale/hash pair before either cache layer computes a key or does a
+ * lookup, so a colliding hash for one locale can never read another locale's cache entry.
  */
-const _messagesHandler = defineEventHandler(async (event: H3Event) => {
+async function validateLocaleRequest(event: H3Event) {
   const locale = getRouterParam(event, 'locale')
 
   if (!locale) {
     throw createError({ status: 400, message: 'Locale not specified.' })
   }
 
-  const ctx = useI18nContext(event)
+  // prerendering may require initializing context
+  const ctx = tryUseI18nContext(event) || await initializeI18nContext(event)
   if (
     // reject a locale the build doesn't know about
     (ctx.localeConfigs && !Object.hasOwn(ctx.localeConfigs, locale)) ||
@@ -25,7 +27,14 @@ const _messagesHandler = defineEventHandler(async (event: H3Event) => {
   ) {
     throw createError({ status: 404, message: `Locale '${locale}' not found.` })
   }
+}
 
+/**
+ * Load messages for the specified locale event parameter
+ */
+const _messagesHandler = defineEventHandler(async (event: H3Event) => {
+  const locale = getRouterParam(event, 'locale')!
+  const ctx = useI18nContext(event)
   const messages = await ctx.loadMessages(locale)
   // this response is where message functions get dropped - prerender is when SSG bakes it
   if (import.meta.dev || import.meta.prerender) {
@@ -67,8 +76,11 @@ const _messagesHandlerCached = defineCachedEventHandler(_cachedMessageLoader, {
 
 /**
  * Load messages for the specified locale event parameter
- * - uses `messagesHandler` in development
- * - uses `cachedMessagesHandler` in production
+ * - validates the locale/hash before either cache layer sees the request
+ * - uses `_messagesHandler` in development
+ * - uses `_messagesHandlerCached` in production
  */
-// export default _messagesHandler
-export default import.meta.dev ? _messagesHandler : _messagesHandlerCached
+export default defineEventHandler(async (event: H3Event) => {
+  await validateLocaleRequest(event)
+  return import.meta.dev ? _messagesHandler(event) : _messagesHandlerCached(event)
+})


### PR DESCRIPTION
## Summary
- The `/_i18n/:hash/:locale/messages.json` endpoint keyed its cache entirely off the `hash` and `locale` router params, but never checked `hash` against the build's own content hash. Any string in that segment produced a fresh 200 response and a 24h cache entry, letting an unauthenticated caller mint unbounded cache entries by iterating the segment (CWE-770).
- Reject a `hash` that doesn't equal `__I18N_LOCALE_HASHES__[locale]` before the request reaches either caching layer, restoring the hash's intended role as a content fingerprint rather than an arbitrary accepted cache key. Combined with the existing locale check into a single 404, since both reject for the same externally observable reason.
- Fixes `specs/lazy_load/app_context_locale.spec.ts`, which had hardcoded a fake hash value and documented the old behavior as expected. It now reads the real hash out of the fixture's own build output, so it can't go stale.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for localized message requests.
  * Missing locales now return a clear bad-request response.
  * Invalid locales or outdated URL hashes now return a 404 instead of attempting to load messages.
  * Prevented crafted requests from accessing another locale’s cached messages.
  * Valid requests continue using build-generated locale hashes for reliable message retrieval.
  * Added safeguards to ensure cached messages remain isolated between similar locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->