### PR TITLE
docs: improve route disable guide

### DIFF
--- a/docs/content/docs/02.guide/04.ignoring-localized-routes.md
+++ b/docs/content/docs/02.guide/04.ignoring-localized-routes.md
@@ -13,7 +13,7 @@ If you'd like some pages to be available in some languages only, you can configu
 The `definePageMeta()`{lang="ts"} examples work in all [`customRoutes`](/docs/api/options#customroutes) modes, the `defineI18nRoute()`{lang="ts"} and `pages` examples require `customRoutes` to be set to `'page'`{lang="ts-type"} (default) or `'config'`{lang="ts-type"} respectively.
 ::
 
-### Pick localized routes
+## Pick localized routes
 
 ::code-group
 
@@ -48,7 +48,7 @@ i18n: {
 
 ::
 
-### Disable localized routes
+## Disable localized routes
 
 ::code-group
 
@@ -76,3 +76,47 @@ i18n: {
 ```
 
 ::
+
+## What disabling changes
+
+Disabling turns off **route localization** for the page, not i18n itself — the page is still part of the app and keeps using the active locale:
+
+- The page mounts at its plain path only (`/about`), no per-locale variants (`/fr/about`) are generated. A page with nested children disables its whole subtree.
+- Translations keep working. `$t()`{lang="ts"}, `useI18n()`{lang="ts"}, `<i18n-t>`{lang="html"} and [lazy-loaded messages](/docs/guide/lazy-load-translations) render in the locale that is active when the page is visited.
+- Navigating to the page from a localized one keeps the current locale, and `setLocale()`{lang="ts"} switches locale in place without changing the URL.
+- [`localePath()`](/docs/composables/use-locale-path), [`<NuxtLinkLocale>`](/docs/components/nuxt-link-locale) and the other routing helpers still resolve **other** pages to their localized paths.
+
+What no longer applies to the page:
+
+- It is never redirected to a prefixed variant, including by [browser language detection](/docs/guide/browser-language-detection).
+- [`switchLocalePath()`](/docs/composables/use-switch-locale-path) returns an empty string for it, since there is no localized route to switch to. A [language switcher](/docs/guide/lang-switcher) built on it renders no links here — use `setLocale()`{lang="ts"} instead.
+- [`useLocaleHead()`](/docs/composables/use-locale-head) emits no `hreflang` alternate links, `canonical` or `og:url` for it, as the page has a single URL shared by every locale. The `lang` and `dir` attributes are still set.
+
+::callout{icon="i-heroicons-light-bulb"}
+With the default `detectBrowserLanguage.redirectOn: 'root'`{lang="ts-type"}, a locale is only detected on the root path, so opening such a page directly renders it in the default locale instead of the visitor's. Set [`redirectOn`](/docs/api/options#redirecton) to `'no prefix'`{lang="ts-type"} to have the cookie or browser locale apply on unprefixed paths as well.
+::
+
+## Disable a group of routes
+
+The `i18n` route meta is also read from routes set up in the [`pages:extend`](https://nuxt.com/docs/api/advanced/hooks#nuxt-hooks-build-time) hook, which lets you disable localized routes for an entire section of the app — such as an authenticated area that does not need indexable per-locale URLs — without editing each page:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  hooks: {
+    'pages:extend'(pages) {
+      for (const page of pages) {
+        if (page.path.startsWith('/account') || page.path === '/login') {
+          page.meta ??= {}
+          page.meta.i18n = false
+        }
+      }
+    }
+  }
+})
+```
+
+::callout{icon="i-heroicons-exclamation-triangle" color="warning"}
+With Nuxt's default `experimental.scanPageMeta: 'after-resolve'`{lang="yml"}, routes are localized in the `pages:resolved` hook, so meta set in any `pages:extend` hook is picked up. With `scanPageMeta: true`{lang="yml"}, localization runs in `pages:extend` itself and only hooks registered earlier (e.g. by modules listed before `@nuxtjs/i18n`) are.
+::
+
+See [Custom Paths](/docs/guide/custom-paths#hooks-and-modules) for the other values this route meta accepts.

--- a/specs/fixtures/basic/pages/define-i18n-route-false.vue
+++ b/specs/fixtures/basic/pages/define-i18n-route-false.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <h1 id="disable-route-text">Page with disabled localized route</h1>
+    <p id="disable-route-translation">{{ $t('home') }}</p>
     <nuxt-link id="goto-home" :to="$localePath('/')"> Goto Home </nuxt-link>
   </div>
 </template>

--- a/specs/routing_strategies/prefix.spec.ts
+++ b/specs/routing_strategies/prefix.spec.ts
@@ -159,6 +159,9 @@ describe('strategy: prefix', async () => {
 
     await expect.poll(() => page.locator('#disable-route-text').innerText()).toEqual('Page with disabled localized route')
 
+    // only the route is unlocalized, the page still renders in the active locale
+    await expect.poll(() => page.locator('#disable-route-translation').innerText()).toEqual('Accueil')
+
     // back to home
     await page.locator('#goto-home').clickNavigate()
     await expect.poll(() => page.locator('#home-header').innerText()).toEqual('Accueil')


### PR DESCRIPTION
### 🔗 Linked issue
* https://github.com/nuxt-modules/i18n/discussions/4115#discussioncomment-17856052
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This is a gap in our documentation, right now it's unclear that disabling i18n through the meta property or other custom route configuration that this only disables route localization and that i18n is otherwise functioning as normal on such a page.

The documentation is generated, maybe it's a bit too verbose in its current state, so might iterate before merging.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how disabling localized routes affects URLs, translations, navigation, locale switching, redirects, metadata, and browser-language detection.
  - Added configuration guidance for disabling localization across route groups, including hook ordering and supported route metadata.

- **Bug Fixes**
  - Confirmed that routes marked as non-localized retain translated page content while keeping their URLs unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->