### PR TITLE
fix: transform export error in dev mode

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -63,8 +63,10 @@ export function extendBundler(ctx: ResolvedI18nContext, nuxt: Nuxt) {
     }
     // `prepend` - without it kit appends after ResourcePlugin, which then claims the virtual ids
     addVitePlugin(() => jsonParsePlugin!.vite(), { client: false, prepend: true })
-    addVitePlugin(() => VueI18nPlugin.vite(vueI18nPluginOptions), { server: false })
-    addVitePlugin(() => VueI18nPlugin.vite(serverPluginOptions), { client: false })
+    // `prepend` - kit's environment wrapper drops the inner `enforce: 'pre'` for `post`, landing
+    // the resource transform after vite's builtin json-to-esm (#4116)
+    addVitePlugin(() => VueI18nPlugin.vite(vueI18nPluginOptions), { server: false, prepend: true })
+    addVitePlugin(() => VueI18nPlugin.vite(serverPluginOptions), { client: false, prepend: true })
     addWebpackPlugin(() => VueI18nPlugin.webpack(vueI18nPluginOptions))
   } else {
     addBuildPlugin({


### PR DESCRIPTION
### 🔗 Linked issue
* Resolves #4116 
* Related https://github.com/nuxt/nuxt/issues/35918
* Related https://github.com/nuxt/nuxt/pull/35942
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description
This has already been resolved upstream but not yet released (https://github.com/nuxt/nuxt/pull/35942), but we can work around the underlying issue by explicitly passing `prepend: true` to our transformation plugin.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internationalization resource processing during builds.
  * Ensured localized JSON resources are transformed in the correct order for both client and server configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->