### PR TITLE
fix: fetch a region-tagged locale's base tag when it's configured

### DIFF
--- a/docs/content/docs/02.guide/11.locale-fallback.md
+++ b/docs/content/docs/02.guide/11.locale-fallback.md
@@ -25,3 +25,7 @@ export default {
 ```
 
 More information in [Vue I18n documentation](https://vue-i18n.intlify.dev/guide/essentials/fallback.html)
+
+<callout icon="i-heroicons-exclamation-triangle" color="warning">
+**Vue I18n** automatically falls back from a region-specific locale to its base language (`fr-CA` tries `fr` before giving up), but this only works for messages that are already loaded in memory. Because **Nuxt i18n lazy-loads locale files**, it only loads the current locale’s file and any fallback locales explicitly configured in `fallbackLocale`. To make `fr-CA` fall back to `fr`, you therefore need to configure `fr` as a fallback yourself.
+</callout>

--- a/docs/content/docs/02.guide/11.locale-fallback.md
+++ b/docs/content/docs/02.guide/11.locale-fallback.md
@@ -25,7 +25,3 @@ export default {
 ```
 
 More information in [Vue I18n documentation](https://vue-i18n.intlify.dev/guide/essentials/fallback.html)
-
-<callout icon="i-heroicons-exclamation-triangle" color="warning">
-**Vue I18n** automatically falls back from a region-specific locale to its base language (`fr-CA` tries `fr` before giving up), but this only works for messages that are already loaded in memory. Because **Nuxt i18n lazy-loads locale files**, it only loads the current locale’s file and any fallback locales explicitly configured in `fallbackLocale`. To make `fr-CA` fall back to `fr`, you therefore need to configure `fr` as a fallback yourself.
-</callout>

--- a/src/runtime/shared/locales.ts
+++ b/src/runtime/shared/locales.ts
@@ -17,6 +17,8 @@ export function createLocaleConfigs(fallbackLocale: FallbackLocale): Record<stri
   return localeConfigs
 }
 
+const localeCodeSet = new Set(localeCodes)
+
 /**
  * When a key is missing on a region-tagged locale like `en-US`, vue-i18n automatically tries its
  * base tag `en` before it even looks at `fallbackLocale`. That only works if `en`'s messages are
@@ -24,8 +26,6 @@ export function createLocaleConfigs(fallbackLocale: FallbackLocale): Record<stri
  * isn't configured, there's no file to load for it anyway, so we leave it alone rather than
  * fetching something the user never defined.
  */
-const localeCodeSet = new Set(localeCodes)
-
 function configuredBaseTags(locale: string): string[] {
   const tags: string[] = []
   let tag = locale
@@ -38,25 +38,26 @@ function configuredBaseTags(locale: string): string[] {
 
 export function getFallbackLocaleCodes(fallback: FallbackLocale, locales: string[]): string[] {
   const baseTags = locales.flatMap(configuredBaseTags).filter(tag => !locales.includes(tag))
-
-  if (fallback === false) { return baseTags }
-  if (isArray(fallback)) { return [...baseTags, ...fallback] }
-
   const fallbackLocales: string[] = [...baseTags]
-  if (isString(fallback)) {
+
+  // an explicit `fallbackLocale` entry can name the same locale the base-tag walk already added
+  // (e.g. `{'en-US': ['en']}` alongside `en-US`'s own implicit `en`), so dedupe once at the end
+  // rather than special-casing it in every branch below
+  if (isArray(fallback)) {
+    fallbackLocales.push(...fallback)
+  } else if (isString(fallback)) {
     if (locales.every(locale => locale !== fallback)) {
       fallbackLocales.push(fallback)
     }
-    return fallbackLocales
+  } else if (fallback !== false) {
+    const targets = [...locales, 'default']
+    for (const locale of targets) {
+      if (locale in fallback == false) { continue }
+      fallbackLocales.push(...fallback[locale]!.filter(Boolean))
+    }
   }
 
-  const targets = [...locales, 'default']
-  for (const locale of targets) {
-    if (locale in fallback == false) { continue }
-    fallbackLocales.push(...fallback[locale]!.filter(Boolean))
-  }
-
-  return fallbackLocales
+  return [...new Set(fallbackLocales)]
 }
 
 /**

--- a/src/runtime/shared/locales.ts
+++ b/src/runtime/shared/locales.ts
@@ -17,11 +17,32 @@ export function createLocaleConfigs(fallbackLocale: FallbackLocale): Record<stri
   return localeConfigs
 }
 
-function getFallbackLocaleCodes(fallback: FallbackLocale, locales: string[]): string[] {
-  if (fallback === false) { return [] }
-  if (isArray(fallback)) { return fallback }
+/**
+ * When a key is missing on a region-tagged locale like `en-US`, vue-i18n automatically tries its
+ * base tag `en` before it even looks at `fallbackLocale`. That only works if `en`'s messages are
+ * actually loaded though, so we add the base tag here when it's also a configured locale. If it
+ * isn't configured, there's no file to load for it anyway, so we leave it alone rather than
+ * fetching something the user never defined.
+ */
+const localeCodeSet = new Set(localeCodes)
 
-  let fallbackLocales: string[] = []
+function configuredBaseTags(locale: string): string[] {
+  const tags: string[] = []
+  let tag = locale
+  while (tag.includes('-')) {
+    tag = tag.slice(0, tag.lastIndexOf('-'))
+    if (localeCodeSet.has(tag)) { tags.push(tag) }
+  }
+  return tags
+}
+
+export function getFallbackLocaleCodes(fallback: FallbackLocale, locales: string[]): string[] {
+  const baseTags = locales.flatMap(configuredBaseTags).filter(tag => !locales.includes(tag))
+
+  if (fallback === false) { return baseTags }
+  if (isArray(fallback)) { return [...baseTags, ...fallback] }
+
+  const fallbackLocales: string[] = [...baseTags]
   if (isString(fallback)) {
     if (locales.every(locale => locale !== fallback)) {
       fallbackLocales.push(fallback)
@@ -32,7 +53,7 @@ function getFallbackLocaleCodes(fallback: FallbackLocale, locales: string[]): st
   const targets = [...locales, 'default']
   for (const locale of targets) {
     if (locale in fallback == false) { continue }
-    fallbackLocales = [...fallbackLocales, ...fallback[locale]!.filter(Boolean)]
+    fallbackLocales.push(...fallback[locale]!.filter(Boolean))
   }
 
   return fallbackLocales

--- a/test/locales.test.ts
+++ b/test/locales.test.ts
@@ -38,4 +38,12 @@ describe('getFallbackLocaleCodes', () => {
   test('does not duplicate a base tag that is already an explicit locale', () => {
     expect(getFallbackLocaleCodes({ default: ['ja'] }, ['en-US', 'en'])).toEqual(['ja'])
   })
+
+  test('(#regression) does not duplicate a base tag the user also lists explicitly', () => {
+    // writing `en` explicitly here achieves exactly what the base-tag walk already adds on its
+    // own, so the two sources overlap and need deduping rather than appearing twice
+    expect(getFallbackLocaleCodes({ 'en-US': ['en'] }, ['en-US'])).toEqual(['en'])
+    expect(getFallbackLocaleCodes(['en'], ['en-US'])).toEqual(['en'])
+    expect(getFallbackLocaleCodes('en', ['en-US'])).toEqual(['en'])
+  })
 })

--- a/test/locales.test.ts
+++ b/test/locales.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('#build/i18n-options.mjs', () => ({
+  localeCodes: ['en', 'en-US', 'de-DE', 'de', 'ja'],
+  localeLoaders: {},
+  normalizedLocales: [],
+}))
+
+const { getFallbackLocaleCodes } = await import('../src/runtime/shared/locales')
+
+describe('getFallbackLocaleCodes', () => {
+  test('(#regression) a region-tagged locale implicitly falls back to its base tag, when that base tag is a configured locale', () => {
+    // `en` is configured alongside `en-US` here, so vue-i18n's own implicit chain (`en-US` tries
+    // `en` before consulting `fallbackLocale`) needs `en`'s messages loaded too, or content that
+    // exists there is silently skipped straight to the configured fallback
+    expect(getFallbackLocaleCodes({ default: ['ja'] }, ['en-US'])).toEqual(['en', 'ja'])
+    expect(getFallbackLocaleCodes(['ja'], ['en-US'])).toEqual(['en', 'ja'])
+    expect(getFallbackLocaleCodes('ja', ['en-US'])).toEqual(['en', 'ja'])
+    expect(getFallbackLocaleCodes(false, ['en-US'])).toEqual(['en'])
+  })
+
+  test('does not add a base tag that was never configured as its own locale', () => {
+    // no `fr` locale is configured here, so there's no file to load for it, widening the
+    // lazy-loading footprint for a tag nobody defined isn't worth it
+    expect(getFallbackLocaleCodes({ default: ['ja'] }, ['fr-CA'])).toEqual(['ja'])
+    expect(getFallbackLocaleCodes(false, ['fr-CA'])).toEqual([])
+  })
+
+  test('a plain locale with no region tag gets no implicit fallback', () => {
+    expect(getFallbackLocaleCodes(false, ['en'])).toEqual([])
+    expect(getFallbackLocaleCodes({ default: ['ja'] }, ['en'])).toEqual(['ja'])
+  })
+
+  test('walks multiple dash-separated levels, only keeping tags that are configured (`de-DE-bavarian` -> `de-DE` -> `de`)', () => {
+    expect(getFallbackLocaleCodes(false, ['de-DE-bavarian'])).toEqual(['de-DE', 'de'])
+  })
+
+  test('does not duplicate a base tag that is already an explicit locale', () => {
+    expect(getFallbackLocaleCodes({ default: ['ja'] }, ['en-US', 'en'])).toEqual(['ja'])
+  })
+})


### PR DESCRIPTION
## Summary

vue-i18n automatically falls back a region-tagged locale to its base language tag (`en-US` tries `en`) before it even looks at `fallbackLocale`. This is documented, default behavior in vue-i18n itself. Nuxt i18n's lazy loading never fetched that base tag's messages unless it was listed explicitly in `fallbackLocale`, so this fallback silently did nothing for anyone with a region-tagged locale like `en-US` alongside `en`.

`getFallbackLocaleCodes` now adds a locale's base tag to its fallbacks when that base tag is itself a configured locale, walking multiple dash-separated levels where needed (`de-DE-bavarian` → `de-DE` → `de`). If the base tag isn't configured at all, nothing changes, there's no file to load for it and no reason to widen the lazy-loading footprint for a tag nobody defined.

Also fixes a duplicate entry this introduced: an explicit `fallbackLocale` entry can name the same locale the base-tag walk already adds on its own (writing `{'en-US': ['en']`} achieves exactly what `en-US`'s implicit `en` already does), so the result is deduped.

## ~~Summary~~
~~Vue I18n automatically falls back a region-tagged locale to its base language tag (fr-CA tries fr), but that only works for messages already loaded in memory. Since Nuxt i18n lazy-loads locale files, it only fetches what's explicitly listed in fallbackLocale, so that implicit chain silently does nothing unless the base tag is configured too.~~

~~I ran into this and initially thought it was a bug, but on reflection I think it's probably intentional: automatically fetching a base tag's file on top of whatever's explicitly configured would mean loading more locale files than the user asked for, which cuts against the whole point of lazy loading. So instead of changing behavior, this PR just documents it, with a callout showing how to get the same effect by listing the base tag yourself in fallbackLocale.~~

~~@BobbieGoede can you confirm that's the intended reasoning? If not, and this is actually considered a bug, let me know and I'll put together a code fix instead of the docs note.~~

This is an older summary from before I force-pushed the changes. I’m just keeping it here for reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved locale fallback handling for regional and multi-level locale tags.
  - Regional locales now correctly include configured base locales in fallback results.
  - Prevented duplicate fallback locales across disabled, array-based, and mapped fallback configurations.

- **Tests**
  - Added coverage for regional, plain, multi-level, missing-base, and duplicate locale scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->