### PR TITLE
fix: resolve intlify dependencies relative to the module

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -14,6 +14,8 @@ import { relative } from 'pathe'
 import { generateTemplateNuxtI18nOptions } from './template'
 import { generateI18nTypes, simplifyLocaleOptions } from './gen'
 
+const moduleURL = new URL(import.meta.url)
+
 export * from './types'
 
 export default defineNuxtModule<NuxtI18nOptions>({
@@ -78,11 +80,11 @@ export default defineNuxtModule<NuxtI18nOptions>({
 
     for (const dep of deps) {
       if (dep === 'vue-i18n' || dep === '@intlify/core') { continue }
-      nuxt.options.alias[dep] = resolveModule(dep)
+      nuxt.options.alias[dep] = resolveModule(dep, { url: moduleURL })
     }
     const vueI18nRuntimeOnly = !nuxt.options.dev && !nuxt.options._prepare && ctx.options.bundle?.runtimeOnly
-    nuxt.options.alias['vue-i18n'] = resolveModule(`vue-i18n/dist/vue-i18n${vueI18nRuntimeOnly ? '.runtime' : ''}`)
-    nuxt.options.alias['@intlify/core'] = resolveModule(`@intlify/core/dist/core.node`)
+    nuxt.options.alias['vue-i18n'] = resolveModule(`vue-i18n/dist/vue-i18n${vueI18nRuntimeOnly ? '.runtime' : ''}`, { url: moduleURL })
+    nuxt.options.alias['@intlify/core'] = resolveModule(`@intlify/core/dist/core.node`, { url: moduleURL })
     nuxt.options.build.transpile.push('@nuxtjs/i18n', ...deps)
 
     // the aliased node build has no declaration file, drop the generated paths entries

--- a/src/nitro.ts
+++ b/src/nitro.ts
@@ -15,6 +15,8 @@ import type { FileMeta } from './types'
 import type { ResolvedI18nContext } from './context'
 import { generateTemplateNuxtI18nOptions } from './template'
 
+const moduleURL = new URL(import.meta.url)
+
 export async function setupNitro(ctx: ResolvedI18nContext, nuxt: Nuxt) {
   addServerTemplate({
     filename: '#internal/i18n-options.mjs',
@@ -61,7 +63,7 @@ export async function setupNitro(ctx: ResolvedI18nContext, nuxt: Nuxt) {
     { name: 'defineI18nLocaleDetector', from: ctx.resolver.resolve('runtime/composables/server') },
   ])
 
-  const h3UtilsExports = await resolveModuleExportNames(resolveModule('@intlify/utils/h3'))
+  const h3UtilsExports = await resolveModuleExportNames(resolveModule('@intlify/utils/h3', { url: moduleURL }))
   addServerImports([
     { name: 'useTranslation', from: '@intlify/h3' },
     ...h3UtilsExports.map(name => ({ name, from: '@intlify/utils/h3' })),


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

spotted this in https://github.com/unjs/magic-regexp/pull/718 - whilst deploying to vercel

```
[error] Cannot resolve module "@intlify/shared" (from: /vercel/path0/node_modules/.pnpm/@nuxt+kit@4.3.1_magicast@0.5.2/node_modules/@nuxt/kit/dist/index.mjs)
 at resolveModule (.../@nuxt/kit/dist/index.mjs:422:9)
 at setup (.../@nuxtjs/i18n/dist/module.mjs:1807:33)
```

`@intlify/*` are dependencies of this module and so should be resolved from `import.meta.url` as that is where they are resolvable. otherwise it requires shamefully hoisting dependencies...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module resolution for internationalization and server integrations.
  * Fixed URL-relative dependency resolution to ensure required modules are located reliably across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->