### PR TITLE
fix(vite): load YAML messages in server environments

### DIFF
--- a/src/transform/resource.ts
+++ b/src/transform/resource.ts
@@ -46,8 +46,14 @@ export const ResourcePlugin = (options: BundlerPluginOptions, ctx: ResolvedI18nC
           return id
         }
 
-        if (i18nFileHashSet.has(id)) {
-          return i18nFileHashSet.get(id)
+        const path = i18nFileHashSet.get(id)
+        const environment = (this as typeof this & { environment?: { config: { consumer: string } } }).environment
+        if (meta.framework === 'vite' && environment?.config.consumer === 'server' && path && ctx.rawResourcePaths.has(path)) {
+          return
+        }
+
+        if (path) {
+          return path
         }
       },
 

--- a/test/resource-transform.test.ts
+++ b/test/resource-transform.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import { ResourcePlugin } from '../src/transform/resource'
+import { asI18nVirtual } from '../src/transform/utils'
 
 import type { ResolvedI18nContext } from '../src/context'
 
-function createPlugin(paths: string[]) {
+function createPlugin(paths: string[], rawResourcePaths: string[] = []) {
   const ctx = {
     localeFileMetas: paths.map(path => ({ path, hash: path })),
+    rawResourcePaths: new Set(rawResourcePaths),
     vueI18nConfigPaths: []
   } as unknown as ResolvedI18nContext
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -19,6 +21,15 @@ async function transform(code: string, id: string) {
 }
 
 describe('ResourcePlugin', () => {
+  it('does not resolve raw resource virtual IDs in Vite server environments', () => {
+    const path = '/app/i18n/locales/en.yml'
+    const plugin = createPlugin([path], [path])
+    const id = asI18nVirtual(path)
+
+    expect(plugin.resolveId.call({ environment: { config: { consumer: 'server' } } }, id)).toBeUndefined()
+    expect(plugin.resolveId.call({ environment: { config: { consumer: 'client' } } }, id)).toBe(path)
+  })
+
   it('unwraps `defineI18nLocale` calls', async () => {
     const code = `export default defineI18nLocale(() => ({ msg: 'English message' }))`
 


### PR DESCRIPTION
### 🔗 Linked issue

Related to #4066. This is extracted from #4088 so the Vite resource fix can be reviewed independently.

### 📚 Description

With message bundling optimization enabled, static YAML and other raw locale resources should be handled by the server JSON-parse plugin. Vite's server environment currently reaches the resource plugin first, which resolves the virtual ID to the YAML file and leaves development SSR loading it through the wrong path.

The resource plugin now leaves tracked raw virtual IDs unresolved only for Vite server consumers, while preserving existing client and non-raw resolution. The focused unit test fails with the previous resolver and covers the server yield and client fallback.

Verified with:

- `pnpm test:unit` — 465 passed, 1 skipped
- `pnpm lint` — passes with six existing JSDoc warnings
- `pnpm exec tsc --noEmit`

`pnpm test:types` passes its root TypeScript phase, then reaches existing `typed_routes` fixture errors on current `main`.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt I18n!
----------------------------------------------------------------------->
