### PR TITLE
fix: walk vue-i18n's actual fallback chain instead of approximating it

### DIFF
--- a/docs/content/docs/02.guide/11.locale-fallback.md
+++ b/docs/content/docs/02.guide/11.locale-fallback.md
@@ -25,3 +25,7 @@ export default {
 ```
 
 More information in [Vue I18n documentation](https://vue-i18n.intlify.dev/guide/essentials/fallback.html)
+
+<callout icon="i-heroicons-exclamation-triangle" color="warning">
+**Vue I18n** automatically falls back from a region-specific locale to its base language (`fr-CA` tries `fr` before giving up), but this only works for messages that are already loaded in memory. Because **Nuxt i18n lazy-loads locale files**, it only loads the current locale’s file and any fallback locales explicitly configured in `fallbackLocale`. To make `fr-CA` fall back to `fr`, you therefore need to configure `fr` as a fallback yourself.
+</callout>

--- a/docs/content/docs/02.guide/11.locale-fallback.md
+++ b/docs/content/docs/02.guide/11.locale-fallback.md
@@ -25,3 +25,51 @@ export default {
 ```
 
 More information in [Vue I18n documentation](https://vue-i18n.intlify.dev/guide/essentials/fallback.html)
+
+## Implicit fallback for region tags
+
+Vue I18n also falls back a region tagged locale to its base language tag on its own, before it even looks at `fallbackLocale`. A missing key on `en-US` tries `en` first, regardless of what `fallbackLocale` says. Nuxt i18n lazy loads that base tag's messages too, so this keeps working, as long as the base tag is also a configured locale. If it isn't configured, there's no file to load for it and nothing changes.
+
+To stop a locale from trying its own base tag, add a `fallbackLocale` entry keyed on that exact locale. Once such an entry exists, it takes over before the base tag walk ever starts:
+
+```js [i18n/i18n.config.ts]
+export default {
+  fallbackLocale: {
+    // en-US never tries en, it goes straight to ja
+    'en-US': ['ja'],
+    // de-DE-bavarian never tries de-DE or de
+    'de-DE-bavarian': []
+  }
+  // ...
+}
+```
+
+A `default` entry still applies on top of either of these though, it isn't skipped just because a locale got redirected or fully suppressed above. Adding `default: ['en']` to the config above would still add `en` after `ja` for `en-US`, and would still add it for `de-DE-bavarian` even though its own array is empty.
+
+## Stopping a fallback from walking further on its own
+
+A locale named inside `fallbackLocale` still gets its own implicit base tag walk once it's reached, unless you tell it not to. Redirecting `de-DE-bavarian` to `de-DE` doesn't stop `de-DE` from then trying `de` on its own, `de` still gets pulled in even though nothing asked for it directly:
+
+```js [i18n/i18n.config.ts]
+export default {
+  fallbackLocale: {
+    'de-DE-bavarian': ['de-DE'] // still ends up trying de-DE-bavarian, de-DE, and de
+  }
+  // ...
+}
+```
+
+Adding `!` right after that entry stops it there:
+
+```js [i18n/i18n.config.ts]
+export default {
+  fallbackLocale: {
+    'de-DE-bavarian': ['de-DE!'] // ends up trying only de-DE-bavarian and de-DE, de is never touched
+  }
+  // ...
+}
+```
+
+This only scopes the suppression to this one redirect. Someone visiting `de-DE` directly still falls back to `de` normally, that part of `de-DE`'s own behavior is untouched. Suppressing `de-DE` everywhere instead would mean giving it its own entry, `'de-DE': []`, which comes with that wider side effect.
+
+The `!` only ever makes sense on a fallback target like this, an entry inside the array on the right side of a `fallbackLocale` map. Putting it on the key side (`'de-DE!': [...]`) does nothing, Vue I18n always strips it before checking the key, so that entry is silently ignored. And it should never be written into a locale's own `code`, that's the actual identifier Vue I18n uses to look up its messages, and a `!` there breaks that lookup entirely.

--- a/docs/content/docs/02.guide/11.locale-fallback.md
+++ b/docs/content/docs/02.guide/11.locale-fallback.md
@@ -25,7 +25,3 @@ export default {
 ```
 
 More information in [Vue I18n documentation](https://vue-i18n.intlify.dev/guide/essentials/fallback.html)
-
-<callout icon="i-heroicons-exclamation-triangle" color="warning">
-**Vue I18n** automatically falls back from a region-specific locale to its base language (`fr-CA` tries `fr` before giving up), but this only works for messages that are already loaded in memory. Because **Nuxt i18n lazy-loads locale files**, it only loads the current locale’s file and any fallback locales explicitly configured in `fallbackLocale`. To make `fr-CA` fall back to `fr`, you therefore need to configure `fr` as a fallback yourself.
-</callout>

--- a/src/runtime/shared/locales.ts
+++ b/src/runtime/shared/locales.ts
@@ -17,6 +17,8 @@ export function createLocaleConfigs(fallbackLocale: FallbackLocale): Record<stri
   return localeConfigs
 }
 
+const localeCodeSet = new Set(localeCodes)
+
 /**
  * When a key is missing on a region-tagged locale like `en-US`, vue-i18n automatically tries its
  * base tag `en` before it even looks at `fallbackLocale`. That only works if `en`'s messages are
@@ -24,8 +26,6 @@ export function createLocaleConfigs(fallbackLocale: FallbackLocale): Record<stri
  * isn't configured, there's no file to load for it anyway, so we leave it alone rather than
  * fetching something the user never defined.
  */
-const localeCodeSet = new Set(localeCodes)
-
 function configuredBaseTags(locale: string): string[] {
   const tags: string[] = []
   let tag = locale
@@ -38,25 +38,26 @@ function configuredBaseTags(locale: string): string[] {
 
 export function getFallbackLocaleCodes(fallback: FallbackLocale, locales: string[]): string[] {
   const baseTags = locales.flatMap(configuredBaseTags).filter(tag => !locales.includes(tag))
-
-  if (fallback === false) { return baseTags }
-  if (isArray(fallback)) { return [...baseTags, ...fallback] }
-
   const fallbackLocales: string[] = [...baseTags]
-  if (isString(fallback)) {
+
+  // an explicit `fallbackLocale` entry can name the same locale the base-tag walk already added
+  // (e.g. `{'en-US': ['en']}` alongside `en-US`'s own implicit `en`), so dedupe once at the end
+  // rather than special-casing it in every branch below
+  if (isArray(fallback)) {
+    fallbackLocales.push(...fallback)
+  } else if (isString(fallback)) {
     if (locales.every(locale => locale !== fallback)) {
       fallbackLocales.push(fallback)
     }
-    return fallbackLocales
+  } else if (fallback !== false) {
+    const targets = [...locales, 'default']
+    for (const locale of targets) {
+      if (locale in fallback == false) { continue }
+      fallbackLocales.push(...fallback[locale]!.filter(Boolean))
+    }
   }
 
-  const targets = [...locales, 'default']
-  for (const locale of targets) {
-    if (locale in fallback == false) { continue }
-    fallbackLocales.push(...fallback[locale]!.filter(Boolean))
-  }
-
-  return fallbackLocales
+  return [...new Set(fallbackLocales)]
 }
 
 /**

--- a/src/runtime/shared/locales.ts
+++ b/src/runtime/shared/locales.ts
@@ -20,44 +20,113 @@ export function createLocaleConfigs(fallbackLocale: FallbackLocale): Record<stri
 const localeCodeSet = new Set(localeCodes)
 
 /**
- * When a key is missing on a region-tagged locale like `en-US`, vue-i18n automatically tries its
- * base tag `en` before it even looks at `fallbackLocale`. That only works if `en`'s messages are
- * actually loaded though, so we add the base tag here when it's also a configured locale. If it
- * isn't configured, there's no file to load for it anyway, so we leave it alone rather than
- * fetching something the user never defined.
+ * What a fallback map entry redirects a walk to when it names `tag` exactly, or false when there's
+ * nothing configured for it.
  */
-function configuredBaseTags(locale: string): string[] {
-  const tags: string[] = []
-  let tag = locale
-  while (tag.includes('-')) {
+function redirectFor(tag: string, fallback: FallbackLocale): string[] | false {
+  if (fallback === false || isString(fallback) || isArray(fallback)) { return false }
+  const targets = fallback[tag]
+  return isArray(targets) ? targets.filter(Boolean) : false
+}
+
+/**
+ * What vue-i18n tries once a locale's own chain runs out: the whole `fallbackLocale` value when
+ * it's a string or array, or its `default` entry when it's a map.
+ */
+function defaultTargets(fallback: FallbackLocale): string[] | false {
+  if (fallback === false) { return false }
+  if (isString(fallback)) { return [fallback] }
+  if (isArray(fallback)) { return fallback }
+  return isArray(fallback.default) ? fallback.default.filter(Boolean) : false
+}
+
+/**
+ * Walks one locale tag from its full form down to its base tag, recording every tag it passes
+ * through into `chain`. Stops early when the tag ends in `!`, vue-i18n's own way of suppressing
+ * further fallback for that tag, or when `fallbackLocale` names this exact tag, in which case the
+ * walk redirects to whatever that entry configures instead of continuing to strip the tag down.
+ */
+function walkLocale(chain: Map<string, boolean>, locale: string, fallback: FallbackLocale): string[] | false {
+  const stopHere = locale.endsWith('!')
+  let tag = stopHere ? locale.slice(0, -1) : locale
+  let explicit = true
+
+  while (true) {
+    const alreadyWalked = chain.has(tag)
+    // a tag can be reached implicitly first and only later turn out to be named explicitly, or
+    // the other way round, so once it's explicit we keep it that way
+    chain.set(tag, explicit || (chain.get(tag) ?? false))
+    // a tag that's already been walked doesn't get walked or redirected again. This is also what
+    // stops a fallback map with a cycle in it, like `{en: ['fr'], fr: ['en']}`, from looping forever
+    if (alreadyWalked) { return false }
+
+    const redirect = redirectFor(tag, fallback)
+    if (redirect) { return redirect }
+    if (stopHere || !tag.includes('-')) { return false }
+
     tag = tag.slice(0, tag.lastIndexOf('-'))
-    if (localeCodeSet.has(tag)) { tags.push(tag) }
+    explicit = false
   }
-  return tags
+}
+
+/**
+ * Walks a list of locale tags left to right, abandoning the rest of the list the moment one of
+ * them redirects the walk elsewhere, matching how vue-i18n resolves a fallback block.
+ */
+function walkBlock(chain: Map<string, boolean>, block: string[], fallback: FallbackLocale): string[] | false {
+  for (const locale of block) {
+    const redirect = walkLocale(chain, locale, fallback)
+    if (redirect) { return redirect }
+  }
+  return false
+}
+
+/**
+ * Every tag vue-i18n's own fallback resolution would reach for `locale`, mapped to whether it was
+ * named directly in `fallbackLocale` rather than only reached by stripping a region off some other
+ * tag. Mirrors vue-i18n's own chain building (`fallbackWithLocaleChain` in @intlify/core-base)
+ * closely enough to answer that question, without taking a runtime dependency on that undocumented
+ * internal.
+ */
+function walkFallbackChain(locale: string, fallback: FallbackLocale): Map<string, boolean> {
+  const chain = new Map<string, boolean>()
+
+  let block: string[] | false = [locale]
+  while (isArray(block)) {
+    block = walkBlock(chain, block, fallback)
+  }
+
+  const targets = defaultTargets(fallback)
+  if (targets) {
+    // the default block can't be redirected by another map key, though its own entries still
+    // get base-tag-walked and still honor a trailing `!`
+    walkBlock(chain, targets, false)
+  }
+
+  return chain
 }
 
 export function getFallbackLocaleCodes(fallback: FallbackLocale, locales: string[]): string[] {
-  const baseTags = locales.flatMap(configuredBaseTags).filter(tag => !locales.includes(tag))
-  const fallbackLocales: string[] = [...baseTags]
+  // a Map already keeps insertion order and doesn't reorder on a repeated set of the same key, so
+  // it doubles as the ordered list of tags reached, no separate array needed alongside it
+  const explicitByTag = new Map<string, boolean>()
+  // a trailing `!` works the same on a source locale as on any fallbackLocale entry, so compare
+  // against the stripped form here too, or a source locale written that way would never match its
+  // own (stripped) tag and end up listed as a fallback for itself
+  const primaryTags = new Set(locales.map(locale => (locale.endsWith('!') ? locale.slice(0, -1) : locale)))
 
-  // an explicit `fallbackLocale` entry can name the same locale the base-tag walk already added
-  // (e.g. `{'en-US': ['en']}` alongside `en-US`'s own implicit `en`), so dedupe once at the end
-  // rather than special-casing it in every branch below
-  if (isArray(fallback)) {
-    fallbackLocales.push(...fallback)
-  } else if (isString(fallback)) {
-    if (locales.every(locale => locale !== fallback)) {
-      fallbackLocales.push(fallback)
-    }
-  } else if (fallback !== false) {
-    const targets = [...locales, 'default']
-    for (const locale of targets) {
-      if (locale in fallback == false) { continue }
-      fallbackLocales.push(...fallback[locale]!.filter(Boolean))
+  for (const locale of locales) {
+    for (const [tag, explicit] of walkFallbackChain(locale, fallback)) {
+      if (primaryTags.has(tag)) { continue } // a primary locale, loaded separately by the caller
+      explicitByTag.set(tag, explicit || (explicitByTag.get(tag) ?? false))
     }
   }
 
-  return [...new Set(fallbackLocales)]
+  // a tag named directly somewhere in fallbackLocale is kept even if it isn't itself a configured
+  // locale, matching the old behavior of never filtering explicit entries. A tag only reached
+  // implicitly, by stripping a region off some other tag, only gets kept when it's configured,
+  // there's no file to load for a base tag nobody defined
+  return [...explicitByTag].filter(([tag, explicit]) => explicit || localeCodeSet.has(tag)).map(([tag]) => tag)
 }
 
 /**

--- a/src/runtime/shared/locales.ts
+++ b/src/runtime/shared/locales.ts
@@ -17,11 +17,32 @@ export function createLocaleConfigs(fallbackLocale: FallbackLocale): Record<stri
   return localeConfigs
 }
 
-function getFallbackLocaleCodes(fallback: FallbackLocale, locales: string[]): string[] {
-  if (fallback === false) { return [] }
-  if (isArray(fallback)) { return fallback }
+/**
+ * When a key is missing on a region-tagged locale like `en-US`, vue-i18n automatically tries its
+ * base tag `en` before it even looks at `fallbackLocale`. That only works if `en`'s messages are
+ * actually loaded though, so we add the base tag here when it's also a configured locale. If it
+ * isn't configured, there's no file to load for it anyway, so we leave it alone rather than
+ * fetching something the user never defined.
+ */
+const localeCodeSet = new Set(localeCodes)
 
-  let fallbackLocales: string[] = []
+function configuredBaseTags(locale: string): string[] {
+  const tags: string[] = []
+  let tag = locale
+  while (tag.includes('-')) {
+    tag = tag.slice(0, tag.lastIndexOf('-'))
+    if (localeCodeSet.has(tag)) { tags.push(tag) }
+  }
+  return tags
+}
+
+export function getFallbackLocaleCodes(fallback: FallbackLocale, locales: string[]): string[] {
+  const baseTags = locales.flatMap(configuredBaseTags).filter(tag => !locales.includes(tag))
+
+  if (fallback === false) { return baseTags }
+  if (isArray(fallback)) { return [...baseTags, ...fallback] }
+
+  const fallbackLocales: string[] = [...baseTags]
   if (isString(fallback)) {
     if (locales.every(locale => locale !== fallback)) {
       fallbackLocales.push(fallback)
@@ -32,7 +53,7 @@ function getFallbackLocaleCodes(fallback: FallbackLocale, locales: string[]): st
   const targets = [...locales, 'default']
   for (const locale of targets) {
     if (locale in fallback == false) { continue }
-    fallbackLocales = [...fallbackLocales, ...fallback[locale]!.filter(Boolean)]
+    fallbackLocales.push(...fallback[locale]!.filter(Boolean))
   }
 
   return fallbackLocales

--- a/test/locales.test.ts
+++ b/test/locales.test.ts
@@ -46,4 +46,83 @@ describe('getFallbackLocaleCodes', () => {
     expect(getFallbackLocaleCodes(['en'], ['en-US'])).toEqual(['en'])
     expect(getFallbackLocaleCodes('en', ['en-US'])).toEqual(['en'])
   })
+
+  test('a trailing ! stops the walk right there, vue-i18n\'s own way of suppressing further fallback', () => {
+    expect(getFallbackLocaleCodes(['de-DE!'], ['fr'])).toEqual(['de-DE'])
+  })
+
+  test('(#regression) a trailing ! on the source locale itself works the same way, and doesn\'t make it show up in its own fallback list', () => {
+    expect(getFallbackLocaleCodes(false, ['de-DE!'])).toEqual([])
+    expect(getFallbackLocaleCodes(['ja'], ['de-DE!'])).toEqual(['ja'])
+  })
+
+  test('a fallbackLocale map entry keyed on the exact locale being resolved diverts the walk before it ever reaches that locale\'s own base tag', () => {
+    expect(getFallbackLocaleCodes({ 'en-US': ['ja'] }, ['en-US'])).toEqual(['ja'])
+  })
+
+  test('a map entry keyed on a base tag reached mid walk still lets the walk reach it first, then diverts from there', () => {
+    expect(getFallbackLocaleCodes({ en: ['ja'] }, ['en-US'])).toEqual(['en', 'ja'])
+  })
+
+  test('a map entry that names nothing reached by the walk changes nothing', () => {
+    expect(getFallbackLocaleCodes({ fr: ['ja'] }, ['en-US'])).toEqual(['en'])
+  })
+
+  test('default still applies after a walk that was never diverted', () => {
+    // `ko` isn't a configured locale here, but it's named directly in `default`, so it's kept
+    // regardless, the same way an explicit fallbackLocale entry always is
+    expect(getFallbackLocaleCodes({ fr: ['ja'], default: ['ko'] }, ['en-US'])).toEqual(['en', 'ko'])
+  })
+
+  test('default still applies after a walk that was diverted, the diversion doesn\'t skip it', () => {
+    expect(getFallbackLocaleCodes({ 'en-US': ['ja'], default: ['ko'] }, ['en-US'])).toEqual(['ja', 'ko'])
+  })
+
+  test('a diversion from a mid-walk tag on a multi level locale stops the walk there too, its own base tag is never reached', () => {
+    expect(getFallbackLocaleCodes({ 'de-DE': ['ja'] }, ['de-DE-bavarian'])).toEqual(['de-DE', 'ja'])
+  })
+
+  test('(#regression) a diverted walk abandons every sibling still left in that block, and never reaches the locale\'s own base tag', () => {
+    // the old implementation unioned base tags with whatever fallbackLocale contained, so it
+    // would have returned something like ['en', 'de-DE', 'ko'] here: `en` because it never
+    // noticed the map key intercepts en-US before its base tag, and `ko` because it never
+    // noticed de-DE already redirected the walk away before ko got a turn
+    expect(getFallbackLocaleCodes({ 'en-US': ['de-DE', 'ko'], 'de-DE': ['ja'] }, ['en-US'])).toEqual(['de-DE', 'ja'])
+  })
+
+  test('a fallbackLocale map with a cycle in it resolves instead of looping forever', () => {
+    expect(getFallbackLocaleCodes({ en: ['fr'], fr: ['en'] }, ['en'])).toEqual(['fr'])
+  })
+
+  test('an explicit entry is kept even when it is not itself a configured locale, whether or not it is also reached implicitly', () => {
+    expect(getFallbackLocaleCodes(['fr'], ['fr-CA'])).toEqual(['fr'])
+  })
+
+  test('a tag only reached implicitly still gets filtered against configured locales even when it descends from an explicit entry', () => {
+    expect(getFallbackLocaleCodes({ default: ['xx-YY'] }, ['fr'])).toEqual(['xx-YY'])
+  })
+
+  test('merges and dedupes across multiple source locales, each keeping its own explicit or configured tags', () => {
+    expect(getFallbackLocaleCodes({ default: ['ja'] }, ['de-DE', 'fr-CA'])).toEqual(['de', 'ja'])
+  })
+
+  test('an empty array on the exact locale suppresses its fallback entirely, including its own base tag', () => {
+    expect(getFallbackLocaleCodes({ 'en-US': [] }, ['en-US'])).toEqual([])
+  })
+
+  test('(#regression) a ! on a redirect target stops that target from walking its own base tag, scoped to just that redirect', () => {
+    // without the bang, redirecting de-DE-bavarian to de-DE doesn't stop de-DE from then trying
+    // its own base tag de on its own, so de still gets pulled in
+    expect(getFallbackLocaleCodes({ 'de-DE-bavarian': ['de-DE'] }, ['de-DE-bavarian'])).toEqual(['de-DE', 'de'])
+    // the bang stops it there, de is never touched
+    expect(getFallbackLocaleCodes({ 'de-DE-bavarian': ['de-DE!'] }, ['de-DE-bavarian'])).toEqual(['de-DE'])
+  })
+
+  test('that scoped suppression only applies to the redirect it\'s written on, de-DE visited on its own still falls back to de normally', () => {
+    expect(getFallbackLocaleCodes({ 'de-DE-bavarian': ['de-DE!'] }, ['de-DE'])).toEqual(['de'])
+  })
+
+  test('a ! on the key side of a map entry is a dead entry, vue-i18n always strips it before checking the key', () => {
+    expect(getFallbackLocaleCodes({ 'de-DE!': ['ja'] }, ['de-DE'])).toEqual(['de'])
+  })
 })

--- a/test/locales.test.ts
+++ b/test/locales.test.ts
@@ -38,4 +38,12 @@ describe('getFallbackLocaleCodes', () => {
   test('does not duplicate a base tag that is already an explicit locale', () => {
     expect(getFallbackLocaleCodes({ default: ['ja'] }, ['en-US', 'en'])).toEqual(['ja'])
   })
+
+  test('(#regression) does not duplicate a base tag the user also lists explicitly', () => {
+    // writing `en` explicitly here achieves exactly what the base-tag walk already adds on its
+    // own, so the two sources overlap and need deduping rather than appearing twice
+    expect(getFallbackLocaleCodes({ 'en-US': ['en'] }, ['en-US'])).toEqual(['en'])
+    expect(getFallbackLocaleCodes(['en'], ['en-US'])).toEqual(['en'])
+    expect(getFallbackLocaleCodes('en', ['en-US'])).toEqual(['en'])
+  })
 })

--- a/test/locales.test.ts
+++ b/test/locales.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('#build/i18n-options.mjs', () => ({
+  localeCodes: ['en', 'en-US', 'de-DE', 'de', 'ja'],
+  localeLoaders: {},
+  normalizedLocales: [],
+}))
+
+const { getFallbackLocaleCodes } = await import('../src/runtime/shared/locales')
+
+describe('getFallbackLocaleCodes', () => {
+  test('(#regression) a region-tagged locale implicitly falls back to its base tag, when that base tag is a configured locale', () => {
+    // `en` is configured alongside `en-US` here, so vue-i18n's own implicit chain (`en-US` tries
+    // `en` before consulting `fallbackLocale`) needs `en`'s messages loaded too, or content that
+    // exists there is silently skipped straight to the configured fallback
+    expect(getFallbackLocaleCodes({ default: ['ja'] }, ['en-US'])).toEqual(['en', 'ja'])
+    expect(getFallbackLocaleCodes(['ja'], ['en-US'])).toEqual(['en', 'ja'])
+    expect(getFallbackLocaleCodes('ja', ['en-US'])).toEqual(['en', 'ja'])
+    expect(getFallbackLocaleCodes(false, ['en-US'])).toEqual(['en'])
+  })
+
+  test('does not add a base tag that was never configured as its own locale', () => {
+    // no `fr` locale is configured here, so there's no file to load for it, widening the
+    // lazy-loading footprint for a tag nobody defined isn't worth it
+    expect(getFallbackLocaleCodes({ default: ['ja'] }, ['fr-CA'])).toEqual(['ja'])
+    expect(getFallbackLocaleCodes(false, ['fr-CA'])).toEqual([])
+  })
+
+  test('a plain locale with no region tag gets no implicit fallback', () => {
+    expect(getFallbackLocaleCodes(false, ['en'])).toEqual([])
+    expect(getFallbackLocaleCodes({ default: ['ja'] }, ['en'])).toEqual(['ja'])
+  })
+
+  test('walks multiple dash-separated levels, only keeping tags that are configured (`de-DE-bavarian` -> `de-DE` -> `de`)', () => {
+    expect(getFallbackLocaleCodes(false, ['de-DE-bavarian'])).toEqual(['de-DE', 'de'])
+  })
+
+  test('does not duplicate a base tag that is already an explicit locale', () => {
+    expect(getFallbackLocaleCodes({ default: ['ja'] }, ['en-US', 'en'])).toEqual(['ja'])
+  })
+})


### PR DESCRIPTION
## Summary

Builds on the changes from #4124.
That PR fixed one specific case: a region tagged locale like `en-US` implicitly falls back to its base tag `en` before vue-i18n even looks at `fallbackLocale`, and lazy loading never fetched that base tag's messages unless it was also listed explicitly. 
Testing that fix directly against vue-i18n's real internal resolver(`fallbackWithLocaleChain` in `@intlify/core-base`) showed it only covered part of the actual behavior. vue-i18n'sreal algorithm is a per-tag walk, not base tags unioned with whatever's in `fallbackLocale`:

- A `fallbackLocale` map entry keyed by the exact tag being resolved intercepts the walk before it ever reaches that tag's own base tag.
- A map entry keyed by a tag reached mid-walk intercepts from there instead.
- Once a fallback entry redirects the walk, every sibling still left in that block gets abandoned, never visited.
- A trailing `!` on any entry stops the walk at that tag, skipping its own base tag descent, scoped to just that one redirect.
- The `default` block still applies afterward regardless of whether the walk was redirected.

The previous approach could both under fetch (miss locales vue-i18n would actually reach) and over fetch (pull in locales vue-i18n would never touch).
This replaces that approximation with a small walk (`walkLocale`, `walkBlock`, `walkFallbackChain` in `src/runtime/shared/locales.ts`) that mirrors vue-i18n's real chain building closely enough to answer which locales it will actually reach, without taking a runtime dependency on that internal.

Also documents the implicit fallback behavior and how to control it in `docs/content/docs/02.guide/11.locale-fallback.md`, including the `!` suffix and its scoping (it stops the redirect target's own walk, not the whole locale's fallback everywhere).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved locale fallback resolution for regional and base locales.
  * Added support for explicit fallback mappings, default fallbacks, suppression markers, redirect scoping, and cycle prevention.
  * Preserved correct fallback ordering while avoiding invalid or duplicate locale targets.

* **Documentation**
  * Added guidance and examples explaining implicit locale fallback, explicit overrides, default entries, and suppression behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->