### PR TITLE
perf: cache createLocaleConfigs per fallbackLocale value

### DIFF
--- a/src/runtime/shared/locales.ts
+++ b/src/runtime/shared/locales.ts
@@ -5,7 +5,19 @@ import type { FallbackLocale } from 'vue-i18n'
 import type { NormalizedLocaleObject } from '#internal-i18n-types'
 
 type LocaleConfig = { cacheable: boolean, fallbacks: string[] }
+
+// `fallbackLocale` is normally the same value on every request, computing every locale's fallback
+// chain from scratch each time is wasted work. It comes from `defineI18nConfig`, which can be
+// async, so it could in theory differ per request, keying the cache by the value itself (rather
+// than memoizing once and reusing forever) keeps that case correct while still skipping the work
+// whenever it's what it almost always is: unchanged
+const localeConfigsCache = new Map<string, Record<string, LocaleConfig>>()
+
 export function createLocaleConfigs(fallbackLocale: FallbackLocale): Record<string, LocaleConfig> {
+  const cacheKey = JSON.stringify(fallbackLocale)
+  const cached = localeConfigsCache.get(cacheKey)
+  if (cached) { return cached }
+
   const localeConfigs: Record<string, LocaleConfig> = {}
 
   for (const locale of localeCodes) {
@@ -14,6 +26,7 @@ export function createLocaleConfigs(fallbackLocale: FallbackLocale): Record<stri
     localeConfigs[locale] = { fallbacks, cacheable }
   }
 
+  localeConfigsCache.set(cacheKey, localeConfigs)
   return localeConfigs
 }
 


### PR DESCRIPTION
## Summary

`createLocaleConfigs` recomputes every configured locale's fallback chain from scratch on every request that doesn't already have a cached i18n context, `initializeI18nContext` runs on Nitro's `request` hook unconditionally, so this happens on every single request. Its only real input, `fallbackLocale`, is normally the same value every time.

This adds a small in-memory cache keyed by a serialization of `fallbackLocale` itself, rather than memoizing once and reusing forever. `fallbackLocale` comes from `defineI18nConfig`, which can be async, so in theory it could differ per request, keying by value keeps that case correct (a different value just gets its own cache entry) while still skipping the work entirely whenever it's what it almost always is: unchanged.

## Benchmark

Measured directly against the real function (forcing a genuine cache miss on every "uncached" call versus repeated calls with the same value):

| locales | uncached (per call) | cached (per call) | speedup |
|---|---|---|---|
| 5 | 5.3 µs | 0.9 µs | 5.6x |
| 20 | 11.8 µs | 0.8 µs | 14.9x |
| 100 | 39.8 µs | 0.7 µs | 54.9x |

The cached path stays flat regardless of locale count, it's just a map lookup. The uncached path scales with locale count, since it walks every configured locale's fallback chain. Small in absolute terms per request, but free to keep, and it scales better the more locales are configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved locale configuration handling by reusing previously generated configurations, reducing repeated processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->