### PR TITLE
fix(pages): localize nested routes only for their parent's locale

### DIFF
--- a/src/kit/gen.ts
+++ b/src/kit/gen.ts
@@ -145,7 +145,11 @@ export function localizeSingleRoute(
   }
 
   const resultRoutes: LocalizableRoute[] = []
-  for (const locale of routeOptions.locales) {
+  // a child is localized only for the locale of the parent tree it is mounted in;
+  // `routeOptions.locales` may carry the full list when the resolver reads it
+  // from route meta (`getRouteFromResource`), which would bypass the narrowing
+  // applied by `localizeChildren`
+  for (const locale of routeOptions.locales.filter(l => options.locales.includes(l))) {
     // use custom path if found
     const unprefixed = routeOptions.paths?.[locale] ?? route.path
 

--- a/test/pages/localize_routes.test.ts
+++ b/test/pages/localize_routes.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { createMemoryHistory, createRouter } from 'vue-router'
 
-import { getNormalizedLocales, getNuxtOptions } from './utils'
+import { createMockOptionsResolver, createTestConfig, getNormalizedLocales, getNuxtOptions } from './utils'
 import { localizeRoutes, shouldLocalizeRoutes } from '../../src/routing'
 import { setupMultiDomainLocales } from '../../src/runtime/routing/domain'
 import type { NuxtPage } from '@nuxt/schema'
@@ -595,5 +595,98 @@ describe('localizeRoutes', function () {
 
       expect(localizedRoutes).toMatchSnapshot()
     })
+  })
+
+  describe('nested route locale narrowing', function () {
+    /** Flattens a localized route tree into `{ name, path }` records, tracking the full nested path. */
+    function flattenRoutes(routes: LocalizableRoute[], parentPath = ''): { name?: string, path: string }[] {
+      const flat: { name?: string, path: string }[] = []
+      for (const route of routes) {
+        const path = parentPath + (route.path.startsWith('/') ? route.path : '/' + route.path)
+        flat.push({ name: route.name, path })
+        if (route.children?.length) {
+          flat.push(...flattenRoutes(route.children, path))
+        }
+      }
+      return flat
+    }
+
+    const blogRoutes: NuxtPage[] = [
+      {
+        path: '/blog',
+        name: 'blog',
+        children: [{ path: 'archive', name: 'blog-archive' }]
+      }
+    ]
+
+    it('only mounts a locale-restricted child under its own locale tree', function () {
+      const localizedRoutes = localizeRoutes(structuredClone(blogRoutes) as LocalizableRoute[], createTestConfig({
+        locales: ['en', 'nl', 'de'],
+        strategy: 'prefix_except_default',
+        defaultLocale: 'en',
+        optionsResolver: createMockOptionsResolver({
+          'blog-archive': { locales: ['en'], paths: {} }
+        })
+      }))
+
+      const flat = flattenRoutes(localizedRoutes)
+      const paths = flat.map(x => x.path)
+
+      expect(flat.filter(x => x.name === 'blog-archive___en')).toHaveLength(1)
+      expect(paths).not.toContain('/nl/blog/archive')
+      expect(paths).not.toContain('/de/blog/archive')
+      // the parents themselves are unaffected by the child's restriction
+      expect(paths).toContain('/nl/blog')
+      expect(paths).toContain('/de/blog')
+    })
+
+    it('produces identical output whether the child locale list is explicit or falls back to the passed localeCodes', function () {
+      const paths = { en: 'archive', nl: 'archief' }
+      const sharedConfig = {
+        locales: ['en', 'nl'],
+        strategy: 'prefix_except_default' as const,
+        defaultLocale: 'en'
+      }
+
+      // explicit locale list restating exactly the locales in scope for this config
+      const explicit = localizeRoutes(structuredClone(blogRoutes) as LocalizableRoute[], createTestConfig({
+        ...sharedConfig,
+        optionsResolver: createMockOptionsResolver({
+          'blog-archive': { locales: ['en', 'nl'], paths }
+        })
+      }))
+
+      // no explicit locale list at all - the resolver falls back to whatever localeCodes it's called with,
+      // as it would for a route that only sets custom paths without restricting locales
+      const fallback = localizeRoutes(structuredClone(blogRoutes) as LocalizableRoute[], createTestConfig({
+        ...sharedConfig,
+        optionsResolver: (route, localeCodes) => ({
+          locales: localeCodes,
+          paths: route.name === 'blog-archive' ? paths : {}
+        })
+      }))
+
+      expect(explicit).toEqual(fallback)
+    })
+
+    describe.each(['prefix', 'prefix_except_default', 'prefix_and_default'] as const)(
+      'strategy: "%s"',
+      (strategy) => {
+        it('keeps route names globally unique across the flattened tree', function () {
+          const localizedRoutes = localizeRoutes(structuredClone(blogRoutes) as LocalizableRoute[], createTestConfig({
+            locales: ['en', 'nl', 'de'],
+            strategy,
+            defaultLocale: 'en',
+            optionsResolver: createMockOptionsResolver({
+              'blog-archive': { locales: ['en'], paths: {} }
+            })
+          }))
+
+          const names = flattenRoutes(localizedRoutes).map(x => x.name).filter(Boolean)
+          const duplicates = names.filter((name, index) => names.indexOf(name) !== index)
+          expect(duplicates).toEqual([])
+        })
+      }
+    )
   })
 })


### PR DESCRIPTION
## Summary

`localizeSingleRoute()` in `src/kit/gen.ts` looped over whatever locale list the options resolver returned for a route, instead of narrowing it to the locale of the parent tree currently being localized. For top-level routes that never mattered, since the resolver's list already was the full locale set. For a nested route with its own restriction, `defineI18nRoute({ locales: ['en'] })` on a child page, or a `pages` config entry disabling a locale, or `definePageMeta({ i18n: { locales: [...] } })`, it meant the child got localized once per parent locale rather than once for its own locale, and every one of those localizations produced a route with the same name.

Vue Router's `addRoute` doesn't rename on a collision, it deletes the previous matcher for that name and adds the new one, path binding included. So the earlier variants don't just become mislabeled, they stop resolving at all. In a three-locale repro (`en` default, `nl`, `de`, `prefix_except_default`) with a `blog` page whose `archive` child is restricted to `en`, the last-registered variant ends up being the only one reachable, and it isn't necessarily the correct one:

| path | before | after |
|---|---|---|
| `/blog` | `blog___en` | `blog___en` |
| `/blog/archive` | **404** | **`blog-archive___en`** |
| `/nl/blog` | `blog___nl` | `blog___nl` |
| `/nl/blog/archive` | 404 | 404  |
| `/de/blog` | `blog___de` | `blog___de` |
| `/de/blog/archive` | **`blog-archive___en`** | **404** |

The actual English URL 404'd while the English page rendered instead at a German-prefixed URL that was never supposed to exist, and `localePath('blog-archive')` followed the same surviving matcher, pointing English users at it too. It also disagreed with the build's own `i18n-route-resources.mjs`, which already had this right (`pathToI18nConfig: { '/blog/archive': { nl: false, de: false } }`), the server's `matchLocalized` refused both wrong-locale paths while the client router happily resolved one of them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Route localization now respects both configured and currently available locales, preventing unsupported localized routes from being generated.
  * Improved handling of nested routes, localized paths, fallback locale lists, and parent route preservation.

* **Tests**
  * Added coverage for locale-restricted child routes and globally unique route names across route-prefixing strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->