### PR TITLE
fix(head): only re-apply i18n params to the route they belong to

### DIFF
--- a/src/runtime/routing/head.ts
+++ b/src/runtime/routing/head.ts
@@ -5,6 +5,7 @@ import { type HeadContext, localeHead as _localeHead } from '#i18n-kit/head'
 import type { I18nHeadMetaInfo, I18nHeadOptions, LocaleObject, SeoAttributesOptions } from '#internal-i18n-types'
 import type { ComposableContext } from '../composable-context'
 import type { I18nRouteMeta } from '../types'
+import type { RouteRecordName } from 'vue-router'
 import { localeRoute, switchLocalePath } from './routing'
 
 function patchHead(head: ComposableContext['head'] | undefined, input: I18nHeadMetaInfo): void {
@@ -121,12 +122,16 @@ export function _useSetI18nParams(
   const evt = ctx.strictSeo && import.meta.server && useRequestEvent()
 
   const _i18nParams = ref({})
+  // The route the params describe. Each instance re-applies its own params on
+  // navigation, so without this they land on whichever route comes next.
+  let _i18nParamsRoute: RouteRecordName | null | undefined = null
   const i18nParams = computed({
     get() {
       return router.currentRoute.value.meta[__DYNAMIC_PARAMS_KEY__]
     },
     set(val: I18nRouteMeta) {
       _i18nParams.value = val
+      _i18nParamsRoute = router.currentRoute.value.name
       router.currentRoute.value.meta[__DYNAMIC_PARAMS_KEY__] = val
       if (evt && evt?.context.nuxtI18n?.slp) {
         evt.context.nuxtI18n.slp = val
@@ -137,6 +142,12 @@ export function _useSetI18nParams(
   const unsub = watch(
     () => router.currentRoute.value.fullPath,
     () => {
+      // Only re-apply to the route these params belong to. A page is kept mounted
+      // while the next one resolves, so without this check the page being left
+      // stamps its params onto the page being entered.
+      if (router.currentRoute.value.name !== _i18nParamsRoute) {
+        return
+      }
       router.currentRoute.value.meta[__DYNAMIC_PARAMS_KEY__] = _i18nParams.value
       ctx.strictSeo && updateState()
     },

--- a/src/runtime/routing/head.ts
+++ b/src/runtime/routing/head.ts
@@ -5,7 +5,6 @@ import { type HeadContext, localeHead as _localeHead } from '#i18n-kit/head'
 import type { I18nHeadMetaInfo, I18nHeadOptions, LocaleObject, SeoAttributesOptions } from '#internal-i18n-types'
 import type { ComposableContext } from '../composable-context'
 import type { I18nRouteMeta } from '../types'
-import type { RouteRecordName } from 'vue-router'
 import { localeRoute, switchLocalePath } from './routing'
 
 function patchHead(head: ComposableContext['head'] | undefined, input: I18nHeadMetaInfo): void {
@@ -122,16 +121,17 @@ export function _useSetI18nParams(
   const evt = ctx.strictSeo && import.meta.server && useRequestEvent()
 
   const _i18nParams = ref({})
-  // The route the params describe. Each instance re-applies its own params on
-  // navigation, so without this they land on whichever route comes next.
-  let _i18nParamsRoute: RouteRecordName | null | undefined = null
+  // The route these params belong to, captured where the composable is created —
+  // that is, in the owning page's `setup()`. Checked by both the setter and the
+  // navigation watcher below, so a page can neither write to a route it no
+  // longer occupies nor re-apply its params to whichever route comes next.
+  const _i18nParamsRoute = router.currentRoute.value.name
   const i18nParams = computed({
     get() {
       return router.currentRoute.value.meta[__DYNAMIC_PARAMS_KEY__]
     },
     set(val: I18nRouteMeta) {
       _i18nParams.value = val
-      _i18nParamsRoute = router.currentRoute.value.name
       router.currentRoute.value.meta[__DYNAMIC_PARAMS_KEY__] = val
       if (evt && evt?.context.nuxtI18n?.slp) {
         evt.context.nuxtI18n.slp = val
@@ -142,10 +142,9 @@ export function _useSetI18nParams(
   const unsub = watch(
     () => router.currentRoute.value.fullPath,
     () => {
-      // Only re-apply to the route these params belong to. A page is kept mounted
-      // while the next one resolves, so without this check the page being left
-      // stamps its params onto the page being entered.
-      if (router.currentRoute.value.name !== _i18nParamsRoute) {
+      // A page is kept mounted while the next one resolves, so without this
+      // check the page being left stamps its params onto the page being entered.
+      if (!ownsCurrentRoute()) {
         return
       }
       router.currentRoute.value.meta[__DYNAMIC_PARAMS_KEY__] = _i18nParams.value
@@ -155,6 +154,10 @@ export function _useSetI18nParams(
 
   if (getCurrentScope()) {
     onScopeDispose(unsub)
+  }
+
+  function ownsCurrentRoute() {
+    return router.currentRoute.value.name === _i18nParamsRoute
   }
 
   function updateState() {
@@ -169,6 +172,12 @@ export function _useSetI18nParams(
   })
 
   return function (params: I18nRouteMeta) {
+    // A page whose data resolves only after the user has navigated away must not
+    // write its params onto the route they landed on.
+    if (!ownsCurrentRoute()) {
+      return
+    }
+
     i18nParams.value = { ...params }
     ctx.strictSeo && updateState()
     if (!ctx.strictSeo) {

--- a/test/routing-head.test.ts
+++ b/test/routing-head.test.ts
@@ -471,6 +471,21 @@ describe('_useSetI18nParams', () => {
     expect(router.currentRoute.value.meta.nuxtI18nInternal).toEqual(chairParams)
   })
 
+  test('ignores a setter that resolves after the user has navigated away', async () => {
+    const { router, ctx } = createTestContext()
+    await router.push('/products/big-chair')
+
+    // created in the page's setup, while its own route is current
+    const setI18nParams = _useSetI18nParams(ctx)
+
+    // the page's data resolves only after the user has moved on
+    await router.push('/')
+    await nextTick()
+    setI18nParams(chairParams)
+
+    expect(router.currentRoute.value.meta.nuxtI18nInternal).toBeUndefined()
+  })
+
   test('does not carry dynamic params onto a different route', async () => {
     const { router, ctx } = createTestContext()
     await router.push('/products/big-chair')

--- a/test/routing-head.test.ts
+++ b/test/routing-head.test.ts
@@ -457,17 +457,32 @@ describe('_useSetI18nParams', () => {
     expect(patched.link.find(x => x.hreflang === 'nl')!.href).toBe('https://example.com/nl/products/grote-stoel')
   })
 
-  test('restores dynamic params after navigation', async () => {
+  test('restores dynamic params when navigating within the same route', async () => {
     const { router, ctx } = createTestContext()
     await router.push('/products/big-chair')
 
     const setI18nParams = _useSetI18nParams(ctx)
     setI18nParams(chairParams)
 
-    // navigation resets route meta, the composable re-applies the params
-    await router.push('/')
+    // every navigation builds a fresh merged route meta, so the composable
+    // re-applies the params it owns
+    await router.push('/products/big-chair?page=2')
     await nextTick()
     expect(router.currentRoute.value.meta.nuxtI18nInternal).toEqual(chairParams)
+  })
+
+  test('does not carry dynamic params onto a different route', async () => {
+    const { router, ctx } = createTestContext()
+    await router.push('/products/big-chair')
+
+    const setI18nParams = _useSetI18nParams(ctx)
+    setI18nParams(chairParams)
+
+    // the page that set these params stays mounted while the next route
+    // resolves; a page that declares none must not inherit them
+    await router.push('/')
+    await nextTick()
+    expect(router.currentRoute.value.meta.nuxtI18nInternal).toBeUndefined()
   })
 
   test('seo attributes override global canonicalQueries in strict seo mode', async () => {


### PR DESCRIPTION
Fixes #4129.

### The problem

`_useSetI18nParams` registers one watcher per instance which re-applies **that instance's** params to whatever route is current, with no binding between the params and the route they describe. `<NuxtPage>`'s Suspense keeps the outgoing page mounted while the incoming one resolves, so the outgoing watcher is still live when the route commits — and it stamps its params onto the incoming route.

A page with its own setter overwrites them (its instance registers later, so its watcher runs last), which hides this for most routes. A page that never calls `useSetI18nParams` has nothing to overwrite them with and simply inherits the previous page's params.

Measured in a [minimal reproduction](https://github.com/jansalwowski/nuxt-i18n-4129-repro) on 10.6.0 — the homepage, which never calls the composable, ends up owning an article's slugs after a client-side navigation.

### The change

Capture the route the params belong to where the composable is created — in the owning page's `setup()` — and check it in both the setter and the navigation watcher.

An earlier revision of this PR recorded the route at *set* time. [@coderabbitai](https://github.com/nuxt-modules/i18n/pull/4132#discussion_r3758400508) pointed out that leaves the leak reachable through the setter itself: a page whose data resolves after the user has navigated away writes its params onto the destination route *and* re-points the owner at it, defeating the watcher guard. Since the documented pattern is to call the setter after awaiting data, losing that race is ordinary. Capturing at creation closes both paths.

### On the test I changed

`restores dynamic params after navigation` asserted the reported behaviour directly: it set params on `/products/big-chair`, pushed `/`, and expected the product's params on the index route. So this PR does flip a covered behaviour, and that deserves an explicit look rather than being buried in the diff.

What that test protects is real, though: every navigation builds a fresh merged `meta`, so params **are** lost on navigation and something must re-apply them. Splitting it in two keeps that half and drops only the cross-route bleed:

- `restores dynamic params when navigating within the same route` — same route, fresh `meta`, params re-applied. Passes before and after.
- `does not carry dynamic params onto a different route` — fails on `main`, passes here.
- `ignores a setter that resolves after the user has navigated away` — fails on `main`, passes here.

If the original intent was broader than I've read it, I'm happy to rework this.

### One thing I could not determine

I could not construct a case where the watcher fires **usefully** on a *different* route. Instrumenting the composable across a direct load, a navigation to a page with a setter, a navigation to a page without one, and a same-record param change, the setter always ran with `router.currentRoute` already on its own route — so the direct write in `set()` was sufficient every time, and the only cross-route write the watcher made was the defect itself.

That suggests the guard is safe, but it also means I don't know what the unguarded re-apply was originally for. The one case this changes is params set *before* their route commits: `_i18nParamsRoute` would hold the previous route and the re-apply would now be skipped. I could not make that happen on Nuxt 4.5.2, but I can't rule it out for older Nuxt, `keepalive`, or a custom `<NuxtPage>` key where the component is reused. If you know of such a case, comparing on something other than the route name would be the fix — happy to adjust.

### One more behavioural note

Capturing at creation is stricter than capturing at set: an instance created **outside** a page — in a plugin or layout — now owns whatever route was current at creation and no-ops elsewhere. I couldn't find such usage here or in the docs, and it was arguably already unsound, but it is wider than the reported bug and worth a deliberate yes/no.

### Verification

- `pnpm test:unit` — 467 passed
- `pnpm lint` — 0 errors (6 pre-existing jsdoc warnings, unchanged)
- `tsc --noEmit` — clean
- Both new tests verified red against `main`, green here


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where localized route parameters could persist after navigating to a different route.
  * Route parameters are now correctly restored when revisiting the same route and cleared when switching to another route.
  * Prevented retained pages from applying stale parameters during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->