### PR TITLE
fix(routing): resolve catch-all routes with a single trailing slash

### DIFF
--- a/src/runtime/routing/routing.ts
+++ b/src/runtime/routing/routing.ts
@@ -77,6 +77,19 @@ function resolveRoute(ctx: RoutingContext, route: RouteLocationRaw, locale: Loca
 }
 
 /**
+ * A repeatable param matched against a trailing slash captures a trailing empty segment, which the
+ * route it is resolved against turns into a duplicate slash (#4135)
+ */
+function trimEmptyParamSegments(params: CompatRoute['params']) {
+  const trimmed: CompatRoute['params'] = {}
+  for (const key in params) {
+    const value = params[key]!
+    trimmed[key] = Array.isArray(value) ? value.slice(0, value.findLastIndex(x => x !== '') + 1) : value
+  }
+  return trimmed
+}
+
+/**
  * Resolve the localized path of the current route.
  */
 export function switchLocalePath(
@@ -99,7 +112,7 @@ export function switchLocalePath(
     name,
     params: assign(
       {},
-      route.params,
+      trimEmptyParamSegments(route.params),
       ctx.getLocalizedDynamicParams(locale),
     ),
     fullPath: route.fullPath,

--- a/test/routing-head.test.ts
+++ b/test/routing-head.test.ts
@@ -21,16 +21,19 @@ const locales = getNormalizedLocales([
 ])
 
 const component = {}
-const routes = [
+const routeDefs = [
   { name: 'index', path: '/' },
   { name: 'products-slug', path: '/products/:slug()' },
-].flatMap(r =>
-  locales.map(l => ({
-    name: `${r.name}___${l.code}`,
-    path: l.code === 'en' ? r.path : `/${l.code}${r.path === '/' ? '' : r.path}`,
-    component,
-  })),
-)
+]
+const localizeRoutes = (defs: typeof routeDefs) =>
+  defs.flatMap(r =>
+    locales.map(l => ({
+      name: `${r.name}___${l.code}`,
+      path: l.code === 'en' ? r.path : `/${l.code}${r.path === '/' ? '' : r.path}`,
+      component,
+    })),
+  )
+const routes = localizeRoutes(routeDefs)
 
 // one cluster of two hosts sharing every locale, with per-host defaults (`multiDomainLocales`)
 const clusterLocales = getNormalizedLocales([
@@ -47,20 +50,25 @@ const clusterRoutesFor = (cluster: typeof clusterLocales) => [
     .map(l => ({ name: `index___${l.code}___default`, path: '/', component })),
 ]
 
+// mirrors the trailing slash the build appends to every localized route path, catch-all included
+const trailingSlashRoutes = localizeRoutes([...routeDefs, { name: 'slug', path: '/:slug(.*)*' }])
+  .map(r => ({ ...r, path: r.path.replace(/\/+$/, '') + '/' }))
+
 type TestContextOptions = {
   strictSeo?: boolean
   /** `true` gives every locale its own domain, an object selects the shared-domain cluster */
   domains?: boolean | { host: string, locales?: typeof clusterLocales }
   defaultLocale?: string
+  trailingSlash?: boolean
 }
 
 function createTestContext(initialLocale = 'en', opts: TestContextOptions = {}) {
-  const { strictSeo = false, domains = false, defaultLocale: configuredDefault = 'en' } = opts
+  const { strictSeo = false, domains = false, defaultLocale: configuredDefault = 'en', trailingSlash = false } = opts
   let locale = initialLocale
   const cluster = typeof domains === 'object' ? (domains.locales ?? clusterLocales) : undefined
   const router = createRouter({
     history: createMemoryHistory(),
-    routes: cluster ? clusterRoutesFor(cluster) : routes,
+    routes: cluster ? clusterRoutesFor(cluster) : trailingSlash ? trailingSlashRoutes : routes,
   })
   const head = { patches: [] as I18nHeadMetaInfo[], patch(val: I18nHeadMetaInfo) { this.patches.push(val) } }
   const domainLocales = getNormalizedLocales(
@@ -84,7 +92,7 @@ function createTestContext(initialLocale = 'en', opts: TestContextOptions = {}) 
       strategy: 'prefix_except_default',
       routing: true,
       domains: !!domains,
-      trailingSlash: false,
+      trailingSlash,
       strictSeo,
       compactRoutes: false,
       getLocale: () => locale,
@@ -369,6 +377,19 @@ describe('switchLocalePath', () => {
 
     expect(switchLocalePath(ctx, 'en')).toBe('/products/red-mug')
     expect(switchLocalePath(ctx, 'ja')).toBe('/ja/products/rode-mok')
+  })
+
+  test('(#4135) a catch-all route under `trailingSlash` keeps a single trailing slash', async () => {
+    const { router, ctx } = createTestContext('en', { trailingSlash: true })
+    await router.push('/posts/')
+
+    expect(switchLocalePath(ctx, 'fr')).toBe('/fr/posts/')
+    expect(localeHead(ctx, {}).link.find(x => x.rel === 'canonical')!.href).toBe('https://example.com/posts/')
+
+    // each switch resolves the path the previous one produced, which is where the slashes stacked
+    await router.push(switchLocalePath(ctx, 'fr'))
+    expect(switchLocalePath(ctx, 'fr')).toBe('/fr/posts/')
+    expect(switchLocalePath(ctx, 'en')).toBe('/posts/')
   })
 })
 


### PR DESCRIPTION
* Resolves #4135

With `trailingSlash: true`, a catch-all route such as `pages/[...slug].vue` matched against `/posts/` captures an empty last segment in its repeatable param. `switchLocalePath()` reuses the current route params, so rebuilding the path emits that empty segment on top of the slash the localized route already ends with, giving `/posts//`, and every further switch stacks another one. Trailing empty segments are now dropped before the route is resolved, so the switch links and the `useLocaleHead()` canonical and alternates keep a single slash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed localized navigation for catch-all routes with empty trailing parameters.
  - Ensured generated canonical URLs retain exactly one trailing slash when trailing-slash routing is enabled.
  - Improved consistency when switching locales on dynamic routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->