### PR TITLE
fix(types): type the i18n config key with the augmentable ModuleOptions interface

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -274,10 +274,10 @@ declare module '#app' {
 
 declare module '@nuxt/schema' {
   interface NuxtConfig {
-    ['i18n']?: Partial<UserNuxtI18nOptions>
+    ['i18n']?: Partial<ModuleOptions>
   }
   interface NuxtOptions {
-    ['i18n']: UserNuxtI18nOptions
+    ['i18n']: ModuleOptions
   }
   interface NuxtHooks extends ModuleHooks {}
   interface PublicRuntimeConfig extends ModulePublicRuntimeConfig {}


### PR DESCRIPTION
### 🔗 Linked issue

* Resolves #4138

### 📚 Description

`ModuleOptions` is an interface, so companion modules can extend it through declaration merging. The `i18n` key on `NuxtConfig` and `NuxtOptions` is typed with the `UserNuxtI18nOptions` alias instead, which an augmentation never reaches, so adding a custom key under `i18n` fails with TS2353 even though the value survives at runtime.

Both keys now point at `ModuleOptions`. It extends `UserNuxtI18nOptions` and adds no members, so the exposed type stays the same and only augmentability changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TypeScript support for internationalization configuration in Nuxt projects.
  - Configuration options now provide more accurate and consistent type checking across Nuxt configuration contexts.
  - Helps surface invalid settings earlier and improves editor autocomplete when configuring internationalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->