### PR TITLE
feat: allow locale codes with slashes

### DIFF
--- a/specs/helper.ts
+++ b/specs/helper.ts
@@ -260,10 +260,13 @@ export async function startServerWithRuntimeConfig(env: Record<string, unknown>,
  * Wait for the locale route to be requested or received.
  */
 export function waitForLocaleNetwork(page: Page, locale: string, type: 'request' | 'response') {
+  // the real request encodes the locale into a single path segment (#4142), so a locale
+  // containing `/` (or other reserved characters) needs the same encoding to match it
+  const encodedLocale = encodeURIComponent(locale)
   if (type === 'request') {
-    return page.waitForRequest(new RegExp(`/_i18n/.*/${locale}/messages.json`))
+    return page.waitForRequest(new RegExp(`/_i18n/.*/${encodedLocale}/messages.json`))
   }
-  return page.waitForResponse(new RegExp(`/_i18n/.*/${locale}/messages.json`))
+  return page.waitForResponse(new RegExp(`/_i18n/.*/${encodedLocale}/messages.json`))
 }
 
 /**

--- a/specs/helper.ts
+++ b/specs/helper.ts
@@ -260,7 +260,7 @@ export async function startServerWithRuntimeConfig(env: Record<string, unknown>,
  * Wait for the locale route to be requested or received.
  */
 export function waitForLocaleNetwork(page: Page, locale: string, type: 'request' | 'response') {
-  // the real request encodes the locale into a single path segment (#4142), so a locale
+  // the real request encodes the locale into a single path segment, so a locale
   // containing `/` (or other reserved characters) needs the same encoding to match it
   const encodedLocale = encodeURIComponent(locale)
   if (type === 'request') {

--- a/src/context.ts
+++ b/src/context.ts
@@ -7,7 +7,7 @@ import { computeLocaleHashes, filterLocales, getLayerI18n, normalizeDomainLocale
 import { resolveRawResourcePaths } from './resources'
 import { generateLoaderOptions } from './gen'
 // takes its facts as config and reads no `__FLAG__` defines, so the build can share it
-import { createPrerenderablePredicate } from './runtime/shared/delivery'
+import { createPrerenderablePredicate, localeNeedsPathEncoding } from './runtime/shared/delivery'
 
 import type { Resolver } from '@nuxt/kit'
 import type { FileMeta, LocaleInfo, NormalizedLocaleObject, NuxtI18nOptions } from './types'
@@ -55,7 +55,11 @@ const isDynamicMeta = (meta: FileMeta) => meta.type !== 'static' && meta.cache =
 
 export function resolveDeliveryLocales(localeInfo: LocaleInfo[]) {
   return {
-    dynamicLocales: localeInfo.filter(x => x.meta.some(isDynamicMeta)).map(x => x.code),
+    // a locale needing URL encoding is "dynamic" too - nitro's prerender crawler can't carry it
+    // through, so it has to run its own loaders instead of relying on a baked file (#4142)
+    dynamicLocales: localeInfo
+      .filter(x => x.meta.some(isDynamicMeta) || localeNeedsPathEncoding(x.code))
+      .map(x => x.code),
     // one list, because nothing downstream cares which of the two reasons applies
     undeliverableLocales: localeInfo.filter(x => x.meta.some(m => !m.serializable || m.appContext)).map(x => x.code),
   }

--- a/src/context.ts
+++ b/src/context.ts
@@ -56,7 +56,7 @@ const isDynamicMeta = (meta: FileMeta) => meta.type !== 'static' && meta.cache =
 export function resolveDeliveryLocales(localeInfo: LocaleInfo[]) {
   return {
     // a locale needing URL encoding is "dynamic" too - nitro's prerender crawler can't carry it
-    // through, so it has to run its own loaders instead of relying on a baked file (#4142)
+    // through, so it has to run its own loaders instead of relying on a baked file
     dynamicLocales: localeInfo
       .filter(x => x.meta.some(isDynamicMeta) || localeNeedsPathEncoding(x.code))
       .map(x => x.code),

--- a/src/module.ts
+++ b/src/module.ts
@@ -8,6 +8,7 @@ import type { HookResult } from '@nuxt/schema'
 import type { I18nPublicRuntimeConfig, LocaleObject, NuxtI18nOptions } from './types'
 import type { Locale } from 'vue-i18n'
 import { createContext, prerenderableLocales, resolveContext } from './context'
+import { messagesRoutePath } from './runtime/shared/delivery'
 import { prepareOptions } from './prepare/options'
 import { prepareTypeGeneration } from './prepare/type-generation'
 import { relative } from 'pathe'
@@ -206,7 +207,7 @@ export default defineNuxtModule<NuxtI18nOptions>({
       // as static assets (uploadable to a CDN) instead of being served from the dynamic Nitro route.
       if (resolved.options.experimental.prerenderMessages) {
         const messagesRoutes = prerenderableLocales(resolved).map(
-          locale => `${resolved.options.serverRoutePrefix}/${resolved.localeHashes[locale]}/${locale}/messages.json`,
+          locale => `${resolved.options.serverRoutePrefix}/${messagesRoutePath(resolved.localeHashes[locale]!, locale)}`,
         )
         nuxt.hook('nitro:config', (config) => {
           config.prerender ??= {}

--- a/src/runtime/context.ts
+++ b/src/runtime/context.ts
@@ -3,7 +3,7 @@ import { isRef, unref } from 'vue'
 import { useCookie, useRequestURL, useState } from '#imports'
 import { localeLoaders } from '#build/i18n-options.mjs'
 import { cloneDeep, fillMissing, getLocaleMessagesMergedCached, warnMissedMessageFunctions } from './shared/messages'
-import { createPrerenderablePredicate, createRuntimeLoaderPredicate } from './shared/delivery'
+import { createPrerenderablePredicate, createRuntimeLoaderPredicate, messagesRoutePath } from './shared/delivery'
 import { createComposableContext } from './composable-context'
 import { getComposer, getI18nTarget } from './compatibility'
 import { canonicalDomainFromLocale, domainForHost, domainFromLocale } from './shared/domain'
@@ -244,7 +244,7 @@ export function createNuxtI18nContext(nuxt: NuxtApp, vueI18n: I18n, defaultLocal
     }
 
     const headers: HeadersInit = getLocaleConfig(locale)?.cacheable ? {} : { 'Cache-Control': 'no-cache' }
-    const url = joinURL(cdnPrefix(locale), __I18N_SERVER_ROUTE__, __I18N_LOCALE_HASHES__[locale]!, locale, 'messages.json')
+    const url = joinURL(cdnPrefix(locale), __I18N_SERVER_ROUTE__, messagesRoutePath(__I18N_LOCALE_HASHES__[locale]!, locale))
     const messages = await $fetch<LocaleMessages<DefineLocaleMessage>>(url, { headers })
     for (const k of deliverable(messages)) {
       i18n.mergeLocaleMessage(k, messages[k])

--- a/src/runtime/kit/routing.ts
+++ b/src/runtime/kit/routing.ts
@@ -48,7 +48,7 @@ export function prefixable(currentLocale: string, defaultLocale: string, options
  * Extract the locale from a route path. A locale code may span more than one path segment
  * (`en/formal`), so recognizing one takes matching against the actual configured codes rather than
  * just taking the first `/`-delimited segment. Trims one segment off the end at a time, so a
- * configured `en/formal` is not shadowed by a shorter, coincidentally matching `en` (#4142). Costs
+ * configured `en/formal` is not shadowed by a shorter, coincidentally matching `en`. Costs
  * one pass over the path's own segments rather than over `localeCodes`, so it stays cheap regardless
  * of how many locales are configured.
  */

--- a/src/runtime/kit/routing.ts
+++ b/src/runtime/kit/routing.ts
@@ -1,4 +1,4 @@
-import { withTrailingSlash, withoutTrailingSlash } from 'ufo'
+import { parsePath, withTrailingSlash, withoutTrailingSlash } from 'ufo'
 import type { Strategies } from '#internal-i18n-types'
 import type { RouteName, RouteObject } from './types'
 
@@ -47,20 +47,20 @@ export function prefixable(currentLocale: string, defaultLocale: string, options
 /**
  * Extract the locale from a route path. A locale code may span more than one path segment
  * (`en/formal`), so recognizing one takes matching against the actual configured codes rather than
- * just taking the first `/`-delimited segment. Walks from the longest possible prefix down to a
- * single segment, so a configured `en/formal` is not shadowed by a shorter, coincidentally matching
- * `en` (#4142). Costs one pass over the path's own segments rather than over `localeCodes`, so it
- * stays cheap regardless of how many locales are configured.
+ * just taking the first `/`-delimited segment. Trims one segment off the end at a time, so a
+ * configured `en/formal` is not shadowed by a shorter, coincidentally matching `en` (#4142). Costs
+ * one pass over the path's own segments rather than over `localeCodes`, so it stays cheap regardless
+ * of how many locales are configured.
  */
 export function getLocaleFromRoutePath(path: string, localeCodes: readonly string[]): string {
-  const withoutQuery = path.split('?')[0] ?? ''
-  const trimmed = withoutQuery[0] === '/' ? withoutQuery.slice(1) : withoutQuery
-  if (!trimmed) { return '' }
+  const { pathname } = parsePath(path)
+  let candidate = pathname[0] === '/' ? pathname.slice(1) : pathname
 
-  const segments = trimmed.split('/')
-  for (let end = segments.length; end > 0; end--) {
-    const candidate = segments.slice(0, end).join('/')
+  while (candidate) {
     if (localeCodes.includes(candidate)) { return candidate }
+    const lastSlash = candidate.lastIndexOf('/')
+    if (lastSlash === -1) { break }
+    candidate = candidate.slice(0, lastSlash)
   }
   return ''
 }

--- a/src/runtime/kit/routing.ts
+++ b/src/runtime/kit/routing.ts
@@ -1,4 +1,3 @@
-import { createPathIndexLanguageParser } from '@intlify/utils'
 import { withTrailingSlash, withoutTrailingSlash } from 'ufo'
 import type { Strategies } from '#internal-i18n-types'
 import type { RouteName, RouteObject } from './types'
@@ -45,8 +44,27 @@ export function prefixable(currentLocale: string, defaultLocale: string, options
   return options.routing && (currentLocale !== defaultLocale || options.strategy === 'prefix')
 }
 
-const pathLanguageParser = createPathIndexLanguageParser(0)
-export const getLocaleFromRoutePath = (path: string) => pathLanguageParser(path)
+/**
+ * Extract the locale from a route path. A locale code may span more than one path segment
+ * (`en/formal`), so recognizing one takes matching against the actual configured codes rather than
+ * just taking the first `/`-delimited segment. Walks from the longest possible prefix down to a
+ * single segment, so a configured `en/formal` is not shadowed by a shorter, coincidentally matching
+ * `en` (#4142). Costs one pass over the path's own segments rather than over `localeCodes`, so it
+ * stays cheap regardless of how many locales are configured.
+ */
+export function getLocaleFromRoutePath(path: string, localeCodes: readonly string[]): string {
+  const withoutQuery = path.split('?')[0] ?? ''
+  const trimmed = withoutQuery[0] === '/' ? withoutQuery.slice(1) : withoutQuery
+  if (!trimmed) { return '' }
+
+  const segments = trimmed.split('/')
+  for (let end = segments.length; end > 0; end--) {
+    const candidate = segments.slice(0, end).join('/')
+    if (localeCodes.includes(candidate)) { return candidate }
+  }
+  return ''
+}
+
 export const getLocaleFromRouteName = (name: string) => name.split(separator).at(1) ?? ''
 
 function normalizeInput(input: RouteName | RouteObject) {
@@ -58,10 +76,10 @@ function normalizeInput(input: RouteName | RouteObject) {
 /**
  * Extract locale code from route name or path
  */
-export function getLocaleFromRoute(route: RouteName | RouteObject) {
+export function getLocaleFromRoute(route: RouteName | RouteObject, localeCodes: readonly string[]) {
   const input = normalizeInput(route)
   if (input[0] === '/') {
-    return getLocaleFromRoutePath(input)
+    return getLocaleFromRoutePath(input, localeCodes)
   }
 
   const fromName = getLocaleFromRouteName(input)
@@ -70,7 +88,7 @@ export function getLocaleFromRoute(route: RouteName | RouteObject) {
   // Fallback: for compact routes the name has no locale suffix,
   // try path-based detection if the route object has a path.
   if (typeof route === 'object' && route?.path) {
-    return getLocaleFromRoutePath(String(route.path))
+    return getLocaleFromRoutePath(String(route.path), localeCodes)
   }
 
   return ''

--- a/src/runtime/plugins/i18n.ts
+++ b/src/runtime/plugins/i18n.ts
@@ -10,6 +10,7 @@ import { useLocalePath, useLocaleRoute, useRouteBaseName, useSwitchLocalePath } 
 import { createLocaleConfigs, resolveDefaultLocale, resolveSupportedLocale } from '../shared/locales'
 import { setupVueI18nOptions } from '../shared/vue-i18n'
 import { type NuxtI18nContext, createNuxtI18nContext, isPrerenderable, useLocaleConfigs } from '../context'
+import { messagesRoutePath } from '../shared/delivery'
 import { useI18nDetection, useRuntimeI18n } from '../shared/utils'
 import { useDetectors } from '../shared/detection'
 import { setupMultiDomainLocales } from '../routing/domain'
@@ -46,7 +47,7 @@ export default defineNuxtPlugin({
     prerenderRoutes(
       localeCodes
         .filter(isPrerenderable)
-        .map(locale => `${__I18N_SERVER_ROUTE__}/${__I18N_LOCALE_HASHES__[locale]}/${locale}/messages.json`),
+        .map(locale => `${__I18N_SERVER_ROUTE__}/${messagesRoutePath(__I18N_LOCALE_HASHES__[locale]!, locale)}`),
     )
 
     // create i18n instance

--- a/src/runtime/plugins/switch-locale-path-ssr.ts
+++ b/src/runtime/plugins/switch-locale-path-ssr.ts
@@ -3,7 +3,7 @@ import { useSwitchLocalePath } from '#i18n'
 import { escapeHtmlAttr } from '../shared/utils'
 
 const identifier = __SWITCH_LOCALE_PATH_LINK_IDENTIFIER__
-// `\w+` couldn't capture a locale code containing `/` (#4142). Matching up to the closing `]`
+// `\w+` couldn't capture a locale code containing `/`. Matching up to the closing `]`
 // instead covers that, along with anything else a locale code is allowed to contain.
 const switchLocalePathLinkWrapperExpr = new RegExp(
   [`<!--${identifier}-\\[([^\\]]+)\\]-->`, `.+?`, `<!--/${identifier}-->`].join(''),

--- a/src/runtime/plugins/switch-locale-path-ssr.ts
+++ b/src/runtime/plugins/switch-locale-path-ssr.ts
@@ -3,8 +3,10 @@ import { useSwitchLocalePath } from '#i18n'
 import { escapeHtmlAttr } from '../shared/utils'
 
 const identifier = __SWITCH_LOCALE_PATH_LINK_IDENTIFIER__
+// `\w+` couldn't capture a locale code containing `/` (#4142). Matching up to the closing `]`
+// instead covers that, along with anything else a locale code is allowed to contain.
 const switchLocalePathLinkWrapperExpr = new RegExp(
-  [`<!--${identifier}-\\[(\\w+)\\]-->`, `.+?`, `<!--/${identifier}-->`].join(''),
+  [`<!--${identifier}-\\[([^\\]]+)\\]-->`, `.+?`, `<!--/${identifier}-->`].join(''),
   'g',
 )
 

--- a/src/runtime/routing/context.ts
+++ b/src/runtime/routing/context.ts
@@ -182,7 +182,7 @@ export function createRoutingContext(options: RoutingContextOptions): RoutingCon
       if (!base) {
         return path
       }
-      if (stripsDefaultPrefix && unprefixesLocale(canonicalDomain(target), locale, locales) && getLocaleFromRoutePath(path) === locale) {
+      if (stripsDefaultPrefix && unprefixesLocale(canonicalDomain(target), locale, locales) && getLocaleFromRoutePath(path, locales.map(l => l.code)) === locale) {
         path = path.slice(locale.length + 1) || '/'
       }
       return joinURL(base, path)

--- a/src/runtime/server/context.ts
+++ b/src/runtime/server/context.ts
@@ -5,6 +5,7 @@ import { type H3Event, type H3EventContext, getRequestURL } from 'h3'
 import { type ResolvedI18nOptions, setupVueI18nOptions } from '../shared/vue-i18n'
 import { useRuntimeI18n } from '../shared/utils'
 import { createLocaleConfigs, resolveDefaultLocale } from '../shared/locales'
+import { messagesRoutePath } from '../shared/delivery'
 import { cloneDeep } from '../shared/messages'
 import { getMergedMessages } from './utils/messages'
 
@@ -44,7 +45,7 @@ export const fetchMessages = async (locale: string) => {
   if (import.meta.dev) {
     headers.set('Cache-Control', 'no-cache')
   }
-  return await $fetch<LocaleMessages<DefineLocaleMessage>>(`${__I18N_SERVER_ROUTE__}/${__I18N_LOCALE_HASHES__[locale]}/${locale}/messages.json`, {
+  return await $fetch<LocaleMessages<DefineLocaleMessage>>(`${__I18N_SERVER_ROUTE__}/${messagesRoutePath(__I18N_LOCALE_HASHES__[locale]!, locale)}`, {
     headers,
   })
 }

--- a/src/runtime/server/routes/messages.ts
+++ b/src/runtime/server/routes/messages.ts
@@ -6,7 +6,7 @@ import { buildCacheKey } from '../../shared/delivery'
 
 import type { H3Event } from 'h3'
 
-// the route matches `:locale` as a single, percent-encoded segment (#4036). h3 only decodes a
+// the route matches `:locale` as a single, percent-encoded segment. h3 only decodes a
 // router param when asked to, so every read of it needs the same option, or the locale comes back
 // still encoded.
 const getLocaleParam = (event: H3Event) => getRouterParam(event, 'locale', { decode: true })

--- a/src/runtime/server/routes/messages.ts
+++ b/src/runtime/server/routes/messages.ts
@@ -9,7 +9,7 @@ import type { H3Event } from 'h3'
  * Load messages for the specified locale event parameter
  */
 const _messagesHandler = defineEventHandler(async (event: H3Event) => {
-  const locale = getRouterParam(event, 'locale')
+  const locale = getRouterParam(event, 'locale', { decode: true })
 
   if (!locale) {
     throw createError({ status: 400, message: 'Locale not specified.' })
@@ -31,10 +31,10 @@ const _messagesHandler = defineEventHandler(async (event: H3Event) => {
 })
 
 const getCacheKey = (event: H3Event) =>
-  [getRouterParam(event, 'locale') ?? 'null', getRouterParam(event, 'hash') ?? 'null'].join('-')
+  [getRouterParam(event, 'locale', { decode: true }) ?? 'null', getRouterParam(event, 'hash') ?? 'null'].join('-')
 
 async function shouldBypassCache(event: H3Event) {
-  const locale = getRouterParam(event, 'locale')
+  const locale = getRouterParam(event, 'locale', { decode: true })
   if (locale == null) { return false }
   // prerendering may require initializing context
   const ctx = tryUseI18nContext(event) || await initializeI18nContext(event)

--- a/src/runtime/server/routes/messages.ts
+++ b/src/runtime/server/routes/messages.ts
@@ -2,14 +2,20 @@ import { defineCachedEventHandler, defineCachedFunction } from 'nitropack/runtim
 import { createError, defineEventHandler, getRouterParam } from 'h3'
 import { initializeI18nContext, tryUseI18nContext, useI18nContext } from '../context'
 import { warnMissedMessageFunctions } from '../../shared/messages'
+import { buildCacheKey } from '../../shared/delivery'
 
 import type { H3Event } from 'h3'
+
+// the route matches `:locale` as a single, percent-encoded segment (#4036). h3 only decodes a
+// router param when asked to, so every read of it needs the same option, or the locale comes back
+// still encoded.
+const getLocaleParam = (event: H3Event) => getRouterParam(event, 'locale', { decode: true })
 
 /**
  * Load messages for the specified locale event parameter
  */
 const _messagesHandler = defineEventHandler(async (event: H3Event) => {
-  const locale = getRouterParam(event, 'locale', { decode: true })
+  const locale = getLocaleParam(event)
 
   if (!locale) {
     throw createError({ status: 400, message: 'Locale not specified.' })
@@ -31,10 +37,10 @@ const _messagesHandler = defineEventHandler(async (event: H3Event) => {
 })
 
 const getCacheKey = (event: H3Event) =>
-  [getRouterParam(event, 'locale', { decode: true }) ?? 'null', getRouterParam(event, 'hash') ?? 'null'].join('-')
+  buildCacheKey(getLocaleParam(event) ?? 'null', getRouterParam(event, 'hash') ?? 'null')
 
 async function shouldBypassCache(event: H3Event) {
-  const locale = getRouterParam(event, 'locale', { decode: true })
+  const locale = getLocaleParam(event)
   if (locale == null) { return false }
   // prerendering may require initializing context
   const ctx = tryUseI18nContext(event) || await initializeI18nContext(event)

--- a/src/runtime/shared/delivery.ts
+++ b/src/runtime/shared/delivery.ts
@@ -38,3 +38,26 @@ export function createRuntimeLoaderPredicate(config: DeliveryConfig) {
     || config.undeliverable.includes(locale)
     || (config.dynamic.includes(locale) && (config.prerender || config.ssg))
 }
+
+/**
+ * Path segments after the server route prefix for a locale's messages endpoint. The route matches
+ * `:hash/:locale/messages.json` as single segments, and a locale code is free to contain characters
+ * (`/`, `?`, ...) that would otherwise split into extra segments or corrupt the URL, so it gets
+ * encoded here to keep the request a single segment. h3 decodes route params back to the original
+ * locale on the way in (#4036).
+ */
+export function messagesRoutePath(hash: string, locale: Locale): string {
+  return `${hash}/${encodeURIComponent(locale)}/messages.json`
+}
+
+/**
+ * Whether a locale code needs percent-encoding to fit `messagesRoutePath` as a single path segment.
+ * Nitro's own prerender crawler can only carry a route through unencoded (it round-trips every
+ * queued route through `decodeURI`/`encodeURI`, which never reproduces a pre-encoded segment), so a
+ * locale like this can never be baked into a static messages file - callers treat it as `dynamic`
+ * and have it run its own loaders instead, wherever there's no live server left to fall back on
+ * (prerendering, static hosting) (#4142).
+ */
+export function localeNeedsPathEncoding(locale: Locale): boolean {
+  return encodeURIComponent(locale) !== locale
+}

--- a/src/runtime/shared/delivery.ts
+++ b/src/runtime/shared/delivery.ts
@@ -44,7 +44,7 @@ export function createRuntimeLoaderPredicate(config: DeliveryConfig) {
  * `:hash/:locale/messages.json` as single segments, and a locale code is free to contain characters
  * (`/`, `?`, ...) that would otherwise split into extra segments or corrupt the URL, so it gets
  * encoded here to keep the request a single segment. h3 decodes route params back to the original
- * locale on the way in (#4036).
+ * locale on the way in.
  */
 export function messagesRoutePath(hash: string, locale: Locale): string {
   return `${hash}/${encodeURIComponent(locale)}/messages.json`
@@ -56,7 +56,7 @@ export function messagesRoutePath(hash: string, locale: Locale): string {
  * `messagesRoutePath` already percent-encoded (`/` decodes to itself, then re-encoding turns the
  * literal `%` back into `%25`), so a locale needing that encoding can never be baked into a static
  * messages file. Callers treat it as `dynamic` and have it run its own loaders instead, wherever
- * there's no live server left to fall back on (prerendering, static hosting) (#4142). A code using
+ * there's no live server left to fall back on (prerendering, static hosting). A code using
  * only non-ASCII characters still round-trips fine (those aren't in `decodeURI`'s protected set),
  * so it isn't penalized here just for needing `encodeURIComponent` at all.
  */
@@ -80,7 +80,7 @@ export function localeNeedsPathEncoding(locale: Locale): boolean {
  * the first into `en%2Fformal`, which strips right back down to the same `en2Fformal` as the
  * second. `JSON.stringify` puts the pair into one string with the boundary between locale and hash
  * spelled out explicitly, and hex-encoding every character of that string turns it into one made
- * only of digits and `a` to `f`, which are all word characters the stripping leaves alone (#4142).
+ * only of digits and `a` to `f`, which are all word characters the stripping leaves alone.
  */
 export function buildCacheKey(locale: string, hash: string): string {
   const pair = JSON.stringify([locale, hash])

--- a/src/runtime/shared/delivery.ts
+++ b/src/runtime/shared/delivery.ts
@@ -51,13 +51,33 @@ export function messagesRoutePath(hash: string, locale: Locale): string {
 }
 
 /**
- * Whether a locale code needs percent-encoding to fit `messagesRoutePath` as a single path segment.
- * Nitro's own prerender crawler can only carry a route through unencoded (it round-trips every
- * queued route through `decodeURI`/`encodeURI`, which never reproduces a pre-encoded segment), so a
- * locale like this can never be baked into a static messages file - callers treat it as `dynamic`
- * and have it run its own loaders instead, wherever there's no live server left to fall back on
- * (prerendering, static hosting) (#4142).
+ * Whether a locale code survives Nitro's own prerender crawler, which round-trips every queued
+ * route through `encodeURI(decodeURI(...))` before fetching it. That never reproduces a segment
+ * `messagesRoutePath` already percent-encoded (`/` decodes to itself, then re-encoding turns the
+ * literal `%` back into `%25`), so a locale needing that encoding can never be baked into a static
+ * messages file. Callers treat it as `dynamic` and have it run its own loaders instead, wherever
+ * there's no live server left to fall back on (prerendering, static hosting) (#4142). A code using
+ * only non-ASCII characters still round-trips fine (those aren't in `decodeURI`'s protected set),
+ * so it isn't penalized here just for needing `encodeURIComponent` at all.
  */
 export function localeNeedsPathEncoding(locale: Locale): boolean {
-  return encodeURIComponent(locale) !== locale
+  let encoded: string
+  try {
+    encoded = encodeURIComponent(locale)
+  } catch {
+    // malformed input, such as a lone surrogate, can't be routed to at all, so treat it the same
+    // as needing encoding, which sends it to the loaders instead of failing later, less clearly
+    return true
+  }
+  return encodeURI(decodeURI(encoded)) !== encoded
+}
+
+/**
+ * The cache key the messages endpoint gives Nitro for a (locale, hash) pair. Nitro escapes a
+ * custom key by stripping every non-word character, so joining the raw locale and hash with `-`
+ * can collide, since `en/formal` and `enformal` both reduce to the same key. Encoding the locale
+ * first keeps a `/` (or any other stripped character) from disappearing outright (#4142).
+ */
+export function buildCacheKey(locale: string, hash: string): string {
+  return `${encodeURIComponent(locale)}-${hash}`
 }

--- a/src/runtime/shared/delivery.ts
+++ b/src/runtime/shared/delivery.ts
@@ -74,10 +74,19 @@ export function localeNeedsPathEncoding(locale: Locale): boolean {
 
 /**
  * The cache key the messages endpoint gives Nitro for a (locale, hash) pair. Nitro escapes a
- * custom key by stripping every non-word character, so joining the raw locale and hash with `-`
- * can collide, since `en/formal` and `enformal` both reduce to the same key. Encoding the locale
- * first keeps a `/` (or any other stripped character) from disappearing outright (#4142).
+ * custom key by stripping every character that is not a word character, so the key has to survive
+ * that stripping without losing what makes two pairs different. Encoding just the locale isn't
+ * enough on its own: `en/formal` and `en2Fformal` are both valid locale codes, and encoding turns
+ * the first into `en%2Fformal`, which strips right back down to the same `en2Fformal` as the
+ * second. `JSON.stringify` puts the pair into one string with the boundary between locale and hash
+ * spelled out explicitly, and hex-encoding every character of that string turns it into one made
+ * only of digits and `a` to `f`, which are all word characters the stripping leaves alone (#4142).
  */
 export function buildCacheKey(locale: string, hash: string): string {
-  return `${encodeURIComponent(locale)}-${hash}`
+  const pair = JSON.stringify([locale, hash])
+  let key = ''
+  for (let i = 0; i < pair.length; i++) {
+    key += pair.charCodeAt(i).toString(16).padStart(4, '0')
+  }
+  return key
 }

--- a/src/runtime/shared/detection.ts
+++ b/src/runtime/shared/detection.ts
@@ -17,11 +17,15 @@ import { type NuxtApp, useCookie } from '#app'
 
 // TODO: add unit tests for these detectors
 
+// locale codes may span more than one path segment (#4142), path-based detection needs the full
+// configured list to tell those apart from a plain path segment that happens to match a prefix
+const localeCodes = normalizedLocales.map(l => l.code)
+
 const getCookieLocale = (event: H3Event | undefined, cookieName: string): string | undefined =>
   (import.meta.client ? useCookie(cookieName).value : getCookie(event!, cookieName)) || undefined
 
 const getRouteLocale = (event: H3Event | undefined, route: string | CompatRoute): string | undefined =>
-  getLocaleFromRoute(route)
+  getLocaleFromRoute(route, localeCodes)
 
 const getHeaderLocale = (event: H3Event | undefined) =>
   findBrowserLocale(normalizedLocales, parseAcceptLanguage(getRequestHeader(event!, 'accept-language') || ''))
@@ -63,7 +67,7 @@ export const useDetectors = (
     cookie: () => getCookieLocale(event, config.cookieKey),
     header: () => (import.meta.server ? getHeaderLocale(event) : undefined),
     navigator: () => (import.meta.client ? getNavigatorLocale(event) : undefined),
-    host: (path: string) => matchDomainLocale(getLocales(), getHost(), getLocaleFromRoutePath(path)),
+    host: (path: string) => matchDomainLocale(getLocales(), getHost(), getLocaleFromRoutePath(path, localeCodes)),
     route: (path: string | CompatRoute) => getRouteLocale(event, path),
     /** Passes the locale through when the current host serves it, `undefined` otherwise */
     onHost: (locale: string | null | undefined) =>

--- a/src/runtime/shared/detection.ts
+++ b/src/runtime/shared/detection.ts
@@ -17,7 +17,7 @@ import { type NuxtApp, useCookie } from '#app'
 
 // TODO: add unit tests for these detectors
 
-// locale codes may span more than one path segment (#4142), path-based detection needs the full
+// locale codes may span more than one path segment, path-based detection needs the full
 // configured list to tell those apart from a plain path segment that happens to match a prefix
 const localeCodes = normalizedLocales.map(l => l.code)
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,7 +35,7 @@ export function filterLocales(ctx: I18nNuxtContext) {
 }
 
 // locale codes are used as URL path segments (route prefixes, messages endpoint), in route names
-// and cookies (#4036). `/` is not banned since a locale can span more than one path segment (#4142).
+// and cookies. `/` is not banned since a locale can span more than one path segment.
 const INVALID_LOCALE_CODE_CHAR_RE = /[\\?#%:[\]\s]/
 
 // a `/`-containing code is still only safe as a sequence of real path segments. A leading,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,10 +34,16 @@ export function filterLocales(ctx: I18nNuxtContext) {
   return ctx.options.locales.filter(x => include.includes(isString(x) ? x : x.code)) as string[] | LocaleObject[]
 }
 
-// locale codes are used as single URL path segments (route prefixes, messages endpoint), in route
-// names and in cookies (#4036). `/` is no longer banned here since the messages endpoint now encodes
-// it (#4142), the rest is still unsafe.
+// locale codes are used as URL path segments (route prefixes, messages endpoint), in route names
+// and in cookies (#4036). `/` is no longer banned here since a locale can now span more than one
+// path segment (#4142), the rest is still unsafe.
 const INVALID_LOCALE_CODE_CHAR_RE = /[\\?#%:\s]/
+
+// a `/`-containing code is still only safe as a sequence of real path segments. A leading,
+// trailing, or doubled slash would build an empty segment nothing can ever match, and a `.`/`..`
+// segment gets resolved away during URL normalization before a request ever reaches the route.
+const hasInvalidSlashPlacement = (code: string) =>
+  code.split('/').some(segment => segment === '' || segment === '.' || segment === '..')
 
 /**
  * A `defaultLocale` naming no configured locale cannot be the unprefixed locale, so a host relying
@@ -54,11 +60,12 @@ export function validateDefaultLocale(defaultLocale: string | undefined, codes: 
 }
 
 export function validateLocaleCodes(codes: string[]) {
-  const invalid = codes.filter(code => !code || INVALID_LOCALE_CODE_CHAR_RE.test(code))
+  const invalid = codes.filter(code => !code || INVALID_LOCALE_CODE_CHAR_RE.test(code) || hasInvalidSlashPlacement(code))
   if (invalid.length) {
     throw new Error(
       `[nuxt-i18n] Invalid locale code${invalid.length > 1 ? 's' : ''}: ${invalid.map(x => JSON.stringify(x)).join(', ')}. `
-      + 'Locale codes are used as URL path segments and must not be empty or contain `\\ ? # % :` or whitespace.',
+      + 'Locale codes are used as URL path segments and must not be empty, start or end with `/`, contain `//`, '
+      + 'contain `.` or `..` as a segment, or contain `\\ ? # % :` or whitespace.',
     )
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,8 +34,10 @@ export function filterLocales(ctx: I18nNuxtContext) {
   return ctx.options.locales.filter(x => include.includes(isString(x) ? x : x.code)) as string[] | LocaleObject[]
 }
 
-// locale codes are used as single URL path segments (route prefixes, messages endpoint), in route names and in cookies (#4036)
-const INVALID_LOCALE_CODE_CHAR_RE = /[/\\?#%:\s]/
+// locale codes are used as single URL path segments (route prefixes, messages endpoint), in route
+// names and in cookies (#4036). `/` is no longer banned here since the messages endpoint now encodes
+// it (#4142), the rest is still unsafe.
+const INVALID_LOCALE_CODE_CHAR_RE = /[\\?#%:\s]/
 
 /**
  * A `defaultLocale` naming no configured locale cannot be the unprefixed locale, so a host relying
@@ -56,7 +58,7 @@ export function validateLocaleCodes(codes: string[]) {
   if (invalid.length) {
     throw new Error(
       `[nuxt-i18n] Invalid locale code${invalid.length > 1 ? 's' : ''}: ${invalid.map(x => JSON.stringify(x)).join(', ')}. `
-      + 'Locale codes are used as URL path segments and must not be empty or contain `/ \\ ? # % :` or whitespace.',
+      + 'Locale codes are used as URL path segments and must not be empty or contain `\\ ? # % :` or whitespace.',
     )
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,9 +35,8 @@ export function filterLocales(ctx: I18nNuxtContext) {
 }
 
 // locale codes are used as URL path segments (route prefixes, messages endpoint), in route names
-// and in cookies (#4036). `/` is no longer banned here since a locale can now span more than one
-// path segment (#4142), the rest is still unsafe.
-const INVALID_LOCALE_CODE_CHAR_RE = /[\\?#%:\s]/
+// and cookies (#4036). `/` is not banned since a locale can span more than one path segment (#4142).
+const INVALID_LOCALE_CODE_CHAR_RE = /[\\?#%:[\]\s]/
 
 // a `/`-containing code is still only safe as a sequence of real path segments. A leading,
 // trailing, or doubled slash would build an empty segment nothing can ever match, and a `.`/`..`
@@ -65,7 +64,7 @@ export function validateLocaleCodes(codes: string[]) {
     throw new Error(
       `[nuxt-i18n] Invalid locale code${invalid.length > 1 ? 's' : ''}: ${invalid.map(x => JSON.stringify(x)).join(', ')}. `
       + 'Locale codes are used as URL path segments and must not be empty, start or end with `/`, contain `//`, '
-      + 'contain `.` or `..` as a segment, or contain `\\ ? # % :` or whitespace.',
+      + 'contain `.` or `..` as a segment, or contain `\\ ? # % : [ ]` or whitespace.',
     )
   }
 }

--- a/test/detection.test.ts
+++ b/test/detection.test.ts
@@ -15,7 +15,7 @@ const createDetectors = () => ({
   header: (): string | undefined => undefined,
   navigator: (): string | undefined => undefined,
   host: (): string | undefined => undefined,
-  route: (path: string | object) => getLocaleFromRoutePath(String(path)),
+  route: (path: string | object) => getLocaleFromRoutePath(String(path), LOCALES),
   onHost: (locale: string | null | undefined) => locale,
   fromOwnDomain: () => false,
   cookieSpans: () => false,

--- a/test/kit-routing.test.ts
+++ b/test/kit-routing.test.ts
@@ -48,7 +48,7 @@ describe('getLocaleFromRoute', () => {
     expect(getLocaleFromRoute({ name: 'about', path: '/en/about' }, LOCALES)).toBe('en')
   })
 
-  // (#4142) a locale code can span more than one path segment
+  // a locale code can span more than one path segment
   test('recognizes a locale code that spans more than one path segment', () => {
     expect(getLocaleFromRoute('/en/formal/about', ['en', 'en/formal'])).toBe('en/formal')
     expect(getLocaleFromRoute({ path: '/en/formal' }, ['en', 'en/formal'])).toBe('en/formal')
@@ -60,7 +60,7 @@ describe('getLocaleFromRoutePath', () => {
     expect(getLocaleFromRoutePath('/en/about', ['en', 'fr'])).toBe('en')
   })
 
-  // (#4142) a locale code may span more than one path segment
+  // a locale code may span more than one path segment
   test('matches a multi-segment locale, even alongside an overlapping shorter one', () => {
     expect(getLocaleFromRoutePath('/en/formal/about', ['en', 'en/formal'])).toBe('en/formal')
     expect(getLocaleFromRoutePath('/en/about', ['en', 'en/formal'])).toBe('en')

--- a/test/kit-routing.test.ts
+++ b/test/kit-routing.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 import {
   getLocaleFromRoute,
   getLocaleFromRouteName,
+  getLocaleFromRoutePath,
   getLocalizedRouteName,
   getRouteBaseName,
   prefixable,
@@ -32,17 +33,50 @@ describe('localized route name encode/decode', () => {
 })
 
 describe('getLocaleFromRoute', () => {
+  const LOCALES = ['en', 'nl', 'fr']
+
   test('parses locale from path input', () => {
-    expect(getLocaleFromRoute('/en/about')).toBe('en')
-    expect(getLocaleFromRoute({ path: '/nl/about' })).toBe('nl')
+    expect(getLocaleFromRoute('/en/about', LOCALES)).toBe('en')
+    expect(getLocaleFromRoute({ path: '/nl/about' }, LOCALES)).toBe('nl')
   })
 
   test('prefers route name over path', () => {
-    expect(getLocaleFromRoute({ name: 'about___fr', path: '/en/about' })).toBe('fr')
+    expect(getLocaleFromRoute({ name: 'about___fr', path: '/en/about' }, LOCALES)).toBe('fr')
   })
 
   test('falls back to path for names without locale suffix (compact routes)', () => {
-    expect(getLocaleFromRoute({ name: 'about', path: '/en/about' })).toBe('en')
+    expect(getLocaleFromRoute({ name: 'about', path: '/en/about' }, LOCALES)).toBe('en')
+  })
+
+  // (#4142) a locale code can span more than one path segment
+  test('recognizes a locale code that spans more than one path segment', () => {
+    expect(getLocaleFromRoute('/en/formal/about', ['en', 'en/formal'])).toBe('en/formal')
+    expect(getLocaleFromRoute({ path: '/en/formal' }, ['en', 'en/formal'])).toBe('en/formal')
+  })
+})
+
+describe('getLocaleFromRoutePath', () => {
+  test('matches a single-segment locale', () => {
+    expect(getLocaleFromRoutePath('/en/about', ['en', 'fr'])).toBe('en')
+  })
+
+  // (#4142) a locale code may span more than one path segment
+  test('matches a multi-segment locale, even alongside an overlapping shorter one', () => {
+    expect(getLocaleFromRoutePath('/en/formal/about', ['en', 'en/formal'])).toBe('en/formal')
+    expect(getLocaleFromRoutePath('/en/about', ['en', 'en/formal'])).toBe('en')
+  })
+
+  test('does not match a segment that merely starts with a configured code', () => {
+    expect(getLocaleFromRoutePath('/english/about', ['en'])).toBe('')
+  })
+
+  test('matches the locale alone, with nothing trailing', () => {
+    expect(getLocaleFromRoutePath('/en/formal', ['en/formal'])).toBe('en/formal')
+  })
+
+  test('returns nothing for the root path or an unconfigured locale', () => {
+    expect(getLocaleFromRoutePath('/', ['en'])).toBe('')
+    expect(getLocaleFromRoutePath('/de/about', ['en'])).toBe('')
   })
 })
 

--- a/test/kit-routing.test.ts
+++ b/test/kit-routing.test.ts
@@ -78,6 +78,12 @@ describe('getLocaleFromRoutePath', () => {
     expect(getLocaleFromRoutePath('/', ['en'])).toBe('')
     expect(getLocaleFromRoutePath('/de/about', ['en'])).toBe('')
   })
+
+  // a fragment glued onto the last segment must not shadow a longer configured locale
+  test('strips a query string or hash fragment before matching', () => {
+    expect(getLocaleFromRoutePath('/en/formal?x=1', ['en', 'en/formal'])).toBe('en/formal')
+    expect(getLocaleFromRoutePath('/en/formal#pricing', ['en', 'en/formal'])).toBe('en/formal')
+  })
 })
 
 describe('prefixable', () => {

--- a/test/message-delivery.test.ts
+++ b/test/message-delivery.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { createPrerenderablePredicate, createRuntimeLoaderPredicate } from '../src/runtime/shared/delivery'
+import { createPrerenderablePredicate, createRuntimeLoaderPredicate, messagesRoutePath } from '../src/runtime/shared/delivery'
 import { generateTemplateNuxtI18nOptions } from '../src/template'
 import { resolveDeliveryLocales } from '../src/context'
 import { resolveLocales } from '../src/utils'
@@ -66,6 +66,21 @@ describe('message delivery', () => {
     expect(deliverable(LOCALES.unserializable)).toBe(false)
     expect(deliverable(LOCALES.both)).toBe(false)
     expect(deliverable(LOCALES.appContext)).toBe(false)
+  })
+
+  test('(#4036) a locale code with characters that would otherwise split the URL stays a single segment', () => {
+    // `/` (or `?`, `#`, ...) in a locale code would otherwise be read as extra path segments or
+    // query/hash markers, so the messages endpoint (`:hash/:locale/messages.json`) never matches
+    expect(messagesRoutePath('abc123', 'at/de')).toBe('abc123/at%2Fde/messages.json')
+    expect(messagesRoutePath('abc123', 'en')).toBe('abc123/en/messages.json')
+  })
+
+  test('(#4142) a locale needing URL encoding also runs its own loaders', () => {
+    // nitro's prerender crawler can only carry a route through unencoded, so it can never bake a
+    // static messages file for this locale, it has to fall back on running its own loaders instead
+    const locales = [{ code: 'en', file: 'en.json' }, { code: 'en/formal', file: 'en.json' }] as LocaleObject[]
+    const { dynamicLocales } = resolveDeliveryLocales(resolveLocales('/i18n', locales, {}))
+    expect(dynamicLocales).toEqual(['en/formal'])
   })
 })
 

--- a/test/message-delivery.test.ts
+++ b/test/message-delivery.test.ts
@@ -100,6 +100,12 @@ describe('message delivery', () => {
     // `getKey` result before it's used as the actual cache entry name
     const escapeKey = (key: string) => key.replace(/\W/g, '')
     expect(escapeKey(buildCacheKey('en/formal', 'abc123'))).not.toBe(escapeKey(buildCacheKey('enformal', 'abc123')))
+    // encoding the locale on its own isn't enough: encoding `/` and then stripping non-word
+    // characters lands `en/formal` on the same key as a locale literally spelled `en2Fformal`
+    expect(escapeKey(buildCacheKey('en/formal', 'abc123'))).not.toBe(escapeKey(buildCacheKey('en2Fformal', 'abc123')))
+    // joining locale and hash with a fixed separator collides whenever a locale or hash contains
+    // that separator itself, `en-US` with hash `formal` looks the same as `en` with hash `US-formal`
+    expect(escapeKey(buildCacheKey('en-US', 'formal'))).not.toBe(escapeKey(buildCacheKey('en', 'US-formal')))
   })
 })
 

--- a/test/message-delivery.test.ts
+++ b/test/message-delivery.test.ts
@@ -68,14 +68,14 @@ describe('message delivery', () => {
     expect(deliverable(LOCALES.appContext)).toBe(false)
   })
 
-  test('(#4036) a locale code with characters that would otherwise split the URL stays a single segment', () => {
+  test('a locale code with characters that would otherwise split the URL stays a single segment', () => {
     // `/` (or `?`, `#`, ...) in a locale code would otherwise be read as extra path segments or
     // query/hash markers, so the messages endpoint (`:hash/:locale/messages.json`) never matches
     expect(messagesRoutePath('abc123', 'at/de')).toBe('abc123/at%2Fde/messages.json')
     expect(messagesRoutePath('abc123', 'en')).toBe('abc123/en/messages.json')
   })
 
-  test('(#4142) a locale needing URL encoding also runs its own loaders', () => {
+  test('a locale needing URL encoding also runs its own loaders', () => {
     // nitro's prerender crawler can only carry a route through unencoded, so it can never bake a
     // static messages file for this locale, it has to fall back on running its own loaders instead
     const locales = [{ code: 'en', file: 'en.json' }, { code: 'en/formal', file: 'en.json' }] as LocaleObject[]
@@ -83,19 +83,19 @@ describe('message delivery', () => {
     expect(dynamicLocales).toEqual(['en/formal'])
   })
 
-  test('(#4142) a locale code needing only non-ASCII characters still survives the crawler', () => {
+  test('a locale code needing only non-ASCII characters still survives the crawler', () => {
     // non-ASCII characters aren't in `decodeURI`'s protected set, so they round-trip through the
     // crawler's `encodeURI(decodeURI(...))` cleanly and don't need the loader fallback
     expect(localeNeedsPathEncoding('français')).toBe(false)
     expect(localeNeedsPathEncoding('en/formal')).toBe(true)
   })
 
-  test('(#4142) a malformed locale code (lone surrogate) is treated as needing encoding, not a crash', () => {
+  test('a malformed locale code (lone surrogate) is treated as needing encoding, not a crash', () => {
     expect(() => localeNeedsPathEncoding('en\uD800formal')).not.toThrow()
     expect(localeNeedsPathEncoding('en\uD800formal')).toBe(true)
   })
 
-  test('(#4142) a slash-containing locale no longer collides with its slash-stripped sibling in the cache key', () => {
+  test('a slash-containing locale no longer collides with its slash-stripped sibling in the cache key', () => {
     // mirrors nitro's own key escaping (`String(key).replace(/\W/g, '')`), applied to a custom
     // `getKey` result before it's used as the actual cache entry name
     const escapeKey = (key: string) => key.replace(/\W/g, '')

--- a/test/message-delivery.test.ts
+++ b/test/message-delivery.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { createPrerenderablePredicate, createRuntimeLoaderPredicate, messagesRoutePath } from '../src/runtime/shared/delivery'
+import { buildCacheKey, createPrerenderablePredicate, createRuntimeLoaderPredicate, localeNeedsPathEncoding, messagesRoutePath } from '../src/runtime/shared/delivery'
 import { generateTemplateNuxtI18nOptions } from '../src/template'
 import { resolveDeliveryLocales } from '../src/context'
 import { resolveLocales } from '../src/utils'
@@ -81,6 +81,25 @@ describe('message delivery', () => {
     const locales = [{ code: 'en', file: 'en.json' }, { code: 'en/formal', file: 'en.json' }] as LocaleObject[]
     const { dynamicLocales } = resolveDeliveryLocales(resolveLocales('/i18n', locales, {}))
     expect(dynamicLocales).toEqual(['en/formal'])
+  })
+
+  test('(#4142) a locale code needing only non-ASCII characters still survives the crawler', () => {
+    // non-ASCII characters aren't in `decodeURI`'s protected set, so they round-trip through the
+    // crawler's `encodeURI(decodeURI(...))` cleanly and don't need the loader fallback
+    expect(localeNeedsPathEncoding('français')).toBe(false)
+    expect(localeNeedsPathEncoding('en/formal')).toBe(true)
+  })
+
+  test('(#4142) a malformed locale code (lone surrogate) is treated as needing encoding, not a crash', () => {
+    expect(() => localeNeedsPathEncoding('en\uD800formal')).not.toThrow()
+    expect(localeNeedsPathEncoding('en\uD800formal')).toBe(true)
+  })
+
+  test('(#4142) a slash-containing locale no longer collides with its slash-stripped sibling in the cache key', () => {
+    // mirrors nitro's own key escaping (`String(key).replace(/\W/g, '')`), applied to a custom
+    // `getKey` result before it's used as the actual cache entry name
+    const escapeKey = (key: string) => key.replace(/\W/g, '')
+    expect(escapeKey(buildCacheKey('en/formal', 'abc123'))).not.toBe(escapeKey(buildCacheKey('enformal', 'abc123')))
   })
 })
 

--- a/test/navigation.test.ts
+++ b/test/navigation.test.ts
@@ -33,7 +33,7 @@ function createResolver(overrides: Partial<NavigationResolverConfig> = {}) {
   return createNavigationResolver({
     localePath: localizePath,
     switchLocalePath: (locale, to) => localizePath(unprefixedPath(String(to.fullPath)), locale),
-    routeLocale: to => getLocaleFromRoutePath(String(to.path)),
+    routeLocale: to => getLocaleFromRoutePath(String(to.path), LOCALES),
     hasRoute: name => ROUTES.has(name),
     getLocaleCodes: () => LOCALES,
     strategy: 'prefix_except_default',

--- a/test/redirect.test.ts
+++ b/test/redirect.test.ts
@@ -17,7 +17,7 @@ const detectors = () => ({
   header: (): string | undefined => undefined,
   navigator: (): string | undefined => undefined,
   host: (): string | undefined => undefined,
-  route: (path: string | object) => getLocaleFromRoutePath(String(path)),
+  route: (path: string | object) => getLocaleFromRoutePath(String(path), LOCALES),
   onHost: (locale: string | null | undefined) => locale,
   fromOwnDomain: () => false,
   cookieSpans: () => false,

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -57,13 +57,17 @@ describe('validateLocaleCodes', () => {
     expect(() => validateLocaleCodes(['en', 'de-AT', 'zh-Hans', 'pt_BR', 'kr.v2'])).not.toThrow()
   })
 
-  test.each(['at/de', 'at\\de', 'en us', 'en?', 'en#x', 'en%20', 'en:us', ''])('throws for %j', code => {
+  test('(#4142) accepts codes containing a slash', () => {
+    expect(() => validateLocaleCodes(['en/formal', 'en/informal'])).not.toThrow()
+  })
+
+  test.each(['at\\de', 'en us', 'en?', 'en#x', 'en%20', 'en:us', ''])('throws for %j', code => {
     expect(() => validateLocaleCodes([code])).toThrowError('[nuxt-i18n] Invalid locale code')
   })
 
   test('lists all invalid codes', () => {
-    expect(() => validateLocaleCodes(['en', 'at/de', 'at/en'])).toThrowError(
-      /Invalid locale codes: "at\/de", "at\/en"/,
+    expect(() => validateLocaleCodes(['en', 'en?', 'en#x'])).toThrowError(
+      /Invalid locale codes: "en\?", "en#x"/,
     )
   })
 })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -61,7 +61,7 @@ describe('validateLocaleCodes', () => {
     expect(() => validateLocaleCodes(['en/formal', 'en/informal'])).not.toThrow()
   })
 
-  test.each(['at\\de', 'en us', 'en?', 'en#x', 'en%20', 'en:us', ''])('throws for %j', code => {
+  test.each(['at\\de', 'en us', 'en?', 'en#x', 'en%20', 'en:us', 'en[x]', 'en]', ''])('throws for %j', code => {
     expect(() => validateLocaleCodes([code])).toThrowError('[nuxt-i18n] Invalid locale code')
   })
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -57,7 +57,7 @@ describe('validateLocaleCodes', () => {
     expect(() => validateLocaleCodes(['en', 'de-AT', 'zh-Hans', 'pt_BR', 'kr.v2'])).not.toThrow()
   })
 
-  test('(#4142) accepts codes containing a slash', () => {
+  test('accepts codes containing a slash', () => {
     expect(() => validateLocaleCodes(['en/formal', 'en/informal'])).not.toThrow()
   })
 
@@ -65,7 +65,7 @@ describe('validateLocaleCodes', () => {
     expect(() => validateLocaleCodes([code])).toThrowError('[nuxt-i18n] Invalid locale code')
   })
 
-  // (#4142) a `/` is only safe as a real path segment. A leading, trailing, or doubled slash
+  // a `/` is only safe as a real path segment. A leading, trailing, or doubled slash
   // would build an empty segment nothing can ever match.
   test.each(['en/', '/en', 'en//formal', 'en/./formal', 'en/../formal', '.', '..'])(
     'throws for %j',

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -65,6 +65,13 @@ describe('validateLocaleCodes', () => {
     expect(() => validateLocaleCodes([code])).toThrowError('[nuxt-i18n] Invalid locale code')
   })
 
+  // (#4142) a `/` is only safe as a real path segment. A leading, trailing, or doubled slash
+  // would build an empty segment nothing can ever match.
+  test.each(['en/', '/en', 'en//formal', 'en/./formal', 'en/../formal', '.', '..'])(
+    'throws for %j',
+    code => expect(() => validateLocaleCodes([code])).toThrowError('[nuxt-i18n] Invalid locale code'),
+  )
+
   test('lists all invalid codes', () => {
     expect(() => validateLocaleCodes(['en', 'en?', 'en#x'])).toThrowError(
       /Invalid locale codes: "en\?", "en#x"/,


### PR DESCRIPTION
### 🔗 Linked issue

#4142
#4036 

### 📚 Description

v10.5.0 banned `/` in locale codes to fix #4036, where a locale code could get read as extra path segments or query and hash markers on the messages endpoint (`:hash/:locale/messages.json`). That ban also broke locale codes that genuinely need to span more than one path segment, like `en/formal`.

The messages endpoint now encodes the locale into a single path segment and decodes it back on the way in, so a locale containing `/` can't split the URL into extra segments. Route-based locale detection now matches against the actual configured locale codes instead of just taking the first slash-delimited segment, so a locale like `en/formal` is recognized correctly and isn't shadowed by a shorter, coincidentally matching `en`. `SwitchLocalePathLink`'s SSR href patching now matches up to its closing bracket instead of `\w+`, so it keeps working for a locale code containing a slash.

Nitro's caching layer strips every non-word character from a cache-key before using it, so just encodingthe locale wasn't enough, since `en/formal` and a locale literally spelled `en2Fformal` collided once encoded and stripped.
The cache key is now built by turning the locale and hash into a single JSON string and hex encoding the whole thing, so the two fields can never bleed into each other regardless of what characters either one contains.

Square brackets are now banned in locale codes too, since `SwitchLocalePathLink`'s wrapper comment uses them as delimiters and a locale containing one would break that match outright.


### :notebook:  Note 

@BobbieGoede  I initially thought this was going to be a small fix, but it ended up growing into a bigger PR than I expected :sweat:  I'm opening it as a draft for now, and I'd completely understand if this isn't something you want to take on or support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for locale codes containing slash-separated path segments.
  * Improved locale detection for multi-segment, encoded, and overlapping locale codes.
  * Added safer message delivery URLs and cache handling for special-character locales.

* **Bug Fixes**
  * Fixed message loading, prerendering, routing, redirects, and SSR locale switching for encoded or non-ASCII locales.
  * Improved validation for malformed locale paths and reserved path segments.

* **Tests**
  * Expanded coverage for encoded locales, routing, message delivery, cache collisions, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->