### PR TITLE
perf: skip i18n context setup for build asset requests

### DIFF
--- a/src/runtime/server/plugin.ts
+++ b/src/runtime/server/plugin.ts
@@ -35,6 +35,9 @@ function createRedirectResponse(event: H3Event, dest: string, code: number) {
 
 export default defineNitroPlugin(async (nitro) => {
   const runtimeI18n = useRuntimeI18n()
+  const { baseURL, buildAssetsDir } = useRuntimeConfig().app
+  // unlike in `render:before`, `event.path` still carries `app.baseURL` in the `request` hook
+  const buildAssetsPath = buildAssetsDir !== '/' ? joinURL(baseURL, buildAssetsDir) : undefined
   const rootRedirect = resolveRootRedirect(runtimeI18n.rootRedirect)
   const _defaultLocale: string = runtimeI18n.defaultLocale || ''
 
@@ -99,6 +102,9 @@ export default defineNitroPlugin(async (nitro) => {
   }
 
   nitro.hooks.hook('request', async (event: H3Event) => {
+    // build assets are served without ever reading the context, and setting it up reprocesses
+    // the runtime config on every one of those requests (#4144)
+    if (buildAssetsPath && event.path.startsWith(buildAssetsPath)) { return }
     await initializeI18nContext(event)
   })
 

--- a/test/mocks/i18n.locale-detector.ts
+++ b/test/mocks/i18n.locale-detector.ts
@@ -1,0 +1,1 @@
+export const localeDetector = undefined

--- a/test/mocks/nuxt.internal-config.ts
+++ b/test/mocks/nuxt.internal-config.ts
@@ -1,0 +1,1 @@
+export const appId = 'test'

--- a/test/server-plugin.test.ts
+++ b/test/server-plugin.test.ts
@@ -1,0 +1,61 @@
+import { expect, test, vi } from 'vitest'
+import type { H3Event } from 'h3'
+
+const { initializeI18nContext, app } = vi.hoisted(() => ({
+  initializeI18nContext: vi.fn(),
+  app: { baseURL: '/', buildAssetsDir: '/_nuxt/' },
+}))
+vi.mock('../src/runtime/server/context', () => ({
+  initializeI18nContext,
+  tryUseI18nContext: vi.fn(),
+  useI18nContext: vi.fn(),
+}))
+vi.mock('#imports', async importOriginal => ({
+  ...(await importOriginal<typeof import('#imports')>()),
+  useRuntimeConfig: () => ({ public: { i18n: {} } }),
+}))
+vi.mock('nitropack/runtime', () => ({
+  defineNitroPlugin: (plugin: unknown) => plugin,
+  useRuntimeConfig: () => ({ app }),
+  useStorage: () => ({ getKeys: () => [], removeItem: () => {} }),
+}))
+
+async function setupRequestHook(appOverrides: Partial<typeof app> = {}) {
+  Object.assign(app, { baseURL: '/', buildAssetsDir: '/_nuxt/' }, appOverrides)
+  const plugin = (await import('../src/runtime/server/plugin')).default
+  const hooks: Record<string, (...args: never[]) => unknown> = {}
+  await plugin({ hooks: { hook: (name: string, fn: () => unknown) => (hooks[name] = fn) } } as never)
+  return hooks['request'] as (event: H3Event) => Promise<void>
+}
+
+test('(#4144) does not set up the i18n context for build asset requests', async () => {
+  const onRequest = await setupRequestHook()
+
+  await onRequest({ path: '/_nuxt/CzQ8YQCV.js' } as H3Event)
+
+  expect(initializeI18nContext).not.toHaveBeenCalled()
+})
+
+test('(#4144) does not set up the i18n context for build assets served under a base URL', async () => {
+  const onRequest = await setupRequestHook({ baseURL: '/docs/' })
+
+  await onRequest({ path: '/docs/_nuxt/CzQ8YQCV.js' } as H3Event)
+
+  expect(initializeI18nContext).not.toHaveBeenCalled()
+})
+
+test('sets up the i18n context for page requests', async () => {
+  const onRequest = await setupRequestHook()
+
+  await onRequest({ path: '/nl/over-ons' } as H3Event)
+
+  expect(initializeI18nContext).toHaveBeenCalledOnce()
+})
+
+test('sets up the i18n context when build assets are served from the root', async () => {
+  const onRequest = await setupRequestHook({ buildAssetsDir: '/' })
+
+  await onRequest({ path: '/nl/over-ons' } as H3Event)
+
+  expect(initializeI18nContext).toHaveBeenCalledOnce()
+})

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -10,6 +10,8 @@ vi.stubGlobal('__PARALLEL_PLUGIN__', false)
 vi.stubGlobal('__TRAILING_SLASH__', false)
 vi.stubGlobal('__I18N_DOMAINS__', false)
 
+vi.stubGlobal('__DEFAULT_COOKIE_KEY__', 'i18n_redirected')
+
 vi.stubGlobal('__ROUTE_NAME_SEPARATOR__', '___')
 vi.stubGlobal('__ROUTE_NAME_DEFAULT_SUFFIX__', 'default')
 

--- a/vitest.config.test.ts
+++ b/vitest.config.test.ts
@@ -15,6 +15,8 @@ export default defineConfig({
       ...vitestConfig.test?.alias,
       '#build/i18n-options.mjs': resolve('./test/mocks/i18n.options.ts'),
       '#build/i18n-route-resources.mjs': resolve('./test/mocks/i18n.route-resources.ts'),
+      '#internal/nuxt.config.mjs': resolve('./test/mocks/nuxt.internal-config.ts'),
+      '#internal/i18n-locale-detector.mjs': resolve('./test/mocks/i18n.locale-detector.ts'),
       '#app': 'nuxt',
       '#imports': resolve('./test/mocks/imports.ts'),
       // resolve from source - the package `imports` map points at `dist`, which may be stale


### PR DESCRIPTION
* Resolves #4144

The nitro `request` hook sets up the i18n context for every request, including the `/_nuxt/*` chunks a node-server deployment serves itself. That setup calls `useRuntimeConfig(event)`, which clones the whole runtime config and walks every key looking for env overrides, so a 442-byte JS chunk pays for a full config pass it never reads. The reporter profiled it at ~16.5% of non-idle CPU, with throughput dropping from ~9060 rps on Nuxt 3.15 + i18n 9.5.6 to ~2065 rps on 10.6.0.

The hook now returns early for paths under `app.buildAssetsDir`, resolved once during plugin setup. Nothing downstream reads the context on that path: nitro serves or 404s build assets before `render:before` runs, so `useI18nContext` is never reached for them. The reporter measured ~8290 rps with the same guard, and SSR requests are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented i18n initialization for build asset requests, improving asset delivery and avoiding unnecessary request processing.
  * Preserved i18n initialization for regular page requests, including applications served from the root path.

* **Tests**
  * Added coverage for build assets with and without a configured base URL, as well as standard page requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->