### PR TITLE
fix: narrow logger type to methods used

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -518,4 +518,4 @@ export function toArray<T>(value: T | T[]): T[] {
 }
 
 // annotated so the declaration does not have to name consola through its resolved path (TS2742)
-export const logger: ConsolaInstance = useLogger('nuxt-i18n')
+export const logger: Pick<ConsolaInstance, 'debug' | 'error' | 'info' | 'warn'> = useLogger('nuxt-i18n')


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

I have a better fix coming in (self-contained nuxt/kit types for the logger) but for now this should unbreak ecosystem-ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the publicly available logging interface while preserving existing logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->