### PR TITLE
fix: take cached locale messages by reference into the preload payload

### DIFF
--- a/src/runtime/server/context.ts
+++ b/src/runtime/server/context.ts
@@ -1,6 +1,5 @@
 import type { LocaleMessages } from '@intlify/core'
 import type { DefineLocaleMessage } from '@intlify/h3'
-import { deepCopy } from '@intlify/shared'
 import { type H3Event, type H3EventContext, getRequestURL } from 'h3'
 import { type ResolvedI18nOptions, setupVueI18nOptions } from '../shared/vue-i18n'
 import { useRuntimeI18n } from '../shared/utils'
@@ -64,7 +63,9 @@ export function createI18nContext(): NonNullable<H3EventContext['nuxtI18n']> {
       const messages = (await getMergedMessages(locale, this.localeConfigs?.[locale]?.fallbacks ?? [])) ?? {}
       // only the payload reads `ctx.messages`, and copying the full tree per request is expensive
       if (__I18N_PRELOAD__) {
-        deepCopy(messages, this.messages)
+        for (const key of Object.keys(messages)) {
+          this.messages[key] ??= messages[key]!
+        }
       }
       // vue-i18n rewrites flat keys in place, so it can't be handed cached messages
       return this.vueI18nOptions?.flatJson ? cloneDeep(messages) : messages

--- a/test/server-context.test.ts
+++ b/test/server-context.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const getMergedMessages = vi.fn()
+
+vi.mock('../src/runtime/server/utils/messages', () => ({ getMergedMessages }))
+
+const { createI18nContext } = await import('../src/runtime/server/context')
+
+const cachedCatalogue = () => Object.freeze({ ar: Object.freeze({ HOTELS: 'فندق' }) })
+
+describe('createI18nContext().loadMessages', () => {
+  beforeEach(() => {
+    vi.stubGlobal('__I18N_PRELOAD__', true)
+    getMergedMessages.mockReset()
+  })
+
+  test('(#4152) a load after the preload pass leaves its frozen entry untouched', async () => {
+    const ctx = createI18nContext()
+    ctx.messages.ar = Object.freeze({ HOTELS: 'فندق', FROM_VUE_I18N_CONFIG: 'اعداد' })
+    getMergedMessages.mockResolvedValue(cachedCatalogue())
+
+    await expect(ctx.loadMessages('ar')).resolves.toBeDefined()
+
+    expect(ctx.messages.ar).toEqual({ HOTELS: 'فندق', FROM_VUE_I18N_CONFIG: 'اعداد' })
+  })
+
+  test('a locale reached through a fallback chain lands once', async () => {
+    const ctx = createI18nContext()
+    getMergedMessages.mockResolvedValue(Object.freeze({
+      ar: Object.freeze({ HOTELS: 'فندق' }),
+      ku: Object.freeze({ HOTELS: 'ھۆتێل' }),
+    }))
+
+    await ctx.loadMessages('ku')
+    await ctx.loadMessages('ar')
+
+    expect(ctx.messages).toEqual({ ar: { HOTELS: 'فندق' }, ku: { HOTELS: 'ھۆتێل' } })
+  })
+
+  test('the caller still receives the merged messages', async () => {
+    const ctx = createI18nContext()
+    getMergedMessages.mockResolvedValue(cachedCatalogue())
+
+    await expect(ctx.loadMessages('ar')).resolves.toEqual({ ar: { HOTELS: 'فندق' } })
+  })
+
+  test('no payload is collected when preload is off', async () => {
+    vi.stubGlobal('__I18N_PRELOAD__', false)
+    const ctx = createI18nContext()
+    getMergedMessages.mockResolvedValue(cachedCatalogue())
+
+    await ctx.loadMessages('ar')
+
+    expect(ctx.messages).toEqual({})
+  })
+})


### PR DESCRIPTION
resolves #4152

Moved SSR message loading in-process and hands the cached tree out by reference, frozen so that a stray mutation surfaces instead of leaking across requests. `ctx.messages`, which exists only to build the preload payload, still merges into whatever is already in the slot with `deepCopy`.

On the server the preload plugin fills `ctx.messages` from `vueI18n.global.messages`, so its entries are those frozen cached trees. The next `ctx.loadMessages()` in the same request — `loadAndSetLocale` on a locale-prefixed route, or a `setLocale` — writes into one and throws, which `loadMessages` catches and logs:


```
Failed to load messages for locale "ar" TypeError: Cannot assign to read only property 'HOTELS' of object '#<Object>'
    at Array.forEach (<anonymous>)
    at deepCopy (...)
    at Object.loadMessages (...)
    at async loadMessagesFromServer (...)
    at async loadAndSetLocale (...)
```

A locale key in the merged result is already the complete tree for that locale — the per-file and fallback merging happens inside `getMergedMessages` — so filling the slot only when it is empty leaves the payload identical while never writing into the frozen tree, and drops a full walk of every locale's tree per request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved preloaded translation messages when additional locale data is loaded.
  - Prevented duplicate or unnecessary message collection across locale fallback chains.
  - Ensured merged messages are returned consistently to callers.
  - Avoided collecting messages when message preloading is disabled.

- **Tests**
  - Added coverage for preloaded, fallback-chain, merged-message, and disabled-preloading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->